### PR TITLE
fix: SyncProgressListener exported from at_client

### DIFF
--- a/at_client/lib/at_client.dart
+++ b/at_client/lib/at_client.dart
@@ -18,3 +18,4 @@ export 'package:at_client/src/util/encryption_util.dart';
 export 'package:at_client/src/key_stream/key_stream.dart';
 export 'package:at_client/src/service/sync/sync_conflict.dart';
 export 'package:at_commons/at_commons.dart';
+export 'package:at_client/src/listener/sync_progress_listener.dart';


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- exported SyncProgressListener from at_client, so apps do not have to explicitly import it.

**- How I did it**
- exported class file from `at_client.dart`

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->