### PR TITLE
fix: do not sync cached keys to cloud secondary

### DIFF
--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -325,7 +325,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
             var commitEntry = unCommittedEntryList.elementAt(batchId - 1);
             if (commitId == -1) {
               _logger.severe(
-                  'update/delete for key ${commitEntry.atKey} failed. Error code ${responseObject.errorCode} error message ${responseObject.errorMessage}');
+                  '${commitEntry.operation} for key ${commitEntry.atKey} failed. Error code ${responseObject.errorCode} error message ${responseObject.errorMessage}');
             }
 
             _logger.finer('***batchId:$batchId key: ${commitEntry.atKey}');
@@ -395,6 +395,12 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     var batchId = 1;
     for (var entry in uncommittedEntries) {
       String command;
+      //Skipping the cached keys to sync to cloud secondary.
+      if (entry.atKey!.startsWith('cached:')) {
+        _logger.finer(
+            '${entry.atKey} is skipped. cached keys will not be synced to cloud secondary');
+        continue;
+      }
       try {
         command = await _getCommand(entry);
       } on KeyNotFoundException {

--- a/at_client/lib/src/util/at_client_validation.dart
+++ b/at_client/lib/src/util/at_client_validation.dart
@@ -107,9 +107,11 @@ class AtClientValidation {
       throw BufferOverFlowException(
           'The length of value exceeds the buffer size. Maximum buffer size is ${atClientPreference.maxDataSize} bytes. Found ${value.toString().length} bytes');
     }
-    // If key is cached, throw exception
-    if (atKey.metadata != null && atKey.metadata!.isCached) {
-      throw AtKeyException('User cannot create a cached key');
+    // If key starts with 'cached:' (or) if the metadata of key has isCached set to true; it represent
+    // a cached key. Prevent client updating the cached key. Hence throw exception.
+    if (atKey.key!.startsWith('$CACHED:') ||
+        (atKey.metadata != null && atKey.metadata!.isCached)) {
+      throw AtKeyException('Cannot create/update a cached key');
     }
     // If namespace is not set on key and in preferences, throw exception
     if ((atKey.namespace == null || atKey.namespace!.isEmpty) &&


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Modify the sync logic to skip the cached keys being sync'ed to cloud secondary.

**- How I did it**
1. Add an IF condition what checks if key starts with `cached:`. If yes, ignores the key to sync-batch request that is sent to cloud secondary.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->