### PR TITLE
fix: stop dependabot PRs from trying to run e2e tests without secrets

### DIFF
--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -137,6 +137,8 @@ jobs:
 
       # Logs into CICD VMs and runs script to update to the latest secondary image
       - name: update image on cicd VMs
+        # Needs a secret, so don't run for Dependabot PRs
+        if: ${{ github.actor != 'dependabot[bot]' }}
         uses: appleboy/ssh-action@v0.1.5
         with:
           host: "cicd1.atsign.wtf,cicd2.atsign.wtf"
@@ -147,9 +149,13 @@ jobs:
 
       # Populate at_credentials.dart from CICD_DATA_DART secret
       - name: Get CICD keys into place
+        # Needs a secret, so don't run for Dependabot PRs
+        if: ${{ github.actor != 'dependabot[bot]' }}
         run: echo "${{secrets.AT_CICD_CREDENTIALS}}" > at_end2end_test/test/at_credentials.dart
 
       # Run end-to-end test
       - name: End to end test
+        # Needs a secret, so don't run for Dependabot PRs
+        if: ${{ github.actor != 'dependabot[bot]' }}
         working-directory: at_end2end_test
         run: dart test --concurrency=1


### PR DESCRIPTION
PRs raised by Dependabot fail end2end tests because it doesn't have access to secrets needed by the tests, but those PRs can't be merged, because e2e tests are mandatory status checks in this repo.

**- What I did**

Introduced conditional checks to prevent dependabot PRs from running steps that need secrets (or depend on secrets to work)

**- How to verify it**

Wait for another Dependabot PR

**- Description for the changelog**

fix: stop dependabot PRs from trying to run e2e tests without secrets