### PR TITLE
fix: unit test failure due to exception intent chaining message text

### DIFF
--- a/at_client/test/decryption_service_test.dart
+++ b/at_client/test/decryption_service_test.dart
@@ -159,7 +159,7 @@ void main() {
         await remoteSecondary.executeVerb(lookupVerbBuilder);
       } on AtException catch (e) {
         expect(e.getTraceMessage(),
-            'Failed to fetch data caused by\nConnection timeout');
+            'Failed to fetchData caused by\nConnection timeout');
       }
     });
   });


### PR DESCRIPTION
**- What I did**
- fixed unit test failure in at client
**- How I did it**
- modified exception message in test/decryption_service_test.dart
**- How to verify it**
- run the unit tests using the command "dart run test"
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->