### PR TITLE
fix: invalid pad block issue

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -5,6 +5,7 @@ RemoteSecondary connection rather than creating a new one
 - fix: put try-catch around most of the `SyncServiceImpl._checkConflict` method so sync is not impeded if
 _checkConflict encounters an exception
 - Fix null pointer exception in monitorResponse due to delayed server response
+- fix: Skip reserved keys from decryption in the notification callback
 ## 3.0.41
 - chore: upgrade persistence secondary to version 3.0.38 which reverts sync of signing keys and statsNotificationKey
 ## 3.0.40

--- a/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
+++ b/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
@@ -33,7 +33,11 @@ class NotificationResponseTransformer
       atNotification.key = '${tuple.one.to}:$decryptedValue';
       return atNotification;
     } else if ((tuple.one.value.isNotNull) &&
-        (tuple.two.shouldDecrypt && tuple.one.id != '-1')) {
+        (tuple.two.shouldDecrypt && tuple.one.id != '-1') &&
+        // The shared_key (which is a reserved key) has different decryption process
+        // and is not a user created key.
+        // Hence do not decrypt if key's are reserved keys
+        AtKey.getKeyType(atKey.key!) != KeyType.reservedKey) {
       // decrypt the value
       atNotification.value = await _getDecryptedValue(atKey, tuple.one.value!);
       return atNotification;

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -352,6 +352,30 @@ void main() {
       expect(transformedNotification.id, '124');
       expect(transformedNotification.key, 'key-1');
     });
+
+    test('A test to verify the reserved key is not decrypted', () async {
+      var isEncrypted = true;
+      var atNotification = at_notification.AtNotification(
+          '124',
+          '@bob:shared_key@alice',
+          '@alice',
+          '@bob',
+          DateTime.now().millisecondsSinceEpoch,
+          MessageTypeEnum.key.toString(),
+          isEncrypted,
+          value: 'encryptedValue');
+      var notificationResponseTransformer = NotificationResponseTransformer();
+      notificationResponseTransformer.atKeyDecryption = mockSharedKeyDecryption;
+
+      var transformedNotification =
+          await notificationResponseTransformer.transform(Tuple()
+            ..one = atNotification
+            ..two = (NotificationConfig()
+              ..regex = '.*'
+              ..shouldDecrypt = true));
+      expect(transformedNotification.id, '124');
+      expect(transformedNotification.value, 'encryptedValue');
+    });
   });
 
   group('A group of tests to validate notification exception chaining', () {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Referring to the issue: https://github.com/atsign-foundation/at_client_sdk/issues/749, In notification callback, skip the 'shared_key' from the decryption process

**- How I did it**
- Added an IF condition that check's if the key is a reserved key. If yes, skips the decryption process
- Added unit test to verify the same

**- How to verify it**
- When shared_key is received in notification callback, do not decrypt.

**- Description for the changelog**
- Skip reserved keys from decryption in notification callback
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->