### PR TITLE
feat: Add enforceNamespace (default value true) to AtClientPreference.

### DIFF
--- a/at_client/lib/src/client/at_client_impl.dart
+++ b/at_client/lib/src/client/at_client_impl.dart
@@ -384,13 +384,18 @@ class AtClientImpl implements AtClient {
       atKey.namespace ??= preference?.namespace;
     }
     // validate the atKey
-    // Setting the validateOwnership to true to perform KeyOwnerShip validation and
-    // KeyShare validation
+    // * Setting the validateOwnership to true to perform KeyOwnerShip validation and KeyShare validation
+    // * Setting enforceNamespace to true unless specifically set to false in the AtClientPreference
+    bool enforceNamespace = true;
+    if (preference != null && preference!.enforceNamespace == false) {
+      enforceNamespace = false;
+    }
     var validationResult = AtKeyValidators.get().validate(
         atKey.toString(),
         ValidationContext()
           ..atSign = currentAtSign
-          ..validateOwnership = true);
+          ..validateOwnership = true
+          ..enforceNamespace = enforceNamespace);
     // If the validationResult.isValid is false, validation of AtKey failed.
     // throw AtClientException with failure reason.
     if (!validationResult.isValid) {

--- a/at_client/lib/src/preference/at_client_preference.dart
+++ b/at_client/lib/src/preference/at_client_preference.dart
@@ -70,6 +70,16 @@ class AtClientPreference {
 
   ///[OptionalParameter] path to trusted certificates. Required to create security context.
   String? pathToCerts;
+
+  // TODO Remove this in next major version
+  @Deprecated("namespace presence will become mandatory in next major version of the SDK")
+  /// [AtClient.put] uses this parameter to decide whether to check for presence of a namespace in the
+  /// string representation of the AtKey.
+  /// * When set to true, keys such as public:foo@alice or @bob:foo@alice will be rejected
+  /// because they do not have a namespace. But keys such as public:foo.bar@alice of @bob:foo.bar.baz.bash@alice will be accepted.
+  /// * When set to false keys such as public:foo@alice or @bob:foo@alice will not be rejected
+  /// * Defaults to true, as applications should always be placing keys within a namespace
+  bool enforceNamespace = true;
 }
 
 @Deprecated("Use SyncService")

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -22,21 +22,21 @@ dependencies:
   http: ^0.13.3
   internet_connection_checker: ^0.0.1+2
   async: ^2.8.2
-  at_persistence_spec: ^2.0.6
-  at_persistence_secondary_server: ^3.0.30
-  at_lookup: ^3.0.28
+  at_persistence_spec: ^2.0.7
+  at_persistence_secondary_server: ^3.0.32
+  at_lookup: ^3.0.29
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
-  at_commons: ^3.0.21
+  at_commons: ^3.0.23
   at_utils: ^3.0.10
-  meta: ^1.7.0
+  meta: ^1.8.0
 
-dependency_overrides:
-  at_commons:
-     git:
-       url: https://github.com/atsign-foundation/at_tools.git
-       path: at_commons
-       ref: trunk
+#dependency_overrides:
+#  at_commons:
+#     git:
+#       url: https://github.com/atsign-foundation/at_tools.git
+#       path: at_commons
+#       ref: trunk
 #  at_persistence_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git
@@ -65,8 +65,8 @@ dependency_overrides:
 
 dev_dependencies:
   lints: ^2.0.0
-  test: ^1.17.2
-  at_demo_data: ^0.0.3+1
-  coverage: ^1.0.3
+  test: ^1.21.4
+  at_demo_data: ^1.0.0
+  coverage: ^1.5.0
   mocktail: ^0.3.0
-  dart_code_metrics: ^4.8.1
+  dart_code_metrics: ^4.17.0

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -31,12 +31,12 @@ dependencies:
   at_utils: ^3.0.10
   meta: ^1.7.0
 
-#dependency_overrides:
-#  at_commons:
-#     git:
-#       url: https://github.com/atsign-foundation/at_tools.git
-#       path: at_commons
-#       ref: trunk
+dependency_overrides:
+  at_commons:
+     git:
+       url: https://github.com/atsign-foundation/at_tools.git
+       path: at_commons
+       ref: trunk
 #  at_persistence_spec:
 #    git:
 #      url: https://github.com/atsign-foundation/at_server.git

--- a/at_client_mobile/pubspec.yaml
+++ b/at_client_mobile/pubspec.yaml
@@ -18,16 +18,16 @@ dependencies:
   hive: ^2.0.4
   crypton: ^2.0.3
   at_client: ^3.0.33
-  at_lookup: ^3.0.27
-  at_commons: ^3.0.19
+  at_lookup: ^3.0.29
+  at_commons: ^3.0.23
   at_utils: ^3.0.10
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: at_commons
-      ref: trunk
+#dependency_overrides:
+#  at_commons:
+#    git:
+#      url: https://github.com/atsign-foundation/at_tools.git
+#      path: at_commons
+#      ref: trunk
 #   at_client:
 #     path: ../at_client
 #    git:

--- a/at_client_mobile/pubspec.yaml
+++ b/at_client_mobile/pubspec.yaml
@@ -22,7 +22,12 @@ dependencies:
   at_commons: ^3.0.19
   at_utils: ^3.0.10
 
-# dependency_overrides:
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: trunk
 #   at_client:
 #     path: ../at_client
 #    git:
@@ -38,11 +43,6 @@ dependencies:
 #    git:
 #      url: https://github.com/atsign-foundation/at_tools.git
 #      path: at_utils
-#      ref: trunk
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: at_commons
 #      ref: trunk
 
 dev_dependencies:

--- a/at_end2end_test/pubspec.yaml
+++ b/at_end2end_test/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   at_client:
     path: ../at_client
 
-#   at_commons:
-#     git:
-#       url: https://github.com/atsign-foundation/at_tools.git
-#       path: at_commons
-#       ref: trunk
-
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: trunk
 #  at_lookup:
 #    git:
 #      url: https://github.com/atsign-foundation/at_libraries.git

--- a/at_end2end_test/pubspec.yaml
+++ b/at_end2end_test/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   at_client:
     path: ../at_client
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: at_commons
-      ref: trunk
+#dependency_overrides:
+#  at_commons:
+#    git:
+#      url: https://github.com/atsign-foundation/at_tools.git
+#      path: at_commons
+#      ref: trunk
 #  at_lookup:
 #    git:
 #      url: https://github.com/atsign-foundation/at_libraries.git
@@ -25,5 +25,5 @@ dependency_overrides:
 #      ref: deprecate_find_secondary
 
 dev_dependencies:
-  pedantic: ^1.10.0
-  test: ^1.16.0
+  pedantic: ^1.11.1
+  test: ^1.21.4

--- a/at_functional_test/pubspec.yaml
+++ b/at_functional_test/pubspec.yaml
@@ -10,13 +10,12 @@ dependencies:
   at_client:
     path: ../at_client
 
-# dependency_overrides:
-#   at_commons:
-#     git:
-#       url: https://github.com/atsign-foundation/at_tools.git
-#       path: at_commons
-#       ref: trunk
-
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: at_commons
+      ref: trunk
 #  at_lookup:
 #    git:
 #      url: https://github.com/atsign-foundation/at_libraries.git

--- a/at_functional_test/pubspec.yaml
+++ b/at_functional_test/pubspec.yaml
@@ -10,12 +10,12 @@ dependencies:
   at_client:
     path: ../at_client
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: at_commons
-      ref: trunk
+#dependency_overrides:
+#  at_commons:
+#    git:
+#      url: https://github.com/atsign-foundation/at_tools.git
+#      path: at_commons
+#      ref: trunk
 #  at_lookup:
 #    git:
 #      url: https://github.com/atsign-foundation/at_libraries.git
@@ -23,7 +23,7 @@ dependency_overrides:
 #      ref: deprecate_find_secondary
 
 dev_dependencies:
-  test: ^1.17.2
-  lints: ^1.0.1
-  at_demo_data: ^0.0.3+1
-  coverage: ^1.0.3
+  test: ^1.21.4
+  lints: ^2.0.0
+  at_demo_data: ^1.0.0
+  coverage: ^1.5.0


### PR DESCRIPTION
**- What I did**
* As a temporary measure allow app developers to disable the enforcement of namespace presence during AtKey validation for `put` requests **if they really need to do so** for backwards compatibility.

**- How I did it**
* Added `enforceNamespace` to AtClientPreference, default true
* Marked it as Deprecated as this is intended as a temporary measure only and will be removed in version 4
* Added code to respect value of AtClientPreference.enforceNamespace when doing validation of the AtKey during `put` requests

**- How to verify it**
Tests pass

**- Description for the changelog**
feat: Add enforceNamespace (default value true) to AtClientPreference.