### PR TITLE
fix: prevent _checkConflict from ever failing

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,11 +1,14 @@
 ## 3.0.42
 - fix: Improved performance of getKeys (and getAtKeys) when sharedBy is specified, by using the existing 
 RemoteSecondary connection rather than creating a new one
+- fix: Do not try to decrypt empty or null serverEncryptedValue when generating SyncConflict info
+- fix: put try-catch around most of the `SyncServiceImpl._checkConflict` method so sync is not impeded if
+_checkConflict encounters an exception
 ## 3.0.41
 - chore: upgrade persistence secondary to version 3.0.38 which reverts sync of signing keys and statsNotificationKey
 ## 3.0.40
 - chore: upgrade at_commons to 3.0.26
-- fix: check isencrypted flag in sync conflict
+- fix: check isEncrypted flag in sync conflict
 - docs: Fixed broken links
 ## 3.0.39
 - chore: upgrade 3rd party dependencies except hive

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -9,5 +9,5 @@ class AtClientConfig {
   }
 
   /// Represents the at_client version.
-  final String atClientVersion = '3.0.41';
+  final String atClientVersion = '3.0.42';
 }

--- a/packages/at_client/lib/src/service/sync/sync_conflict.dart
+++ b/packages/at_client/lib/src/service/sync/sync_conflict.dart
@@ -25,9 +25,10 @@ class ResolutionContext {
 class ConflictInfo {
   dynamic remoteValue;
   dynamic localValue;
+  String? errorOrExceptionMessage;
 
   @override
   String toString() {
-    return 'ConflictInfo{remoteValue: $remoteValue, localValue: $localValue}';
+    return 'ConflictInfo{remoteValue: $remoteValue, localValue: $localValue, errorOrExceptionMessage: $errorOrExceptionMessage}';
   }
 }

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -7,7 +7,6 @@ description: The at_client library is the non-platform specific Client SDK which
 version: 3.0.42
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
-##
 
 repository: https://github.com/atsign-foundation/at_client_sdk
 homepage: https://docs.atsign.com/

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -1,7 +1,14 @@
 name: at_client
 description: The at_client library is the non-platform specific Client SDK which provides the essential methods for building an app using the atProtocol.
-## When incrementing the version, update the version in AtClientConfig file
+
+##
+##
+## NB: When incrementing the version, please also increment the version in AtClientConfig file
 version: 3.0.42
+## NB: When incrementing the version, please also increment the version in AtClientConfig file
+##
+##
+
 repository: https://github.com/atsign-foundation/at_client_sdk
 homepage: https://docs.atsign.com/
 


### PR DESCRIPTION
**- What I did**
* fix: prevent _checkConflict from ever failing
* build: update CHANGELOG and pubspec.yaml and AtClientConfig

**- How I did it**
* fix: put try-catch around most of the `SyncServiceImpl._checkConflict` method so a WARNING is logged but sync is not impeded if _checkConflict encounters an exception. Also added errorOrExceptionMessage to ConflictInfo
* build: update CHANGELOG and pubspec.yaml and AtClientConfig

**- How to verify it**
Tests pass

**- Description for the changelog**
* fix: prevent _checkConflict from ever failing
