### PR TITLE
test: Parallelise unit and functional tests

### DIFF
--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -44,18 +44,18 @@ jobs:
         working-directory: packages/at_client
         run: dart test --concurrency=1 --coverage="coverage"
 
-      - name: Convert coverage to LCOV format
-        working-directory: packages/at_client
-        run: dart pub run coverage:format_coverage --lcov --in=coverage --out=unit_test_coverage.lcov --packages=.packages --report-on=lib
-
-      - name: Upload coverage to Codecov
-        working-directory: packages/at_client
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
-        with:
-          # According to codecov docs, the token is not required for open-source repos
-          # token: ${{secrets.CODECOV_TOKEN_AT_CLIENT_SDK}}
-          file: unit_test_coverage.lcov
-          flags: unit_tests
+#      - name: Convert coverage to LCOV format
+#        working-directory: packages/at_client
+#        run: dart pub run coverage:format_coverage --lcov --in=coverage --out=unit_test_coverage.lcov --packages=.packages --report-on=lib
+#
+#      - name: Upload coverage to Codecov
+#        working-directory: packages/at_client
+#        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
+#        with:
+#          # According to codecov docs, the token is not required for open-source repos
+#          # token: ${{secrets.CODECOV_TOKEN_AT_CLIENT_SDK}}
+#          file: unit_test_coverage.lcov
+#          flags: unit_tests
 
       # Adding flutter to path
       - name: Installing Flutter
@@ -114,18 +114,18 @@ jobs:
         working-directory: tests/at_functional_test
         run: dart test --concurrency=1 --coverage="coverage"
 
-      - name: Convert coverage to LCOV format
-        working-directory: tests/at_functional_test
-        run: dart pub run coverage:format_coverage --lcov --in=coverage --out=functional_test_coverage.lcov --packages=.packages --report-on=../../packages/at_client/lib
-
-      - name: Upload coverage to Codecov
-        working-directory: tests/at_functional_test
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
-        with:
-          # According to codecov docs, the token is not required for open-source repos
-          # token: ${{secrets.CODECOV_TOKEN_AT_CLIENT_SDK}}
-          file: functional_test_coverage.lcov
-          flags: functional_tests
+#      - name: Convert coverage to LCOV format
+#        working-directory: tests/at_functional_test
+#        run: dart pub run coverage:format_coverage --lcov --in=coverage --out=functional_test_coverage.lcov --packages=.packages --report-on=../../packages/at_client/lib
+#
+#      - name: Upload coverage to Codecov
+#        working-directory: tests/at_functional_test
+#        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
+#        with:
+#          # According to codecov docs, the token is not required for open-source repos
+#          # token: ${{secrets.CODECOV_TOKEN_AT_CLIENT_SDK}}
+#          file: functional_test_coverage.lcov
+#          flags: functional_tests
 
       # stop docker containers
       - name: stop docker containers

--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -17,7 +17,7 @@ permissions:  # added using https://github.com/step-security/secure-workflows
   contents: read
 
 jobs:
-  unit_and_functional_tests:
+  unit_tests_and_code_analysis:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3
@@ -44,17 +44,46 @@ jobs:
         working-directory: packages/at_client
         run: dart test --concurrency=1 --coverage="coverage"
 
-      #     Commenting out for now, need to investigate and fix but there are hotter fires burning right now
-      #      - name: Convert coverage to LCOV format
-      #        working-directory: packages/at_client
-      #        run: pub run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=lib
-      #
-      #      - name: Upload coverage to Codecov
-      #        uses: codecov/codecov-action@v3.1.0
-      #        with:
-      #          token: ${{secrets.CODECOV_TOKEN_AT_CLIENT_SDK}}
-      #          file: at_client/coverage.lcov
-      #          flags: unit_tests
+      - name: Convert coverage to LCOV format
+        working-directory: packages/at_client
+        run: dart pub run coverage:format_coverage --lcov --in=coverage --out=unit_test_coverage.lcov --packages=.packages --report-on=lib
+
+      - name: Upload coverage to Codecov
+        working-directory: packages/at_client
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
+        with:
+          # According to codecov docs, the token is not required for open-source repos
+          # token: ${{secrets.CODECOV_TOKEN_AT_CLIENT_SDK}}
+          file: unit_test_coverage.lcov
+          flags: unit_tests
+
+      # Adding flutter to path
+      - name: Installing Flutter
+        uses: britannio/action-install-flutter@a486b7e3148e54a76390d849100b9dee819ff810 # v1.1
+        with:
+          version: stable
+
+      # Install dependencies of at_client_mobile
+      - name: Installing dependencies
+        working-directory: packages/at_client_mobile
+        run: flutter pub get
+
+      # Analyze at_client_mobile package
+      - name: flutter analyze
+        working-directory: packages/at_client_mobile
+        run: flutter analyze
+
+  functional_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3
+
+      # Note: This workflow uses the latest stable version of the Dart SDK.
+      # You can specify other versions if desired, see documentation here:
+      # https://github.com/dart-lang/setup-dart/blob/main/README.md
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d # v1.3
+        with:
+          sdk: stable
 
       # Install dependencies in at_functional_test
       - name: Install dependencies in at_functional_test
@@ -85,33 +114,18 @@ jobs:
         working-directory: tests/at_functional_test
         run: dart test --concurrency=1 --coverage="coverage"
 
-      #     Commenting out for now, need to investigate and fix but there are hotter fires burning right now
-      #      - name: Convert coverage to LCOV format
-      #        working-directory: tests/at_functional_test
-      #        run: pub run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=../at_client/lib
-      #
-      #      - name: Upload coverage to Codecov
-      #        uses: codecov/codecov-action@v3.1.0
-      #        with:
-      #          token: ${{secrets.CODECOV_TOKEN_AT_CLIENT_SDK}}
-      #          file: tests/at_functional_test/coverage.lcov
-      #          flags: functional_tests
+      - name: Convert coverage to LCOV format
+        working-directory: tests/at_functional_test
+        run: dart pub run coverage:format_coverage --lcov --in=coverage --out=functional_test_coverage.lcov --packages=.packages --report-on=../../packages/at_client/lib
 
-      # Adding flutter to path
-      - name: Installing Flutter
-        uses: britannio/action-install-flutter@a486b7e3148e54a76390d849100b9dee819ff810 # v1.1
+      - name: Upload coverage to Codecov
+        working-directory: tests/at_functional_test
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
-          version: stable
-
-      # Install dependencies of at_client_mobile
-      - name: Installing dependencies
-        working-directory: packages/at_client_mobile
-        run: flutter pub get
-
-      # Analyze at_client_mobile package
-      - name: flutter analyze
-        working-directory: packages/at_client_mobile
-        run: flutter analyze
+          # According to codecov docs, the token is not required for open-source repos
+          # token: ${{secrets.CODECOV_TOKEN_AT_CLIENT_SDK}}
+          file: functional_test_coverage.lcov
+          flags: functional_tests
 
       # stop docker containers
       - name: stop docker containers

--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -48,14 +48,12 @@ jobs:
         working-directory: packages/at_client
         run: dart pub run coverage:format_coverage --lcov --in=coverage --out=unit_test_coverage.lcov --packages=.packages --report-on=lib
 
-#      - name: Upload coverage to Codecov
-#        working-directory: packages/at_client
-#        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
-#        with:
-#          # According to codecov docs, the token is not required for open-source repos
-#          # token: ${{secrets.CODECOV_TOKEN_AT_CLIENT_SDK}}
-#          file: unit_test_coverage.lcov
-#          flags: unit_tests
+      - name: Upload coverage to Codecov
+        working-directory: packages/at_client
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
+        with:
+          file: unit_test_coverage.lcov
+          flags: unit_tests
 
       # Adding flutter to path
       - name: Installing Flutter
@@ -122,8 +120,6 @@ jobs:
 #        working-directory: tests/at_functional_test
 #        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
 #        with:
-#          # According to codecov docs, the token is not required for open-source repos
-#          # token: ${{secrets.CODECOV_TOKEN_AT_CLIENT_SDK}}
 #          file: functional_test_coverage.lcov
 #          flags: functional_tests
 

--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -44,10 +44,10 @@ jobs:
         working-directory: packages/at_client
         run: dart test --concurrency=1 --coverage="coverage"
 
-#      - name: Convert coverage to LCOV format
-#        working-directory: packages/at_client
-#        run: dart pub run coverage:format_coverage --lcov --in=coverage --out=unit_test_coverage.lcov --packages=.packages --report-on=lib
-#
+      - name: Convert coverage to LCOV format
+        working-directory: packages/at_client
+        run: dart pub run coverage:format_coverage --lcov --in=coverage --out=unit_test_coverage.lcov --packages=.packages --report-on=lib
+
 #      - name: Upload coverage to Codecov
 #        working-directory: packages/at_client
 #        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
@@ -114,10 +114,10 @@ jobs:
         working-directory: tests/at_functional_test
         run: dart test --concurrency=1 --coverage="coverage"
 
-#      - name: Convert coverage to LCOV format
-#        working-directory: tests/at_functional_test
-#        run: dart pub run coverage:format_coverage --lcov --in=coverage --out=functional_test_coverage.lcov --packages=.packages --report-on=../../packages/at_client/lib
-#
+      - name: Convert coverage to LCOV format
+        working-directory: tests/at_functional_test
+        run: dart pub run coverage:format_coverage --lcov --in=coverage --out=functional_test_coverage.lcov --packages=.packages --report-on=../../packages/at_client/lib
+
 #      - name: Upload coverage to Codecov
 #        working-directory: tests/at_functional_test
 #        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1

--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Convert coverage to LCOV format
         working-directory: packages/at_client
-        run: dart pub run coverage:format_coverage --lcov --in=coverage --out=unit_test_coverage.lcov --packages=.packages --report-on=lib
+        run: dart run coverage:format_coverage --lcov --in=coverage --out=unit_test_coverage.lcov --report-on=lib
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
@@ -113,7 +113,7 @@ jobs:
 
       - name: Convert coverage to LCOV format
         working-directory: tests/at_functional_test
-        run: dart pub run coverage:format_coverage --lcov --in=coverage --out=functional_test_coverage.lcov --packages=.packages --report-on=../../packages/at_client/lib
+        run: dart run coverage:format_coverage --lcov --in=coverage --out=functional_test_coverage.lcov --report-on=../../packages/at_client/lib
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1

--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -49,10 +49,9 @@ jobs:
         run: dart pub run coverage:format_coverage --lcov --in=coverage --out=unit_test_coverage.lcov --packages=.packages --report-on=lib
 
       - name: Upload coverage to Codecov
-        working-directory: packages/at_client
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
         with:
-          file: unit_test_coverage.lcov
+          file: packages/at_client/unit_test_coverage.lcov
           flags: unit_tests
 
       # Adding flutter to path
@@ -116,12 +115,11 @@ jobs:
         working-directory: tests/at_functional_test
         run: dart pub run coverage:format_coverage --lcov --in=coverage --out=functional_test_coverage.lcov --packages=.packages --report-on=../../packages/at_client/lib
 
-#      - name: Upload coverage to Codecov
-#        working-directory: tests/at_functional_test
-#        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
-#        with:
-#          file: functional_test_coverage.lcov
-#          flags: functional_tests
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
+        with:
+          file: tests/at_functional_test/functional_test_coverage.lcov
+          flags: functional_tests
 
       # stop docker containers
       - name: stop docker containers

--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -217,4 +217,3 @@ jobs:
         if: ${{ github.actor != 'dependabot[bot]' }}
         working-directory: tests/at_end2end_test
         run: dart test --concurrency=1
-

--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -217,3 +217,4 @@ jobs:
         if: ${{ github.actor != 'dependabot[bot]' }}
         working-directory: tests/at_end2end_test
         run: dart test --concurrency=1
+


### PR DESCRIPTION
fixes #812

**- What I did**
Parallelise unit and functional tests

**- How I did it**
* Split current `unit_and_functional_tests` job into two jobs : `unit_tests_and_code_analysis`, and `functional_tests`
* Re-enable the code coverage uploads to codecov.io
* Updated branch protection rules accordingly, with regards to which checks must pass

**- How to verify it**
* Jobs run successfully, in parallel
* Code coverage uploaded to https://app.codecov.io/gh/atsign-foundation/at_client_sdk [Note: won't be visible until merged to trunk]

**- Description for the changelog**
test: Parallelise unit and functional tests
