### PR TITLE
Supress lint issues

### DIFF
--- a/at_client_mobile/analysis_options.yaml
+++ b/at_client_mobile/analysis_options.yaml
@@ -1,15 +1,22 @@
 # Defines a default set of lint rules enforced for
 # projects at Google. For details and rationale,
 # see https://pub.dev/packages/lints.
-include: package:lints/recommended.yaml
+include: package:flutter_lints/flutter.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
 linter:
   rules:
-    - camel_case_types
-    - unnecessary_string_interpolations
-    - await_only_futures
+# Supresses 22 issues
+    constant_identifier_names: false
+# Supresses 5 issues
+    prefer_typing_uninitialized_variables: false
+# Supresses 2 issues
+    provide_deprecation_message: false
+# Supresses 2 issues
+    implementation_imports: false
+# Supresses 2 issues
+    non_constant_identifier_names: false
 
 analyzer:
 #   exclude:

--- a/at_client_mobile/example/pubspec.yaml
+++ b/at_client_mobile/example/pubspec.yaml
@@ -21,5 +21,5 @@ dependencies:
   at_utils: ^1.0.1+2
 
 dev_dependencies:
-  lints: ^1.0.1
+  flutter_lints: ^1.0.4
   test: ^1.6.0

--- a/at_client_mobile/pubspec.yaml
+++ b/at_client_mobile/pubspec.yaml
@@ -43,5 +43,5 @@ dependencies:
 #      ref: trunk
 
 dev_dependencies:
-  lints: ^1.0.1
+  flutter_lints: ^1.0.4
   test: ^1.6.0


### PR DESCRIPTION
Fixes #309 

**- What I did**

Added linter rules to supress the 33 issues being found by `flutter analyse` against standard Flutter lints.

**- How to verify it**

Tests will now pass

**- Description for the changelog**

Supress lint issues