### PR TITLE
Fix notify texts fails with spaces

### DIFF
--- a/at_client/lib/src/client/at_client_impl.dart
+++ b/at_client/lib/src/client/at_client_impl.dart
@@ -1027,7 +1027,11 @@ class AtClientImpl implements AtClient {
     notificationParams.atKey.sharedBy ??= getCurrentAtSign();
     AtUtils.fixAtSign(notificationParams.atKey.sharedBy!);
     // validate atKey
-    AtClientValidation.validateKey(notificationParams.atKey.key);
+    // For messageType is text, text may contains spaces but key should not have spaces
+    // Hence do not validate the key.
+    if (notificationParams.messageType != MessageTypeEnum.text) {
+      AtClientValidation.validateKey(notificationParams.atKey.key);
+    }
     // validate metadata
     AtClientValidation.validateMetadata(notificationParams.atKey.metadata);
     // If namespaceAware is set to true, append nameSpace to key.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did** Fix notification fails when message type text contains spaces.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->