### PR TITLE
fix: Fix behaviour associated with the 'fetchOfflineNotifications' flag

### DIFF
--- a/at_client/lib/src/service/notification_service_impl.dart
+++ b/at_client/lib/src/service/notification_service_impl.dart
@@ -101,6 +101,7 @@ class NotificationServiceImpl
     }
   }
 
+
   Future<int?> _getLastNotificationTime() async {
     if (AtClientManager.getInstance().atClient.getPreferences()!.fetchOfflineNotifications == false) {
       // Don't fetch notifications which were received by the server while this client was offline ...


### PR DESCRIPTION
**- What I did**
Corrected behaviour of the recently-added 'fetchOfflineNotifications' flag. Expected behaviour was:
* Flag set to true - current behaviour - monitor verb requests the server for all notifications after locally-stored lastNotificationTime
* Flag set to false - monitor verb requests server for all notifications after _right now_
* Actual behaviour when set to false was that the monitor verb requests server for all previously-received notifications - i.e. the opposite of intended

Also made change so that the fetchOfflineNotifications flag is honoured in the event of the monitor reconnecting after disconnecting. (For example, let's say your phone loses network connectivity for 4 hours but the app is running for all of that time - if fetchOfflineNotifications flag is still false when the monitor reconnects, then we will again request server for all notifications after _right now_. If an app happens to have behaviour where it wants to sometimes have fetchOfflineNotifications be false and sometimes true, the app should have logic to change the flag.)

**- How I did it**
* In order to have the behaviour be consistent, moved the check of fetchOfflineNotifications into the `_getLastNotificationTime()` method

**- How to verify it**
* Tests pass

**- Description for the changelog**
* Corrected behaviour when the recently-added 'fetchOfflineNotifications' flag is set to false