### PR TITLE
fix: add unit test for error during sync 

### DIFF
--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -418,6 +418,9 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
           var cause = (e is AtException) ? e.getTraceMessage() : e.toString();
           _logger.severe(
               'exception syncing entry to local $serverCommitEntry - $cause');
+        } on Error catch(e) {
+          _logger.severe(
+              'error syncing entry to local $serverCommitEntry - ${e.toString()}');
         }
       }
       // assigning the lastSynced local commit id.


### PR DESCRIPTION
**- What I did**
- added a unit test to replicate error during sync
**- How I did it**
- added a new test  to sync_service_test.dart
- one entry of the batch has invalid data type for commit id.This entry will thrown an error and skipped. Other entries should get processed
**- How to verify it**
- run the unit test - "A group of tests to validate exception during sync processing" to sync_service_test.dart
