### PR TITLE
Fix sync issue on atsign reset

### DIFF
--- a/at_client/lib/src/manager/at_client_manager.dart
+++ b/at_client/lib/src/manager/at_client_manager.dart
@@ -1,7 +1,6 @@
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/listener/at_sign_change_listener.dart';
 import 'package:at_client/src/listener/switch_at_sign_event.dart';
-import 'package:at_client/src/service/notification_service.dart';
 import 'package:at_client/src/service/notification_service_impl.dart';
 import 'package:at_client/src/service/sync_service.dart';
 import 'package:at_client/src/service/sync_service_impl.dart';
@@ -60,8 +59,8 @@ class AtClientManager {
         SwitchAtSignEvent(_previousAtClient, _currentAtClient);
     notificationService = await NotificationServiceImpl.create(_currentAtClient,
         atClientManager: this);
-    syncService =
-        await SyncServiceImpl.create(_currentAtClient, atClientManager: this);
+    syncService = await SyncServiceImpl.create(_currentAtClient,
+        atClientManager: this, notificationService: notificationService);
     _previousAtClient = _currentAtClient;
     _notifyListeners(switchAtSignEvent);
     return this;

--- a/at_client/lib/src/manager/sync_manager.dart
+++ b/at_client/lib/src/manager/sync_manager.dart
@@ -36,6 +36,8 @@ class SyncManager {
 
   var _isScheduled = false;
 
+  SyncUtil? syncUtil;
+
   SyncManager(this._atSign);
 
   void init(String atSign, AtClientPreference preference,
@@ -48,18 +50,18 @@ class SyncManager {
     if (preference.syncStrategy == SyncStrategy.scheduled && !_isScheduled) {
       _scheduleSyncTask();
     }
+    syncUtil = SyncUtil();
   }
 
   @Deprecated("Use SyncService.isInSync")
   Future<bool> isInSync() async {
     var serverCommitId = await SyncUtil.getLatestServerCommitId(
         _remoteSecondary!, _preference!.syncRegex);
-    var lastSyncedEntry = await SyncUtil.getLastSyncedEntry(
-        _preference!.syncRegex,
-        atSign: _atSign!);
+    var lastSyncedEntry = await syncUtil
+        ?.getLastSyncedEntry(_preference!.syncRegex, atSign: _atSign!);
     var lastSyncedCommitId = lastSyncedEntry?.commitId;
     var lastSyncedLocalSeq = lastSyncedEntry != null ? lastSyncedEntry.key : -1;
-    var unCommittedEntries = await SyncUtil.getChangesSinceLastCommit(
+    var unCommittedEntries = await syncUtil?.getChangesSinceLastCommit(
         lastSyncedLocalSeq, _preference!.syncRegex,
         atSign: _atSign!);
     return SyncUtil.isInSync(
@@ -96,7 +98,7 @@ class SyncManager {
       //once sync process done, it will again set to false.
       isSyncInProgress = true;
       var lastSyncedEntry =
-          await SyncUtil.getLastSyncedEntry(regex, atSign: _atSign!);
+          await syncUtil?.getLastSyncedEntry(regex, atSign: _atSign!);
       var lastSyncedCommitId = lastSyncedEntry?.commitId;
       var serverCommitId =
           await SyncUtil.getLatestServerCommitId(_remoteSecondary!, regex);
@@ -109,7 +111,7 @@ class SyncManager {
         }
         logger.finer('app init: lastSyncedLocalSeq: $lastSyncedLocalSeq');
       }
-      var unCommittedEntries = await SyncUtil.getChangesSinceLastCommit(
+      var unCommittedEntries = await syncUtil?.getChangesSinceLastCommit(
           lastSyncedLocalSeq, regex,
           atSign: _atSign!);
       // cloud and local are in sync if there is no synced changes in local and commitIDs are equals
@@ -144,14 +146,15 @@ class SyncManager {
           }
           // assigning the lastSynced local commit id.
           var lastSyncedEntry =
-              await SyncUtil.getLastSyncedEntry(regex, atSign: _atSign!);
+              await syncUtil?.getLastSyncedEntry(regex, atSign: _atSign!);
           lastSyncedCommitId = lastSyncedEntry?.commitId;
         }
         return;
       }
 
       // local is ahead. push the changes to secondary server
-      var uncommittedEntryBatch = _getUnCommittedEntryBatch(unCommittedEntries);
+      var uncommittedEntryBatch =
+          _getUnCommittedEntryBatch(unCommittedEntries!);
       for (var unCommittedEntryList in uncommittedEntryBatch) {
         try {
           var batchRequests = await _getBatchRequests(unCommittedEntryList);
@@ -172,7 +175,8 @@ class SyncManager {
               }
 
               logger.finer('***batchId:$batchId key: ${commitEntry.atKey}');
-              await SyncUtil.updateCommitEntry(commitEntry, commitId, _atSign!);
+              await syncUtil?.updateCommitEntry(
+                  commitEntry, commitId, _atSign!);
             } on Exception catch (e) {
               logger.severe(
                   'exception while updating commit entry for entry:$entry ${e.toString()}');
@@ -193,9 +197,8 @@ class SyncManager {
   }
 
   Future<void> syncWithIsolate() async {
-    var lastSyncedEntry = await SyncUtil.getLastSyncedEntry(
-        _preference!.syncRegex,
-        atSign: _atSign!);
+    var lastSyncedEntry = await syncUtil
+        ?.getLastSyncedEntry(_preference!.syncRegex, atSign: _atSign!);
     var lastSyncedCommitId = lastSyncedEntry?.commitId;
     var commitIdReceivePort = ReceivePort();
     var privateKey = await _localSecondary!.keyStore!.get(AT_PKAM_PRIVATE_KEY);
@@ -225,7 +228,7 @@ class SyncManager {
             var serverCommitId = message['commit_id'];
             var lastSyncedLocalSeq =
                 lastSyncedEntry != null ? lastSyncedEntry.key : -1;
-            var unCommittedEntries = await SyncUtil.getChangesSinceLastCommit(
+            var unCommittedEntries = await syncUtil?.getChangesSinceLastCommit(
                 lastSyncedLocalSeq, _preference!.syncRegex!,
                 atSign: _atSign!);
             if (SyncUtil.isInSync(
@@ -247,7 +250,7 @@ class SyncManager {
             } else {
               //3. local is ahead
               //3.1 For each uncommitted entry send request to isolate to send update/delete to server
-              pushedCount = unCommittedEntries.length;
+              pushedCount = unCommittedEntries!.length;
               for (var entry in unCommittedEntries) {
                 var command = await _getCommand(entry);
                 logger.info('command:$command');
@@ -293,7 +296,7 @@ class SyncManager {
             var entry = SyncUtil.getEntry(entryKey, _atSign!);
             logger.info(
                 'received remote push result: $entryKey $entry $entryKey');
-            await SyncUtil.updateCommitEntry(
+            await syncUtil?.updateCommitEntry(
                 entry, int.parse(serverCommitId), _atSign!);
             pushedCount--;
             if (pushedCount == 0) syncDone = true;
@@ -381,7 +384,7 @@ class SyncManager {
       return;
     }
     commitEntry.operation = operation;
-    await SyncUtil.updateCommitEntry(
+    await syncUtil?.updateCommitEntry(
         commitEntry, serverCommitEntry['commitId'], _atSign!);
   }
 
@@ -396,7 +399,7 @@ class SyncManager {
         return;
       }
       localCommitEntry.operation = operation;
-      await SyncUtil.updateCommitEntry(
+      await syncUtil?.updateCommitEntry(
           localCommitEntry, int.parse(serverCommitId), _atSign!);
     } on SecondaryConnectException {
       logger.severe('Unable to connect to secondary');
@@ -498,12 +501,11 @@ class SyncManager {
   }
 
   void _scheduleSyncTask() {
-      var cron = Cron();
-      cron.schedule(
-          Schedule.parse('*/${_preference!.syncIntervalMins} * * * *'),
-          () async {
-        await syncWithIsolate();
-      });
-      _isScheduled = true;
+    var cron = Cron();
+    cron.schedule(Schedule.parse('*/${_preference!.syncIntervalMins} * * * *'),
+        () async {
+      await syncWithIsolate();
+    });
+    _isScheduled = true;
   }
 }

--- a/at_client/lib/src/util/sync_util.dart
+++ b/at_client/lib/src/util/sync_util.dart
@@ -6,8 +6,13 @@ import 'package:at_commons/at_builders.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_utils/at_logger.dart';
 
+/// Class contains all the util methods that perform CRUD operations on the commit log keystore.
 class SyncUtil {
   static var logger = AtSignLogger('SyncUtil');
+
+  AtCommitLog? atCommitLog;
+
+  SyncUtil({this.atCommitLog});
 
   static Future<CommitEntry?> getCommitEntry(
       int sequenceNumber, String atSign) async {
@@ -17,23 +22,23 @@ class SyncUtil {
     return commitEntry;
   }
 
-  static Future<void> updateCommitEntry(
+  Future<void> updateCommitEntry(
       var commitEntry, int commitId, String atSign) async {
-    var commitLogInstance =
-        await (AtCommitLogManagerImpl.getInstance().getCommitLog(atSign));
-    await commitLogInstance?.update(commitEntry, commitId);
+    atCommitLog ??=
+        await AtCommitLogManagerImpl.getInstance().getCommitLog(atSign);
+    await atCommitLog?.update(commitEntry, commitId);
   }
 
-  static Future<CommitEntry?> getLastSyncedEntry(String? regex,
+  Future<CommitEntry?> getLastSyncedEntry(String? regex,
       {required String atSign}) async {
-    var commitLogInstance =
+    atCommitLog ??=
         await AtCommitLogManagerImpl.getInstance().getCommitLog(atSign);
 
     CommitEntry? lastEntry;
     if (regex != null) {
-      lastEntry = await commitLogInstance!.lastSyncedEntryWithRegex(regex);
+      lastEntry = await atCommitLog?.lastSyncedEntryWithRegex(regex);
     } else {
-      lastEntry = await commitLogInstance!.lastSyncedEntry();
+      lastEntry = await atCommitLog?.lastSyncedEntry();
     }
     return lastEntry;
   }
@@ -45,15 +50,15 @@ class SyncUtil {
     return entry;
   }
 
-  static Future<List<CommitEntry>> getChangesSinceLastCommit(
+  Future<List<CommitEntry>> getChangesSinceLastCommit(
       int? seqNum, String? regex,
       {required String atSign}) async {
-    var commitLogInstance =
-        await (AtCommitLogManagerImpl.getInstance().getCommitLog(atSign));
-    if (commitLogInstance == null) {
+    atCommitLog ??=
+        await AtCommitLogManagerImpl.getInstance().getCommitLog(atSign);
+    if (atCommitLog == null) {
       return [];
     }
-    return commitLogInstance.getChanges(seqNum, regex);
+    return atCommitLog!.getChanges(seqNum, regex);
   }
 
   //#TODO change return type to enum which says in sync, local ahead or server ahead

--- a/at_client/test/sync_test.dart
+++ b/at_client/test/sync_test.dart
@@ -1,0 +1,138 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:at_client/at_client.dart';
+import 'package:at_client/src/response/at_notification.dart'
+    as _at_notification;
+import 'package:at_client/src/service/sync/sync_request.dart';
+import 'package:at_client/src/service/sync_service_impl.dart';
+import 'package:at_client/src/service/notification_service_impl.dart';
+import 'package:at_client/src/util/sync_util.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+var mockCommitLogStore = {};
+
+class MockSecondaryKeyStore extends Mock implements SecondaryKeyStore {
+  Map<String, AtData> localKeyStore = {
+    'mobile.wavi': AtData()..data = '12345',
+    'country.wavi': AtData()..data = 'India',
+    'location.wavi': AtData()..data = 'Hyderabad',
+    'about.wavi': AtData()..data = '@sign',
+    'phone.wavi': AtData()..data = '12345'
+  };
+
+  @override
+  Future<AtData> get(key) async {
+    return Future.value(localKeyStore[key]);
+  }
+}
+
+class MockLocalSecondary extends Mock implements LocalSecondary {
+  @override
+  SecondaryKeyStore? get keyStore => MockSecondaryKeyStore();
+}
+
+class MockRemoteSecondary extends Mock implements RemoteSecondary {
+  var remoteKeyStore = {};
+}
+
+class MockAtClient extends Mock implements AtClient {
+  @override
+  String? getCurrentAtSign() {
+    return '@alice';
+  }
+
+  @override
+  AtClientPreference? getPreferences() {
+    return AtClientPreference();
+  }
+
+  @override
+  LocalSecondary? getLocalSecondary() {
+    return MockLocalSecondary();
+  }
+}
+
+class MockAtClientManager extends Mock implements AtClientManager {}
+
+class MockNotificationServiceImpl extends Mock
+    implements NotificationServiceImpl {
+  @override
+  Stream<_at_notification.AtNotification> subscribe(
+      {String? regex, bool shouldDecrypt = false}) {
+    return StreamController<_at_notification.AtNotification>().stream;
+  }
+}
+
+class MockAtCommitLog extends Mock implements AtCommitLog {
+  @override
+  Future<CommitEntry?> lastSyncedEntry() async {
+    return CommitEntry('phone.wavi', CommitOp.UPDATE, DateTime.now())
+      ..commitId = 5;
+  }
+
+  @override
+  Future<List<CommitEntry>> getChanges(int? sequenceNumber, String? regex,
+      {int? limit}) async {
+    return [
+      CommitEntry('mobile.wavi', CommitOp.UPDATE, DateTime.now())..commitId = 1,
+      CommitEntry('country.wavi', CommitOp.UPDATE, DateTime.now())
+        ..commitId = 2,
+      CommitEntry('location.wavi', CommitOp.UPDATE, DateTime.now())
+        ..commitId = 3,
+      CommitEntry('about.wavi', CommitOp.UPDATE, DateTime.now())..commitId = 4,
+      CommitEntry('phone.wavi', CommitOp.UPDATE, DateTime.now())..commitId = 5,
+    ];
+  }
+
+  @override
+  Future<void> update(CommitEntry commitEntry, int commitId) async {
+    mockCommitLogStore.putIfAbsent(
+        commitId, () => commitEntry..commitId = commitId);
+  }
+}
+
+void main() async {
+  AtClient mockAtClient = MockAtClient();
+  AtClientManager mockAtClientManager = MockAtClientManager();
+  NotificationServiceImpl mockNotificationService =
+      MockNotificationServiceImpl();
+  AtCommitLog mockAtCommitLog = MockAtCommitLog();
+  RemoteSecondary mockRemoteSecondary = MockRemoteSecondary();
+
+  var syncServiceImpl = await SyncServiceImpl.create(mockAtClient,
+      atClientManager: mockAtClientManager,
+      notificationService: mockNotificationService,
+      remoteSecondary: mockRemoteSecondary) as SyncServiceImpl;
+  syncServiceImpl.syncUtil = SyncUtil(atCommitLog: mockAtCommitLog);
+
+  test('sync local changes when server is reset', () async {
+    when(() => mockRemoteSecondary
+            .executeCommand(any(that: startsWith('batch:')), auth: true))
+        .thenAnswer((_) => Future.value('data:${jsonEncode([
+                  {
+                    "id": 1,
+                    "response": {"data": "1"}
+                  },
+                  {
+                    "id": 2,
+                    "response": {"data": "2"}
+                  },
+                  {
+                    "id": 3,
+                    "response": {"data": "3"}
+                  },
+                  {
+                    "id": 4,
+                    "response": {"data": "4"}
+                  }
+                ])}'));
+    var serverCommitId = -1;
+    var syncRequest = SyncRequest()..result = SyncResult();
+    await syncServiceImpl.syncInternal(serverCommitId, syncRequest);
+    expect(mockCommitLogStore.isNotEmpty, true);
+    mockCommitLogStore.clear();
+  });
+}

--- a/at_functional_test/test/at_client_sync_test.dart
+++ b/at_functional_test/test/at_client_sync_test.dart
@@ -1,4 +1,5 @@
-import 'package:at_client/at_client.dart';
+import 'package:at_client/src/manager/at_client_manager.dart';
+import 'package:at_client/src/util/at_client_util.dart';
 import 'package:at_client/src/transformer/response_transformer/get_response_transformer.dart';
 import 'package:at_client/src/util/sync_util.dart';
 import 'package:at_commons/at_builders.dart';
@@ -9,6 +10,7 @@ import 'set_encryption_keys.dart';
 import 'test_utils.dart';
 
 void main() {
+  var syncUtil = SyncUtil();
   test('Verify local changes are synced to server - local ahead', () async {
     var atSign = '@alice🛠';
     var preference = TestUtils.getPreference(atSign);
@@ -65,7 +67,7 @@ void main() {
     // To setup encryption keys
     await setEncryptionKeys(atSign, preference);
     // Get local commit id before put operation
-    var localEntry = await SyncUtil.getLastSyncedEntry('', atSign: atSign);
+    var localEntry = await syncUtil.getLastSyncedEntry('', atSign: atSign);
     print('localCommitId before put method ${localEntry?.commitId}');
     expect(localEntry?.commitId != null, true);
     // twitter.me@alice🛠
@@ -82,7 +84,7 @@ void main() {
     await Future.delayed(Duration(seconds: 10));
     // Getting server commit id after put
     var localEntryAfterSync =
-        await SyncUtil.getLastSyncedEntry('', atSign: atSign);
+        await syncUtil.getLastSyncedEntry('', atSign: atSign);
     print('localCommitId after put method ${localEntryAfterSync?.commitId}');
     // After sync successful, the localCommitId after put should be greater
     // than localCommitId before put


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Sync the local changes to server when server is reset.
2. Refactor the sync_service_impl.dart file to write unit test
3. Write unit test for server reset scenario.

NOTE: **sync_service_impl supersedes the sync_manager.dart. The changes to sync_manager are made only to avoid compile time issue. sync_manager.dart is not in use.

**- How I did it**
If localCommitId is greater than serverCommitId indicates server is reset (In other conditions localCommitId is either equal or less than serverCommitId). then set localSeqNumber to serverCommitId to get all the changes to sync to server.

**- How to verify it**
Pair the atsign in mobile app and reset the server. Upon activation the data should be sync'ed back to server.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->