### PR TITLE
build: updated changelog and pubpsec.yaml  for at_client release 3.0.34

### DIFF
--- a/at_client/CHANGELOG.md
+++ b/at_client/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 3.0.33
+* fix: Ensure _syncFromServer rethrows caught exceptions once it's handled the exception chaining
+* feat: Add enforceNamespace (default value true) to AtClientPreference
+## 3.0.33
 - feat: Upgrade lints version to 2.0.0 
 ## 3.0.32
 - fix: while syncing keys from server to local if there is an issue syncing a key, continue syncing rest of the keys

--- a/at_client/CHANGELOG.md
+++ b/at_client/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.33
+## 3.0.34
 * fix: Ensure _syncFromServer rethrows caught exceptions once it's handled the exception chaining
 * feat: Add enforceNamespace (default value true) to AtClientPreference
 ## 3.0.33

--- a/at_client/lib/src/client/at_client_impl.dart
+++ b/at_client/lib/src/client/at_client_impl.dart
@@ -29,7 +29,6 @@ import 'package:at_client/src/transformer/response_transformer/put_response_tran
 import 'package:at_client/src/util/at_client_util.dart';
 import 'package:at_client/src/util/at_client_validation.dart';
 import 'package:at_client/src/util/constants.dart';
-import 'package:at_client/src/util/network_util.dart';
 import 'package:at_client/src/util/sync_util.dart';
 import 'package:at_client/src/client/request_options.dart';
 import 'package:at_commons/at_builders.dart';
@@ -92,6 +91,7 @@ class AtClientImpl implements AtClient {
 
   @Deprecated("Use [create]")
   AtClientImpl(
+      // ignore: no_leading_underscores_for_local_identifiers
       String _atSign, String? namespace, AtClientPreference preference) {
     currentAtSign = AtUtils.formatAtSign(_atSign);
     _preference = preference;
@@ -117,6 +117,7 @@ class AtClientImpl implements AtClient {
     return _atClientInstanceMap[currentAtSign];
   }
 
+  // ignore: no_leading_underscores_for_local_identifiers
   AtClientImpl._(String _atSign, String? namespace,
       AtClientPreference preference, AtClientManager atClientManager) {
     currentAtSign = AtUtils.formatAtSign(_atSign);
@@ -387,6 +388,7 @@ class AtClientImpl implements AtClient {
     // * Setting the validateOwnership to true to perform KeyOwnerShip validation and KeyShare validation
     // * Setting enforceNamespace to true unless specifically set to false in the AtClientPreference
     bool enforceNamespace = true;
+    // ignore: deprecated_member_use_from_same_package
     if (preference != null && preference!.enforceNamespace == false) {
       enforceNamespace = false;
     }

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client
 description: The at_client library is the non-platform specific Client SDK which provides the essential methods for building an app using the @protocol.
-version: 3.0.33
+version: 3.0.34
 repository: https://github.com/atsign-foundation/at_client_sdk
 homepage: https://atsign.dev
 documentation: https://atsign.dev/docs/


### PR DESCRIPTION
**- What I did**
build: updated changelog and pubpsec.yaml  for at_client release 3.0.34, which allows use of enforceNamespace functionality from at_commons version 3.0.23

**- How to verify it**
Checks pass

**- Description for the changelog**
build: updated changelog and pubpsec.yaml  for at_client release 3.0.34
