### PR TITLE
Full Regular Expression matching for notificationService.subscribe

### DIFF
--- a/at_client/lib/src/service/notification_service_impl.dart
+++ b/at_client/lib/src/service/notification_service_impl.dart
@@ -10,6 +10,7 @@ import 'package:at_client/src/preference/monitor_preference.dart';
 import 'package:at_client/src/response/default_response_parser.dart';
 import 'package:at_client/src/response/notification_response_parser.dart';
 import 'package:at_client/src/service/notification_service.dart';
+import 'package:at_client/src/util/regex_match_util.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_utils/at_logger.dart';
@@ -139,8 +140,7 @@ class NotificationServiceImpl
                 await _getDecryptedNotifications(atNotification);
           }
           if (notificationConfig.regex != emptyRegex) {
-            if (RegExp(notificationConfig.regex)
-                .hasMatch(atNotification.key)) {
+            if (hasRegexMatch(atNotification.key, notificationConfig.regex)) {
               streamController.add(atNotification);
             }
           } else {

--- a/at_client/lib/src/service/notification_service_impl.dart
+++ b/at_client/lib/src/service/notification_service_impl.dart
@@ -139,9 +139,8 @@ class NotificationServiceImpl
                 await _getDecryptedNotifications(atNotification);
           }
           if (notificationConfig.regex != emptyRegex) {
-            if (notificationConfig.regex
-                .allMatches(atNotification.key)
-                .isNotEmpty) {
+            if (RegExp(notificationConfig.regex)
+                .hasMatch(atNotification.key)) {
               streamController.add(atNotification);
             }
           } else {

--- a/at_client/lib/src/util/regex_match_util.dart
+++ b/at_client/lib/src/util/regex_match_util.dart
@@ -1,0 +1,3 @@
+bool hasRegexMatch(String key, String regex) {
+  return RegExp(regex).hasMatch(key);
+}

--- a/at_client/test/regex_match_util_test.dart
+++ b/at_client/test/regex_match_util_test.dart
@@ -1,0 +1,28 @@
+import 'package:at_client/src/util/regex_match_util.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of regex match tests', () {
+    test('test regex match - wild card', () async {
+      final testKey = '@alice:phone.wavi@bob';
+      final regex = '.*';
+      expect(hasRegexMatch(testKey, regex), true);
+    });
+    test('test regex match - compound', () async {
+      final testKey = '@alice:phone.wavi@bob';
+      final regex = '.*phone.*';
+      expect(hasRegexMatch(testKey, regex), true);
+    });
+    test('test regex match - exact - backward compatibility', () async {
+      final testKey = '@alice:phone.wavi@bob';
+      final regex = 'phone';
+      expect(hasRegexMatch(testKey, regex), true);
+    });
+    test('test regex match - exact with namespace - backward compatibility', () async {
+      final testKey = '@alice:phone.wavi@bob';
+      final regex = 'phone.wavi';
+      expect(hasRegexMatch(testKey, regex), true);
+    });
+    
+  });
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

closes #523 

**- What I did**

- Replaced exact string match (`String.allMatches().isNotEmpty`) with `RegExp().hasMatch()`

**- How I did it**

- Local Changes

**- How to verify it**

**- Description for the changelog**
Full Regular Expression matching for notificationService.subscribe
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->