### PR TITLE
Separate unit tests and end2end tests

### DIFF
--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -56,9 +56,24 @@ jobs:
         working-directory: at_client
         run: dart run test/functional_test/check_test_env.dart
 
-      # Run unit and functional tests
-      - name: Run unit and functional tests
+      # Run unit tests
+      - name: Run unit tests, with code coverage measurement
         working-directory: at_client
+        run: dart test --concurrency=1 --coverage="coverage"
+
+      - name: Convert coverage to LCOV format
+        working-directory: at_client
+        run: pub run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=lib
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2.1.0
+        with:
+          token: ${{secrets.CODECOV_TOKEN_AT_CLIENT_SDK}}
+          file: at_client/coverage.lcov
+
+      # Run end2end tests
+      - name: Run end2end tests
+        working-directory: at_end2end_test
         run: dart test --concurrency=1
 
       # Adding flutter to path

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -60,3 +60,5 @@ dependencies:
 dev_dependencies:
   test: ^1.17.2
   at_demo_data: ^0.0.3+1
+  coverage: ^1.0.3
+  mockito: ^5.0.7

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   http: ^0.13.3
   internet_connection_checker: ^0.0.1+2
   at_persistence_spec: ^2.0.2
-  at_persistence_secondary_server: ^3.0.8
+  at_persistence_secondary_server: ^3.0.11
   at_lookup: ^3.0.4
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0

--- a/at_end2end_test/.gitignore
+++ b/at_end2end_test/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/at_end2end_test/.gitignore
+++ b/at_end2end_test/.gitignore
@@ -2,6 +2,10 @@
 .dart_tool/
 .packages
 
+# code coverage related
+coverage
+coverage.lcov
+
 # Conventional directory for build outputs.
 build/
 

--- a/at_end2end_test/CHANGELOG.md
+++ b/at_end2end_test/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/at_end2end_test/README.md
+++ b/at_end2end_test/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/at_end2end_test/analysis_options.yaml
+++ b/at_end2end_test/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/at_end2end_test/pubspec.yaml
+++ b/at_end2end_test/pubspec.yaml
@@ -1,0 +1,15 @@
+name: at_end2end_test
+description: A starting point for Dart libraries or applications.
+version: 1.0.0
+# homepage: https://www.example.com
+
+environment:
+  sdk: '>=2.14.4 <3.0.0'
+
+
+# dependencies:
+#   path: ^1.8.0
+
+dev_dependencies:
+  lints: ^1.0.1
+  test: ^1.16.0

--- a/at_end2end_test/pubspec.yaml
+++ b/at_end2end_test/pubspec.yaml
@@ -11,5 +11,7 @@ dependencies:
     path: ../at_client
 
 dev_dependencies:
+  test: ^1.17.3
+  coverage: ^1.0.3
+  mockito: ^5.0.7
   lints: ^1.0.1
-  test: ^1.16.0

--- a/at_end2end_test/pubspec.yaml
+++ b/at_end2end_test/pubspec.yaml
@@ -1,14 +1,14 @@
 name: at_end2end_test
-description: A starting point for Dart libraries or applications.
+publish_to: none
+description: End to end tests for the at_client_sdk packages
 version: 1.0.0
-# homepage: https://www.example.com
 
 environment:
   sdk: '>=2.14.4 <3.0.0'
 
-
-# dependencies:
-#   path: ^1.8.0
+dependencies:
+  at_client:
+    path: ../at_client
 
 dev_dependencies:
   lints: ^1.0.1

--- a/at_end2end_test/test/atclient_notify_test.dart
+++ b/at_end2end_test/test/atclient_notify_test.dart
@@ -6,8 +6,8 @@ import 'package:at_client/src/service/notification_service_impl.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:test/test.dart';
 
-import 'at_demo_credentials.dart' as demo_credentials;
-import 'set_encryption_keys.dart';
+import '../../at_client/test/functional_test/at_demo_credentials.dart' as demo_credentials;
+import '../../at_client/test/functional_test/set_encryption_keys.dart';
 
 void main() {
   test('notify updating of a key to sharedWith atSign - using await', () async {

--- a/at_end2end_test/test/atclient_put_test.dart
+++ b/at_end2end_test/test/atclient_put_test.dart
@@ -4,8 +4,8 @@ import 'package:at_client/at_client.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:test/test.dart';
 
-import 'at_demo_credentials.dart' as demo_credentials;
-import 'set_encryption_keys.dart';
+import '../../at_client/test/functional_test/at_demo_credentials.dart' as demo_credentials;
+import '../../at_client/test/functional_test/set_encryption_keys.dart';
 
 void main() {
   test('put method - create a key sharing to other atsign', () async {

--- a/at_functional_test/.gitignore
+++ b/at_functional_test/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/at_functional_test/CHANGELOG.md
+++ b/at_functional_test/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/at_functional_test/README.md
+++ b/at_functional_test/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/at_functional_test/analysis_options.yaml
+++ b/at_functional_test/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/at_functional_test/pubspec.yaml
+++ b/at_functional_test/pubspec.yaml
@@ -1,14 +1,14 @@
 name: at_functional_test
-description: A starting point for Dart libraries or applications.
+publish_to: none
+description: Functional tests for the at_client_sdk packages
 version: 1.0.0
-# homepage: https://www.example.com
 
 environment:
   sdk: '>=2.14.4 <3.0.0'
 
-
-# dependencies:
-#   path: ^1.8.0
+dependencies:
+  at_client:
+    path: ../at_client
 
 dev_dependencies:
   lints: ^1.0.1

--- a/at_functional_test/pubspec.yaml
+++ b/at_functional_test/pubspec.yaml
@@ -1,0 +1,15 @@
+name: at_functional_test
+description: A starting point for Dart libraries or applications.
+version: 1.0.0
+# homepage: https://www.example.com
+
+environment:
+  sdk: '>=2.14.4 <3.0.0'
+
+
+# dependencies:
+#   path: ^1.8.0
+
+dev_dependencies:
+  lints: ^1.0.1
+  test: ^1.16.0


### PR DESCRIPTION
**- What I did**
Split out some tests from at_client/test to a new at_end2end_test directory, as they were in fact end-to-end tests rather than unit tests; also added code coverage measurement for the unit tests.

**- How I did it**
* created new top-level directories at_functional_test and at_end2end_test for functional tests and end-to-end tests
* moved some tests from at_client/test/functional_tests to at_end2end_test/test as they are in fact end-to-end tests not unit tests
* Changed version for dependency at_persistence_secondary_server from 3.0.8 to 3.0.11 in order to pick up the new isKeyExists method
* Modified at_client_sdk.yaml GitHub workflow to separate out the test runs for unit tests and end2end tests, and run unit tests with code coverage measurement uploading to codecov.io

**- How to verify it**
at_client_sdk.yaml workflow completes successfully when this pull request is created

**- Description for the changelog**
Split out some tests from at_client/test to a new at_end2end_test directory, as they were in fact end-to-end tests rather than unit tests; also added code coverage measurement for the unit tests.