### PR TITLE
fix: use dev_env for e2e tests and source script from this repo

### DIFF
--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -130,7 +130,9 @@ jobs:
           username: ubuntu
           key: ${{ secrets.CICD_SSH_KEY }}
           script: |
-            wget -q -O update_ce2e_images.sh https://raw.githubusercontent.com/atsign-foundation/at_client_sdk/trunk/tools/$HOSTNAME/update_ce2e_images.sh
+            scriptURL="https://raw.githubusercontent.com/atsign-foundation/at_client_sdk/trunk/tools/${HOSTNAME}/update_ce2e_images.sh"
+            echo "$scriptURL"
+            wget -q -O update_ce2e_images.sh "$scriptURL"
             ./update_ce2e_images.sh
 
   # The Job runs end-to-end tests between two atSign's running on server trunk branch

--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -130,6 +130,7 @@ jobs:
           username: ubuntu
           key: ${{ secrets.CICD_SSH_KEY }}
           script: |
+            wget -q -O update_ce2e_images.sh https://raw.githubusercontent.com/atsign-foundation/at_client_sdk/trunk/tools/$HOSTNAME/update_ce2e_images.sh
             ./update_ce2e_images.sh
 
   # The Job runs end-to-end tests between two atSign's running on server trunk branch

--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -140,7 +140,7 @@ jobs:
     needs: [ end2end_tests_prep ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1.3
         with:
           sdk: stable
@@ -176,7 +176,7 @@ jobs:
     needs: [   end2end_tests ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1.3
         with:
           sdk: stable

--- a/tools/cicd1x64/update_ce2e_images.sh
+++ b/tools/cicd1x64/update_ce2e_images.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sudo docker service update --image atsigncompany/secondary:dess_cicd \
+sudo docker service update --image atsigncompany/secondary:dev_env \
  ce2e1_secondary
 sudo docker service update --image atsigncompany/secondary:canary \
  ce2e3_secondary

--- a/tools/cicd2x64/update_ce2e_images.sh
+++ b/tools/cicd2x64/update_ce2e_images.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-sudo docker service update --image atsigncompany/secondary:dess_cicd \
+sudo docker service update --image atsigncompany/secondary:dev_env \
  ce2e2_secondary
 sudo docker service update --image atsigncompany/secondary:canary \
  ce2e4_secondary


### PR DESCRIPTION
Making fix from #780 permanent

**- What I did**

Update scripts switched to using `:dev_env` tag rather than `:dess_cicd`
Scripts will be sourced from this repo rather than manually maintained

**- How to verify it**

Next run of end2end tests

**- Description for the changelog**

fix: use dev_env for e2e tests and source script from this repo