### PR TITLE
Issue #305 Migrate from package:pedantic to package:lints

### DIFF
--- a/at_client/analysis_options.yaml
+++ b/at_client/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
-# see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+# see https://pub.dev/packages/lints.
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   uuid: ^3.0.4
   crypto: ^3.0.1
   collection: ^1.15.0
-  pedantic: ^1.11.0
+  lints: ^1.0.1
   archive: ^3.1.2
   http: ^0.13.3
   internet_connection_checker: ^0.0.1+2

--- a/at_client_mobile/analysis_options.yaml
+++ b/at_client_mobile/analysis_options.yaml
@@ -1,7 +1,7 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
-# see https://github.com/dart-lang/pedantic#enabled-lints.
-include: package:pedantic/analysis_options.yaml
+# see https://pub.dev/packages/lints.
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.

--- a/at_client_mobile/example/pubspec.yaml
+++ b/at_client_mobile/example/pubspec.yaml
@@ -21,5 +21,5 @@ dependencies:
   at_utils: ^1.0.1+2
 
 dev_dependencies:
-  pedantic: ^1.8.0
+  lints: ^1.0.1
   test: ^1.6.0

--- a/at_client_mobile/pubspec.yaml
+++ b/at_client_mobile/pubspec.yaml
@@ -43,5 +43,5 @@ dependencies:
 #      ref: trunk
 
 dev_dependencies:
-  pedantic: ^1.8.0
+  lints: ^1.0.1
   test: ^1.6.0


### PR DESCRIPTION
Hi applied the changes as described in https://github.com/atsign-foundation/at_client_sdk/issues/305

Updated the linter and url to latest Dart rules.

Please let me know if more is needed.
Regards