### PR TITLE
Fix modification of AtKey objects when calling notify with namespace aware keys.

### DIFF
--- a/at_client/lib/src/client/at_client_impl.dart
+++ b/at_client/lib/src/client/at_client_impl.dart
@@ -704,6 +704,8 @@ class AtClientImpl implements AtClient {
 
   @override
   Future<String?> notifyChange(NotificationParams notificationParams) async {
+    String? notifyKey = notificationParams.atKey.key;
+
     // Check for internet. Since notify invoke remote secondary directly, network connection
     // is mandatory.
     if (!await NetworkUtil.isNetworkAvailable()) {
@@ -722,21 +724,20 @@ class AtClientImpl implements AtClient {
     // For messageType is text, text may contains spaces but key should not have spaces
     // Hence do not validate the key.
     if (notificationParams.messageType != MessageTypeEnum.text) {
-      AtClientValidation.validateKey(notificationParams.atKey.key);
+      AtClientValidation.validateKey(notifyKey);
     }
     // validate metadata
     AtClientValidation.validateMetadata(notificationParams.atKey.metadata);
     // If namespaceAware is set to true, append nameSpace to key.
     if (notificationParams.atKey.metadata != null &&
         notificationParams.atKey.metadata!.namespaceAware) {
-      notificationParams.atKey.key =
-          _getKeyWithNamespace(notificationParams.atKey.key!);
+      notifyKey = _getKeyWithNamespace(notifyKey!);
     }
     notificationParams.atKey.sharedBy ??= currentAtSign;
 
     var builder = NotifyVerbBuilder()
       ..id = notificationParams.id
-      ..atKey = notificationParams.atKey.key
+      ..atKey = notifyKey
       ..sharedBy = notificationParams.atKey.sharedBy
       ..sharedWith = notificationParams.atKey.sharedWith
       ..operation = notificationParams.operation
@@ -789,8 +790,8 @@ class AtClientImpl implements AtClient {
           notificationParams.atKey.metadata!.sharedKeyEnc;
       builder.pubKeyChecksum = notificationParams.atKey.metadata!.pubKeyCS;
     }
-    if (notificationParams.atKey.key!.startsWith(AT_PKAM_PRIVATE_KEY) ||
-        notificationParams.atKey.key!.startsWith(AT_PKAM_PUBLIC_KEY)) {
+    if (notifyKey!.startsWith(AT_PKAM_PRIVATE_KEY) ||
+        notifyKey.startsWith(AT_PKAM_PUBLIC_KEY)) {
       builder.sharedBy = null;
     }
     return await getRemoteSecondary()?.executeVerb(builder);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
fixes #527 

**- What I did**

Created a copy of notificationParams.atKey.key which can be safely modified and passed to the NotifyVerbBuilder.

**- How I did it**

Local changes.

**- How to verify it**

See the notify tests.

**- Description for the changelog**
Fix modification of AtKey objects when calling notify with namespace aware keys.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->