### PR TITLE
feat: Refraining syncing of stats notification id

### DIFF
--- a/at_client/lib/src/service/notification_service_impl.dart
+++ b/at_client/lib/src/service/notification_service_impl.dart
@@ -92,7 +92,7 @@ class NotificationServiceImpl
 
   Future<int?> _getLastNotificationTime() async {
     var lastNotificationKeyStr =
-        'public:$notificationIdKey.${_atClient.getPreferences()!.namespace}${_atClient.getCurrentAtSign()}';
+        '$notificationIdKey.${_atClient.getPreferences()!.namespace}${_atClient.getCurrentAtSign()}';
     var atKey = AtKey.fromString(lastNotificationKeyStr);
     if (_atClient
         .getLocalSecondary()!
@@ -132,8 +132,7 @@ class NotificationServiceImpl
       for (var atNotification in atNotifications) {
         // Saves latest notification id to the keys if its not a stats notification.
         if (atNotification.id != '-1') {
-          await _atClient.put(AtKey()..key = notificationIdKey
-          ..metadata =(Metadata() ..isPublic = true),
+          await _atClient.put(AtKey()..key = notificationIdKey,
               jsonEncode(atNotification.toJson()));
         }
         _streamListeners.forEach((notificationConfig, streamController) async {

--- a/at_client/lib/src/service/notification_service_impl.dart
+++ b/at_client/lib/src/service/notification_service_impl.dart
@@ -21,7 +21,7 @@ class NotificationServiceImpl
     implements NotificationService, AtSignChangeListener {
   final Map<NotificationConfig, StreamController> _streamListeners = {};
   final emptyRegex = '';
-  static const notificationIdKey = 'public:_latestNotificationIdv2';
+  static const notificationIdKey = '_latestNotificationIdv2';
   static final Map<String, NotificationService> _notificationServiceMap = {};
 
   final _logger = AtSignLogger('NotificationServiceImpl');
@@ -92,7 +92,7 @@ class NotificationServiceImpl
 
   Future<int?> _getLastNotificationTime() async {
     var lastNotificationKeyStr =
-        '$notificationIdKey.${_atClient.getPreferences()!.namespace}${_atClient.getCurrentAtSign()}';
+        'public:$notificationIdKey.${_atClient.getPreferences()!.namespace}${_atClient.getCurrentAtSign()}';
     var atKey = AtKey.fromString(lastNotificationKeyStr);
     if (_atClient
         .getLocalSecondary()!
@@ -132,7 +132,8 @@ class NotificationServiceImpl
       for (var atNotification in atNotifications) {
         // Saves latest notification id to the keys if its not a stats notification.
         if (atNotification.id != '-1') {
-          await _atClient.put(AtKey()..key = notificationIdKey,
+          await _atClient.put(AtKey()..key = notificationIdKey
+          ..metadata =(Metadata() ..isPublic = true),
               jsonEncode(atNotification.toJson()));
         }
         _streamListeners.forEach((notificationConfig, streamController) async {

--- a/at_client/lib/src/service/notification_service_impl.dart
+++ b/at_client/lib/src/service/notification_service_impl.dart
@@ -21,7 +21,7 @@ class NotificationServiceImpl
     implements NotificationService, AtSignChangeListener {
   final Map<NotificationConfig, StreamController> _streamListeners = {};
   final emptyRegex = '';
-  static const notificationIdKey = '_latestNotificationIdv2';
+  static const notificationIdKey = 'public:_latestNotificationIdv2';
   static final Map<String, NotificationService> _notificationServiceMap = {};
 
   final _logger = AtSignLogger('NotificationServiceImpl');

--- a/at_client/lib/src/util/sync_util.dart
+++ b/at_client/lib/src/util/sync_util.dart
@@ -112,7 +112,7 @@ class SyncUtil {
     if (key.startsWith(AT_PKAM_PRIVATE_KEY) ||
         key.startsWith(AT_PKAM_PUBLIC_KEY) ||
         key.startsWith(AT_ENCRYPTION_PRIVATE_KEY) ||
-        key.startsWith(notificationIdKey)) {
+        key.startsWith(statsNotificationId)) {
       return false;
     }
     return true;

--- a/at_client/lib/src/util/sync_util.dart
+++ b/at_client/lib/src/util/sync_util.dart
@@ -111,7 +111,8 @@ class SyncUtil {
   static bool shouldSync(String key) {
     if (key.startsWith(AT_PKAM_PRIVATE_KEY) ||
         key.startsWith(AT_PKAM_PUBLIC_KEY) ||
-        key.startsWith(AT_ENCRYPTION_PRIVATE_KEY)) {
+        key.startsWith(AT_ENCRYPTION_PRIVATE_KEY) ||
+        key.startsWith(notificationIdKey)) {
       return false;
     }
     return true;

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -32,7 +32,12 @@ dependencies:
   at_utils: ^3.0.10
   meta: ^1.7.0
 
-#dependency_overrides:
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: issue#596
 #  at_persistence_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git
@@ -43,11 +48,7 @@ dependencies:
 #      url: https://github.com/atsign-foundation/at_tools.git
 #      path: at_utils
 #      ref: trunk
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
-#      ref: trunk
+#  
 #  at_persistence_secondary_server:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git

--- a/at_end2end_test/pubspec.yaml
+++ b/at_end2end_test/pubspec.yaml
@@ -15,7 +15,7 @@ dependency_overrides:
     git:
       url: https://github.com/atsign-foundation/at_tools.git
       path: at_commons
-      ref: trunk
+      ref: issue#596
 
 dev_dependencies:
   pedantic: ^1.10.0

--- a/at_functional_test/pubspec.yaml
+++ b/at_functional_test/pubspec.yaml
@@ -15,7 +15,7 @@ dependency_overrides:
     git:
       url: https://github.com/atsign-foundation/at_tools.git
       path: at_commons
-      ref: trunk
+      ref: issue#596
 
 dev_dependencies:
   test: ^1.17.2

--- a/at_functional_test/test/stats_notification_sync_test.dart
+++ b/at_functional_test/test/stats_notification_sync_test.dart
@@ -1,0 +1,40 @@
+import 'dart:io';
+
+import 'package:at_client/at_client.dart';
+import 'package:test/test.dart';
+
+import 'set_encryption_keys.dart';
+import 'test_utils.dart';
+
+const notificationIdKey = '_latestNotificationIdv2';
+
+void main() {
+   test('put method - create a key sharing to other atSign', () async {
+    var atsign = '@alice🛠';
+    var preference = TestUtils.getPreference(atsign);
+    final atClientManager = await AtClientManager.getInstance()
+        .setCurrentAtSign(atsign, 'me', preference);
+    var atClient = atClientManager.atClient;
+    atClientManager.syncService.sync();
+    // To setup encryption keys
+    await setEncryptionKeys(atsign, preference);
+    // phone.me@alice🛠
+    var notificationKey = AtKey()
+      ..key = notificationIdKey
+      ..metadata = (Metadata() ..isPublic = true);
+    var value = '-1';
+    var putResult = await atClient.put(notificationKey, value);
+    expect(putResult, true);
+    atClientManager.syncService.sync();
+    var getResult = await atClient.getAtKeys(regex: notificationIdKey); 
+    assert(!getResult.contains(notificationKey));
+  });
+  tearDownFunc();
+}
+
+Future<void> tearDownFunc() async {
+  var isExists = await Directory('test/hive').exists();
+  if (isExists) {
+    Directory('test/hive').deleteSync(recursive: true);
+  }
+}

--- a/at_functional_test/test/stats_notification_sync_test.dart
+++ b/at_functional_test/test/stats_notification_sync_test.dart
@@ -10,7 +10,7 @@ const notificationIdKey = '_latestNotificationIdv2';
 
 void main() {
    test('put method - create a key sharing to other atSign', () async {
-    var atsign = '@alice🛠';
+    var atsign = '@sitaram';
     var preference = TestUtils.getPreference(atsign);
     final atClientManager = await AtClientManager.getInstance()
         .setCurrentAtSign(atsign, 'me', preference);
@@ -20,8 +20,7 @@ void main() {
     await setEncryptionKeys(atsign, preference);
     // phone.me@alice🛠
     var notificationKey = AtKey()
-      ..key = notificationIdKey
-      ..metadata = (Metadata() ..isPublic = true);
+      ..key = notificationIdKey;
     var value = '-1';
     var putResult = await atClient.put(notificationKey, value);
     expect(putResult, true);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #596 "

Please provide the following information:
-->

**- What I did**
Made latestnotificationId as a public key

**- How I did it**
By setting the isPublic(metadata) to true

**- How to verify it**
stats_notification_sync_test.dart should pass

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->