### PR TITLE
fix: sync running into loop on invalid keys

### DIFF
--- a/.github/workflows/refreshcerts.yaml
+++ b/.github/workflows/refreshcerts.yaml
@@ -59,7 +59,7 @@ jobs:
       # create PR with renewed certificate
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@d7db273d6c7206ba99224e659c982ae34a1025e3 # v4.2.1
+        uses: peter-evans/create-pull-request@331d02c7e2104af23ad5974d4d5cbc58a3e6dc77 # v4.2.2
         with:
           token: ${{ secrets.MY_GITHUB_TOKEN }}
           commit-message: 'chore: New certificates for at_server'

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -421,12 +421,11 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
           await _syncLocal(serverCommitEntry);
           keyInfoList.add(keyInfo);
         } on Exception catch (e, stacktrace) {
-          var cause = (e is AtException) ? e.getTraceMessage() : e.toString();
           _logger.severe(
-              'exception syncing entry to local $serverCommitEntry - $cause - stacktrace: $stacktrace');
+              'exception syncing entry to local $serverCommitEntry Exception: ${e.toString()} - stacktrace: $stacktrace');
         } on Error catch (e, stacktrace) {
           _logger.severe(
-              'error syncing entry to local $serverCommitEntry - ${e.toString()} - stacktrace: $stacktrace');
+              'error syncing entry to local $serverCommitEntry - Exception: ${e.toString()} - stacktrace: $stacktrace');
         }
       }
       // assigning the lastSynced local commit id.

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -420,13 +420,13 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
           keyInfo.conflictInfo = conflictInfo;
           await _syncLocal(serverCommitEntry);
           keyInfoList.add(keyInfo);
-        } on Exception catch (e) {
+        } on Exception catch (e, stacktrace) {
           var cause = (e is AtException) ? e.getTraceMessage() : e.toString();
           _logger.severe(
-              'exception syncing entry to local $serverCommitEntry - $cause');
-        } on Error catch (e) {
+              'exception syncing entry to local $serverCommitEntry - $cause - stacktrace: $stacktrace');
+        } on Error catch (e, stacktrace) {
           _logger.severe(
-              'error syncing entry to local $serverCommitEntry - ${e.toString()}');
+              'error syncing entry to local $serverCommitEntry - ${e.toString()} - stacktrace: $stacktrace');
         }
       }
       // assigning the lastSynced local commit id.


### PR DESCRIPTION
**- What I did**
* Fix the sync infinite loop issue.

**- How I did it**
* At the moment, When the server is ahead of the local secondary, to ensure all the delta commits are received, we run a loop until the localCommitId is equal to serverCommitId.
* The problem with this approach is if an invalid key is not synced to local  secondary, the sync runs into an infinite loop.
* Hence we replaced the `while (serverCommitId > localCommitId)` with `while (serverCommitId > lastReceivedServerCommitId)` so that we run the loop until the lastReceivedServerCommitId is equal to serverCommitId

**- How to verify it**
* The end-to-end tests and the unit tests should pass.

**- Description for the changelog**
* Fix the sync running into an infinite loop when invalid keys do not sync to the local secondary
