### PR TITLE
fix: force pull for docker-compose in functional tests

### DIFF
--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -64,7 +64,7 @@ jobs:
       # Start docker container to run functional tests
       - name: Start docker instance
         working-directory: at_functional_test/test
-        run: docker-compose up -d
+        run: docker-compose pull && docker-compose up -d
 
       - name: Check for docker container readiness
         working-directory: at_functional_test

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,7 @@ doc/api/
 *.ipr
 *.iws
 *.idea/
+
+# Codecov related
+
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .dart_tool/
 .packages
 build/
+
 # If you're building an application, you may want to check-in your pubspec.lock
 pubspec.lock
 
@@ -29,3 +30,7 @@ doc/api/
 # Codecov related
 
 coverage/
+
+# Functional test related
+
+hive/


### PR DESCRIPTION
**- What I did**

added `docker-compose pull` before bringing `up`

Also added `coverage/` directory to .gitignore

**- Description for the changelog**

fix: force pull for docker-compose in functional tests
fix: add coverage directory to .gitignore