### PR TITLE
fix: isError called on null monitorResponse

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.42
 - fix: Improved performance of getKeys (and getAtKeys) when sharedBy is specified, by using the existing 
 RemoteSecondary connection rather than creating a new one
+- Fix null pointer exception in monitorResponse due to delayed server response
 ## 3.0.41
 - chore: upgrade persistence secondary to version 3.0.38 which reverts sync of signing keys and statsNotificationKey
 ## 3.0.40

--- a/packages/at_client/test/monitor_test.dart
+++ b/packages/at_client/test/monitor_test.dart
@@ -427,4 +427,60 @@ void main() {
       expect(monitor.status, MonitorStatus.started);
     });
   });
+
+  group('A group of tests to validate verb queue', () {
+    test('test when verb queue response is not populated', () async {
+      Monitor monitor = Monitor(
+          (String json) => print('onResponse: $json'),
+          (e) => print('onError: $e'),
+          atSign,
+          atClientPreference,
+          MonitorPreference(),
+          () => print('onRetry called'),
+          monitorConnectivityChecker: mockMonitorConnectivityChecker,
+          remoteSecondary: mockRemoteSecondary,
+          monitorOutboundConnectionFactory:
+              mockMonitorOutboundConnectionFactory);
+
+      expect(() async => await monitor.getQueueResponse(maxWaitTimeInMills: 2),
+          throwsA(predicate((dynamic e) => e is AtTimeoutException)));
+    });
+
+    test('test when verb queue response is populated with data: response', () async {
+      Monitor monitor = Monitor(
+          (String json) => print('onResponse: $json'),
+          (e) => print('onError: $e'),
+          atSign,
+          atClientPreference,
+          MonitorPreference(),
+          () => print('onRetry called'),
+          monitorConnectivityChecker: mockMonitorConnectivityChecker,
+          remoteSecondary: mockRemoteSecondary,
+          monitorOutboundConnectionFactory:
+              mockMonitorOutboundConnectionFactory);
+      monitor.addMonitorResponseToQueue('data:success');
+
+      var response = await monitor.getQueueResponse();
+      expect(response, 'success');
+    });
+
+    test('test when verb queue response is populated with error: response', () async {
+      Monitor monitor = Monitor(
+              (String json) => print('onResponse: $json'),
+              (e) => print('onError: $e'),
+          atSign,
+          atClientPreference,
+          MonitorPreference(),
+              () => print('onRetry called'),
+          monitorConnectivityChecker: mockMonitorConnectivityChecker,
+          remoteSecondary: mockRemoteSecondary,
+          monitorOutboundConnectionFactory:
+          mockMonitorOutboundConnectionFactory);
+      monitor.addMonitorResponseToQueue('error: AT0003 - Invalid syntax exception');
+
+      expect(() async => await monitor.getQueueResponse(maxWaitTimeInMills: 2),
+          throwsA(predicate((dynamic e) => e is AtClientException)));
+
+    });
+  });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

Root Cause:
* When server delays/fails to respond to a monitor connection, the `monitorResponse` has a null value. 
* In the subsequent line, we check for isError. So when monitorResponse has a null value, calling isError would lead to a null pointer exception.

**- How I did it**
* Check if monitorResponse is null. If yes throw `AtTimeoutException` which gets handled on the caller method `start` method.
* Added unit tests for the following scenarios:
    * When verb response is not received.
    * When verb response is data:success
    * When verb response is error:

**- How to verify it**
* When server fails to respond in time, null pointer exception should not be thrown.

**- Description for the changelog**
* Fix null pointer issue in monitor when server fails to respond in time.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->