### PR TITLE
export encryption_util.dart

### DIFF
--- a/at_client/lib/at_client.dart
+++ b/at_client/lib/at_client.dart
@@ -7,3 +7,4 @@ export 'package:at_client/src/client/remote_secondary.dart';
 export 'package:at_client/src/preference/at_client_preference.dart';
 export 'package:at_client/src/exception/at_client_exception.dart';
 export 'package:at_client/src/util/at_client_util.dart';
+export 'package:at_client/src/util/encryption_util.dart';


### PR DESCRIPTION
This is used at the `ServerDemoService` it the most basic example and it can be confusing for newcomers not to know from where or why this is sending a pedantic error besides if your project is running `flutter analyze` this will fail, you can omit this rule (not recommended) but if it needs to be used in the method `encryptKeyPairs` from `server_demo_service.dart`  it should be exported. 

This is the broken [pedantic rule](https://dart-lang.github.io/linter/lints/implementation_imports.html) `Don't import implementation files from another package.`