### PR TITLE
build: uptake persistence secondary server 3.0.39

### DIFF
--- a/at_client/CHANGELOG.md
+++ b/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.41
+- chore: upgrade persistence secondary to version 3.0.38 which reverts sync of signing keys and statsNotificationKey
 ## 3.0.40
 - chore: upgrade at_commons to 3.0.26
 - fix: check isencrypted flag in sync conflict

--- a/at_client/lib/src/preference/at_client_config.dart
+++ b/at_client/lib/src/preference/at_client_config.dart
@@ -9,5 +9,5 @@ class AtClientConfig {
   }
 
   /// Represents the at_client version.
-  final String atClientVersion = '3.0.40';
+  final String atClientVersion = '3.0.41';
 }

--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -460,7 +460,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       }
       final serverEncryptedValue = serverCommitEntry['value'];
       final serverMetaData = serverCommitEntry['metadata'];
-      if (serverMetaData != null && (serverMetaData[IS_ENCRYPTED] != null && serverMetaData[IS_ENCRYPTED] == "true")) {
+      if (serverMetaData != null && serverMetaData[IS_ENCRYPTED] == "true") {
         final decryptionManager =
             AtKeyDecryptionManager.get(atKey, _atClient.getCurrentAtSign()!);
         final serverDecryptedValue =

--- a/at_client/lib/src/service/sync_service_impl.dart
+++ b/at_client/lib/src/service/sync_service_impl.dart
@@ -460,7 +460,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       }
       final serverEncryptedValue = serverCommitEntry['value'];
       final serverMetaData = serverCommitEntry['metadata'];
-      if (serverMetaData != null && serverMetaData[IS_ENCRYPTED] == "true") {
+      if (serverMetaData != null && (serverMetaData[IS_ENCRYPTED] != null && serverMetaData[IS_ENCRYPTED] == "true")) {
         final decryptionManager =
             AtKeyDecryptionManager.get(atKey, _atClient.getCurrentAtSign()!);
         final serverDecryptedValue =

--- a/at_client/pubspec.yaml
+++ b/at_client/pubspec.yaml
@@ -1,7 +1,7 @@
 name: at_client
 description: The at_client library is the non-platform specific Client SDK which provides the essential methods for building an app using the atProtocol.
 ## When incrementing the version, update the version in AtClientConfig file
-version: 3.0.40
+version: 3.0.41
 repository: https://github.com/atsign-foundation/at_client_sdk
 homepage: https://atsign.dev
 documentation: https://docs.atsign.com/
@@ -24,7 +24,7 @@ dependencies:
   internet_connection_checker: ^0.0.1+4
   async: ^2.9.0
   at_persistence_spec: ^2.0.7
-  at_persistence_secondary_server: ^3.0.36
+  at_persistence_secondary_server: ^3.0.39
   at_lookup: ^3.0.30
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Uptake at_persistence_secondary_server to 3.0.38 version
- Add an addition condition that verifies if serverMetadata contains isEncrypted

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->