### PR TITLE
feat: add sync conflict info to sync progress

### DIFF
--- a/at_client/lib/at_client.dart
+++ b/at_client/lib/at_client.dart
@@ -15,4 +15,5 @@ export 'package:at_client/src/service/sync/sync_result.dart';
 export 'package:at_client/src/service/sync/sync_status.dart';
 export 'package:at_client/src/util/at_client_util.dart';
 export 'package:at_client/src/util/encryption_util.dart';
+export 'package:at_client/src/service/sync/sync_conflict.dart';
 export 'package:at_commons/at_commons.dart';

--- a/at_client/lib/src/service/sync/sync_conflict.dart
+++ b/at_client/lib/src/service/sync/sync_conflict.dart
@@ -1,0 +1,27 @@
+import 'package:at_client/at_client.dart';
+
+enum ResolutionStrategy { useLocal, useRemote }
+
+enum SyncType {
+  initialPushToRemote,
+  initialPullFromRemote,
+  pullFromRemote,
+  pushToRemote
+}
+
+class SyncEntry {
+  String commitID;
+  String decryptedValue;
+  SyncEntry(this.commitID, this.decryptedValue);
+}
+
+class ResolutionContext {
+  AtKey? key;
+  SyncEntry? localEntry;
+  SyncEntry? remoteEntry;
+  SyncType? syncType;
+}
+
+abstract class KeyConflictResolver {
+  ResolutionStrategy resolve(ResolutionContext context);
+}

--- a/at_client/lib/src/service/sync/sync_conflict.dart
+++ b/at_client/lib/src/service/sync/sync_conflict.dart
@@ -25,3 +25,10 @@ class ResolutionContext {
 abstract class KeyConflictResolver {
   Future<ResolutionStrategy> resolve(ResolutionContext context);
 }
+
+class ConflictInfo {
+  dynamic remoteValue;
+  dynamic localValue;
+  bool conflictExists = false;
+  ResolutionStrategy resolutionStrategy = ResolutionStrategy.useRemote;
+}

--- a/at_client/lib/src/service/sync/sync_conflict.dart
+++ b/at_client/lib/src/service/sync/sync_conflict.dart
@@ -22,11 +22,12 @@ class ResolutionContext {
   SyncType? syncType;
 }
 
-abstract class KeyConflictResolver {
-  Future<ResolutionStrategy> resolve(ResolutionContext context);
-}
-
 class ConflictInfo {
   dynamic remoteValue;
   dynamic localValue;
+
+  @override
+  String toString() {
+    return 'ConflictInfo{remoteValue: $remoteValue, localValue: $localValue}';
+  }
 }

--- a/at_client/lib/src/service/sync/sync_conflict.dart
+++ b/at_client/lib/src/service/sync/sync_conflict.dart
@@ -29,6 +29,4 @@ abstract class KeyConflictResolver {
 class ConflictInfo {
   dynamic remoteValue;
   dynamic localValue;
-  bool conflictExists = false;
-  ResolutionStrategy resolutionStrategy = ResolutionStrategy.useRemote;
 }

--- a/at_client/lib/src/service/sync/sync_conflict.dart
+++ b/at_client/lib/src/service/sync/sync_conflict.dart
@@ -23,5 +23,5 @@ class ResolutionContext {
 }
 
 abstract class KeyConflictResolver {
-  ResolutionStrategy resolve(ResolutionContext context);
+  Future<ResolutionStrategy> resolve(ResolutionContext context);
 }

--- a/at_client/lib/src/service/sync_service.dart
+++ b/at_client/lib/src/service/sync_service.dart
@@ -41,11 +41,4 @@ abstract class SyncService {
 
   /// Removes a sync progress listener
   void removeProgressListener(SyncProgressListener listener);
-
-  /// sets the [KeyConflictResolver] which determines the action to be taken in case of
-  /// conflict during sync
-  void setKeyConflictResolver(KeyConflictResolver resolver);
-
-  /// removes the [KeyConflictResolver]
-  void removeKeyConflictResolver(KeyConflictResolver resolver);
 }

--- a/at_client/lib/src/service/sync_service.dart
+++ b/at_client/lib/src/service/sync_service.dart
@@ -1,4 +1,5 @@
 import 'package:at_client/src/listener/sync_progress_listener.dart';
+import 'package:at_client/src/service/sync/sync_conflict.dart';
 import 'package:at_client/src/service/sync/sync_status.dart';
 
 abstract class SyncService {
@@ -40,4 +41,11 @@ abstract class SyncService {
 
   /// Removes a sync progress listener
   void removeProgressListener(SyncProgressListener listener);
+
+  /// sets the [KeyConflictResolver] which determines the action to be taken in case of
+  /// conflict during sync
+  void setKeyConflictResolver(KeyConflictResolver resolver);
+
+  /// removes the [KeyConflictResolver]
+  void removeKeyConflictResolver(KeyConflictResolver resolver);
 }

--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -433,9 +433,9 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
         }
       }
       final serverEncryptedValue = serverCommitEntry['value'];
-      var serverDecryptedValue;
-      AtKeyDecryptionManager.get(atKey, _atClient.getCurrentAtSign()!)
-          .decrypt(atKey, serverEncryptedValue);
+      final serverDecryptedValue =
+          await AtKeyDecryptionManager.get(atKey, _atClient.getCurrentAtSign()!)
+              .decrypt(atKey, serverEncryptedValue);
       final localDecryptedValue = await _atClient.get(atKey);
       if (localDecryptedValue != serverDecryptedValue) {
         return true;

--- a/at_functional_test/test/atclient_sync_conflict_test.dart
+++ b/at_functional_test/test/atclient_sync_conflict_test.dart
@@ -1,0 +1,60 @@
+import 'package:at_client/at_client.dart';
+import 'package:at_client/src/listener/sync_progress_listener.dart';
+import 'package:at_commons/at_builders.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:test/test.dart';
+
+import 'set_encryption_keys.dart';
+import 'test_utils.dart';
+
+void main() async {
+  test('notify updating of a key to sharedWith atSign - using await', () async {
+    AtSignLogger.root_level = 'info';
+    final atSign = '@alice🛠';
+    var preference = TestUtils.getPreference(atSign);
+    var atClientManager = await AtClientManager.getInstance()
+        .setCurrentAtSign(atSign, 'wavi', TestUtils.getPreference(atSign));
+    final progressListener = MySyncProgressListener();
+    atClientManager.syncService.addProgressListener(progressListener);
+    final atClient = atClientManager.atClient;
+    // To setup encryption keys
+    await setEncryptionKeys(atSign, preference);
+    final remoteSecondary = atClient.getRemoteSecondary()!;
+    final updateVerbBuilder = UpdateVerbBuilder()
+      ..sharedBy = atSign
+      ..atKey = 'phone_0.wavi' //conflicting key
+      ..value = 'sMBnYFctMOg+lqX67ah9UA=='; //encrypted value of 4
+    await remoteSecondary.executeVerb(updateVerbBuilder);
+    //
+    for (var i = 0; i < 5; i++) {
+      var phoneKey = AtKey()..key = 'phone_$i';
+      var value = '$i';
+      await atClient.put(phoneKey, value);
+    }
+    await Future.delayed(Duration(seconds: 10));
+  });
+}
+
+class MySyncProgressListener extends SyncProgressListener {
+  @override
+  void onSyncProgressEvent(SyncProgress syncProgress) {
+    expect(syncProgress.syncStatus, SyncStatus.success);
+    expect(syncProgress.keyInfoList, isNotEmpty);
+    bool conflictExists = false;
+    for (var keyInfo in syncProgress.keyInfoList!) {
+      if (keyInfo.key == 'phone_0.wavi@alice🛠' &&
+          keyInfo.syncDirection.toString() == 'SyncDirection.remoteToLocal') {
+        final conflictInfo = keyInfo.conflictInfo;
+        if (conflictInfo != null &&
+            conflictInfo.remoteValue == '4' &&
+            conflictInfo.localValue == '0') {
+          conflictExists = true;
+        }
+      }
+    }
+    expect(conflictExists, true);
+    expect(syncProgress.localCommitId,
+        greaterThan(syncProgress.localCommitIdBeforeSync!));
+    expect(syncProgress.localCommitId, equals(syncProgress.serverCommitId));
+  }
+}


### PR DESCRIPTION
**- What I did**
added conflict information to SyncProgress 
**- How I did it**
Added ConflictInfo object with local and remote values
Implemented logic in sync_service_impl --> _checkConflict method. When same key is updated in remote server and the key is updated in local storage/app, conflictinfo object will be added to SyncProgress.KeyInfo
App developers can make use of this information to know about conflicts during sync via SyncProgressListener
**- How to verify it**
Run the functional test at_functional_test/test/atclient_sync_conflict_test.dart