### PR TITLE
Automation for placing bugs into project board

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/autobug.yaml
+++ b/.github/workflows/autobug.yaml
@@ -1,0 +1,20 @@
+name: Auto Assign Bugs to Sprint Planning Project Board
+
+on:
+  issues:
+    types: [labeled]
+env:
+  MY_GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to Bugs Column in Sprint Planning Project Board
+    steps:
+    - name: Assign issues and pull requests with `bug` label to project 3
+      uses: srggrs/assign-one-project-github-action@1.2.1
+      if: |
+        contains(github.event.issue.labels.*.name, 'bug') ||
+      with:
+        project: 'https://github.com/orgs/atsign-foundation/projects/3'
+        column_name: 'Bugs'


### PR DESCRIPTION
Part of #158

- What I did

Reuse action after testing in at_server

- How I did it

Reduced scope to just issues labelled 'bug'

- How to verify it

Merge then add a bug issue to this repo and see it in project board/

- Description for the changelog

Automation for placing bugs into project board