### PR TITLE
fix: write shared_key to remote secondary

### DIFF
--- a/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
+++ b/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
@@ -233,5 +233,12 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
         .atClient
         .getLocalSecondary()!
         .executeVerb(updateSharedKeyBuilder, sync: true);
+    // Write the shared_key to the remote secondary to expedite the sync process
+    // The reason behind expediting is because when notification is sent before the shared_key is
+    // sync'ed the decryption fails on the receiver's side.
+    await AtClientManager.getInstance()
+        .atClient
+        .getRemoteSecondary()!
+        .executeVerb(updateSharedKeyBuilder);
   }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Write the shared_key to the remote secondary to expedite the sync process. The reason behind expediting is because when notification is sent before the shared_key is sync'ed the decryption fails on the receiver's side.

**- How I did it**
- Write shared key to remote secondary.

**- How to verify it**
- Initial notifications on a new atsign should not fail with decryption error on the receiver side.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->