### PR TITLE
fix: revert deleted function

### DIFF
--- a/at_client_mobile/lib/src/at_client_service.dart
+++ b/at_client_mobile/lib/src/at_client_service.dart
@@ -388,7 +388,7 @@ class KeychainUtil {
   }
 
   static Future<void> resetAtSignFromKeychain(String atsign) async {
-    await _keyChainManager.resetAtSignFromKeychain(atsign: atsign);
+    await _keyChainManager.resetAtSignFromKeychain(atsign);
   }
 
   static Future<void> deleteAtSignFromKeychain(String atsign) async {

--- a/at_client_mobile/lib/src/keychain_manager.dart
+++ b/at_client_mobile/lib/src/keychain_manager.dart
@@ -354,15 +354,15 @@ class KeyChainManager {
     return atsigns?.secret;
   }
 
-  /// Use [getValue]
-  @Deprecated("Use getValue")
+  /// Use [readAtsign]
+  @Deprecated("Use readAtsign function to get AtsignKey")
   Future<String?> getPrivateKeyFromKeyChain(String atsign) async {
     final atsigns = await readAtsign(name: atsign);
     return atsigns?.pkamPrivateKey;
   }
 
-  /// Use [getValue]
-  @Deprecated("Use getValue")
+  /// Use [readAtsign]
+  @Deprecated("Use readAtsign function to get AtsignKey")
   Future<String?> getPublicKeyFromKeyChain(String atsign) async {
     final atsigns = await readAtsign(name: atsign);
     return atsigns?.pkamPublicKey;
@@ -568,6 +568,40 @@ class KeyChainManager {
     } else {
       return false;
     }
+  }
+
+  /// Fetches the list of onboarded atsign saved in map datatype
+  Future<Map<String, bool?>> checkForValuesInFlutterKeychain() async {
+    return getAtsignsWithStatus();
+  }
+
+  /// Function to clear all entries from keychain
+  Future<void> clearKeychainEntries() async {
+    for (var element
+        in (await KeyChainManager.getInstance().getAtSignListFromKeychain())) {
+      await KeyChainManager.getInstance().deleteAtSignFromKeychain(element);
+    }
+  }
+
+  /// This function will removed
+  @Deprecated("This function will removed")
+  Future<BiometricStorageFile> getBiometricStorageFile(String key) async {
+    return await BiometricStorage().getStorage(key,
+        options: StorageFileInitOptions(
+          authenticationRequired: false,
+        ));
+  }
+
+  /// Function to get value for the key passed from keychain
+  @Deprecated("This function isn't working correctly for now")
+  Future<String?> getValue(String atsign, String key) async {
+    throw UnimplementedError();
+  }
+
+  /// Function to save value for the key passed to keychain
+  @Deprecated("This function isn't working correctly for now")
+  Future<String> putValue(String atsign, String key, String value) async {
+    throw UnimplementedError();
   }
 
   Future<BiometricStorageFile> _getAppStorage({

--- a/at_client_mobile/lib/src/keychain_manager.dart
+++ b/at_client_mobile/lib/src/keychain_manager.dart
@@ -349,9 +349,9 @@ class KeyChainManager {
   }
 
   /// Function to get atsign secret from keychain
-  Future<String?> getSecretFromKeychain(String atsign) async {
+  Future<String> getSecretFromKeychain(String atsign) async {
     final atsigns = await readAtsign(name: atsign);
-    return atsigns?.secret;
+    return atsigns?.secret ?? '';
   }
 
   /// Use [readAtsign]
@@ -557,7 +557,7 @@ class KeyChainManager {
   }
 
   /// Function to delete all values related to the atsign passed from keychain
-  Future<bool> resetAtSignFromKeychain({required String atsign}) async {
+  Future<bool> resetAtSignFromKeychain(String atsign) async {
     final atClientData = await readAtClientData(useSharedStorage: false);
     final useSharedStorage = atClientData?.config?.useSharedStorage ?? false;
     atClientData?.keys.removeWhere((element) => element.atSign == atsign);
@@ -570,7 +570,9 @@ class KeyChainManager {
     }
   }
 
-  /// Fetches the list of onboarded atsign saved in map datatype
+  /// This function is deprecated and will be removed in upcoming version. Use `getAtsignsWithStatus()` instead
+  @Deprecated(
+      "This function is deprecated and will be removed in upcoming version. Use `getAtsignsWithStatus()` instead")
   Future<Map<String, bool?>> checkForValuesInFlutterKeychain() async {
     return getAtsignsWithStatus();
   }

--- a/at_client_mobile/lib/src/keychain_manager.dart
+++ b/at_client_mobile/lib/src/keychain_manager.dart
@@ -583,8 +583,9 @@ class KeyChainManager {
     }
   }
 
-  /// This function will removed
-  @Deprecated("This function will removed")
+  /// This function is deprecated and will be removed in upcoming version
+  @Deprecated(
+      "This function is deprecated and will be removed in upcoming version")
   Future<BiometricStorageFile> getBiometricStorageFile(String key) async {
     return await BiometricStorage().getStorage(key,
         options: StorageFileInitOptions(
@@ -593,13 +594,15 @@ class KeyChainManager {
   }
 
   /// Function to get value for the key passed from keychain
-  @Deprecated("This function isn't working correctly for now")
+  @Deprecated(
+      "This function is deprecated and will be removed in upcoming version")
   Future<String?> getValue(String atsign, String key) async {
     throw UnimplementedError();
   }
 
   /// Function to save value for the key passed to keychain
-  @Deprecated("This function isn't working correctly for now")
+  @Deprecated(
+      "This function is deprecated and will be removed in upcoming version")
   Future<String> putValue(String atsign, String key, String value) async {
     throw UnimplementedError();
   }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Because we lost some functions in at_client_mobile when upgrading the data structure, I bring all of them back for a patch release with a deprecated warning.

- `getValue` and `putValue` are not supported with 3.2.0. So, we are throwing **UnimplementedError** from them with a Depraceted warning. Also, these methods should not be exposed to app side and onboarding package should have the control over updating keychain data.



**- How I did it**
Add deleted functions and make it compatible with the now at_client_mobile version.

**- How to verify it**
Should review my code and try out on your app

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->