### PR TITLE
handle empty sync response

### DIFF
--- a/at_client/CHANGELOG.md
+++ b/at_client/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 3.0.25
+- Fix for regex issue in notification service. Issue #523
+- Fix for namespace issue in notify method.Issue #527
 - Fix for handling empty sync responses from server. App issue #624
 ## 3.0.24
 - Update the @platform logo

--- a/at_client/CHANGELOG.md
+++ b/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.25
+- Fix for handling empty sync responses from server. App issue #624
 ## 3.0.24
 - Update the @platform logo
 - Default the AtKey.sharedBy to currentAtSign

--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -274,7 +274,8 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
         atSign: _atClient.getCurrentAtSign()!);
     var localCommitId = await _getLocalCommitId();
     if (serverCommitId > localCommitId) {
-      _logger.finer('syncing to local');
+      _logger.finer(
+          'syncing to local: localCommitId $localCommitId serverCommitId $serverCommitId');
       await _syncFromServer(serverCommitId, localCommitId);
     }
     if (unCommittedEntries.isNotEmpty) {
@@ -339,9 +340,22 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
           .parse(await _remoteSecondary.executeVerb(syncBuilder))
           .response);
       _logger.finest('** syncResponse $syncResponseJson');
+
+      if (syncResponseJson == null || syncResponseJson.isEmpty) {
+        _logger.finer(
+            'sync response is empty: local commitID: $localCommitId server commitID: $serverCommitId');
+        break;
+      }
       // Iterates over each commit
-      await Future.forEach(syncResponseJson,
-          (dynamic serverCommitEntry) => _syncLocal(serverCommitEntry));
+      for(dynamic serverCommitEntry in syncResponseJson) {
+        try {
+          await _syncLocal(serverCommitEntry);
+        } on Exception catch(e) {
+          _logger.severe('exception syncing entry to local $serverCommitEntry - ${e.toString()}');
+        }
+      }
+      // await Future.forEach(syncResponseJson,
+      //     (dynamic serverCommitEntry) => _syncLocal(serverCommitEntry));
       // assigning the lastSynced local commit id.
       localCommitId = await _getLocalCommitId();
       _logger.finest('**localCommitId $localCommitId');

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client
 description: The at_client library is the non-platform specific Client SDK which provides the essential methods for building an app using the @protocol.
-version: 3.0.24
+version: 3.0.25
 repository: https://github.com/atsign-foundation/at_client_sdk
 homepage: https://atsign.dev
 documentation: https://atsign.dev/docs/


### PR DESCRIPTION
**- What I did**
- handle empty sync responses in at client
**- How I did it**
- in sync service impl, when server returns no response then break the loop to sync from local to remote.
**- How to verify it**
- have an atsign using two different apps with namespaces e.g wavi and atmospherepro
- run few updates in atmospherepro.. commit id on server gets incremented
- login to wavi app. Now new commits will be tried to sync to the app. but since the namespace doesn't match empty response will be sent by the server. After the fix , atsign should be able to login successfully
**- Description for the changelog**
- handle empty sync responses from server in sync service