### PR TITLE
<fix> Add private key null check in monitor.dart

### DIFF
--- a/at_client/lib/src/manager/monitor.dart
+++ b/at_client/lib/src/manager/monitor.dart
@@ -252,6 +252,7 @@ class Monitor {
     }
     _logger.finer(
         'Authenticating the monitor connection: from result:$fromResponse');
+    if(_preference.privateKey == null) throw Exception('Private key is null in preference'); // JEREMY
     var key = RSAPrivateKey.fromString(_preference.privateKey!);
     var sha256signature =
         key.createSHA256Signature(utf8.encode(fromResponse) as Uint8List);

--- a/at_client/lib/src/manager/monitor.dart
+++ b/at_client/lib/src/manager/monitor.dart
@@ -252,7 +252,7 @@ class Monitor {
     }
     _logger.finer(
         'Authenticating the monitor connection: from result:$fromResponse');
-    if(_preference.privateKey == null) throw Exception('Private key is null in preference'); // JEREMY
+    if(_preference.privateKey == null) throw Exception('Private key is null in preference');
     var key = RSAPrivateKey.fromString(_preference.privateKey!);
     var sha256signature =
         key.createSHA256Signature(utf8.encode(fromResponse) as Uint8List);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Added null check for `monitor.dart`. 

**- How I did it**
See line 255

**- How to verify it**
The following code now works. (Before it would throw a null). 
```dart
  AtClientPreference preference = AtClientPreference()
    ..cramSecret = cram
    ..commitLogPath = 'test/commitLogPath'
    ..hiveStoragePath = 'test/hive'
    ..isLocalStoreRequired = true;

  AtClientManager atClientManager = await AtClientManager.getInstance().setCurrentAtSign('fascinatingsnow', 'beaverarmadillo', preference);
  AtClient atClient = atClientManager.atClient;
  await atClient.getRemoteSecondary()!.authenticateCram(cram);
  List<String> keys = await atClient.getRemoteSecondary()!.atLookUp.scan();
  _logger.info(keys); // [@fascinatingsnow:signing_privatekey@fascinatingsnow, public:signing_publickey@fascinatingsnow]
```

**- Description for the changelog**
Authenticating CRAM was never possible through the `AtClientManager`. My change makes it possible.