### PR TITLE
build(deps): bump leonsteinhaeuser/project-beta-automations

### DIFF
--- a/.github/workflows/autobug.yaml
+++ b/.github/workflows/autobug.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Move issue to "Triage"'
-        uses: leonsteinhaeuser/project-beta-automations@v1.3.0
+        uses: leonsteinhaeuser/project-beta-automations@v2.0.0
         with:
           gh_token: ${{ secrets.MY_GITHUB_TOKEN }}
           organization: atsign-foundation


### PR DESCRIPTION
Redo of #691 so that tests pass while we wait for #694 to get fixed.

Bumps [leonsteinhaeuser/project-beta-automations](https://github.com/leonsteinhaeuser/project-beta-automations) from 1.3.0 to 2.0.0.
- [Release notes](https://github.com/leonsteinhaeuser/project-beta-automations/releases)
- [Commits](https://github.com/leonsteinhaeuser/project-beta-automations/compare/v1.3.0...v2.0.0)

---
updated-dependencies:
- dependency-name: leonsteinhaeuser/project-beta-automations dependency-type: direct:production update-type: version-update:semver-major ...

Signed-off-by: dependabot[bot] <support@github.com>

