### PR TITLE
fix: NotificationService.subscribe fails to return existing listener on same regex.

### DIFF
--- a/at_client/test/notification_service_test.dart
+++ b/at_client/test/notification_service_test.dart
@@ -381,4 +381,48 @@ void main() {
           NotificationStatusEnum.undelivered);
     });
   });
+
+  group('A group of tests to validate notification subscribe method', () {
+    test('NotificationService subscribe returns a new stream for a new regex', () async {
+      var notificationServiceImpl = await NotificationServiceImpl.create(
+          mockAtClientImpl,
+          atClientManager: mockAtClientManager,
+          monitor: mockMonitor) as NotificationServiceImpl;
+
+      var notificationStream = notificationServiceImpl.subscribe(
+          regex: '.wavi', shouldDecrypt: false);
+      notificationStream.listen((event) async {
+        print(event);
+      });
+
+      var notificationStream1 = notificationServiceImpl.subscribe(
+          regex: '.buzz', shouldDecrypt: false);
+      notificationStream1.listen((event) {
+        print(event);
+      });
+      expect(notificationServiceImpl.getStreamListenersCount(), 2);
+      notificationServiceImpl.stopAllSubscriptions();
+    });
+
+    test('NotificationService subscribe returns an existing stream for a same regex', () async {
+      var notificationServiceImpl = await NotificationServiceImpl.create(
+          mockAtClientImpl,
+          atClientManager: mockAtClientManager,
+          monitor: mockMonitor) as NotificationServiceImpl;
+
+      var notificationStream = notificationServiceImpl.subscribe(
+          regex: '.wavi', shouldDecrypt: false);
+      notificationStream.listen((event) async {
+        print(event);
+      });
+
+      var notificationStream1 = notificationServiceImpl.subscribe(
+          regex: '.wavi', shouldDecrypt: true);
+      notificationStream1.listen((event) {
+        print(event);
+      });
+      expect(notificationServiceImpl.getStreamListenersCount(), 1);
+      notificationServiceImpl.stopAllSubscriptions();
+    });
+  });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fix the issue of single notification being sent for multiple times.

  **-Root cause**
  At the moment, NotificationService.subscribe returns a Stream.broadcast which supports multiple listeners. From the app,
 `NotificationService.subscribe` method is being invoked multiple time's with same regex which leads to the same notification being fetched in the listen callback.

  **-Fix**
  - Replace the Stream.broadcast with simple Streams which supports only single listener. If subscribed for the second time, 
  throws a `Bad State. stream was already listened to`(This will **NOT** cause the app to crash). 
  - Ideally, for a given regex, having a single listener would suffice and i do not see a scenario which would require multiple 
  listeners for the same regex. Please share your thoughts on this? 
 
**- How I did it**
- Replace the Stream.broadcast with simple Streams.
- Replace the Map with HaspMap and override the equals and hashcode methods to compare the NotificationConfig object on regexes.

**- How to verify it**
- The Notification should be sent to app only once.
- If a NotificationService.subscribe is invoked for more than once, then a `Bad State` erorr would be thrown.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->