### PR TITLE
fix: Also check fetchOfflineNotifications preference when NotificationServiceImpl restarts its Monitor

### DIFF
--- a/at_client/lib/src/service/notification_service_impl.dart
+++ b/at_client/lib/src/service/notification_service_impl.dart
@@ -93,22 +93,23 @@ class NotificationServiceImpl
           'monitor is already started for ${_atClient.getCurrentAtSign()}');
       return;
     }
-    if (AtClientManager.getInstance()
-        .atClient
-        .getPreferences()!
-        .fetchOfflineNotifications) {
-      final lastNotificationTime = await _getLastNotificationTime();
-      await _monitor!.start(lastNotificationTime: lastNotificationTime);
-    } else {
-      await _monitor!.start();
-    }
+    await _monitor!.start(lastNotificationTime: await getLastNotificationTime());
 
     if (_monitor!.status == MonitorStatus.started) {
       _isMonitorPaused = false;
     }
   }
 
-  Future<int?> _getLastNotificationTime() async {
+  @visibleForTesting
+  Future<int?> getLastNotificationTime() async {
+    if (_atClientManager.atClient.getPreferences()!.fetchOfflineNotifications == false) {
+      // fetchOfflineNotifications == false means issue `monitor` command without a lastNotificationTime
+      // which will result in the server not sending any previously received notifications
+      return null;
+    }
+
+    // fetchOfflineNotifications == true (the default) means we want all notifications since the last one we received
+    // We keep track of the last notification id in the client-side key store
     var lastNotificationKeyStr =
         '$notificationIdKey.${_atClient.getPreferences()!.namespace}${_atClient.getCurrentAtSign()}';
     var atKey = AtKey.fromString(lastNotificationKeyStr);
@@ -194,7 +195,7 @@ class NotificationServiceImpl
     Future.delayed(
         Duration(seconds: 15),
         () async => _monitor!
-            .start(lastNotificationTime: await _getLastNotificationTime()));
+            .start(lastNotificationTime: await getLastNotificationTime()));
   }
 
   void _onMonitorError(Exception e) {

--- a/at_client/test/notification_service_test.dart
+++ b/at_client/test/notification_service_test.dart
@@ -1,4 +1,7 @@
+import 'dart:convert';
+
 import 'package:at_client/at_client.dart';
+import 'package:at_client/src/client/request_options.dart';
 import 'package:at_client/src/encryption_service/encryption_manager.dart';
 import 'package:at_client/src/encryption_service/shared_key_encryption.dart';
 import 'package:at_client/src/manager/monitor.dart';
@@ -12,22 +15,81 @@ import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 import 'package:at_client/src/response/at_notification.dart' as at_notification;
 import 'package:at_client/src/decryption_service/shared_key_decryption.dart';
+import 'package:uuid/uuid.dart';
 
-class MockSecondaryKeyStore extends Mock implements SecondaryKeyStore {}
+String? lastNotificationJson;
+
+class MockSecondaryKeyStore extends Mock implements SecondaryKeyStore {
+  @override
+  bool isKeyExists(String key) {
+    if (! key.contains(NotificationServiceImpl.notificationIdKey)) {
+      throw IllegalArgumentException("This mock client only understands how to get, put and delete ${NotificationServiceImpl.notificationIdKey}");
+    }
+    return (lastNotificationJson != null);
+  }
+}
+
+class MockLocalSecondary extends Mock implements LocalSecondary  {
+  @override
+  SecondaryKeyStore? keyStore = MockSecondaryKeyStore();
+
+}
 
 class MockAtClientImpl extends Mock implements AtClientImpl {
+  AtClientPreference mockPreferences = AtClientPreference()..namespace = 'wavi';
   @override
   AtClientPreference getPreferences() {
-    return AtClientPreference()..namespace = 'wavi';
+    mockPreferences.fetchOfflineNotifications = true;
+    return mockPreferences;
   }
 
   @override
   String? getCurrentAtSign() {
     return '@alice';
   }
-}
 
-class MockLocalSecondary extends Mock implements LocalSecondary {}
+  LocalSecondary mockLocalSecondary = MockLocalSecondary();
+  @override
+  LocalSecondary? getLocalSecondary() {
+    return mockLocalSecondary;
+  }
+
+  @override
+  Future<AtValue> get(AtKey atKey,
+      {bool isDedicated = false, GetRequestOptions? getRequestOptions}) async {
+    if (atKey.key != NotificationServiceImpl.notificationIdKey) {
+      throw IllegalArgumentException("This mock client only understands how to get, put and delete ${NotificationServiceImpl.notificationIdKey}");
+    }
+    if (lastNotificationJson != null) {
+      return AtValue()..value = lastNotificationJson;
+    } else {
+      return AtValue();
+    }
+  }
+
+  @override
+  Future<bool> put(AtKey atKey, dynamic value,
+      {bool isDedicated = false}) async {
+    if (atKey.key != NotificationServiceImpl.notificationIdKey) {
+      throw IllegalArgumentException("This mock client only understands how to get, put and delete ${NotificationServiceImpl.notificationIdKey}");
+    }
+    lastNotificationJson = value;
+    return true;
+  }
+
+  @override
+  Future<bool> delete(AtKey atKey, {bool isDedicated = false}) async {
+    if (atKey.key != NotificationServiceImpl.notificationIdKey) {
+      throw IllegalArgumentException("This mock client only understands how to get, put and delete ${NotificationServiceImpl.notificationIdKey}");
+    }
+    if (lastNotificationJson == null) {
+      return false;
+    } else {
+      lastNotificationJson = null;
+      return true;
+    }
+  }
+}
 
 class MockMonitor extends Mock implements Monitor {
   @override
@@ -427,5 +489,63 @@ void main() {
       expect(notificationServiceImpl.getStreamListenersCount(), 1);
       notificationServiceImpl.stopAllSubscriptions();
     });
+  });
+
+  group('Tests of getLastNotificationTime()', () {
+    setUpAll(() {
+      when(() => mockAtClientManager.atClient)
+          .thenAnswer((_) => mockAtClientImpl);
+    });
+
+    test('getLastNotificationTime() returns null if checkOfflineNotifications is set to false',
+            () async {
+          var notificationServiceImpl = await NotificationServiceImpl.create(
+              mockAtClientImpl,
+              atClientManager: mockAtClientManager,
+              monitor: mockMonitor) as NotificationServiceImpl;
+
+          notificationServiceImpl.stopAllSubscriptions();
+
+          mockAtClientImpl.getPreferences()!.fetchOfflineNotifications = false;
+
+          expect(await notificationServiceImpl.getLastNotificationTime(), null);
+        });
+
+    test(
+        'getLastNotificationTime() returns null if checkOfflineNotifications is true but there is no stored value',
+            () async {
+              var notificationServiceImpl = await NotificationServiceImpl.create(
+                  mockAtClientImpl,
+                  atClientManager: mockAtClientManager,
+                  monitor: mockMonitor) as NotificationServiceImpl;
+
+              notificationServiceImpl.stopAllSubscriptions();
+
+              mockAtClientImpl.getPreferences()!.fetchOfflineNotifications = true;
+
+              await mockAtClientImpl.delete(AtKey()..key = NotificationServiceImpl.notificationIdKey);
+
+              expect(await notificationServiceImpl.getLastNotificationTime(), null);
+        });
+
+    test(
+        'getLastNotificationTime() returns the stored value if checkOfflineNotifications is true and there is a stored value',
+            () async {
+          var notificationServiceImpl = await NotificationServiceImpl.create(
+              mockAtClientImpl,
+              atClientManager: mockAtClientManager,
+              monitor: mockMonitor) as NotificationServiceImpl;
+
+          notificationServiceImpl.stopAllSubscriptions();
+
+          mockAtClientImpl.getPreferences()!.fetchOfflineNotifications = true;
+
+          int epochMillis = DateTime.now().millisecondsSinceEpoch;
+          var atNotification = at_notification.AtNotification(Uuid().v4(), '', '@bob', '@alice', epochMillis, 'update', true);
+          await mockAtClientImpl.put(AtKey()..key = NotificationServiceImpl.notificationIdKey,
+              jsonEncode(atNotification.toJson()));
+
+          expect(await notificationServiceImpl.getLastNotificationTime(), epochMillis);
+        });
   });
 }


### PR DESCRIPTION
**- What I did**
Ensure that fetchOfflineNotifications preference is checked not just when the monitor is first started (in _startMonitor()), but also when it is restarted in _monitorRetry()

**- How I did it**
* Moved the code which checks the fetchOfflineNotifications preference into the _getLastNotificationTime() method itself, as this is common code used by both _startMonitor() and _monitorRetry()
* Added some comments into _getLastNotificationTime() to explain what is going on
* Renamed _getLastNotificationTime() to getLastNotificationTime() and annotated it as @visibleForTesting so that we can unit test it
* Added unit tests of getLastNotificationTime() for the three cases:
  * fetchOfflineNotifications is false ==> should return null
  * fetchOfflineNotifications is true, but there _is not_ a lastNotificationId in the keystore ==> should return null
  * fetchOfflineNotifications is true, and there _is_ a lastNotificationId in the keystore ==> should return the epochMillis of the json of the last stored notification

**- How to verify it**
* Unit tests should pass

**- Description for the changelog**
fix: Also check fetchOfflineNotifications preference when NotificationServiceImpl restarts its Monitor

Fixes https://github.com/atsign-foundation/at_client_sdk/issues/740