### PR TITLE
Notifications to have same id across

### DIFF
--- a/at_client/CHANGELOG.md
+++ b/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.18
+- Generate Notification id in SDK
 ## 3.0.17
 - Fix self encryption key not found
 - Fix for _getLastNotificationTime method returning null

--- a/at_client/lib/src/client/at_client_impl.dart
+++ b/at_client/lib/src/client/at_client_impl.dart
@@ -723,6 +723,7 @@ class AtClientImpl implements AtClient {
     notificationParams.atKey.sharedBy ??= currentAtSign;
 
     var builder = NotifyVerbBuilder()
+      ..id = notificationParams.id
       ..atKey = notificationParams.atKey.key
       ..sharedBy = notificationParams.atKey.sharedBy
       ..sharedWith = notificationParams.atKey.sharedWith

--- a/at_client/lib/src/service/notification_service.dart
+++ b/at_client/lib/src/service/notification_service.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:at_client/src/exception/at_client_exception.dart';
 import 'package:at_client/src/response/at_notification.dart';
 import 'package:at_commons/at_commons.dart';
+import 'package:uuid/uuid.dart';
 
 abstract class NotificationService {
   // Gives back stream of notifications from the server to the subscribing client.
@@ -75,10 +76,14 @@ abstract class NotificationService {
 
   /// Stops all subscriptions on the current instance
   void stopAllSubscriptions();
+
+  /// Returns the status of the given notificationId
+  Future<NotificationResult> getStatus(String notificationId);
 }
 
 /// [NotificationParams] represents a notification input params.
 class NotificationParams {
+  late String _id;
   late AtKey _atKey;
   String? _value;
   late OperationEnum _operation;
@@ -87,6 +92,8 @@ class NotificationParams {
   late StrategyEnum _strategy;
   final int _latestN = 1;
   final String _notifier = SYSTEM;
+
+  String get id => _id;
 
   AtKey get atKey => _atKey;
 
@@ -107,6 +114,7 @@ class NotificationParams {
   /// Returns [NotificationParams] to send an update notification.
   static NotificationParams forUpdate(AtKey atKey, {String? value}) {
     return NotificationParams()
+      .._id = Uuid().v4()
       .._atKey = atKey
       .._value = value
       .._operation = OperationEnum.update
@@ -118,6 +126,7 @@ class NotificationParams {
   /// Returns [NotificationParams] to send a delete notification.
   static NotificationParams forDelete(AtKey atKey) {
     return NotificationParams()
+      .._id = Uuid().v4()
       .._atKey = atKey
       .._operation = OperationEnum.delete
       .._messageType = MessageTypeEnum.key
@@ -131,6 +140,7 @@ class NotificationParams {
       ..key = text
       ..sharedWith = whomToNotify;
     return NotificationParams()
+      .._id = Uuid().v4()
       .._atKey = atKey
       .._operation = OperationEnum.update
       .._messageType = MessageTypeEnum.text
@@ -141,8 +151,8 @@ class NotificationParams {
 
 /// [NotificationResult] encapsulates the notification response
 class NotificationResult {
-  String? notificationID;
-  late AtKey atKey;
+  late String notificationID;
+  AtKey? atKey;
   NotificationStatusEnum notificationStatusEnum =
       NotificationStatusEnum.undelivered;
 
@@ -150,8 +160,16 @@ class NotificationResult {
 
   @override
   String toString() {
-    return 'key: ${atKey.key} sharedWith: ${atKey.sharedWith} status: $notificationStatusEnum';
+    return 'id: $notificationID status: $notificationStatusEnum';
   }
 }
 
-enum NotificationStatusEnum { delivered, undelivered }
+enum NotificationStatusEnum {
+  queued,
+  attemptedToDeliver,
+  delivered,
+  undelivered,
+  ackR,
+  ackS,
+  unavailable
+}

--- a/at_client/lib/src/service/notification_service.dart
+++ b/at_client/lib/src/service/notification_service.dart
@@ -97,6 +97,8 @@ class NotificationParams {
   final int _latestN = 1;
   final String _notifier = SYSTEM;
 
+  String get id => _id;
+
   AtKey get atKey => _atKey;
 
   String? get value => _value;
@@ -166,15 +168,6 @@ class NotificationResult {
   }
 }
 
-enum NotificationStatusEnum {
-  queued,
-  attemptedToDeliver,
-  delivered,
-  undelivered,
-  ackR,
-  ackS,
-  unavailable
-}
 /// The configurations for the Notification listeners
 class NotificationConfig {
   /// To filter notification keys matching the regex

--- a/at_client/lib/src/service/notification_service_impl.dart
+++ b/at_client/lib/src/service/notification_service_impl.dart
@@ -91,7 +91,10 @@ class NotificationServiceImpl
     var lastNotificationKeyStr =
         '$notificationIdKey.${_atClient.getPreferences()!.namespace}${_atClient.getCurrentAtSign()}';
     var atKey = AtKey.fromString(lastNotificationKeyStr);
-    if (_atClient.getLocalSecondary()!.keyStore!.isKeyExists(lastNotificationKeyStr)) {
+    if (_atClient
+        .getLocalSecondary()!
+        .keyStore!
+        .isKeyExists(lastNotificationKeyStr)) {
       final atValue = await _atClient.get(atKey);
       if (atValue.value != null) {
         _logger.finer('json from hive: ${atValue.value}');
@@ -174,11 +177,9 @@ class NotificationServiceImpl
       {Function? onSuccess, Function? onError}) async {
     var notificationResult = NotificationResult()
       ..atKey = notificationParams.atKey;
-    dynamic notificationId;
     try {
       // Notifies key to another notificationParams.atKey.sharedWith atsign
-      // Returns the notificationId.
-      notificationId = await _atClient.notifyChange(notificationParams);
+      await _atClient.notifyChange(notificationParams);
     } on Exception catch (e) {
       // Setting notificationStatusEnum to errored
       notificationResult.notificationStatusEnum =
@@ -325,18 +326,8 @@ class NotificationServiceImpl
         return NotificationStatusEnum.delivered;
       case 'undelivered':
         return NotificationStatusEnum.undelivered;
-      case 'acks':
-        return NotificationStatusEnum.ackS;
-      case 'ackr':
-        return NotificationStatusEnum.ackR;
-      case 'queued':
-        return NotificationStatusEnum.queued;
-      case 'attemptedtodeliver':
-        return NotificationStatusEnum.attemptedToDeliver;
-      case 'unavailable':
-        return NotificationStatusEnum.unavailable;
       default:
-        return NotificationStatusEnum.unavailable;
+        return NotificationStatusEnum.undelivered;
     }
   }
 }

--- a/at_client/lib/src/service/notification_service_impl.dart
+++ b/at_client/lib/src/service/notification_service_impl.dart
@@ -176,6 +176,7 @@ class NotificationServiceImpl
   Future<NotificationResult> notify(NotificationParams notificationParams,
       {Function? onSuccess, Function? onError}) async {
     var notificationResult = NotificationResult()
+      ..notificationID = notificationParams.id
       ..atKey = notificationParams.atKey;
     try {
       // Notifies key to another notificationParams.atKey.sharedWith atsign

--- a/at_client/lib/src/service/notification_service_impl.dart
+++ b/at_client/lib/src/service/notification_service_impl.dart
@@ -7,6 +7,7 @@ import 'package:at_client/src/listener/at_sign_change_listener.dart';
 import 'package:at_client/src/listener/switch_at_sign_event.dart';
 import 'package:at_client/src/manager/monitor.dart';
 import 'package:at_client/src/preference/monitor_preference.dart';
+import 'package:at_client/src/response/default_response_parser.dart';
 import 'package:at_client/src/response/notification_response_parser.dart';
 import 'package:at_client/src/service/notification_service.dart';
 import 'package:at_commons/at_commons.dart';
@@ -162,12 +163,12 @@ class NotificationServiceImpl
   Future<NotificationResult> notify(NotificationParams notificationParams,
       {Function? onSuccess, Function? onError}) async {
     var notificationResult = NotificationResult()
+      ..notificationID = notificationParams.id
       ..atKey = notificationParams.atKey;
-    dynamic notificationId;
     try {
       // Notifies key to another notificationParams.atKey.sharedWith atsign
       // Returns the notificationId.
-      notificationId = await _atClient.notifyChange(notificationParams);
+      await _atClient.notifyChange(notificationParams);
     } on Exception catch (e) {
       // Setting notificationStatusEnum to errored
       notificationResult.notificationStatusEnum =
@@ -183,11 +184,9 @@ class NotificationServiceImpl
       return notificationResult;
     }
     var notificationParser = NotificationResponseParser();
-    notificationResult.notificationID =
-        notificationParser.parse(notificationId).response;
     // Gets the notification status and parse the response.
-    var notificationStatus = notificationParser.parse(
-        await _getFinalNotificationStatus(notificationResult.notificationID!));
+    var notificationStatus = notificationParser
+        .parse(await _getFinalNotificationStatus(notificationParams.id));
     switch (notificationStatus.response) {
       case 'delivered':
         notificationResult.notificationStatusEnum =
@@ -259,5 +258,48 @@ class NotificationServiceImpl
     _logger.finer(
         '${_atClient.getCurrentAtSign()} monitor status: ${_monitor!.getStatus()}');
     return _monitor!.getStatus();
+  }
+
+  @override
+  Future<NotificationResult> getStatus(String notificationId) async {
+    var status = await _atClient.notifyStatus(notificationId);
+    var atResponse = DefaultResponseParser().parse(status);
+    NotificationResult notificationResult;
+    // If the Notification Response is error, set the notification status to undelivered
+    if (atResponse.isError) {
+      return NotificationResult()
+        ..notificationID = notificationId
+        ..notificationStatusEnum = NotificationStatusEnum.undelivered
+        ..atClientException = AtClientException(
+            atResponse.errorCode, atResponse.errorDescription);
+    }
+
+    notificationResult = NotificationResult()
+      ..notificationID = notificationId
+      ..notificationStatusEnum =
+          _getNotificationStatusEnum(atResponse.response);
+    return notificationResult;
+  }
+
+  /// Returns the NotificationStatusEnum for the given string of notificationStatus
+  NotificationStatusEnum _getNotificationStatusEnum(String notificationStatus) {
+    switch (notificationStatus.toLowerCase()) {
+      case 'delivered':
+        return NotificationStatusEnum.delivered;
+      case 'undelivered':
+        return NotificationStatusEnum.undelivered;
+      case 'acks':
+        return NotificationStatusEnum.ackS;
+      case 'ackr':
+        return NotificationStatusEnum.ackR;
+      case 'queued':
+        return NotificationStatusEnum.queued;
+      case 'attemptedtodeliver':
+        return NotificationStatusEnum.attemptedToDeliver;
+      case 'unavailable':
+        return NotificationStatusEnum.unavailable;
+      default:
+        return NotificationStatusEnum.unavailable;
+    }
   }
 }

--- a/at_client/lib/src/transformer/response_transformer/get_response_transformer.dart
+++ b/at_client/lib/src/transformer/response_transformer/get_response_transformer.dart
@@ -23,8 +23,8 @@ class GetResponseTransformer
     atValue.value = decodedResponse['data'];
     // parse metadata
     if (decodedResponse['metaData'] != null) {
-      final metadata = AtClientUtil.prepareMetadata(decodedResponse['metaData'],
-          decodedResponse['key'].startsWith('public:'));
+      final metadata = AtClientUtil.prepareMetadata(
+          decodedResponse['metaData'], _isKeyPublic(decodedResponse['key']));
       atValue.metadata = metadata;
       tuple.one.metadata = metadata;
     }
@@ -48,5 +48,11 @@ class GetResponseTransformer
       atValue.value = Base2e15.decode(atValue.value);
     }
     return atValue;
+  }
+
+  /// Return true if key is a public key or a cached public key
+  /// Else returns false
+  bool _isKeyPublic(String key) {
+    return key.startsWith('public:') || key.startsWith('cached:public:');
   }
 }

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client
 description: The at_client library is the non-platform specific Client SDK which provides the essential methods for building an app using the @protocol.
-version: 3.0.17
+version: 3.0.18
 repository: https://github.com/atsign-foundation/at_client_sdk
 homepage: https://atsign.dev
 documentation: https://atsign.dev/docs/
@@ -23,13 +23,13 @@ dependencies:
   http: ^0.13.3
   internet_connection_checker: ^0.0.1+2
   async: ^2.8.2
-  at_persistence_spec: 2.0.5
-  at_persistence_secondary_server: 3.0.19
-  at_lookup: 3.0.14
+  at_persistence_spec: ^2.0.5
+  at_persistence_secondary_server: ^3.0.23
+  at_lookup: ^3.0.18
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
-  at_commons: 3.0.9
-  at_utils: 3.0.6
+  at_commons: ^3.0.12
+  at_utils: ^3.0.9
 
 #dependency_overrides:
 #  at_persistence_spec:

--- a/at_functional_test/test/atclient_notify_test.dart
+++ b/at_functional_test/test/atclient_notify_test.dart
@@ -8,7 +8,6 @@ import 'package:test/test.dart';
 
 import 'set_encryption_keys.dart';
 import 'test_utils.dart';
-import 'package:at_utils/at_logger.dart';
 
 void main() {
   var currentAtSign = '@alice🛠';
@@ -115,37 +114,17 @@ void main() {
     expect(jsonDecode(notifyResult)[bobAtSign], true);
     expect(jsonDecode(notifyResult)[colinAtSign], true);
   });
-  tearDownAll(() async => await tearDownFunc());
-
   test('notify check value decryption on receiver', () async {
-    AtSignLogger.root_level = 'finest';
-    var atsign = '@alice🛠';
-    var preference = TestUtils.getPreference(atsign);
-    var atClientManager = await AtClientManager.getInstance()
-        .setCurrentAtSign(atsign, 'wavi', preference);
-    var atClient = atClientManager.atClient;
-    // To setup encryption keys
-    await setEncryptionKeys(atsign, preference);
     // phone.me@alice🛠
     var phoneKey = AtKey()
       ..key = 'phone'
-      ..sharedWith = '@bob🛠';
+      ..sharedWith = sharedWithAtSign;
     var value = '+1 100 200 300';
-    var notification = await NotificationServiceImpl.create(atClient,
-        atClientManager: atClientManager);
-    await notification
+    await atClientManager.notificationService
         .notify(NotificationParams.forUpdate(phoneKey, value: value));
-//    expect(result.notificationStatusEnum.toString(),
-//        'NotificationStatusEnum.delivered');
-//    expect(result.atKey.key, 'phone');
-//    expect(result.atKey.sharedWith, phoneKey.sharedWith);
-    atsign = '@bob🛠';
-    preference = TestUtils.getPreference(atsign);
+    var preference = TestUtils.getPreference(sharedWithAtSign);
     atClientManager = await AtClientManager.getInstance()
-        .setCurrentAtSign(atsign, 'wavi', preference);
-    atClient = atClientManager.atClient;
-    await NotificationServiceImpl.create(atClient,
-        atClientManager: atClientManager);
+        .setCurrentAtSign(sharedWithAtSign, 'wavi', preference);
     atClientManager.notificationService
         .subscribe(regex: 'phone')
         .listen((event) {
@@ -154,7 +133,7 @@ void main() {
     });
     Future.delayed(Duration(seconds: 10));
   });
-  tearDown(() async => await tearDownFunc());
+  tearDownAll(() async => await tearDownFunc());
 }
 
 void onSuccessCallback(notificationResult) {

--- a/at_functional_test/test/atclient_notify_test.dart
+++ b/at_functional_test/test/atclient_notify_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/service/notification_service.dart';
@@ -35,6 +36,25 @@ void main() {
         'NotificationStatusEnum.delivered');
     expect(result.atKey?.key, 'phone');
     expect(result.atKey?.sharedWith, phoneKey.sharedWith);
+  });
+
+   test('notify updating of a key to sharedWith atSign - get status using the notification Id', () async {
+    // phone.me@alice🛠
+    var lastNumber = Random().nextInt(30);
+    var landlineKey = AtKey()
+      ..key = 'landline'
+      ..sharedWith = sharedWithAtSign;
+    var value = '040-238989$lastNumber';
+
+    var result = await atClientManager.notificationService
+        .notify(NotificationParams.forUpdate(landlineKey, value: value));
+    print('NotificationId : ${result.notificationID}');
+    final notificationStatus = await atClientManager.notificationService.getStatus(result.notificationID);
+    print('Notification status is $notificationStatus');
+    expect(notificationStatus.notificationID, result.notificationID);
+    expect(notificationStatus.notificationStatusEnum, NotificationStatusEnum.delivered);
+    expect(result.atKey?.key, 'landline');
+    expect(result.atKey?.sharedWith, landlineKey.sharedWith);
   });
 
   test('notify updating of a key to sharedWith atSign - using callback',


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Generate notification id in at_client
2. Notification same across sender and receiver.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->