### PR TITLE
fix for isInSync bug

### DIFF
--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -423,10 +423,6 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   ///Throws [AtClientException] if cloud secondary is not reachable
   @override
   Future<bool> isInSync() async {
-    if (_syncInProgress) {
-      _logger.finest('*** isInSync..sync in progress');
-      return true;
-    }
     late RemoteSecondary remoteSecondary;
     try {
       remoteSecondary = RemoteSecondary(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
    Fixed a bug in sync where out of order responses was received on RemoteSecondary due to which format exception was thrown in SyncUtil.getLatestServerCommitId(...)

**- How I did it**
- added a new method _isInSync which will use the existing RemoteSecondary
- Made a change in current isInSync which apps call. Dedicated RemoteSecondary will be created and closed.

**- How to verify it**
- run isInSync in a loop with few seconds delay between calls in main method. No exception should be thrown and sync should complete successfully.
- functional test. TODO

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->