### PR TITLE
Stream resume support

### DIFF
--- a/at_client/lib/src/client/at_client_impl.dart
+++ b/at_client/lib/src/client/at_client_impl.dart
@@ -86,17 +86,17 @@ class AtClientImpl implements AtClient {
 
   AtClientImpl(
       String _atSign, String? namespace, AtClientPreference preference) {
-    currentAtSign = AtUtils.formatAtSign(_atSign);
+    currentAtSign = AtUtils.formatAtSign(_atSign)!;
     _preference = preference;
     _namespace = namespace;
   }
 
   Future<void> _init() async {
-    if (_preference!.isLocalStoreRequired) {
-      _localSecondary = LocalSecondary(currentAtSign!, _preference);
+    if (_preference.isLocalStoreRequired) {
+      _localSecondary = LocalSecondary(currentAtSign, _preference);
     }
-    _remoteSecondary = RemoteSecondary(currentAtSign!, _preference!,
-        privateKey: _preference!.privateKey);
+    _remoteSecondary = RemoteSecondary(currentAtSign, _preference,
+        privateKey: _preference.privateKey);
     _encryptionService = EncryptionService();
     _encryptionService!.remoteSecondary = _remoteSecondary;
     _encryptionService!.currentAtSign = currentAtSign;
@@ -104,12 +104,12 @@ class AtClientImpl implements AtClient {
   }
 
   Secondary getSecondary({bool isDedicated = false}) {
-    if (_preference!.isLocalStoreRequired) {
+    if (_preference.isLocalStoreRequired) {
       return _localSecondary!;
     }
     if (isDedicated) {
-      return RemoteSecondary(currentAtSign!, _preference!,
-          privateKey: _preference!.privateKey);
+      return RemoteSecondary(currentAtSign, _preference,
+          privateKey: _preference.privateKey);
     }
     return _remoteSecondary!;
   }
@@ -133,8 +133,8 @@ class AtClientImpl implements AtClient {
   @override
   RemoteSecondary? getRemoteSecondary({bool isDedicated = false}) {
     if (isDedicated) {
-      var remoteSecondary = RemoteSecondary(currentAtSign!, _preference!,
-          privateKey: _preference!.privateKey);
+      var remoteSecondary = RemoteSecondary(currentAtSign, _preference,
+          privateKey: _preference.privateKey);
       return remoteSecondary;
     }
     return _remoteSecondary;
@@ -593,7 +593,7 @@ class AtClientImpl implements AtClient {
   Future<bool> put(AtKey atKey, dynamic value,
       {bool isDedicated = false}) async {
     if (atKey.metadata != null && atKey.metadata!.isBinary!) {
-      if (value != null && value.length > _preference!.maxDataSize) {
+      if (value != null && value.length > _preference.maxDataSize) {
         throw AtClientException('AT0005', 'BufferOverFlowException');
       }
       value = Base2e15.encode(value);
@@ -838,7 +838,7 @@ class AtClientImpl implements AtClient {
     var command =
         'stream:init$sharedWith namespace:$namespace $streamId $fileName ${encryptedData.length}\n';
     logger.finer('sending stream init:$command');
-    var remoteSecondary = RemoteSecondary(currentAtSign!, _preference!);
+    var remoteSecondary = RemoteSecondary(currentAtSign, _preference);
     var result = await remoteSecondary.executeCommand(command, auth: true);
     logger.finer('ack message:$result');
     if (result != null && result.startsWith('stream:ack')) {
@@ -847,7 +847,7 @@ class AtClientImpl implements AtClient {
       logger.finer('ack received for streamId:$streamId');
       remoteSecondary.atLookUp.connection!.getSocket().add(encryptedData);
       var streamResult = await remoteSecondary.atLookUp.messageListener
-          .read(maxWaitMilliSeconds: _preference!.outboundConnectionTimeout);
+          .read(maxWaitMilliSeconds: _preference.outboundConnectionTimeout);
       if (streamResult != null && streamResult.startsWith('stream:done')) {
         await remoteSecondary.atLookUp.connection!.close();
         streamResponse.status = AtStreamStatus.COMPLETE;
@@ -890,13 +890,12 @@ class AtClientImpl implements AtClient {
       Function streamReceiveCallBack) async {
     var handler = StreamNotificationHandler();
     handler.remoteSecondary = getRemoteSecondary();
-    handler.localSecondary = getLocalSecondary();
     handler.preference = _preference;
     handler.encryptionService = _encryptionService;
     var notification = AtStreamNotification()
       ..streamId = streamId
       ..fileName = fileName
-      ..currentAtSign = currentAtSign!
+      ..currentAtSign = currentAtSign
       ..senderAtSign = senderAtSign
       ..fileLength = fileLength;
     logger.info('Sending ack for stream notification:$notification');
@@ -972,9 +971,9 @@ class AtClientImpl implements AtClient {
         }
 
         // storing sent files in a a directory.
-        if (preference?.downloadPath != null) {
+        if (preference.downloadPath != null) {
           var sentFilesDirectory =
-              await Directory(preference!.downloadPath! + '/sent-files')
+              await Directory(preference.downloadPath! + '/sent-files')
                   .create();
           await File(file.path)
               .copy(sentFilesDirectory.path + '/${fileStatus.fileName}');
@@ -997,7 +996,7 @@ class AtClientImpl implements AtClient {
   @override
   Future<List<File>> downloadFile(String transferId, String sharedByAtSign,
       {String? downloadPath}) async {
-    downloadPath ??= preference!.downloadPath;
+    downloadPath ??= preference.downloadPath;
     if (downloadPath == null) {
       throw Exception('downloadPath not found');
     }

--- a/at_client/lib/src/client/at_client_spec.dart
+++ b/at_client/lib/src/client/at_client_spec.dart
@@ -7,6 +7,7 @@ import 'package:at_client/src/preference/at_client_preference.dart';
 import 'package:at_client/src/stream/at_stream_response.dart';
 import 'package:at_client/src/stream/file_transfer_object.dart';
 import 'package:at_commons/at_commons.dart';
+import 'package:at_client/src/stream/at_stream.dart';
 
 /// Interface for a client application that can communicate with a secondary server.
 abstract class AtClient {
@@ -297,8 +298,15 @@ abstract class AtClient {
       {String? regex});
 
   /// Streams the file in [filePath] to [sharedWith] atSign.
+  /// Optionally specify a unique [namespace] for all stream transfers from your app
+  /// [Deprecated] use [createStream]
   Future<AtStreamResponse> stream(String sharedWith, String filePath,
       {String namespace});
+
+  /// Create a stream for a given [streamType]. If your app is sending a file through stream
+  /// then pass [StreamType.SEND]. If your app is receiving a file pass [StreamType.RECEIVE].
+  /// Optionally pass [streamId] if you want to create a stream for a known stream transfer.
+  AtStream createStream(StreamType streamType, {String? streamId});
 
   /// Uploads list of [files] to filebin and shares the file download url with [sharedWithAtSigns]
   /// returns map containing key of each sharedWithAtSign and value of [FileTransferObject]

--- a/at_client/lib/src/converters/encryption/aes_converter.dart
+++ b/at_client/lib/src/converters/encryption/aes_converter.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:encrypt/encrypt.dart';
+
+class AESEncrypter extends Converter<List<int>, List<int>> {
+  final String _encryptionKey;
+  const AESEncrypter(this._encryptionKey);
+
+  @override
+  List<int> convert(List<int> data) {
+    var aesKey = AES(Key.fromBase64(_encryptionKey), padding: null);
+
+    var initializationVector = IV.fromLength(16);
+    var aesEncrypter = Encrypter(aesKey);
+    var encryptedValue =
+        aesEncrypter.encryptBytes(data, iv: initializationVector);
+    return encryptedValue.bytes;
+  }
+
+  @override
+  AESEncryptionSink startChunkedConversion(sink) {
+    return AESEncryptionSink(_encryptionKey, sink);
+  }
+}
+
+class AESDecrypter extends Converter<List<int>, List<int>> {
+  final String _encryptionKey;
+  const AESDecrypter(this._encryptionKey);
+
+  @override
+  List<int> convert(List<int> data) {
+    var aesKey = AES(Key.fromBase64(_encryptionKey), padding: null);
+    var decrypter = Encrypter(aesKey);
+    var iv2 = IV.fromLength(16);
+    return decrypter.decryptBytes(Encrypted(data as Uint8List), iv: iv2);
+  }
+
+  @override
+  AESDecryptionSink startChunkedConversion(sink) {
+    return AESDecryptionSink(_encryptionKey, sink);
+  }
+}
+
+class AESCodec extends Codec<List<int>, List<int>> {
+  final _key;
+  const AESCodec(this._key);
+
+  @override
+  List<int> encode(List<int> data) {
+    return AESEncrypter(_key).convert(data);
+  }
+
+  @override
+  List<int> decode(List<int> data) {
+    return AESDecrypter(_key).convert(data);
+  }
+
+  @override
+  AESEncrypter get encoder => AESEncrypter(_key);
+  @override
+  AESDecrypter get decoder => AESDecrypter(_key);
+}
+
+class AESEncryptionSink extends ByteConversionSink {
+  final _converter;
+  final Sink<List<int>> _outSink;
+  AESEncryptionSink(key, this._outSink) : _converter = AESEncrypter(key);
+
+  @override
+  void add(List<int> data) {
+    _outSink.add(_converter.convert(data));
+  }
+
+  @override
+  void close() {
+    _outSink.close();
+  }
+
+  @override
+  void addSlice(List<int> chunk, int start, int end, bool isLast) {
+    add(chunk.sublist(start, end));
+    if (isLast) close();
+  }
+}
+
+class AESDecryptionSink extends ChunkedConversionSink<List<int>> {
+  final _converter;
+  final Sink<List<int>> _outSink;
+  AESDecryptionSink(key, this._outSink) : _converter = AESDecrypter(key);
+
+  @override
+  void add(List<int> data) {
+    _outSink.add(_converter.convert(data));
+  }
+
+  @override
+  void close() {
+    _outSink.close();
+  }
+}

--- a/at_client/lib/src/converters/splitter.dart
+++ b/at_client/lib/src/converters/splitter.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+class Splitter extends Converter<List<int>, List<List<int>>> {
+  Splitter(this._splitOnByte);
+
+  final int _splitOnByte;
+
+  @override
+  SplitterSink startChunkedConversion(Sink sink) {
+    return SplitterSink(sink, _splitOnByte);
+  }
+
+  @override
+  List<List<int>> convert(input) {
+    var out = ListSink();
+    var sink = SplitterSink(out, _splitOnByte);
+    sink.add(input);
+    sink.close();
+    return out.list;
+  }
+}
+
+class SplitterSink extends ByteConversionSinkBase {
+  SplitterSink(this._sink, this._splitOnByte);
+
+  final int _splitOnByte;
+  final Sink _sink;
+
+  @override
+  void add(List<int> chunk) {
+    assert(chunk is Uint8List);
+    for (var i = 0; i < chunk.length; i += _splitOnByte) {
+      _sink.add(chunk.sublist(i,
+          i + _splitOnByte > chunk.length ? chunk.length : i + _splitOnByte));
+    }
+  }
+
+  @override
+  void close() {
+    _sink.close();
+  }
+}
+
+class ListSink extends Sink<List<int>> {
+  final List<List<int>> list = <List<int>>[];
+  @override
+  void add(List<int> chunk) => list.add(chunk);
+
+  @override
+  void close() {}
+}

--- a/at_client/lib/src/manager/stream_handler.dart
+++ b/at_client/lib/src/manager/stream_handler.dart
@@ -1,0 +1,26 @@
+import 'package:at_client/src/stream/at_stream.dart';
+import 'package:at_client/src/stream/stream_receiver.dart';
+import 'package:at_client/src/stream/stream_sender.dart';
+import 'package:uuid/uuid.dart';
+
+class StreamHandler {
+  static final StreamHandler _singleton = StreamHandler._internal();
+
+  StreamHandler._internal();
+
+  factory StreamHandler.getInstance() {
+    return _singleton;
+  }
+
+  AtStream createStream(String currentAtSign, StreamType streamType,
+      {String? streamId}) {
+    streamId ??= Uuid().v4();
+    var stream = AtStream(currentAtSign, streamId);
+    if (streamType == StreamType.SEND) {
+      stream.sender = StreamSender(streamId);
+    } else if (streamType == StreamType.RECEIVE) {
+      stream.receiver = StreamReceiver(currentAtSign, streamId);
+    }
+    return stream;
+  }
+}

--- a/at_client/lib/src/response/notification_response_parser.dart
+++ b/at_client/lib/src/response/notification_response_parser.dart
@@ -1,0 +1,47 @@
+import 'package:at_client/src/response/response.dart';
+import 'package:at_client/src/response/response_parser.dart';
+
+/// The implementation of [ResponseParser] for Notification response
+class NotificationResponseParser implements ResponseParser {
+  /// Returns Response object which contains response or error based on the result.
+  /// @param responseString - response coming from secondary server
+  /// @returns Response
+  @override
+  Response parse(String responseString) {
+    var response = Response();
+    if (responseString.startsWith('notification:')) {
+      parseSuccessResponse(responseString, response);
+    }
+    return response;
+  }
+
+  /// Remove data: in responseString and set remaining string to response in Response object
+  /// @param responseString - response coming from secondary server
+  /// @param response - Response object from parse method
+  /// @returns void
+  void parseSuccessResponse(String responseString, Response response) {
+    response.response = responseString.replaceFirst('notification:', '');
+  }
+
+  /// Remove error: in responseString and extract Error code and error response if any
+  /// set isError to true
+  /// set errorCode and errorDescription if any
+  /// @param responseString - response coming from secondary server
+  /// @param response - Response object from parse method
+  /// @returns void
+  void parseFailureResponse(String responseString, Response response) {
+    // Remove error: from responseString
+    responseString = responseString.replaceFirst('error:', '');
+    // Set isError to true
+    response.isError = true;
+    // Find out whether error code exists or not
+    if (responseString.isNotEmpty && responseString.startsWith('AT')) {
+      response.errorCode = (responseString.split(':')[0]);
+      response.errorDescription = (responseString.split(':').length > 1)
+          ? responseString.split(':')[1]
+          : '';
+    } else {
+      response.errorDescription = responseString;
+    }
+  }
+}

--- a/at_client/lib/src/response/response.dart
+++ b/at_client/lib/src/response/response.dart
@@ -1,0 +1,21 @@
+class Response {
+  String? response;
+  bool isError = false;
+  String? errorCode;
+  String? errorDescription;
+
+  Response fromJson(Map<String, dynamic> json) {
+    response = json['response'];
+    isError = json['isError'];
+    errorCode = json['errorCode'];
+    errorDescription = json['errorDescription'];
+    return this;
+  }
+
+  Map<String, dynamic> toJson() => {
+    'response': response,
+    'isError': isError,
+    'errorCode': errorCode,
+    'errorDescription': errorDescription,
+  };
+}

--- a/at_client/lib/src/response/response_parser.dart
+++ b/at_client/lib/src/response/response_parser.dart
@@ -1,0 +1,8 @@
+import 'package:at_client/src/response/response.dart';
+
+abstract class ResponseParser {
+  /// Returns Response object which contains response or error based on the result.
+  /// @param responseString - response coming from secondary server
+  /// @returns Response
+  Response parse(String responseString);
+}

--- a/at_client/lib/src/response/stream_notification_response_parser.dart
+++ b/at_client/lib/src/response/stream_notification_response_parser.dart
@@ -1,0 +1,34 @@
+import 'dart:convert';
+import 'package:at_client/src/response/notification_response_parser.dart';
+import 'package:at_client/src/stream/at_stream_notification.dart';
+
+class StreamNotificationParser extends NotificationResponseParser {
+  final notificationKey = 'stream_id';
+
+  final namespace;
+
+  StreamNotificationParser(this.namespace);
+
+  AtStreamNotification? parseStreamNotification(String responseString) {
+    final notificationResponse = super.parse(responseString);
+    var streamNotificationJson = jsonDecode(notificationResponse.response!);
+    var notificationKey = streamNotificationJson['key'];
+    var fromAtSign = streamNotificationJson['from'];
+    var atKey = notificationKey.split(':')[1];
+    atKey = atKey.replaceFirst(fromAtSign, '');
+    atKey = atKey.trim();
+    if (atKey == '$notificationKey.$namespace') {
+      var valueObject = streamNotificationJson['value'];
+      var streamId = valueObject.split(':')[0];
+      var fileName = valueObject.split(':')[1];
+      var fileLength = int.parse(valueObject.split(':')[2]);
+      fileName = utf8.decode(base64.decode(fileName));
+      return AtStreamNotification()
+        ..streamId = streamId
+        ..fileName = fileName
+        ..fileLength = fileLength
+        ..senderAtSign = fromAtSign;
+    }
+    return null;
+  }
+}

--- a/at_client/lib/src/response/stream_notification_response_parser.dart
+++ b/at_client/lib/src/response/stream_notification_response_parser.dart
@@ -3,7 +3,7 @@ import 'package:at_client/src/response/notification_response_parser.dart';
 import 'package:at_client/src/stream/at_stream_notification.dart';
 
 class StreamNotificationParser extends NotificationResponseParser {
-  final notificationKey = 'stream_id';
+  final streamNotificationKey = 'stream_id';
 
   final namespace;
 
@@ -17,7 +17,7 @@ class StreamNotificationParser extends NotificationResponseParser {
     var atKey = notificationKey.split(':')[1];
     atKey = atKey.replaceFirst(fromAtSign, '');
     atKey = atKey.trim();
-    if (atKey == '$notificationKey.$namespace') {
+    if (atKey == '$streamNotificationKey.$namespace') {
       var valueObject = streamNotificationJson['value'];
       var streamId = valueObject.split(':')[0];
       var fileName = valueObject.split(':')[1];

--- a/at_client/lib/src/service/encryption_service.dart
+++ b/at_client/lib/src/service/encryption_service.dart
@@ -188,8 +188,14 @@ class EncryptionService {
     }
   }
 
-  //TODO remove code duplication - encrypt and encryptStream
   Future<List<int>> encryptStream(List<int> value, String sharedWith) async {
+    var sharedKey = await getStreamEncryptionKey(sharedWith);
+    var encryptedValue = EncryptionUtil.encryptBytes(value, sharedKey);
+    return encryptedValue;
+  }
+
+  //TODO remove code duplication - encrypt and getStreamEncryptionKey
+  Future<String> getStreamEncryptionKey(String sharedWith) async {
     var currentAtSignPublicKey =
         await (localSecondary!.getEncryptionPublicKey(currentAtSign!));
     var currentAtSignPrivateKey =
@@ -206,6 +212,7 @@ class EncryptionService {
       sharedKey = sharedKey.replaceFirst('data:', '');
       sharedKey =
           EncryptionUtil.decryptKey(sharedKey, currentAtSignPrivateKey!);
+      return sharedKey;
     }
     //2. Lookup public key of sharedWith atsign
     var plookupBuilder = PLookupVerbBuilder()
@@ -241,10 +248,7 @@ class EncryptionService {
       ..value = encryptedSharedKeyForCurrentAtSign;
     await localSecondary!
         .executeVerb(updateSharedKeyForCurrentAtSignBuilder, sync: true);
-
-    //5. Encrypt value using sharedKey
-    var encryptedValue = EncryptionUtil.encryptBytes(value, sharedKey);
-    return encryptedValue;
+    return sharedKey;
   }
 
   List<int> decryptStream(List<int> encryptedValue, String sharedKey) {
@@ -323,6 +327,7 @@ class EncryptionService {
     return base64Encode(dataSignature);
   }
 
+  /// [Deprecated] This function was implemented to migrate old unencrypted keys. No longer applicable.
   Future<void> encryptUnencryptedData() async {
     var atClient = await (AtClientImpl.getClient(currentAtSign));
     if (atClient == null) {

--- a/at_client/lib/src/stream/at_stream.dart
+++ b/at_client/lib/src/stream/at_stream.dart
@@ -1,0 +1,12 @@
+import 'package:at_client/src/stream/stream_receiver.dart';
+import 'package:at_client/src/stream/stream_sender.dart';
+
+class AtStream {
+  String streamId;
+  String currentAtSign;
+  StreamSender? sender;
+  StreamReceiver? receiver;
+  AtStream(this.currentAtSign, this.streamId);
+}
+
+enum StreamType { SEND, RECEIVE }

--- a/at_client/lib/src/stream/at_stream_ack.dart
+++ b/at_client/lib/src/stream/at_stream_ack.dart
@@ -1,0 +1,5 @@
+class AtStreamAck {
+  String? senderAtSign;
+  String? fileName;
+  int? fileLength;
+}

--- a/at_client/lib/src/stream/at_stream_notification.dart
+++ b/at_client/lib/src/stream/at_stream_notification.dart
@@ -5,7 +5,7 @@ class AtStreamNotification {
   String? namespace;
   late String senderAtSign;
   late String currentAtSign;
-  late int startByte;
+  int? startByte;
 
   @override
   String toString() {

--- a/at_client/lib/src/stream/at_stream_notification.dart
+++ b/at_client/lib/src/stream/at_stream_notification.dart
@@ -5,9 +5,10 @@ class AtStreamNotification {
   String? namespace;
   late String senderAtSign;
   late String currentAtSign;
+  late int startByte;
 
   @override
   String toString() {
-    return 'StreamNotification{streamId: $streamId, namespace:$namespace, fileName: $fileName, fileLength: $fileLength, senderAtSign: $senderAtSign, currentAtSign: $currentAtSign}';
+    return 'StreamNotification{streamId: $streamId, namespace:$namespace, fileName: $fileName, fileLength: $fileLength, senderAtSign: $senderAtSign, currentAtSign: $currentAtSign, startByte: $startByte}';
   }
 }

--- a/at_client/lib/src/stream/at_stream_request.dart
+++ b/at_client/lib/src/stream/at_stream_request.dart
@@ -1,0 +1,9 @@
+class AtStreamRequest {
+  String receiverAtSign;
+  String filePath;
+  int startByte = 0;
+  int? fileLength;
+  String? namespace;
+
+  AtStreamRequest(this.receiverAtSign, this.filePath);
+}

--- a/at_client/lib/src/stream/at_stream_response.dart
+++ b/at_client/lib/src/stream/at_stream_response.dart
@@ -1,13 +1,16 @@
 class AtStreamResponse {
   AtStreamStatus? status;
   String? errorCode;
+  String? errorMessage;
+  String streamId;
+
+  AtStreamResponse(this.streamId);
 
   @override
   String toString() {
-    return 'AtStreamResponse{status: $status, errorCode: $errorCode, errorMessage: $errorMessage}';
+    return 'AtStreamResponse{streamId: $streamId, status: $status, errorCode: $errorCode, errorMessage: $errorMessage}';
   }
 
-  String? errorMessage;
 }
 
-enum AtStreamStatus { ACK, NO_ACK, COMPLETE, ERROR }
+enum AtStreamStatus { ACK, NO_ACK, COMPLETE, ERROR, CANCELLED }

--- a/at_client/lib/src/stream/stream_receiver.dart
+++ b/at_client/lib/src/stream/stream_receiver.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:at_client/at_client.dart';
+import 'package:at_client/src/service/encryption_service.dart';
+import 'package:at_client/src/stream/at_stream_ack.dart';
+import 'package:at_client/src/stream/at_stream_notification.dart';
+import 'package:at_client/src/stream/stream_notification_handler.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_utils/at_logger.dart';
+
+class StreamReceiver {
+  String streamId;
+
+  late RemoteSecondary remoteSecondary;
+
+  EncryptionService? encryptionService;
+
+  late AtClientPreference preference;
+
+  final String _currentAtSign;
+
+  StreamReceiver(this._currentAtSign, this.streamId);
+
+  final _logger = AtSignLogger('StreamReceiver');
+
+  /// Acknowledges a stream transfer from [atStreamAck.senderAtSign]
+  /// Upon stream completion [streamCompletionCallBack] is triggered with the streamId for the transfer.
+  /// App can use [streamProgressCallBack] to know the total bytes received so far for the acknowledged transfer.
+  Future<void> ack(AtStreamAck atStreamAck, Function streamCompletionCallBack,
+      Function streamProgressCallBack) async {
+    var handler = StreamNotificationHandler();
+    handler.remoteSecondary = remoteSecondary;
+    handler.preference = preference;
+    handler.encryptionService = encryptionService;
+    var notification = AtStreamNotification()
+      ..streamId = streamId
+      ..fileName = atStreamAck.fileName!
+      ..currentAtSign = _currentAtSign
+      ..senderAtSign = atStreamAck.senderAtSign!
+      ..fileLength = atStreamAck.fileLength!;
+    _logger.finer('Sending ack for stream notification:$notification');
+    await handler.streamAck(
+        notification, streamCompletionCallBack, streamProgressCallBack);
+  }
+
+  /// Initiates a stream resume from receiver to the [senderAtSign] from the byte [startByte]
+  Future<void> resume(
+      String streamId, int startByte, String senderAtSign) async {
+    var secondaryUrl = await AtLookupImpl.findSecondary(
+        senderAtSign, preference.rootDomain, preference.rootPort);
+    var secondaryInfo = AtClientUtil.getSecondaryInfo(secondaryUrl);
+    var host = secondaryInfo[0];
+    var port = secondaryInfo[1];
+    var socket = await SecureSocket.connect(host, int.parse(port));
+    _logger.info('sending stream receive for : $streamId');
+    var command =
+        'stream:resume$_currentAtSign namespace:${preference.namespace} startByte:$startByte $streamId\n';
+    socket.write(command);
+  }
+
+  Future<void> cancel() async {
+    //#TODO implement
+  }
+}

--- a/at_client/lib/src/stream/stream_sender.dart
+++ b/at_client/lib/src/stream/stream_sender.dart
@@ -41,6 +41,7 @@ class StreamSender {
       _logger.finer('sending stream init:$command');
       await _checkConnectivity();
       var result = await remoteSecondary.executeCommand(command, auth: true);
+      _logger.finer('got result in stream sender: $result');
       if (result != null && result.startsWith('stream:ack')) {
         result = result.replaceAll('stream:ack ', '');
         result = result.trim();
@@ -48,7 +49,7 @@ class StreamSender {
         await _startStream(
             file, atStreamRequest.receiverAtSign, atStreamRequest.startByte);
         var streamResult =
-        await remoteSecondary.atLookUp.messageListener!.read();
+            await remoteSecondary.atLookUp.messageListener.read();
         if (streamResult != null && streamResult.startsWith('stream:done')) {
           _logger.finer('stream done - streamId: $streamId');
           atStreamResponse.status = AtStreamStatus.COMPLETE;
@@ -77,7 +78,7 @@ class StreamSender {
     var chunkedStream = ChunkedStreamReader(file.openRead(startByte));
     try {
       var encryptionKey =
-      await encryptionService!.getStreamEncryptionKey(receiverAtSign);
+          await encryptionService!.getStreamEncryptionKey(receiverAtSign);
       while (readBytes < length) {
         remoteSecondary.atLookUp.connection!.getSocket().add(
             AESCodec(encryptionKey)
@@ -95,18 +96,19 @@ class StreamSender {
   /// onError[AtStreamResponse] gets called upon failure of the cancel request
   Future<void> cancel(AtStreamRequest atStreamRequest, Function onDone,
       Function onError) async {
-    var atStreamResponse = AtStreamResponse(streamId);
-    try {
-      var command = 'stream:cancel $streamId';
-      await _checkConnectivity();
-      var result = await remoteSecondary.executeCommand(command, auth: true);
-      //#TODO process result
-      atStreamResponse.status = AtStreamStatus.CANCELLED;
-      onDone(atStreamResponse);
-    } on Exception catch (e) {
-      atStreamResponse.errorMessage = e.toString();
-      onError(atStreamResponse);
-    }
+    // #TODO complete implementation when server support is ready
+//    var atStreamResponse = AtStreamResponse(streamId);
+//    try {
+//      var command = 'stream:cancel $streamId';
+//      await _checkConnectivity();
+//      var result = await remoteSecondary.executeCommand(command, auth: true);
+//      //#TODO process result
+//      atStreamResponse.status = AtStreamStatus.CANCELLED;
+//      onDone(atStreamResponse);
+//    } on Exception catch (e) {
+//      atStreamResponse.errorMessage = e.toString();
+//      onError(atStreamResponse);
+//    }
   }
 
   Future<void> _checkConnectivity() async {

--- a/at_client/lib/src/stream/stream_sender.dart
+++ b/at_client/lib/src/stream/stream_sender.dart
@@ -1,0 +1,120 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:async/async.dart';
+import 'package:at_client/src/client/remote_secondary.dart';
+import 'package:at_client/src/converters/encryption/aes_converter.dart';
+import 'package:at_client/src/service/encryption_service.dart';
+import 'package:at_client/src/stream/at_stream_request.dart';
+import 'package:at_client/src/stream/at_stream_response.dart';
+import 'package:at_client/src/util/network_util.dart';
+import 'package:path/path.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:at_commons/at_commons.dart';
+
+class StreamSender {
+  String streamId;
+
+  StreamSender(this.streamId);
+
+  late RemoteSecondary remoteSecondary;
+
+  EncryptionService? encryptionService;
+
+  final _logger = AtSignLogger('StreamSender');
+
+  final chunkSize = 1024;
+
+  /// Sends a file specified in [atStreamRequest.filePath] through a stream verb.
+  /// onDone[AtStreamResponse] is called upon stream completion.
+  /// onError[AtStreamResponse] is called when stream errors out.
+  /// If a stream transfer has to be resumed then specify [atStreamRequest.startByte]. Stream transfer will be resumed from startByte.
+  Future<void> send(AtStreamRequest atStreamRequest, Function onDone,
+      Function onError) async {
+    var atStreamResponse = AtStreamResponse(streamId);
+    try {
+      var file = File(atStreamRequest.filePath);
+      final fileLength = await file.length();
+      var fileName = basename(atStreamRequest.filePath);
+      fileName = base64.encode(utf8.encode(fileName));
+      var command =
+          'stream:init${atStreamRequest.receiverAtSign} namespace:${atStreamRequest.namespace} startByte:${atStreamRequest.startByte} $streamId $fileName $fileLength\n';
+      _logger.finer('sending stream init:$command');
+      await _checkConnectivity();
+      var result = await remoteSecondary.executeCommand(command, auth: true);
+      if (result != null && result.startsWith('stream:ack')) {
+        result = result.replaceAll('stream:ack ', '');
+        result = result.trim();
+        _logger.finer('ack received for streamId:$streamId');
+        await _startStream(
+            file, atStreamRequest.receiverAtSign, atStreamRequest.startByte);
+        var streamResult =
+        await remoteSecondary.atLookUp.messageListener!.read();
+        if (streamResult != null && streamResult.startsWith('stream:done')) {
+          _logger.finer('stream done - streamId: $streamId');
+          atStreamResponse.status = AtStreamStatus.COMPLETE;
+          onDone(atStreamResponse);
+        }
+      } else if (result != null && result.startsWith('error:')) {
+        result = result.replaceAll('error:', '');
+        atStreamResponse.status = AtStreamStatus.ERROR;
+        atStreamResponse.errorCode = result.split('-')[0];
+        atStreamResponse.errorMessage = result.split('-')[1];
+        onError(atStreamResponse);
+      } else {
+        atStreamResponse.status = AtStreamStatus.NO_ACK;
+        onError(atStreamResponse);
+      }
+    } on Exception catch (e) {
+      atStreamResponse.errorMessage = e.toString();
+      onError(atStreamResponse);
+    }
+  }
+
+  Future<void> _startStream(
+      File file, String receiverAtSign, int startByte) async {
+    var readBytes = 0;
+    final length = await file.length();
+    var chunkedStream = ChunkedStreamReader(file.openRead(startByte));
+    try {
+      var encryptionKey =
+      await encryptionService!.getStreamEncryptionKey(receiverAtSign);
+      while (readBytes < length) {
+        remoteSecondary.atLookUp.connection!.getSocket().add(
+            AESCodec(encryptionKey)
+                .encoder
+                .convert(await chunkedStream.readBytes(chunkSize)));
+        readBytes += chunkSize;
+      }
+    } finally {
+      await chunkedStream.cancel();
+    }
+  }
+
+  /// Cancels a [atStreamRequest]
+  /// onDone[AtStreamResponse] gets called upon successful completion of cancel request
+  /// onError[AtStreamResponse] gets called upon failure of the cancel request
+  Future<void> cancel(AtStreamRequest atStreamRequest, Function onDone,
+      Function onError) async {
+    var atStreamResponse = AtStreamResponse(streamId);
+    try {
+      var command = 'stream:cancel $streamId';
+      await _checkConnectivity();
+      var result = await remoteSecondary.executeCommand(command, auth: true);
+      //#TODO process result
+      atStreamResponse.status = AtStreamStatus.CANCELLED;
+      onDone(atStreamResponse);
+    } on Exception catch (e) {
+      atStreamResponse.errorMessage = e.toString();
+      onError(atStreamResponse);
+    }
+  }
+
+  Future<void> _checkConnectivity() async {
+    if (!(await NetworkUtil.isNetworkAvailable())) {
+      throw AtConnectException('Internet connection unavailable to sync');
+    }
+    if (!(await remoteSecondary.isAvailable())) {
+      throw AtConnectException('Secondary server is unavailable');
+    }
+  }
+}

--- a/at_client/lib/src/util/network_util.dart
+++ b/at_client/lib/src/util/network_util.dart
@@ -1,0 +1,15 @@
+import 'package:at_utils/at_logger.dart';
+import 'package:internet_connection_checker/internet_connection_checker.dart';
+
+class NetworkUtil {
+  static final _logger = AtSignLogger('NetworkUtil');
+
+  static Future<bool> isNetworkAvailable() async {
+    var result = await InternetConnectionChecker().hasConnection;
+    if (!result) {
+      _logger.finer(
+          'Unable to connect to internet: ${InternetConnectionChecker().lastTryResults}');
+    }
+    return result;
+  }
+}

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -22,12 +22,12 @@ dependencies:
   archive: ^3.1.2
   http: ^0.13.3
   at_persistence_spec: ^2.0.0
-  at_persistence_secondary_server: ^2.0.2
-  at_lookup: ^2.0.2
+  at_persistence_secondary_server: ^2.0.3
+  at_lookup: ^2.0.3
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
-  at_commons: ^2.0.2
-  at_utils: ^2.0.2
+  at_commons: ^2.0.3
+  at_utils: ^2.0.3
 
 dev_dependencies:
   test: ^1.17.2

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   pedantic: ^1.11.0
   archive: ^3.1.2
   http: ^0.13.3
+  internet_connection_checker: 0.0.1+1
   at_persistence_spec: ^2.0.0
   at_persistence_secondary_server: ^2.0.3
   at_lookup: ^2.0.3
@@ -28,6 +29,7 @@ dependencies:
   at_base2e15: ^1.0.0
   at_commons: ^2.0.3
   at_utils: ^2.0.3
+
 
 dev_dependencies:
   test: ^1.17.2

--- a/at_client/test/samples/stream_receiver_resume.dart
+++ b/at_client/test/samples/stream_receiver_resume.dart
@@ -8,21 +8,28 @@ import 'package:at_client/src/stream/at_stream_ack.dart';
 
 import 'test_util.dart';
 
-AtClientImpl? atClient;
+AtClient? atClient;
 
 void main() async {
   try {
     var preference = TestUtil.getBobPreference();
-    await AtClientImpl.createClient('@bob🛠', 'me', preference);
-    atClient = await AtClientImpl.getClient('@bob🛠') as AtClientImpl;
+    await AtClientImpl.createClient(
+        '@bob🛠', 'me', TestUtil.getBobPreference());
+    atClient = await AtClientImpl.getClient('@bob🛠');
+    var atCommand =
+        'stream:resume@alice🛠 namespace:atmosphere startByte:1024 ac58c95b-6a4b-4fdd-b38d-7c91382f8f0b\n';
+    print('atCommand : ${atCommand}');
+    atClient!.getRemoteSecondary()!.executeCommand(atCommand);
     //var monitorPreference = MonitorPreference()..regex = 'atmosphere';
     //monitorPreference.keepAlive = true;
+    //print('starting monitor');
     //await atClient!.startMonitor(
     //   _notificationCallBack, _monitorErrorCallBack, monitorPreference);
     await atClient!.startMonitor(preference.privateKey!, _notificationCallBack,
         regex: 'atmosphere');
+    print('done starting monitor');
     while (true) {
-      print('Waiting for notification');
+      print("in while");
       await Future.delayed(Duration(seconds: 5));
     }
   } on Exception catch (e, trace) {
@@ -36,7 +43,7 @@ void _monitorErrorCallBack(var error) {
 }
 
 Future<void> _notificationCallBack(var response) async {
-  print('In receiver _notificationCallBack : $response');
+  print('notification received: $response');
   final streamNotification =
       StreamNotificationParser('atmosphere').parseStreamNotification(response);
   if (streamNotification != null) {
@@ -45,7 +52,7 @@ Future<void> _notificationCallBack(var response) async {
       print('user accepted transfer.Sending ack back');
       final atStream = atClient!.createStream(StreamType.RECEIVE,
           streamId: streamNotification.streamId);
-
+      ;
       await atStream.receiver!.ack(
           AtStreamAck()
             ..senderAtSign = streamNotification.senderAtSign
@@ -63,12 +70,8 @@ void _streamProgressCallBack(var bytesReceived) {
   print('Receive callback bytes received: $bytesReceived');
 }
 
-Future<void> _streamCompletionCallBack(var streamId) async {
+void _streamCompletionCallBack(var streamId) {
   print('Transfer done for stream: $streamId');
-  //sleep(Duration(seconds: 1));
-//  var atCommand = 'stream:resume@murali namespace:atmosphere startByte:3 $streamId test1.txt 15\n';
-//  print('In _streamCompletionCallBack atCommand : ${atCommand}');
-//  await atClient!.getRemoteSecondary()!.executeCommand(atCommand);
 }
 
 void streamResumeTest(String streamId, int startByte) {

--- a/at_client/test/samples/stream_sender_resume.dart
+++ b/at_client/test/samples/stream_sender_resume.dart
@@ -2,11 +2,13 @@ import 'dart:convert';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/client/at_client_impl.dart';
+import 'package:at_client/src/response/notification_response_parser.dart';
 import 'package:at_client/src/stream/at_stream_request.dart';
 import 'package:at_client/src/stream/at_stream_response.dart';
 import 'package:at_client/src/stream/at_stream.dart';
 
 import 'test_util.dart';
+
 AtClient? atClient;
 void main() async {
   try {
@@ -18,18 +20,20 @@ void main() async {
       print('unable to create at client instance');
       return;
     }
-    // Function dummyFunction = () {};
+   // Function dummyFunction = () {};
     //var monitorPreference = MonitorPreference();
-    // await atClient!.startMonitor(_notificationCallback, dummyFunction, monitorPreference);
+    //await atClient!
+     //   .startMonitor(_notificationCallback, dummyFunction, monitorPreference);
     await atClient!.startMonitor(preference.privateKey!, _notificationCallback,
         regex: 'atmosphere');
-    var stream = atClient!.createStream(StreamType.SEND, );
+    var stream = atClient!.createStream(
+      StreamType.SEND,
+    );
     print('sender : ${stream.sender} receiver : ${stream.receiver}');
     var atStreamRequest =
-    AtStreamRequest('@bob🛠', 'cat.jpeg');
+    AtStreamRequest('@bob🛠', '/home/murali/Pictures/@/cat.jpeg');
     atStreamRequest.namespace = 'atmosphere';
-    await stream.sender!.send(atStreamRequest, _onDone, _onError);
-    while(true) {
+    while (true) {
       print('Waiting for notification');
       await Future.delayed(Duration(seconds: 5));
     }
@@ -50,5 +54,20 @@ void _onError(AtStreamResponse response) {
 }
 
 Future<void> _notificationCallback(var response) async {
-  print('notification received $response');
+  print('stream resume notification received $response');
+  response = NotificationResponseParser().parse(response);
+  var responseJson = jsonDecode(response);
+  var notificationKey = responseJson['key'].toString();
+  notificationKey = notificationKey.replaceFirst('null', '');
+  notificationKey = notificationKey.replaceFirst('stream_resume ', '');
+  print(notificationKey);
+  var streamId = notificationKey.split(':')[1];
+  var startByte = int.parse(notificationKey.split(':')[2]);
+  var stream = atClient!.createStream(StreamType.SEND, streamId: streamId);
+  print(
+      'sender : ${stream.sender} receiver : ${stream.receiver} streamId:$streamId startByte: $startByte');
+  var atStreamRequest = AtStreamRequest('@bob🛠', 'cat.jpeg');
+  atStreamRequest.namespace = 'atmosphere';
+  atStreamRequest.startByte = startByte;
+  await stream.sender!.send(atStreamRequest, _onDone, _onError);
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Support for stream resume , redesign stream methods and add parsers

**- How I did it**

- Deprecated old stream method
- added new method createStream in spec
- moved stream logic from at_client_impl to StreamSender and StreamReceiver classes

**- How to verify it**
- Run stream sender and stream receiver code in samples
- To test stream resume, stop the receiver after certain bytes have been received. Call stream resume with start byte = received bytes+1

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->