### PR TITLE
feat: Introduce a local key for latestNotificationId so it is not sync'd to server

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.44
+- feat: Introduce fetch method to NotificationService to fetch the notification using id.
+- fix: Replace latestNotificationId with local key to store/fetch last received notification
 ## 3.0.43
 - chore: upgrade persistence secondary to version 3.0.42 and persistence spec to 2.0.9
 ## 3.0.42
@@ -6,7 +9,7 @@ RemoteSecondary connection rather than creating a new one
 - fix: Do not try to decrypt empty or null serverEncryptedValue when generating SyncConflict info
 - fix: put try-catch around most of the `SyncServiceImpl._checkConflict` method so sync is not impeded if
 _checkConflict encounters an exception
-- fix: null pointer exception in monitorResponse due to delayed server response
+- fix: fix null pointer exception in monitorResponse due to delayed server response
 - fix: Skip reserved keys from decryption in the notification callback
 - fix: Update at_commons to 3.0.29 which fixes AtKey sharedWith attribute has incorrect value for public keys
 ## 3.0.41

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -1,11 +1,8 @@
 import 'dart:convert';
 
-import 'package:at_client/src/client/at_client_spec.dart';
+import 'package:at_client/at_client.dart';
 import 'package:at_client/src/client/secondary.dart';
-import 'package:at_client/src/manager/at_client_manager.dart';
-import 'package:at_client/src/util/at_client_util.dart';
 import 'package:at_commons/at_builders.dart';
-import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_utils/at_utils.dart';
@@ -64,7 +61,7 @@ class LocalSecondary implements Secondary {
   Future<String> _update(UpdateVerbBuilder builder) async {
     try {
       dynamic updateResult;
-      var updateKey = AtClientUtil.buildKey(builder);
+      var updateKey = builder.buildKey();
       switch (builder.operation) {
         case UPDATE_META:
           var metadata = Metadata();
@@ -110,21 +107,7 @@ class LocalSecondary implements Secondary {
   Future<String> _llookup(LLookupVerbBuilder builder) async {
     var llookupKey = '';
     try {
-      if (builder.isCached) {
-        llookupKey += 'cached:';
-      }
-      if (builder.isPublic) {
-        llookupKey += 'public:';
-      }
-      if (builder.sharedWith != null) {
-        llookupKey += '${AtUtils.formatAtSign(builder.sharedWith!)}:';
-      }
-      if (builder.atKey != null) {
-        llookupKey += builder.atKey!;
-      }
-      if (builder.sharedBy != null) {
-        llookupKey += AtUtils.formatAtSign(builder.sharedBy)!;
-      }
+      llookupKey = builder.buildKey();
       var llookupMeta = await keyStore!.getMeta(llookupKey);
       var isActive = _isActiveKey(llookupMeta);
       String? result;

--- a/packages/at_client/lib/src/client/verb_builder_manager.dart
+++ b/packages/at_client/lib/src/client/verb_builder_manager.dart
@@ -49,6 +49,7 @@ class LookUpBuilderManager {
       ..isCached = (atKey.metadata != null && atKey.metadata?.isCached != null)
           ? atKey.metadata!.isCached
           : false
+      ..isLocal = atKey.isLocal
       ..operation = 'all';
   }
 }

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -9,5 +9,5 @@ class AtClientConfig {
   }
 
   /// Represents the at_client version.
-  final String atClientVersion = '3.0.43';
+  final String atClientVersion = '3.0.44';
 }

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -699,7 +699,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       case '#':
       case '*':
         var builder = UpdateVerbBuilder()
-          ..atKey = serverCommitEntry['atKey']
+          ..atKeyObj = AtKey.fromString(serverCommitEntry['atKey'])
           ..value = serverCommitEntry['value'];
         builder.operation = UPDATE_ALL;
         _setMetaData(builder, serverCommitEntry);

--- a/packages/at_client/lib/src/transformer/request_transformer/put_request_transformer.dart
+++ b/packages/at_client/lib/src/transformer/request_transformer/put_request_transformer.dart
@@ -72,9 +72,9 @@ class PutRequestTransformer
       ..isEncrypted = (atKey.metadata?.isEncrypted != null)
           ? atKey.metadata?.isEncrypted!
           : false
-      ..isBinary = (atKey.metadata?.isBinary != null)
-          ? atKey.metadata?.isBinary!
-          : false;
+      ..isBinary =
+          (atKey.metadata?.isBinary != null) ? atKey.metadata?.isBinary! : false
+      ..isLocal = atKey.isLocal;
 
     if (atKey.metadata!.ttl != null) {
       updateVerbBuilder.ttl = atKey.metadata!.ttl;

--- a/packages/at_client/lib/src/util/at_client_util.dart
+++ b/packages/at_client/lib/src/util/at_client_util.dart
@@ -3,27 +3,10 @@ import 'dart:typed_data';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/converters/encoder/at_encoder.dart';
-import 'package:at_commons/at_builders.dart';
 import 'package:at_lookup/at_lookup.dart';
-import 'package:at_utils/at_utils.dart';
 import 'package:crypton/crypton.dart';
 
 class AtClientUtil {
-  static String buildKey(UpdateVerbBuilder builder) {
-    var updateKey = '';
-    if (builder.isPublic) {
-      updateKey += 'public:';
-    }
-    if (builder.sharedWith != null && builder.sharedWith!.isNotEmpty) {
-      updateKey += '${AtUtils.formatAtSign(builder.sharedWith!)}:';
-    }
-    updateKey += builder.atKey!;
-    if (builder.sharedBy != null) {
-      updateKey += AtUtils.formatAtSign(builder.sharedBy)!;
-    }
-    return updateKey;
-  }
-
   @Deprecated('use RemoteSecondary.findSecondaryUrl')
   static Future<String> findSecondary(
       String toAtSign, String rootDomain, int rootPort) async {

--- a/packages/at_client/lib/src/util/sync_util.dart
+++ b/packages/at_client/lib/src/util/sync_util.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/response/json_utils.dart';
+import 'package:at_client/src/service/notification_service_impl.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_utils/at_logger.dart';
@@ -117,7 +118,8 @@ class SyncUtil {
     if (key.startsWith(AT_PKAM_PRIVATE_KEY) ||
         key.startsWith(AT_PKAM_PUBLIC_KEY) ||
         key.startsWith(AT_ENCRYPTION_PRIVATE_KEY) ||
-        key.startsWith(statsNotificationId)) {
+        key.startsWith(NotificationServiceImpl.notificationIdKey) ||
+        key.startsWith(NotificationServiceImpl.lastReceivedNotificationKey)) {
       return false;
     }
     return true;

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.43
+version: 3.0.44
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 
@@ -30,10 +30,10 @@ dependencies:
   async: ^2.9.0
   at_persistence_spec: ^2.0.9
   at_persistence_secondary_server: ^3.0.42
-  at_lookup: ^3.0.30
+  at_lookup: ^3.0.32
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
-  at_commons: ^3.0.29
+  at_commons: ^3.0.30
   at_utils: ^3.0.11
   meta: ^1.8.0
 

--- a/packages/at_client/test/at_client_util_test.dart
+++ b/packages/at_client/test/at_client_util_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('test non public key', () {
       var builder = UpdateVerbBuilder()
         ..atKey = 'privatekey:at_pkam_privatekey';
-      var updateKey = AtClientUtil.buildKey(builder);
+      var updateKey = builder.buildKey();
       expect(updateKey, 'privatekey:at_pkam_privatekey');
     });
 
@@ -16,7 +16,7 @@ void main() {
         ..isPublic = true
         ..atKey = 'phone'
         ..sharedBy = 'alice';
-      var updateKey = AtClientUtil.buildKey(builder);
+      var updateKey = builder.buildKey();
       expect(updateKey, 'public:phone@alice');
     });
 
@@ -25,7 +25,7 @@ void main() {
         ..sharedWith = 'bob'
         ..atKey = 'phone'
         ..sharedBy = 'alice';
-      var updateKey = AtClientUtil.buildKey(builder);
+      var updateKey = builder.buildKey();
       expect(updateKey, '@bob:phone@alice');
     });
   });

--- a/packages/at_client/test/local_secondary_test.dart
+++ b/packages/at_client/test/local_secondary_test.dart
@@ -174,8 +174,9 @@ void main() {
         ..sharedBy = atSign;
       await localSecondary.executeVerb(verbBuilder, sync: false);
       final llookupVerbBuilder = LLookupVerbBuilder()
-        ..atKey = 'public:email'
-        ..sharedBy = atSign;
+        ..atKey = 'email'
+        ..sharedBy = atSign
+        ..isPublic = true;
       final llookupResult =
           await localSecondary.executeVerb(llookupVerbBuilder, sync: false);
       expect(llookupResult, 'data:alice@gmail.com');
@@ -196,12 +197,14 @@ void main() {
         ..sharedBy = atSign;
       await localSecondary.executeVerb(verbBuilder, sync: false);
       final deleteVerbBuilder = DeleteVerbBuilder()
-        ..atKey = 'public:email'
-        ..sharedBy = atSign;
+        ..atKey = 'email'
+        ..sharedBy = atSign
+        ..isPublic = true;
       await localSecondary.executeVerb(deleteVerbBuilder, sync: false);
       final llookupVerbBuilder = LLookupVerbBuilder()
-        ..atKey = 'public:email'
-        ..sharedBy = atSign;
+        ..atKey = 'email'
+        ..sharedBy = atSign
+        ..isPublic = true;
       expect(localSecondary.executeVerb(llookupVerbBuilder, sync: false),
           throwsA(isA<KeyNotFoundException>()));
     });

--- a/tests/at_end2end_test/test/notify_test.dart
+++ b/tests/at_end2end_test/test/notify_test.dart
@@ -83,7 +83,7 @@ void main() {
     expect(notificationListJson[0]['from'], currentAtSign);
     expect(notificationListJson[0]['to'], sharedWithAtSign);
     expect(notificationListJson[0]['value'], isNotEmpty);
-  });
+  }, timeout: Timeout(Duration(minutes: 1)));
 
   /// The purpose of this test is to verify the notify text with setting
   /// shouldEncrypt parameter to true (which encrypt the notify text)


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Skip latestNotificationId from the commit log to refrain the key to sync between client and server

**- How I did it**
- Introduce a new key `local:lastReceivedNotification` that do not sync between the cloud and local secondary. (Local keys do not sync between cloud and local secondaries)
- In getLastNotificationTime, check if the new key (local:lastReceivedNotification) is available. If key is available and value is not null, return the epochMillis. If key is not available, get the data from old key (_latestNotificationId) and update the new key with the data.

- Refactor the existing unit tests as follows
   * Moved isKeyExists from MockSecondaryKeyStore class to test : isKeyExists method needs to true/false differently for tests. So moved to tests from common place to get the desired behaviour in tests.
   * Moved get and put methods from MockAtClientImpl to tests: To achieve the desired behaviour of get and put methods specific to tests, moved from class to tests.
   * Moved ` mockPreferences.fetchOfflineNotifications = true;` to tests - To set the fetchOfflineNotifications to true/false for tests, removed from the class level
- Added the following unit tests to verify the getNotificationLastTime behaviour
  * Test 1: When the lastReceivedNotificationKey(new key) and _latestNotificationIdv2(old key) are not available, null value is returned
  * Test 2: When the lastReceivedNotificationKey(new key) is not available, last received notification date time is returned from the old key
  * Test 3: When the lastReceivedNotificationKey(new key) is available, last received notification date time is returned from the new key
  * Test 4: test to verify toString called on lastNotificationReceived key returns correct string representation
  * Test 5: test to verify fromString on lastNotificationReceived key returns correct AtKey instance

- Following files do not have code changes. Only dart formatting changes:
   * at_client_spec.dart
   * at_client_impl.dart
   * sync_service_impl.dart
   * sync_service_test.dart

**- How to verify it**
- Received notifications, latestNotificationId, should not be updated and synced to server.
- The local:lastReceivedNotification should be updated and not sync to the secondary

**- Description for the changelog**
- Deprecate latestNotificationId. Introduce a local key - local:lastReceivedNotification to fetch/store the last received notification date time
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->