### PR TITLE
Enable deletion cached key

### DIFF
--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -364,7 +364,6 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     var batchId = 1;
     for (var entry in uncommittedEntries) {
       var command = await _getCommand(entry);
-      command = command.replaceAll('cached:', '');
       command = VerbUtil.replaceNewline(command);
       var batchRequest = BatchRequest(batchId, command);
       _logger.finer('batchId:$batchId key:${entry.atKey}');


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Enable deletion of cached key's to sync to remote secondary.

**- How I did it**
Remove the line that replaces cached" with empty string.

**- How to verify it**
Delete the cached keys and upon sync the cached key should be deleted in the remote secondary.

**- Description for the changelog**
Sync deletion of cached keys.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->