### PR TITLE
Implement error handling

### DIFF
--- a/at_client/lib/src/client/local_secondary.dart
+++ b/at_client/lib/src/client/local_secondary.dart
@@ -35,7 +35,6 @@ class LocalSecondary implements Secondary {
     try {
       if (builder is UpdateVerbBuilder || builder is DeleteVerbBuilder) {
         //1. if local and server are out of sync, first sync before updating current key-value
-
         //2 . update/delete to local store
         if (builder is UpdateVerbBuilder) {
           verbResult = await _update(builder);
@@ -52,12 +51,10 @@ class LocalSecondary implements Secondary {
       } else if (builder is ScanVerbBuilder) {
         verbResult = await _scan(builder);
       }
-    } on Exception catch (e) {
-      if (e is AtLookUpException) {
-        return Future.error(AtClientException(e.errorCode, e.errorMessage));
-      } else {
-        rethrow;
-      }
+    } on AtLookUpException catch (e) {
+      // Catches AtLookupException and
+      // converts to AtClientException. rethrows any other exception.
+      throw (AtClientException(e.errorCode, e.errorMessage));
     }
     return verbResult;
   }
@@ -120,7 +117,7 @@ class LocalSecondary implements Secondary {
       if (builder.isCached) {
         llookupKey += 'cached:';
       }
-      if(builder.isPublic){
+      if (builder.isPublic) {
         llookupKey += 'public:';
       }
       if (builder.sharedWith != null) {

--- a/at_client/lib/src/client/remote_secondary.dart
+++ b/at_client/lib/src/client/remote_secondary.dart
@@ -41,8 +41,15 @@ class RemoteSecondary implements Secondary {
   }
 
   Future<String> executeAndParse(VerbBuilder builder, {sync = false}) async {
-    var verbResult = await executeVerb(builder);
-    verbResult = verbResult.replaceFirst('data:', '');
+    // ignore: prefer_typing_uninitialized_variables
+    var verbResult;
+    try {
+      verbResult = await executeVerb(builder);
+      verbResult = verbResult.replaceFirst('data:', '');
+    } on AtClientException catch (e) {
+      logger.severe(
+          'Exception occurred in processing the verb ${e.errorCode} - ${e.errorMessage}');
+    }
     return verbResult;
   }
 

--- a/at_client/lib/src/client/remote_secondary.dart
+++ b/at_client/lib/src/client/remote_secondary.dart
@@ -31,9 +31,13 @@ class RemoteSecondary implements Secondary {
   /// Optionally [privateKey] is passed for verb builders which require authentication.
   @override
   Future<String> executeVerb(VerbBuilder builder, {sync = false}) async {
-    String verbResult;
-    verbResult = await atLookUp.executeVerb(builder);
-    return verbResult;
+    try {
+      String verbResult;
+      verbResult = await atLookUp.executeVerb(builder);
+      return verbResult;
+    } on AtLookUpException catch (e) {
+      throw AtClientException(e.errorCode, e.errorMessage);
+    }
   }
 
   Future<String> executeAndParse(VerbBuilder builder, {sync = false}) async {

--- a/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
+++ b/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
@@ -5,7 +5,6 @@ import 'package:at_client/src/encryption_service/stream_encryption.dart';
 import 'package:at_client/src/response/default_response_parser.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_commons/at_commons.dart';
-import 'package:at_lookup/at_lookup.dart';
 import 'package:at_utils/at_logger.dart';
 
 /// Contains the common code for [SharedKeyEncryption] and [StreamEncryption]
@@ -68,7 +67,7 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
       if (key == null || key.isEmpty || key == 'data:null') {
         key = await _getSharedKeyFromRemote(atKey);
       }
-    } on AtLookUpException {
+    } on AtClientException {
       AtSignLogger('AbstractAtKeyEncryption').finer(
           '${llookupVerbBuilder.atKey}${atKey.sharedBy} not found in remote secondary. Generating a new shared key');
     }

--- a/at_client/lib/src/manager/sync_manager.dart
+++ b/at_client/lib/src/manager/sync_manager.dart
@@ -125,7 +125,14 @@ class SyncManager {
           var syncBuilder = SyncVerbBuilder()
             ..commitId = lastSyncedCommitId
             ..regex = regex;
-          var syncResponse = await _remoteSecondary!.executeVerb(syncBuilder);
+          // ignore: prefer_typing_uninitialized_variables
+          var syncResponse;
+          try {
+            syncResponse = await _remoteSecondary!.executeVerb(syncBuilder);
+          } on AtClientException catch (e) {
+            logger.severe(
+                'Exception occurred in processing sync command ${e.errorCode} - ${e.errorMessage}');
+          }
           if (syncResponse.isNotEmpty && syncResponse != 'data:null') {
             syncResponse = syncResponse.replaceFirst('data:', '');
             var syncResponseJson = JsonUtils.decodeJson(syncResponse);

--- a/at_client/lib/src/response/default_response_parser.dart
+++ b/at_client/lib/src/response/default_response_parser.dart
@@ -1,3 +1,4 @@
+import 'package:at_client/at_client.dart';
 import 'package:at_client/src/response/response.dart';
 import 'package:at_client/src/response/response_parser.dart';
 
@@ -42,12 +43,12 @@ class DefaultResponseParser implements ResponseParser {
     response.isError = true;
     // Find out whether error code exists or not
     if (responseString.isNotEmpty && responseString.startsWith('AT')) {
-      response.errorCode = (responseString.split(':')[0]);
-      response.errorDescription = (responseString.split(':').length > 1)
-          ? responseString.split(':')[1]
-          : '';
+      response.errorCode = (responseString.split('-')[0]);
+      response.errorDescription = responseString.split('-')[1];
+      throw AtClientException(response.errorCode, response.errorDescription);
     } else {
       response.errorDescription = responseString;
+      throw AtClientException('AT0014', response.errorDescription);
     }
   }
 }

--- a/at_client/lib/src/service/encryption_service.dart
+++ b/at_client/lib/src/service/encryption_service.dart
@@ -5,7 +5,6 @@ import 'dart:typed_data';
 import 'package:at_client/at_client.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_commons/at_commons.dart';
-import 'package:at_lookup/at_lookup.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:crypton/crypton.dart';
 
@@ -47,7 +46,7 @@ class EncryptionService {
       if (sharedKey == null || sharedKey == 'data:null') {
         sharedKey = await remoteSecondary!.executeVerb(llookupVerbBuilder);
       }
-    } on AtLookUpException {
+    } on AtClientException {
       logger.finer(
           '${llookupVerbBuilder.atKey}$currentAtSign not found in remote secondary. Generating a new shared key');
     }
@@ -78,6 +77,7 @@ class EncryptionService {
     // a. encryptedSharedKey not available (or)
     // b. If the sharedKey is changed.
     if (result == null || result == 'data:null' || !isSharedKeyAvailable) {
+      // ignore: prefer_typing_uninitialized_variables
       var sharedWithPublicKey;
       try {
         sharedWithPublicKey = await _getSharedWithPublicKey(sharedWithUser);
@@ -125,6 +125,7 @@ class EncryptionService {
           'Decryption failed. Encrypted value is null');
     }
     sharedBy = sharedBy.replaceFirst('@', '');
+    // ignore: prefer_typing_uninitialized_variables
     var encryptedSharedKey;
     //1. Get encrypted shared key
     encryptedSharedKey = await _getEncryptedSharedKey(sharedBy);

--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -291,8 +291,15 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
         ..limit = _atClient.getPreferences()!.syncPageLimit
         ..isPaginated = true;
       _logger.finer('** syncBuilder ${syncBuilder.buildCommand()}');
-      var syncResponse = DefaultResponseParser()
-          .parse(await _remoteSecondary.executeVerb(syncBuilder));
+      // ignore: prefer_typing_uninitialized_variables
+      var syncVerbResult;
+      try {
+        syncVerbResult = await _remoteSecondary.executeVerb(syncBuilder);
+      } on AtClientException catch (e) {
+        _logger.severe(
+            'Exception occurred in process sync verb ${e.errorCode} - ${e.errorMessage}');
+      }
+      var syncResponse = DefaultResponseParser().parse(syncVerbResult);
 
       var syncResponseJson = JsonUtils.decodeJson(syncResponse.response);
       _logger.finest('** syncResponse $syncResponseJson');

--- a/at_client/lib/src/util/sync_util.dart
+++ b/at_client/lib/src/util/sync_util.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:at_client/at_client.dart';
 import 'package:at_client/src/client/remote_secondary.dart';
 import 'package:at_client/src/response/json_utils.dart';
 import 'package:at_commons/at_builders.dart';
@@ -81,7 +82,13 @@ class SyncUtil {
     if (regex != null && regex != 'null' && regex.isNotEmpty) {
       builder.regex = regex;
     }
-    var result = await remoteSecondary.executeVerb(builder);
+    // ignore: prefer_typing_uninitialized_variables
+    var result;
+    try {
+      result = await remoteSecondary.executeVerb(builder);
+    } on AtClientException catch (e){
+      logger.severe('Exception occurred in processing stats verb ${e.errorCode} - ${e.errorMessage}');
+    }
     result = result.replaceAll('data: ', '');
     var statsJson = JsonUtils.decodeJson(result);
     if (statsJson[0]['value'] != 'null') {

--- a/at_client/test/default_response_parser_test.dart
+++ b/at_client/test/default_response_parser_test.dart
@@ -1,3 +1,4 @@
+import 'package:at_client/at_client.dart';
 import 'package:at_client/src/response/default_response_parser.dart';
 import 'package:test/test.dart';
 
@@ -10,24 +11,22 @@ void main() {
     });
 
     test('test error response', () {
-      var response =
-          DefaultResponseParser().parse('error:AT-1234:Test Exception');
-      expect(response.isError, true);
-      expect(response.errorCode, 'AT-1234');
-      expect(response.errorDescription, 'Test Exception');
+      expect(
+          () => DefaultResponseParser().parse('error:AT1234-Test Exception'),
+          throwsA(predicate((dynamic e) =>
+              e is AtClientException && e.errorMessage == 'Test Exception')));
     });
 
-    test('test error response with error code only', () {
-      var response = DefaultResponseParser().parse('error:AT-1234');
-      expect(response.isError, true);
-      expect(response.errorCode, 'AT-1234');
-      expect(response.errorDescription, '');
+    test('test errors with unexpected response', () {
+      expect(
+          () => DefaultResponseParser().parse('error:Unexpected response found'),
+          throwsA(predicate((dynamic e) =>
+              e is AtClientException && e.errorCode == 'AT0014')));
     });
 
     test('test error response without error code', () {
-      var response = DefaultResponseParser().parse('error:Exception');
-      expect(response.isError, true);
-      expect(response.errorDescription, 'Exception');
+      expect(() => DefaultResponseParser().parse('error:Exception'),
+          throwsA(predicate((dynamic e) => e is AtClientException)));
     });
 
     test('test random response string', () {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did** Handle `error:` responses from the server.

**- How I did it** 1. Catch the `AtLookupException` and throw as `AtClientException`
                          2. Handle `error` responses in `DefaultResponseParser`