### PR TITLE
feat: Notification sending enhancements

### DIFF
--- a/at_client/lib/src/client/at_client_impl.dart
+++ b/at_client/lib/src/client/at_client_impl.dart
@@ -794,12 +794,6 @@ class AtClientImpl implements AtClient {
   Future<String?> notifyChange(NotificationParams notificationParams) async {
     String? notifyKey = notificationParams.atKey.key;
 
-    // Check for internet. Since notify invoke remote secondary directly, network connection
-    // is mandatory.
-    if (!await NetworkUtil.isNetworkAvailable()) {
-      throw AtClientException(
-          error_codes['AtClientException'], 'No network availability');
-    }
     // validate sharedWith atSign
     AtUtils.fixAtSign(notificationParams.atKey.sharedWith!);
     // Check if sharedWith AtSign exists

--- a/at_client/lib/src/service/notification_service.dart
+++ b/at_client/lib/src/service/notification_service.dart
@@ -75,7 +75,7 @@ abstract class NotificationService {
   ///   await notification.notify(NotificationParams.forText('Hello','@bob'));
   ///```
   Future<NotificationResult> notify(NotificationParams notificationParams,
-      {Function? onSuccess, Function? onError});
+      {Function(NotificationResult)? onSuccess, Function(NotificationResult)? onError, Function(NotificationResult)? onSentToSecondary});
 
   /// Stops all subscriptions on the current instance
   void stopAllSubscriptions();

--- a/at_client/lib/src/service/notification_service.dart
+++ b/at_client/lib/src/service/notification_service.dart
@@ -15,12 +15,25 @@ abstract class NotificationService {
 
   /// Sends notification to [notificationParams.atKey.sharedWith] atSign.
   ///
-  /// Returns [NotificationResult] when await on the method .
-  /// When run asynchronously, register to onSuccess and onError callbacks to get [NotificationResult].
+  /// Returns [NotificationResult] when calling the method synchronously using `await`. Be aware that it could take
+  /// many minutes before we get to a final delivery status when we run synchronously, so we advise against that.
+  /// However there is something in between 'fire and forget' and 'wait a long time' available - if you call the
+  /// method synchronously using `await` but you also set [waitForFinalDeliveryStatus] to false, then the future
+  /// will complete once the notification has been successfully sent to our cloud secondary, which is thereafter
+  /// responsible for forwarding to the recipient; the polling for delivery status will continue asynchronously
+  /// and eventually your provided [onSuccess] or [onError] function will be called.
   ///
-  /// OnSuccess is called when the notification has been delivered to the recipient successfully.
+  /// If you set the optional [checkForFinalDeliveryStatus] parameter to false, then you can prevent the polling for
+  /// final delivery status to be done at all by this method, and instead if you need to, you can do the periodic
+  /// checking for final delivery status elsewhere in your code.
   ///
-  /// onError is called when the notification could not delivered
+  /// When run asynchronously, register to onSentToSecondary, onSuccess and onError callbacks to get [NotificationResult].
+  ///
+  /// onSentToSecondary is called when the notification has been sent from our client to our cloud secondary
+  ///
+  /// onSuccess is called when the notification has been delivered to the recipient's secondary successfully.
+  ///
+  /// onError is called when the notification could not delivered. Note that this could be a very long time
   ///
   /// Following exceptions are encapsulated in [NotificationResult.atClientException]
   ///* [AtKeyException] when invalid [NotificationParams.atKey.key] is formed or when
@@ -74,8 +87,13 @@ abstract class NotificationService {
   ///   var notification = NotificationServiceImpl(atClient!);
   ///   await notification.notify(NotificationParams.forText('Hello','@bob'));
   ///```
-  Future<NotificationResult> notify(NotificationParams notificationParams,
-      {Function(NotificationResult)? onSuccess, Function(NotificationResult)? onError, Function(NotificationResult)? onSentToSecondary});
+  Future<NotificationResult> notify(
+      NotificationParams notificationParams,
+      { bool waitForFinalDeliveryStatus = true, // this was the behaviour before introducing this parameter
+        bool checkForFinalDeliveryStatus = true, // this was the behaviour before introducing this parameter
+        Function(NotificationResult)? onSuccess,
+        Function(NotificationResult)? onError,
+        Function(NotificationResult)? onSentToSecondary});
 
   /// Stops all subscriptions on the current instance
   void stopAllSubscriptions();

--- a/at_client/lib/src/service/notification_service_impl.dart
+++ b/at_client/lib/src/service/notification_service_impl.dart
@@ -98,7 +98,7 @@ class NotificationServiceImpl
         .getLocalSecondary()!
         .keyStore!
         .isKeyExists(lastNotificationKeyStr)) {
-      var atValue;
+      AtValue? atValue;
       try {
         atValue = await _atClient.get(atKey);
       } on Exception catch (e) {
@@ -109,8 +109,8 @@ class NotificationServiceImpl
         _logger.finer('json from hive: ${atValue.value}');
         return jsonDecode(atValue.value)['epochMillis'];
       }
-      return null;
     }
+    return null;
   }
 
   @override

--- a/at_client/lib/src/service/notification_service_impl.dart
+++ b/at_client/lib/src/service/notification_service_impl.dart
@@ -181,13 +181,16 @@ class NotificationServiceImpl
 
   @override
   Future<NotificationResult> notify(NotificationParams notificationParams,
-      {Function? onSuccess, Function? onError}) async {
+      {Function(NotificationResult)? onSuccess, Function(NotificationResult)? onError, Function(NotificationResult)? onSentToSecondary}) async {
     var notificationResult = NotificationResult()
       ..notificationID = notificationParams.id
       ..atKey = notificationParams.atKey;
     try {
       // Notifies key to another notificationParams.atKey.sharedWith atsign
       await _atClient.notifyChange(notificationParams);
+      if (onSentToSecondary != null) {
+        onSentToSecondary(notificationResult);
+      }
     } on Exception catch (e) {
       // Setting notificationStatusEnum to errored
       notificationResult.notificationStatusEnum =

--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -230,7 +230,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   void _syncComplete(SyncRequest syncRequest) {
     syncRequest.result!.lastSyncedOn = DateTime.now().toUtc();
     _logger.info(
-        'Inside syncComplete  ${syncRequest.requestSource}  : ${syncRequest.onDone}');
+        'Inside syncComplete. syncRequest.requestSource : ${syncRequest.requestSource} ; syncRequest.onDone : ${syncRequest.onDone}');
     // If specific onDone callback is set, call specific onDone callback,
     // else call the global onDone callback.
     if (syncRequest.onDone != null &&

--- a/at_client/lib/src/util/sync_util.dart
+++ b/at_client/lib/src/util/sync_util.dart
@@ -21,6 +21,7 @@ class SyncUtil {
       var commitEntry, int commitId, String atSign) async {
     var commitLogInstance =
         await (AtCommitLogManagerImpl.getInstance().getCommitLog(atSign));
+    logger.finer('Updating commit log entry $commitEntry with commitId $commitId');
     await commitLogInstance?.update(commitEntry, commitId);
   }
 


### PR DESCRIPTION
**- What I did**
feat: Remove unnecessary network availability check from AtClientImpl.notifyChange()

feat: Add to NotificationService.notify() signature, adding new optional callback parameter, `onSentToSecondary`

feat: add optional 'checkForFinalDeliveryStatus' parameter to NotificationService.notify(...) and added explanatory documentation. In brief: until now we have only two options when calling notify - either (1) completely asynchronously or (2) completely synchronously including getting the final delivery status, which could be a very long time. This parameter allows you to call the method synchronously using await but it will complete very rapidly i.e. once the notification has been sent to this client's secondary server, with the polling to check final delivery status continuing asynchronously.

feat: add optional 'checkForFinalDeliveryStatus' parameter to NotificationService.notify(...) and added explanatory documentation. This enables you to not bother doing the polling for final delivery status if you wish.

chore: some de-linting, some logging changes 

**- How to verify it**
tests pass

**- Description for the changelog**
As per "what I did" above 