### PR TITLE
fix: check isencrypted flag in sync conflict

### DIFF
--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -459,14 +459,17 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
         return conflictInfo;
       }
       final serverEncryptedValue = serverCommitEntry['value'];
-      final decryptionManager =
-          AtKeyDecryptionManager.get(atKey, _atClient.getCurrentAtSign()!);
-      final serverDecryptedValue =
-          await decryptionManager.decrypt(atKey, serverEncryptedValue);
-      final localDecryptedValue = await _atClient.get(atKey);
-      if (localDecryptedValue.value != serverDecryptedValue) {
-        conflictInfo.localValue = localDecryptedValue.value;
-        conflictInfo.remoteValue = serverDecryptedValue;
+      final serverMetaData = serverCommitEntry['metadata'];
+      if (serverMetaData != null && serverMetaData[IS_ENCRYPTED] == "true") {
+        final decryptionManager =
+            AtKeyDecryptionManager.get(atKey, _atClient.getCurrentAtSign()!);
+        final serverDecryptedValue =
+            await decryptionManager.decrypt(atKey, serverEncryptedValue);
+        final localDecryptedValue = await _atClient.get(atKey);
+        if (localDecryptedValue.value != serverDecryptedValue) {
+          conflictInfo.localValue = localDecryptedValue.value;
+          conflictInfo.remoteValue = serverDecryptedValue;
+        }
       }
       return conflictInfo;
     }


### PR DESCRIPTION
**- What I did**
- check isEncrypted flag while decrypting data for sync conflict
**- How I did it**
- modified _checkConflict method implementation to decrypt value from server only if isEncryptedFlag is set in metadata
**- How to verify it**
- unit tests and functional tests should pass
