### PR TITLE
Fix batch sync issue

### DIFF
--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -353,7 +353,14 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     var batchRequests = <BatchRequest>[];
     var batchId = 1;
     for (var entry in uncommittedEntries) {
-      var command = await _getCommand(entry);
+      String command;
+      try {
+        command = await _getCommand(entry);
+      } on KeyNotFoundException {
+        _logger.severe(
+            '${entry.atKey} is not found in keystore. Skipping to entry to sync');
+        continue;
+      }
       command = VerbUtil.replaceNewline(command);
       var batchRequest = BatchRequest(batchId, command);
       _logger.finer('batchId:$batchId key:${entry.atKey}');


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
When iterating on the list of uncommitted entries, if an exception raises in the _getCommand method, then the subsequent entries will be skipped.

For example, if a key is created and deleted before sync could trigger, then to sync process fails in forming the update command because if fails to get the value.

**- How I did it**
Added a try catch block around _getCommand method.