### PR TITLE
fix: Ensure _syncFromServer, when it encounters an exception and having handled the exception chaining, then rethrows the exception 

### DIFF
--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -93,8 +93,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   void _scheduleSyncRun() {
     _cron = Cron();
 
-    _cron.schedule(Schedule.parse('*/$_syncRunIntervalSeconds * * * * *'),
-        () async {
+    _cron.schedule(Schedule.parse('*/$_syncRunIntervalSeconds * * * * *'), () async {
       try {
         await processSyncRequests();
       } on Exception catch (e, trace) {
@@ -396,6 +395,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
             ExceptionScenario.remoteVerbExecutionFailed, e.message));
         _logger.severe(
             'Exception occurred in fetching sync response : ${e.getTraceMessage()}');
+        rethrow;
       }
       _logger.finest('** syncResponse $syncResponseJson');
 


### PR DESCRIPTION
**- What I did**
Fixed two issues
* Recent changes to SyncServiceImpl to handle chained exceptions required exceptions to be caught in _syncFromServer ... however the exception wasn't then being rethrown
* test for chained exception caused by sync timeout was not actually doing any checks

**- How I did it**
* rethrow exception in the recently-introduced catch block `SyncServiceImpl._syncFromServer`
* finish implementation of the unit test case

**- How to verify it**
Tests pass

**- Description for the changelog**
* fix: Ensure _syncFromServer, when it encounters an exception and having handled the exception chaining, then rethrows the exception 