### PR TITLE
fix: skip reserved keys from conflict resolution

### DIFF
--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -328,7 +328,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
             var commitEntry = unCommittedEntryList.elementAt(batchId - 1);
             if (commitId == -1) {
               _logger.severe(
-                  'update/delete for key ${commitEntry.atKey} failed. Error code ${responseObject.errorCode} error message ${responseObject.errorMessage}');
+                  '${commitEntry.operation} for key ${commitEntry.atKey} failed. Error code ${responseObject.errorCode} error message ${responseObject.errorMessage}');
             }
 
             _logger.finer('***batchId:$batchId key: ${commitEntry.atKey}');
@@ -450,6 +450,12 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     var batchId = 1;
     for (var entry in uncommittedEntries) {
       String command;
+      //Skipping the cached keys to sync to cloud secondary.
+      if (entry.atKey!.startsWith('cached:')) {
+        _logger.finer(
+            '${entry.atKey} is skipped. cached keys will not be synced to cloud secondary');
+        continue;
+      }
       try {
         command = await _getCommand(entry);
       } on KeyNotFoundException {

--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -404,7 +404,8 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     // other atsign. The value is not encrypted.
     // The keys starting with publickey. and shared_key. are the reserved keys
     // and do not require actions. Hence skipping from checking conflict resolution.
-    if (key.startsWith('publickey.') || key.startsWith('shared_key.')) {
+    // TODO: Skipping the cached keys for now. Revisit to check if this is fine or not
+    if (key.startsWith('publickey.') || key.startsWith('shared_key.') || key.startsWith('cached:')) {
       _logger.finer('$key found in conflict resolution, returning null');
       return null;
     }

--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -399,6 +399,15 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   Future<ConflictInfo?> _checkConflict(
       final serverCommitEntry, List<CommitEntry> uncommittedEntries) async {
     final key = serverCommitEntry['atKey'];
+
+    // publickey.<atsign>@<currentatsign> is used to store the public key of
+    // other atsign. The value is not encrypted.
+    // The keys starting with publickey. and shared_key. are the reserved keys
+    // and do not require actions. Hence skipping from checking conflict resolution.
+    if (key.startsWith('publickey.') || key.startsWith('shared_key.')) {
+      _logger.finer('$key found in conflict resolution, returning null');
+      return null;
+    }
     final atKey = AtKey.fromString(key);
     // temporary fix to add @ to sharedBy. permanent fix should be in AtKey.fromString
     atKey.sharedBy = AtUtils.formatAtSign(atKey.sharedBy);
@@ -418,10 +427,11 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
           conflictInfo.localValue = localValue;
           conflictInfo.remoteValue = serverValue;
         }
+        return conflictInfo;
       }
       final serverEncryptedValue = serverCommitEntry['value'];
-      final decryptionManager = await AtKeyDecryptionManager.get(
-          atKey, _atClient.getCurrentAtSign()!);
+      final decryptionManager =
+          AtKeyDecryptionManager.get(atKey, _atClient.getCurrentAtSign()!);
       final serverDecryptedValue =
           await decryptionManager.decrypt(atKey, serverEncryptedValue);
       final localDecryptedValue = await _atClient.get(atKey);
@@ -744,6 +754,7 @@ class KeyInfo {
   String key;
   SyncDirection syncDirection;
   ConflictInfo? conflictInfo;
+
   KeyInfo(this.key, this.syncDirection);
 
   @override

--- a/at_client/lib/src/util/at_client_validation.dart
+++ b/at_client/lib/src/util/at_client_validation.dart
@@ -107,9 +107,11 @@ class AtClientValidation {
       throw BufferOverFlowException(
           'The length of value exceeds the buffer size. Maximum buffer size is ${atClientPreference.maxDataSize} bytes. Found ${value.toString().length} bytes');
     }
-    // If key is cached, throw exception
-    if (atKey.metadata != null && atKey.metadata!.isCached) {
-      throw AtKeyException('User cannot create a cached key');
+    // If key starts with 'cached:' (or) if the metadata of key has isCached set to true; it represent
+    // a cached key. Prevent client updating the cached key. Hence throw exception.
+    if (atKey.key!.startsWith('$CACHED:') ||
+        (atKey.metadata != null && atKey.metadata!.isCached)) {
+      throw AtKeyException('Cannot create/update a cached key');
     }
     // If namespace is not set on key and in preferences, throw exception
     if ((atKey.namespace == null || atKey.namespace!.isEmpty) &&


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Fix the encryption exceptions during sync conflict resolution.

**- How I did it**
1. Skip the publickey since the data is not encrypted.

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->