### PR TITLE
fix: Reverted dependency on 'meta' package to ^1.7.0 as flutter_test package requires 1.7.0

### DIFF
--- a/at_client/CHANGELOG.md
+++ b/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.35
+* fix: Reverted dependency on 'meta' package to ^1.7.0 as flutter_test package requires 1.7.0 
 ## 3.0.34
 * fix: Ensure _syncFromServer rethrows caught exceptions once it's handled the exception chaining
 * feat: Add enforceNamespace (default value true) to AtClientPreference

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client
 description: The at_client library is the non-platform specific Client SDK which provides the essential methods for building an app using the @protocol.
-version: 3.0.34
+version: 3.0.35
 repository: https://github.com/atsign-foundation/at_client_sdk
 homepage: https://atsign.dev
 documentation: https://atsign.dev/docs/
@@ -29,7 +29,7 @@ dependencies:
   at_base2e15: ^1.0.0
   at_commons: ^3.0.23
   at_utils: ^3.0.10
-  meta: ^1.8.0
+  meta: ^1.7.0
 
 #dependency_overrides:
 #  at_commons:


### PR DESCRIPTION
**- What I did**
* fix: Reverted dependency on 'meta' package to ^1.7.0 as flutter_test package requires 1.7.0

**- How to verify it**

**- Description for the changelog**
* fix: Reverted dependency on 'meta' package to ^1.7.0 as flutter_test package requires 1.7.0