### PR TITLE
build(deps): bump leonsteinhaeuser/project-beta-automations

### DIFF
--- a/.github/workflows/autobug.yaml
+++ b/.github/workflows/autobug.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Move issue to "Triage"'
-        uses: leonsteinhaeuser/project-beta-automations@v2.0.0
+        uses: leonsteinhaeuser/project-beta-automations@v2.0.1
         with:
           gh_token: ${{ secrets.MY_GITHUB_TOKEN }}
           organization: atsign-foundation


### PR DESCRIPTION
Couldn't merge #718 due to failing end-end tests for Dependabot

Bumps [leonsteinhaeuser/project-beta-automations](https://github.com/leonsteinhaeuser/project-beta-automations) from 2.0.0 to 2.0.1.
- [Release notes](https://github.com/leonsteinhaeuser/project-beta-automations/releases)
- [Commits](https://github.com/leonsteinhaeuser/project-beta-automations/compare/v2.0.0...v2.0.1)

---
updated-dependencies:
- dependency-name: leonsteinhaeuser/project-beta-automations dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>
