### PR TITLE
fix: expedite the sync'ing of shared key

### DIFF
--- a/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
+++ b/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
@@ -233,5 +233,12 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
         .atClient
         .getLocalSecondary()!
         .executeVerb(updateSharedKeyBuilder, sync: true);
+    // The key is directly written to cloud secondary to expedite the sync'ing of shared key
+    // which helps to prevent the error when decryption of initial notifications
+    // (notifications received before the shared_key is sync'ed to cloud secondary)
+    await AtClientManager.getInstance()
+        .atClient
+        .getRemoteSecondary()!
+        .executeVerb(updateSharedKeyBuilder);
   }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- expedite the sync'ing of shared key to prevent the decryption failure of initial notifications. Notifications received before the shared_key is sync'ed to cloud secondary.

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->