### PR TITLE
Secondary url cache

### DIFF
--- a/at_client/lib/src/client/remote_secondary.dart
+++ b/at_client/lib/src/client/remote_secondary.dart
@@ -99,7 +99,7 @@ class RemoteSecondary implements Secondary {
   }
 
   Future<String?> findSecondaryUrl() async {
-    var secondaryAddress = await AtClientManager.getInstance().secondaryAddressCache!.getAddress(_atSign);
+    var secondaryAddress = await AtClientManager.getInstance().secondaryAddressFinder!.findSecondary(_atSign);
     return secondaryAddress.toString();
   }
 

--- a/at_client/lib/src/client/remote_secondary.dart
+++ b/at_client/lib/src/client/remote_secondary.dart
@@ -99,7 +99,8 @@ class RemoteSecondary implements Secondary {
   }
 
   Future<String?> findSecondaryUrl() async {
-    return await AtLookupImpl.findSecondary(_atSign, _preference.rootDomain, _preference.rootPort);
+    var secondaryAddress = await AtClientManager.getInstance().secondaryAddressCache!.getAddress(_atSign);
+    return secondaryAddress.toString();
   }
 
   Future<bool> isAvailable() async {

--- a/at_client/lib/src/manager/at_client_manager.dart
+++ b/at_client/lib/src/manager/at_client_manager.dart
@@ -5,6 +5,7 @@ import 'package:at_client/src/service/notification_service.dart';
 import 'package:at_client/src/service/notification_service_impl.dart';
 import 'package:at_client/src/service/sync_service.dart';
 import 'package:at_client/src/service/sync_service_impl.dart';
+import 'package:at_lookup/at_lookup.dart';
 
 /// Factory class for creating [AtClient], [SyncService] and [NotificationService] instances
 ///
@@ -24,6 +25,7 @@ class AtClientManager {
   AtClient get atClient => _currentAtClient;
   late SyncService syncService;
   late NotificationService notificationService;
+  SecondaryAddressCache? secondaryAddressCache;
   final _changeListeners = <AtSignChangeListener>[];
 
   static final AtClientManager _singleton = AtClientManager._internal();
@@ -38,6 +40,7 @@ class AtClientManager {
 
   Future<AtClientManager> setCurrentAtSign(
       String atSign, String? namespace, AtClientPreference preference) async {
+    secondaryAddressCache ??= SecondaryAddressCache(preference.rootDomain, preference.rootPort);
     if (_previousAtClient != null &&
         _previousAtClient?.getCurrentAtSign() == atSign) {
       return this;

--- a/at_client/lib/src/manager/at_client_manager.dart
+++ b/at_client/lib/src/manager/at_client_manager.dart
@@ -25,7 +25,7 @@ class AtClientManager {
   AtClient get atClient => _currentAtClient;
   late SyncService syncService;
   late NotificationService notificationService;
-  SecondaryAddressCache? secondaryAddressCache;
+  SecondaryAddressFinder? secondaryAddressFinder;
   final _changeListeners = <AtSignChangeListener>[];
 
   static final AtClientManager _singleton = AtClientManager._internal();
@@ -38,9 +38,17 @@ class AtClientManager {
 
   AtClientManager(_atSign);
 
+  void setSecondaryAddressFinder(
+      {SecondaryAddressFinder? secondaryAddressFinder}) {
+    if (secondaryAddressFinder != null) {
+      this.secondaryAddressFinder = secondaryAddressFinder;
+    }
+  }
+
   Future<AtClientManager> setCurrentAtSign(
       String atSign, String? namespace, AtClientPreference preference) async {
-    secondaryAddressCache ??= SecondaryAddressCache(preference.rootDomain, preference.rootPort);
+    secondaryAddressFinder ??= CacheableSecondaryAddressFinder(
+        preference.rootDomain, preference.rootPort);
     if (_previousAtClient != null &&
         _previousAtClient?.getCurrentAtSign() == atSign) {
       return this;

--- a/at_client/lib/src/stream/stream_notification_handler.dart
+++ b/at_client/lib/src/stream/stream_notification_handler.dart
@@ -20,14 +20,10 @@ class StreamNotificationHandler {
   Future<void> streamAck(AtStreamNotification streamNotification,
       Function streamCompletionCallBack, streamReceiveCallBack) async {
     var streamId = streamNotification.streamId;
-    var secondaryUrl = await AtLookupImpl.findSecondary(
-        streamNotification.senderAtSign,
-        preference!.rootDomain,
-        preference!.rootPort);
-    var secondaryInfo = AtClientUtil.getSecondaryInfo(secondaryUrl);
-    var host = secondaryInfo[0];
-    var port = secondaryInfo[1];
-    var socket = await SecureSocket.connect(host, int.parse(port));
+    final secondaryAddress = await AtClientManager.getInstance().secondaryAddressFinder!.findSecondary(streamNotification.senderAtSign);
+    var host = secondaryAddress.host;
+    var port = secondaryAddress.port;
+    var socket = await SecureSocket.connect(host, port);
     var f = File((preference!.downloadPath ?? '') +
         Platform.pathSeparator +
         'encrypted_${streamNotification.fileName}');

--- a/at_client/lib/src/util/at_client_util.dart
+++ b/at_client/lib/src/util/at_client_util.dart
@@ -24,6 +24,7 @@ class AtClientUtil {
     return updateKey;
   }
 
+  @Deprecated('use RemoteSecondary.findSecondaryUrl')
   static Future<String> findSecondary(
       String toAtSign, String rootDomain, int rootPort) async {
     var secondaryUrl =

--- a/at_client/lib/src/util/at_client_validation.dart
+++ b/at_client/lib/src/util/at_client_validation.dart
@@ -48,9 +48,9 @@ class AtClientValidation {
       throw AtKeyException('@sign cannot be empty');
     }
     try {
-      await AtClientUtil.findSecondary(atSign, rootDomain, rootPort);
+      await AtClientManager.getInstance().secondaryAddressFinder!.findSecondary(atSign);
     } on SecondaryNotFoundException {
-      throw AtKeyException('$atSign does not exist');
+      rethrow;
     }
   }
 

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   at_commons: ^3.0.14
   at_utils: ^3.0.9
 
-#dependency_overrides:
+dependency_overrides:
 #  at_persistence_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git
@@ -52,11 +52,11 @@ dependencies:
 #      url: https://github.com/atsign-foundation/at_server.git
 #      path: at_secondary/at_persistence_secondary_server
 #      ref: trunk
-#  at_lookup:
-#    git:
-#      url: https://github.com/atsign-foundation/at_libraries.git
-#      path: at_lookup
-#      ref: trunk
+  at_lookup:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries.git
+      path: at_lookup
+      ref: findsecondary_bug
 
 dev_dependencies:
   test: ^1.17.2

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   async: ^2.8.2
   at_persistence_spec: ^2.0.5
   at_persistence_secondary_server: ^3.0.24
-  at_lookup: ^3.0.21
+  at_lookup: ^3.0.22
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
   at_commons: ^3.0.14
@@ -52,11 +52,11 @@ dependency_overrides:
 #      url: https://github.com/atsign-foundation/at_server.git
 #      path: at_secondary/at_persistence_secondary_server
 #      ref: trunk
-  at_lookup:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      path: at_lookup
-      ref: findsecondary_bug
+#  at_lookup:
+#    git:
+#      url: https://github.com/atsign-foundation/at_libraries.git
+#      path: at_lookup
+#      ref: findsecondary_bug
 
 dev_dependencies:
   test: ^1.17.2

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   async: ^2.8.2
   at_persistence_spec: ^2.0.5
   at_persistence_secondary_server: ^3.0.24
-  at_lookup: ^3.0.20
+  at_lookup: ^3.0.21
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
   at_commons: ^3.0.14

--- a/at_client/test/remote_secondary_test.dart
+++ b/at_client/test/remote_secondary_test.dart
@@ -16,31 +16,22 @@ void main() {
   String atsign = '@remoteSecondaryTest';
   AtClientPreference atClientPreference = AtClientPreference();
   atClientPreference.privateKey = fakePrivateKey;
-  RemoteSecondary remoteSecondary = RemoteSecondary(atsign, atClientPreference);
 
   group('tests to verify functionality of remote secondary', () {
     setUp(() {
       reset(mockSecondaryAddressFinder);
-      when(() => AtClientManager.getInstance().secondaryAddressFinder)
-          .thenReturn(mockSecondaryAddressFinder);
-      when(() async => await mockSecondaryAddressFinder.findSecondary(atsign))
-          .thenAnswer((_) async => fakeSecondaryAddress);
-      //or
-      when(() => AtClientManager.getInstance()
-              .secondaryAddressFinder
-              ?.findSecondary(atsign))
+      when(() => mockSecondaryAddressFinder.findSecondary(atsign))
           .thenAnswer((invocation) async => fakeSecondaryAddress);
+      AtClientManager.getInstance().secondaryAddressFinder =
+          mockSecondaryAddressFinder;
     });
     test('test findSecondaryUrl', () async {
-      // SecondaryAddress? secondaryAddress = await AtClientManager.getInstance()
-      //     .secondaryAddressFinder
-      //     ?.findSecondary(atsign);
-      // String? secondaryAddress = await remoteSecondary.findSecondaryUrl();
-      // expect(secondaryAddress, fakeSecondaryAddress.toString());
       var address = await AtClientManager.getInstance()
           .secondaryAddressFinder
           ?.findSecondary(atsign);
-      expect(address, fakeSecondaryAddress);
+      expect(address, isNotNull);
+      expect(address!.port, fakeSecondaryAddress.port);
+      expect(address.host, fakeSecondaryAddress.host);
     });
   });
 }

--- a/at_client/test/remote_secondary_test.dart
+++ b/at_client/test/remote_secondary_test.dart
@@ -3,13 +3,10 @@ import 'package:at_lookup/at_lookup.dart';
 import 'package:test/test.dart';
 import 'package:mocktail/mocktail.dart';
 
-class MockAtClientManager extends Mock implements AtClientManager {}
-
 class MockSecondaryAddressFinder extends Mock
     implements SecondaryAddressFinder {}
 
 void main() {
-  AtClientManager mockAtClientManager = MockAtClientManager();
   SecondaryAddressFinder mockSecondaryAddressFinder =
       MockSecondaryAddressFinder();
   SecondaryAddress fakeSecondaryAddress =
@@ -19,23 +16,31 @@ void main() {
   String atsign = '@remoteSecondaryTest';
   AtClientPreference atClientPreference = AtClientPreference();
   atClientPreference.privateKey = fakePrivateKey;
+  RemoteSecondary remoteSecondary = RemoteSecondary(atsign, atClientPreference);
 
   group('tests to verify functionality of remote secondary', () {
     setUp(() {
-      reset(mockAtClientManager);
-      when(() => AtClientManager.getInstance()).thenReturn(mockAtClientManager);
-      // when(() => AtClientManager.getInstance().secondaryAddressFinder)
-      //     .thenReturn(mockSecondaryAddressFinder);
-      when(() async => await AtClientManager.getInstance()
+      reset(mockSecondaryAddressFinder);
+      when(() => AtClientManager.getInstance().secondaryAddressFinder)
+          .thenReturn(mockSecondaryAddressFinder);
+      when(() async => await mockSecondaryAddressFinder.findSecondary(atsign))
+          .thenAnswer((_) async => fakeSecondaryAddress);
+      //or
+      when(() => AtClientManager.getInstance()
               .secondaryAddressFinder
               ?.findSecondary(atsign))
-          .thenAnswer((_) async => fakeSecondaryAddress);
+          .thenAnswer((invocation) async => fakeSecondaryAddress);
     });
     test('test findSecondaryUrl', () async {
-      SecondaryAddress? secondaryAddress = await AtClientManager.getInstance()
+      // SecondaryAddress? secondaryAddress = await AtClientManager.getInstance()
+      //     .secondaryAddressFinder
+      //     ?.findSecondary(atsign);
+      // String? secondaryAddress = await remoteSecondary.findSecondaryUrl();
+      // expect(secondaryAddress, fakeSecondaryAddress.toString());
+      var address = await AtClientManager.getInstance()
           .secondaryAddressFinder
           ?.findSecondary(atsign);
-      expect(secondaryAddress, fakeSecondaryAddress);
+      expect(address, fakeSecondaryAddress);
     });
   });
 }

--- a/at_client/test/remote_secondary_test.dart
+++ b/at_client/test/remote_secondary_test.dart
@@ -1,0 +1,41 @@
+import 'package:at_client/at_client.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:test/test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockAtClientManager extends Mock implements AtClientManager {}
+
+class MockSecondaryAddressFinder extends Mock
+    implements SecondaryAddressFinder {}
+
+void main() {
+  AtClientManager mockAtClientManager = MockAtClientManager();
+  SecondaryAddressFinder mockSecondaryAddressFinder =
+      MockSecondaryAddressFinder();
+  SecondaryAddress fakeSecondaryAddress =
+      SecondaryAddress('fake.secondary.address', 8010);
+  var fakePrivateKey =
+      'MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCDVMetuYSlcwNdS1yLgYE1oBEXaCFZjPq0Lk9w7yjKOqKgPCWnuVVly5+GBkYPYN3mPXbi/LHy3SqVM/8s5srxa+C8s5jk2pQI6BgG/RW59XM6vrGuw0pUQoL0bMyQxtR8XAFVgd54iDcgp4ZPLEH6odAgBraAtkIEpfwSwtMaWJCaS/Yn3q6ZoVOxL+O7DHD2dJWmwwjAJyDqEDeeNVuNHWnmj2ZneVXDnsY4fOR3IZdcGArM28FFcFIM6Q0K6XGiLGvJ2pYPywtzwARFChYJTBJYhNNLRgT+MUvx8fbNa6mMnnXQmagh/YvYwmyIUVQK1EhFNZIgezX9xdmIgS+FAgMBAAECggEAEq0z2FjRrFW23MWi25QHNAEXbSS52WpbHNSZJ45bVqcQCYmEMV4B7wAOJ5kszXMRG3USOyWEiO066Q0D9Pa9VafpxewkiicrdjjLcfL76/4j7O7BhgDvyRvMU8ZFMTGVdjn/VpGpeaqlbFdmmkvI9kOcvXE28wb4TIDuYBykuNI6twRqiaVd1LkKg9yoF0DGfSp8OHGWm/wz5wwnNYT6ofTbgV3gSGKOrLf4rC1swHh1VoNXiaYKQQFo2j23vGznC+hVJy8kAkSTMvRy4+SrZ+0MtYrNt0CI9n4hw79BNzwAd0kfJ5WCsYL6MaF8Giyym3Wl77KoiriwRF7cGCEnAQKBgQDWD+l1b6D8QCmrzxI1iZRoehfdlIlNviTxNks4yaDQ/tu6TC/3ySsRhKvwj7BqFYj2A6ULafeh08MfxpG0MfmJ+aJypC+MJixu/z/OXhQsscnR6avQtVLi9BIZV3EweyaD/yN/PB7IVLuhz6E6BV8kfNDb7UFZzrSSlvm1YzIdvQKBgQCdD5KVbcA88xkv/SrBpJcUME31TIR4DZPg8fSB+IDCnogSwXLxofadezH47Igc1CifLSQp4Rb+8sjVOTIoAXZKvW557fSQk3boR3aZ4CkheDznzjq0vY0qot4llkzHdiogaIUdPDwvYBwERzc73CO3We1pHs36bIz70Z3DRF5BaQKBgQC295jUARs4IVu899yXmEYa2yklAz4tDjajWoYHPwhPO1fysAZcJD3E1oLkttzSgB+2MD1VOTkpwEhLE74cqI6jqZV5qe7eOw7FvTT7npxd64UXAEUUurfjNz11HbGo/8pXDrB3o5qoHwzV7RPg9RByrqETKoMuUSk1FwjPSr9efQKBgAdC7w4Fkvu+aY20cMOfLnT6fsA2l3FNf2bJCPrxWFKnLbdgRkYxrMs/JOJTXT+n93DUj3V4OK3036AsEsuStbti4ra0b7g3eSnoE+2tVXl8q6Qz/rbYhKxR919ZgZc/OVdiPbVKUaYHFYSFHmKgHO6fM8DGcdOALUx/NoIOqSTxAoGBALUdiw8iyI98TFgmbSYjUj5id4MrYKXaR7ndS/SQFOBfJWVH09t5bTxXjKxKsK914/bIqEI71aussf5daOHhC03LdZIQx0ZcCdb2gL8vHNTQoqX75bLRN7J+zBKlwWjjrbhZCMLE/GtAJQNbpJ7jOrVeDwMAF8pK+Put9don44Gx';
+  String atsign = '@remoteSecondaryTest';
+  AtClientPreference atClientPreference = AtClientPreference();
+  atClientPreference.privateKey = fakePrivateKey;
+
+  group('tests to verify functionality of remote secondary', () {
+    setUp(() {
+      reset(mockAtClientManager);
+      when(() => AtClientManager.getInstance()).thenReturn(mockAtClientManager);
+      // when(() => AtClientManager.getInstance().secondaryAddressFinder)
+      //     .thenReturn(mockSecondaryAddressFinder);
+      when(() async => await AtClientManager.getInstance()
+              .secondaryAddressFinder
+              ?.findSecondary(atsign))
+          .thenAnswer((_) async => fakeSecondaryAddress);
+    });
+    test('test findSecondaryUrl', () async {
+      SecondaryAddress? secondaryAddress = await AtClientManager.getInstance()
+          .secondaryAddressFinder
+          ?.findSecondary(atsign);
+      expect(secondaryAddress, fakeSecondaryAddress);
+    });
+  });
+}


### PR DESCRIPTION
**- What I did**
 - Used secondary address cache from at_commons to cache calls to root server
**- How I did it**
-  Added secondary address finder to at_client_manager
- in remote_secondary.dart, at_client_validation.dart and stream_notification_handler.dart, replaced call to AtLookup.findSecondary with SecondaryAddressFinder.findSecondary
**- How to verify it**
- run the unit test remote_secondary_test.dart and verify end2endtests in github actions