### PR TITLE
Upload code coverage info for the end-to-end tests as well

### DIFF
--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -70,11 +70,23 @@ jobs:
         with:
           token: ${{secrets.CODECOV_TOKEN_AT_CLIENT_SDK}}
           file: at_client/coverage.lcov
+          flags: unit_tests
 
       # Run end2end tests
       - name: Run end2end tests
         working-directory: at_end2end_test
-        run: dart test --concurrency=1
+        run: dart test --concurrency=1 --coverage="coverage"
+
+      - name: Convert coverage to LCOV format
+        working-directory: at_end2end_test
+        run: pub run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=lib
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v2.1.0
+        with:
+          token: ${{secrets.CODECOV_TOKEN_AT_CLIENT_SDK}}
+          file: at_end2end_test/coverage.lcov
+          flags: end2end_tests
 
       # Adding flutter to path
       - name: Installing Flutter

--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Convert coverage to LCOV format
         working-directory: at_end2end_test
-        run: pub run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=lib
+        run: pub run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=../at_client/lib
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2.1.0


### PR DESCRIPTION
**- What I did**
Measure and upload code coverage info for the end-to-end tests

**- How I did it**
* Add "flags: unit_tests" to the codecov upload step for the unit tests
* added --coverage to gather coverage for end2end tests
* Add codecov upload steps for the end-to-end tests with "flags: end2end_tests"

**- How to verify it**
The checks succeed for this pull request

**- Description for the changelog**
Measure and upload code coverage info for the end-to-end tests
