### PR TITLE
build(deps): bump leonsteinhaeuser/project-beta-automations

### DIFF
--- a/.github/workflows/autobug.yaml
+++ b/.github/workflows/autobug.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Move issue to "Triage"'
-        uses: leonsteinhaeuser/project-beta-automations@v1.2.1
+        uses: leonsteinhaeuser/project-beta-automations@v1.3.0
         with:
           gh_token: ${{ secrets.MY_GITHUB_TOKEN }}
           organization: atsign-foundation


### PR DESCRIPTION
**- What I did**

Merge of https://github.com/atsign-foundation/at_client_sdk/commit/eaf0f4b4d680bc0e8778dc60d5a54afad1b54ef7 as #633 can't pass automated e2e tests due to lack of access to secrets

**- Description for the changelog**

build(deps): bump leonsteinhaeuser/project-beta-automations to 1.3.0