### PR TITLE
fix: throw exception when an empty string is passed as atsign to setCurrentAtsign()

### DIFF
--- a/at_client/lib/src/manager/at_client_manager.dart
+++ b/at_client/lib/src/manager/at_client_manager.dart
@@ -46,6 +46,9 @@ class AtClientManager {
 
   Future<AtClientManager> setCurrentAtSign(
       String atSign, String? namespace, AtClientPreference preference) async {
+      if(atSign.isEmpty) {
+        throw AtException('atSign cannot be empty', intent: Intent.validateAtSign, exceptionScenario: ExceptionScenario.invalidValueProvided);
+      }
     secondaryAddressFinder ??= CacheableSecondaryAddressFinder(
         preference.rootDomain, preference.rootPort);
     if (_previousAtClient != null &&

--- a/at_client/lib/src/manager/at_client_manager.dart
+++ b/at_client/lib/src/manager/at_client_manager.dart
@@ -5,6 +5,7 @@ import 'package:at_client/src/service/notification_service_impl.dart';
 import 'package:at_client/src/service/sync_service.dart';
 import 'package:at_client/src/service/sync_service_impl.dart';
 import 'package:at_lookup/at_lookup.dart';
+import 'package:at_utils/at_utils.dart';
 
 /// Factory class for creating [AtClient], [SyncService] and [NotificationService] instances
 ///
@@ -46,9 +47,7 @@ class AtClientManager {
 
   Future<AtClientManager> setCurrentAtSign(
       String atSign, String? namespace, AtClientPreference preference) async {
-      if(atSign.isEmpty) {
-        throw AtException('atSign cannot be empty', intent: Intent.validateAtSign, exceptionScenario: ExceptionScenario.invalidValueProvided);
-      }
+    AtUtils.fixAtSign(atSign);
     secondaryAddressFinder ??= CacheableSecondaryAddressFinder(
         preference.rootDomain, preference.rootPort);
     if (_previousAtClient != null &&

--- a/at_client/test/at_key_validation_test.dart
+++ b/at_client/test/at_key_validation_test.dart
@@ -1,3 +1,4 @@
+import 'package:at_client/at_client.dart';
 import 'package:at_client/src/util/at_client_validation.dart';
 import 'package:test/test.dart';
 import 'package:at_commons/at_commons.dart';
@@ -26,5 +27,13 @@ void main() {
               e is AtKeyException &&
               e.message == 'Key cannot be null or empty')));
     });
+  });
+
+  test('Verify empty atsign throws exception', () async {
+    var atSign = '';
+    final namespace = 'test';
+    final preference = AtClientPreference();
+    expect(() async => await AtClientManager.getInstance().setCurrentAtSign(atSign, namespace, preference),
+        throwsA(predicate((dynamic e) => e is InvalidAtSignException)));
   });
 }

--- a/at_functional_test/test/at_exception_test.dart
+++ b/at_functional_test/test/at_exception_test.dart
@@ -40,6 +40,6 @@ void main() {
    test('Verify empty atsign throws exception', () async {
     var atSign = '';
     expect(() async => await AtClientManager.getInstance().setCurrentAtSign(atSign, namespace, TestUtils.getPreference(currentAtSign)),
-        throwsA(predicate((dynamic e) => e is AtException)));
+        throwsA(predicate((dynamic e) => e is InvalidAtSignException)));
   });
 }

--- a/at_functional_test/test/at_exception_test.dart
+++ b/at_functional_test/test/at_exception_test.dart
@@ -36,4 +36,10 @@ void main() {
     expect(() async => await atClient.get(key),
         throwsA(predicate((dynamic e) => e is AtClientException)));
   });
+
+   test('Verify empty atsign throws exception', () async {
+    var atSign = '';
+    expect(() async => await AtClientManager.getInstance().setCurrentAtSign(atSign, namespace, TestUtils.getPreference(currentAtSign)),
+        throwsA(predicate((dynamic e) => e is AtException)));
+  });
 }

--- a/at_functional_test/test/at_exception_test.dart
+++ b/at_functional_test/test/at_exception_test.dart
@@ -36,10 +36,4 @@ void main() {
     expect(() async => await atClient.get(key),
         throwsA(predicate((dynamic e) => e is AtClientException)));
   });
-
-   test('Verify empty atsign throws exception', () async {
-    var atSign = '';
-    expect(() async => await AtClientManager.getInstance().setCurrentAtSign(atSign, namespace, TestUtils.getPreference(currentAtSign)),
-        throwsA(predicate((dynamic e) => e is InvalidAtSignException)));
-  });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #657 "

Please provide the following information:
-->

**- What I did**
throw an exception if an empty string is passed as an atsign in setCurrentAtsign()

**- How I did it**
Added AtUtils.fixAtSign() which validates the atsign

**- How to verify it**
at_exception_test.dart should pass

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->Throws an exception if an empty string is passed as an atsign in setCurrentAtsign()