### PR TITLE
docs: Fixed broken links

### DIFF
--- a/at_client/README.md
+++ b/at_client/README.md
@@ -23,9 +23,9 @@ We call giving people control of access to their data "*flipping the internet*".
 
 ## Get Started
 
-Initially to get a basic overview of the SDK, you must read the [atsign docs](https://atsign.dev/docs/overview/).
+Initially to get a basic overview of the SDK, you must read the [atsign docs](https://docs.atsign.com/).
 
-> To use this package you must be having a basic setup, Follow here to [get started](https://atsign.dev/docs/get-started/setup-your-env/).
+> To use this package you must have a basic setup. Follow this to [get started](https://atsign.dev/docs/get-started/setup-your-env/).
 
 Check how to use this package in the [at_client installation tab](https://pub.dev/packages/at_client/install).
 
@@ -126,7 +126,7 @@ ConnectivityListener().subscribe().listen((isConnected) {
 });
 ```
 
-AtClient has many more methods that are exposed. Please refer to the [atsign docs](https://atsign.dev/docs/overview/) for more details.
+AtClient has many more methods that are exposed. Please refer to the [atsign docs](https://docs.atsign.com/) for more details.
 
 
 ## Example


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I made some updates to two broken links.

**- How I did it**
Changed the links to the new devsite links

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Updated broken devsite links.

**-Notes**
I also was wondering where the *set up your environment link should be*. In the previous devsite, it pointed to setting up the at_app. Where do we want this link to point to? 

I tried searching for the at-app tutorial but couldn't find it on the devsite. Thanks