### PR TITLE
fix: Ensure that we handle any exceptions related to sending heartbeat request

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.46
+- fix: Ensure that we handle any and all exceptions related to sending heartbeat request
+- feat: Made NotificationServiceImpl's retry delay into a public instance variable, so it can be set by application code
+- feat: Changed NotificationServiceImpl's retry delay (from when monitorRetry() is called to when Monitor.start() is called) from 15 seconds to 5 seconds
 ## 3.0.45
 - fix: Fix sync running into infinite loop when invalid keys does not sync into local storage
 - fix: Upgrade persistence secondary to version 3.0.43 to fix empty batch request being sent to cloud secondary

--- a/packages/at_client/lib/src/manager/monitor.dart
+++ b/packages/at_client/lib/src/manager/monitor.dart
@@ -182,7 +182,7 @@ class Monitor {
 
       _scheduleHeartbeat();
       return;
-    } on Exception catch (e) {
+    } catch (e) {
       _handleError(e);
     }
   }
@@ -203,8 +203,6 @@ class Monitor {
       if (status != MonitorStatus.started) {
         _logger.info("status is $status : heartbeat will not be sent");
       } else {
-        // send heartbeat and save the heartbeat sent time
-        _logger.finest("sending heartbeat");
         _lastHeartbeatSentTime = DateTime.now().millisecondsSinceEpoch;
         // schedule a future to check if a timely heartbeat response is received
         Future.delayed(
@@ -222,10 +220,16 @@ class Monitor {
           }
         });
 
-        await _monitorConnection!.write("noop:0\n");
-
-        // schedule the next heartbeat to be sent
-        _scheduleHeartbeat();
+        _logger.finest("sending heartbeat");
+        try {
+          // actually send the heartbeat
+          await _monitorConnection!.write("noop:0\n");
+          // schedule the next heartbeat to be sent
+          _scheduleHeartbeat();
+        } catch (e) {
+          _logger.warning("Exception sending heartbeat: $e");
+          _callCloseStopAndRetry();
+        }
       }
     });
   }
@@ -353,12 +357,10 @@ class Monitor {
     // Pass monitor and error
     // TBD : If retry = true should the onError needs to be called?
     if (_keepAlive) {
-      // We will use a strategy here
-      _logger.info('Retrying start monitor due to error');
+      _logger.info('Monitor error $e - calling the retryCallback');
       _retryCallBack();
     } else {
-      _logger.warning(
-          '_keepAlive is false : monitor is errored, and NOT calling retryCallback');
+      _logger.severe('Monitor error $e - but _keepAlive is false so monitor will NOT be restarted');
       _onError(e);
     }
   }

--- a/packages/at_client/lib/src/manager/monitor.dart
+++ b/packages/at_client/lib/src/manager/monitor.dart
@@ -228,7 +228,6 @@ class Monitor {
           _scheduleHeartbeat();
         } catch (e) {
           _logger.warning("Exception sending heartbeat: $e");
-          _callCloseStopAndRetry();
         }
       }
     });

--- a/packages/at_client/test/monitor_test.dart
+++ b/packages/at_client/test/monitor_test.dart
@@ -532,9 +532,9 @@ void main() {
       // So, let's wait long enough for a couple of heartbeats to be sent, check they have all been sent,
       // and check that the monitor status is still 'started'
       int additionalHeartbeatsToSend = 2;
-      int expectedHeartbeatCount = additionalHeartbeatsToSend;
+      int expectedHeartbeatRequestsSent = additionalHeartbeatsToSend;
       await Future.delayed(Duration(milliseconds: heartbeatIntervalMillis * additionalHeartbeatsToSend + 50)); // 50 == fudge factor
-      expect(numHeartbeatRequests, expectedHeartbeatCount);
+      expect(numHeartbeatRequests, greaterThanOrEqualTo(expectedHeartbeatRequestsSent));
       // We expect same number of responses as requests
       expect(numHeartbeatResponses, numHeartbeatRequests);
       expect(monitor.status, MonitorStatus.started);
@@ -542,10 +542,11 @@ void main() {
       // Now, let's throw exceptions now to heartbeat requests
       heartbeatRequestShouldThrowException = true;
 
-      // Let's wait long enough for the heartbeat request to happen
+      expectedHeartbeatRequestsSent = numHeartbeatRequests + 1;
+      // Let's wait long enough for at least one more heartbeat request to happen
       await Future.delayed(Duration(milliseconds: heartbeatIntervalMillis.floor()));
       // Let's check that at least one more heartbeat has indeed been sent
-      expect(numHeartbeatRequests, greaterThan(expectedHeartbeatCount));
+      expect(numHeartbeatRequests, greaterThanOrEqualTo(expectedHeartbeatRequestsSent));
       // And that the responses received is now fewer than the number of requests sent
       expect(numHeartbeatResponses, lessThan(numHeartbeatRequests));
       // Now let's wait long enough for the heartbeat response monitor to detect that no response has been received

--- a/packages/at_client/test/monitor_test.dart
+++ b/packages/at_client/test/monitor_test.dart
@@ -11,7 +11,17 @@ import 'package:test/test.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockMonitorConnectivityChecker extends Mock
-    implements MonitorConnectivityChecker {}
+    implements MonitorConnectivityChecker {
+  bool shouldFail = false;
+  @override
+  Future<void> checkConnectivity(RemoteSecondary remoteSecondary) async {
+    if (shouldFail) {
+      throw Exception('mock check connectivity - No No No!');
+    } else {
+      print('mock check connectivity - OK');
+    }
+  }
+}
 
 class MockRemoteSecondary extends Mock implements RemoteSecondary {}
 
@@ -31,10 +41,11 @@ void main() {
   RemoteSecondary mockRemoteSecondary = MockRemoteSecondary();
   MonitorOutboundConnectionFactory mockMonitorOutboundConnectionFactory =
       MockMonitorOutboundConnectionFactory();
-  MonitorConnectivityChecker mockMonitorConnectivityChecker =
+  MockMonitorConnectivityChecker mockMonitorConnectivityChecker =
       MockMonitorConnectivityChecker();
   OutboundConnection mockOutboundConnection = MockOutboundConnection();
   SecureSocket mockSocket = MockSecureSocket();
+  MonitorPreference monitorPreference = MonitorPreference()..keepAlive = true;
   late Function(dynamic data) socketOnDataFn;
   late Function() socketOnDoneFn;
   late Function(Exception e) socketOnErrorFn;
@@ -51,53 +62,50 @@ void main() {
   atClientPreference.tlsKeysSavePath = fakeTlsKeysSavePath;
   atClientPreference.pathToCerts = fakeCertsLocation;
 
-  group('Monitor constructor and start tests', () {
-    setUp(() {
-      reset(mockMonitorConnectivityChecker);
-      reset(mockRemoteSecondary);
-      reset(mockSocket);
-      reset(mockOutboundConnection);
-      reset(mockMonitorOutboundConnectionFactory);
+  setUp(() {
+    reset(mockMonitorConnectivityChecker);
+    reset(mockRemoteSecondary);
+    reset(mockSocket);
+    reset(mockOutboundConnection);
+    reset(mockMonitorOutboundConnectionFactory);
+    mockMonitorConnectivityChecker.shouldFail = false;
 
-      when(() => mockMonitorConnectivityChecker
-          .checkConnectivity(mockRemoteSecondary)).thenAnswer((_) async {
-        print('mock check connectivity - OK');
-      });
-      when(() => mockRemoteSecondary.isAvailable())
-          .thenAnswer((_) async => true);
-      when(() => mockRemoteSecondary.findSecondaryUrl())
-          .thenAnswer((_) async => fakeSecondaryUrl);
-      when(() => mockOutboundConnection.getSocket())
-          .thenAnswer((_) => mockSocket);
-      when(() => mockMonitorOutboundConnectionFactory.createConnection(
-              fakeSecondaryUrl,
-              decryptPackets: true,
-              tlsKeysSavePath: fakeTlsKeysSavePath,
-              pathToCerts: fakeCertsLocation))
-          .thenAnswer((_) async => mockOutboundConnection);
-      when(() => mockSocket.listen(any(),
-          onError: any(named: "onError"),
-          onDone: any(named: "onDone"))).thenAnswer((Invocation invocation) {
-        socketOnDataFn = invocation.positionalArguments[0];
-        socketOnDoneFn = invocation.namedArguments[#onDone];
-        socketOnErrorFn = invocation.namedArguments[#onError];
+    when(() => mockRemoteSecondary.isAvailable())
+        .thenAnswer((_) async => true);
+    when(() => mockRemoteSecondary.findSecondaryUrl())
+        .thenAnswer((_) async => fakeSecondaryUrl);
+    when(() => mockOutboundConnection.getSocket())
+        .thenAnswer((_) => mockSocket);
+    when(() => mockMonitorOutboundConnectionFactory.createConnection(
+        fakeSecondaryUrl,
+        decryptPackets: true,
+        tlsKeysSavePath: fakeTlsKeysSavePath,
+        pathToCerts: fakeCertsLocation))
+        .thenAnswer((_) async => mockOutboundConnection);
+    when(() => mockSocket.listen(any(),
+        onError: any(named: "onError"),
+        onDone: any(named: "onDone"))).thenAnswer((Invocation invocation) {
+      socketOnDataFn = invocation.positionalArguments[0];
+      socketOnDoneFn = invocation.namedArguments[#onDone];
+      socketOnErrorFn = invocation.namedArguments[#onError];
 
-        return MockStreamSubscription<Uint8List>();
-      });
-
-      when(() => mockOutboundConnection.write('from:$atSign\n'))
-          .thenAnswer((Invocation invocation) async {
-        socketOnDataFn("server challenge\n"
-            .codeUnits); // actual challenge is different, of course, but not important for unit tests
-      });
-      when(() => mockOutboundConnection.write(any(that: startsWith('pkam:'))))
-          .thenAnswer((Invocation invocation) async {
-        socketOnDataFn("success\n".codeUnits);
-      });
-      when(() => mockOutboundConnection.write(any(that: startsWith('monitor'))))
-          .thenAnswer((Invocation invocation) async {});
+      return MockStreamSubscription<Uint8List>();
     });
 
+    when(() => mockOutboundConnection.write('from:$atSign\n'))
+        .thenAnswer((Invocation invocation) async {
+      socketOnDataFn("server challenge\n"
+          .codeUnits); // actual challenge is different, of course, but not important for unit tests
+    });
+    when(() => mockOutboundConnection.write(any(that: startsWith('pkam:'))))
+        .thenAnswer((Invocation invocation) async {
+      socketOnDataFn("success\n".codeUnits);
+    });
+    when(() => mockOutboundConnection.write(any(that: startsWith('monitor'))))
+        .thenAnswer((Invocation invocation) async {});
+  });
+
+  group('Monitor constructor and start tests', () {
     /// create a monitor without passing a heartbeat interval; it should pick it up from
     /// the AtClientPreference that was passed.
     test('Monitor gets heartbeatInterval from AtClientPreference', () {
@@ -106,7 +114,7 @@ void main() {
           (e) => print('onError: $e'),
           atSign,
           atClientPreference,
-          MonitorPreference(),
+          monitorPreference,
           () => print('onRetry called'),
           monitorConnectivityChecker: mockMonitorConnectivityChecker,
           remoteSecondary: mockRemoteSecondary,
@@ -131,7 +139,7 @@ void main() {
           (e) => print('onError: $e'),
           atSign,
           atClientPreference,
-          MonitorPreference(),
+          monitorPreference,
           () => print('onRetry called'),
           monitorConnectivityChecker: mockMonitorConnectivityChecker,
           remoteSecondary: mockRemoteSecondary,
@@ -155,7 +163,7 @@ void main() {
           (e) => print('onError: $e'),
           atSign,
           atClientPreference,
-          MonitorPreference(),
+          monitorPreference,
           () => print('onRetry called'),
           monitorConnectivityChecker: mockMonitorConnectivityChecker,
           remoteSecondary: mockRemoteSecondary,
@@ -184,7 +192,7 @@ void main() {
           (e) => print('onError: $e'),
           atSign,
           atClientPreference,
-          MonitorPreference(),
+          monitorPreference,
           () => print('onRetry called'),
           monitorConnectivityChecker: mockMonitorConnectivityChecker,
           remoteSecondary: mockRemoteSecondary,
@@ -206,17 +214,13 @@ void main() {
     });
 
     test('Monitor start, secondary not available', () async {
-      when(() => mockMonitorConnectivityChecker
-          .checkConnectivity(mockRemoteSecondary)).thenAnswer((_) async {
-        throw Exception('No No No');
-      });
-
+      mockMonitorConnectivityChecker.shouldFail = true;
       Monitor monitor = Monitor(
           (String json) => print('onResponse: $json'),
           (e) => print('onError: $e'),
           atSign,
           atClientPreference,
-          MonitorPreference(),
+          monitorPreference,
           () => print('onRetry called'),
           monitorConnectivityChecker: mockMonitorConnectivityChecker,
           remoteSecondary: mockRemoteSecondary,
@@ -234,7 +238,7 @@ void main() {
           (e) => print('onError: $e'),
           atSign,
           atClientPreference,
-          MonitorPreference(),
+          monitorPreference,
           () => print('onRetry called'),
           monitorConnectivityChecker: mockMonitorConnectivityChecker,
           remoteSecondary: mockRemoteSecondary,
@@ -257,7 +261,7 @@ void main() {
           (e) => print('onError: $e'),
           atSign,
           atClientPreference,
-          MonitorPreference(),
+          monitorPreference,
           () => print('onRetry called'),
           monitorConnectivityChecker: mockMonitorConnectivityChecker,
           remoteSecondary: mockRemoteSecondary,
@@ -275,13 +279,13 @@ void main() {
     });
 
     test('Monitor heartbeat sending regularly', () async {
-      int heartbeatIntervalMillis = 500;
+      int heartbeatIntervalMillis = 100;
       Monitor monitor = Monitor(
           (String json) => print('onResponse: $json'),
           (e) => print('onError: $e'),
           atSign,
           atClientPreference,
-          MonitorPreference(),
+          monitorPreference,
           () => print('onRetry called'),
           monitorConnectivityChecker: mockMonitorConnectivityChecker,
           remoteSecondary: mockRemoteSecondary,
@@ -318,13 +322,13 @@ void main() {
       // and the monitor status is still 'started'
       expect(monitor.status, MonitorStatus.started);
 
-      // Now let's wait long enough for 5 heartbeats to be sent, check they have all been sent,
+      // Now let's wait long enough for some heartbeats to be sent, check they have all been sent,
       // and check that the monitor status is still 'started'
-      int additionalHeartbeatsToSend = 5;
+      int additionalHeartbeatsToSend = 3;
+      int expectedHeartbeatCount = numHeartbeatsSent + additionalHeartbeatsToSend;
       await Future.delayed(Duration(
           milliseconds: heartbeatIntervalMillis * additionalHeartbeatsToSend +
               (heartbeatIntervalMillis / 3).floor()));
-      int expectedHeartbeatCount = 1 + additionalHeartbeatsToSend;
       expect(numHeartbeatsSent, expectedHeartbeatCount);
       expect(monitor.status, MonitorStatus.started);
 
@@ -337,15 +341,16 @@ void main() {
       expect(numHeartbeatsSent, expectedHeartbeatCount);
     });
 
-    test('Monitor heartbeat response not received in time', () async {
-      int heartbeatIntervalMillis = 500;
+    test('Test when monitor heartbeat response not received, restart monitor first fails, then succeeds', () async {
+      int heartbeatIntervalMillis = 100;
+      Duration delayBeforeRestart = Duration(milliseconds: 200);
       Monitor? monitor;
       // Note that in this test, our retryCallback is doing something real - it's restarting the monitor
-      bool retryCallbackCalled = false;
+      int retryCallbackCalledCount = 0;
       void retryCallback() {
-        retryCallbackCalled = true;
-        print('retryCallback called - will restart the monitor in a second');
-        Future.delayed(Duration(seconds: 1), () {
+        retryCallbackCalledCount++;
+        print('retryCallback called - will restart the monitor in $delayBeforeRestart');
+        Future.delayed(delayBeforeRestart, () {
           print('restarting the monitor');
           monitor!.start(lastNotificationTime: null);
         });
@@ -356,7 +361,7 @@ void main() {
           (e) => print('onError: $e'),
           atSign,
           atClientPreference,
-          MonitorPreference(),
+          monitorPreference,
           () => retryCallback(),
           monitorConnectivityChecker: mockMonitorConnectivityChecker,
           remoteSecondary: mockRemoteSecondary,
@@ -378,18 +383,16 @@ void main() {
 
       when(() => mockOutboundConnection.close()).thenAnswer((_) async => {});
 
-      Future<void> monitorStartFuture =
-          monitor.start(lastNotificationTime: null);
-      await monitorStartFuture;
+      await monitor.start(lastNotificationTime: null);
       expect(monitor.status, MonitorStatus.started);
 
-      // Now let's wait long enough for 5 heartbeats to be sent, check they have all been sent,
+      // Now let's wait long enough for some heartbeats to be sent, check they have all been sent,
       // and check that the monitor status is still 'started'
-      int additionalHeartbeatsToSend = 5;
+      int additionalHeartbeatsToSend = 3;
+      int expectedHeartbeatCount = additionalHeartbeatsToSend;
       await Future.delayed(Duration(
           milliseconds: heartbeatIntervalMillis * additionalHeartbeatsToSend +
               50)); // 50 == fudge factor
-      int expectedHeartbeatCount = additionalHeartbeatsToSend;
       expect(numHeartbeatsSent, expectedHeartbeatCount);
       expect(monitor.status, MonitorStatus.started);
 
@@ -407,18 +410,34 @@ void main() {
               50)); // 50 == fudge factor
       // The Monitor should have set status to stopped
       expect(monitor.status, MonitorStatus.stopped);
+      // We expect that the retryCallback should have been called once
+      expect(retryCallbackCalledCount, 1);
+
+
+      // OK - now let's make the retry fail
+      // First of all let's make sure that "start" will fail
+      mockMonitorConnectivityChecker.shouldFail = true;
+      // The retryCallback will call Monitor.start() after a delay, so let's wait for that delay
+      await Future.delayed(delayBeforeRestart);
+
+      // The Monitor should have set status to errored
+      expect(monitor.status, MonitorStatus.errored);
+      // And expect that the retryCallback should have been called again
+      expect(retryCallbackCalledCount, 2);
+
       // let's start sending responses to heartbeats again
       sendHeartbeatResponse = true;
+      // and let's make the connectivity checks succeed again
+      mockMonitorConnectivityChecker.shouldFail = false;
 
-      // And the retryCallback should have been called
-      expect(retryCallbackCalled, true);
-      // And the retryCallback will restart the monitor after a second, so the monitor state should be 'started' again
-      await Future.delayed(Duration(seconds: 1));
+      // The retryCallback will call Monitor.start() after a delay, so let's wait for that delay
+      await Future.delayed(delayBeforeRestart);
+      // Now the monitor state should be 'started' again
       expect(monitor.status, MonitorStatus.started);
 
       // Finally, let's make sure that heartbeats are happening again, and the monitor is still happy
       int lastHeartbeatCount = numHeartbeatsSent;
-      additionalHeartbeatsToSend = 5;
+      additionalHeartbeatsToSend = 3;
       await Future.delayed(Duration(
           milliseconds: heartbeatIntervalMillis * additionalHeartbeatsToSend +
               50)); // 50 == fudge factor
@@ -435,7 +454,7 @@ void main() {
           (e) => print('onError: $e'),
           atSign,
           atClientPreference,
-          MonitorPreference(),
+          monitorPreference,
           () => print('onRetry called'),
           monitorConnectivityChecker: mockMonitorConnectivityChecker,
           remoteSecondary: mockRemoteSecondary,
@@ -453,7 +472,7 @@ void main() {
           (e) => print('onError: $e'),
           atSign,
           atClientPreference,
-          MonitorPreference(),
+          monitorPreference,
           () => print('onRetry called'),
           monitorConnectivityChecker: mockMonitorConnectivityChecker,
           remoteSecondary: mockRemoteSecondary,
@@ -472,7 +491,7 @@ void main() {
           (e) => print('onError: $e'),
           atSign,
           atClientPreference,
-          MonitorPreference(),
+          monitorPreference,
           () => print('onRetry called'),
           monitorConnectivityChecker: mockMonitorConnectivityChecker,
           remoteSecondary: mockRemoteSecondary,


### PR DESCRIPTION
**- What I did**
* Ensure that we catch any exceptions related to sending heartbeat request.
  * Fixes #741
* Added bunch of tests around monitor retry behaviour.
  * Fixes #819
* Changed NotificationServiceImpl's retry delay (from when monitorRetry() is called to when Monitor.start() is called) from 15 seconds to 5 seconds (and made it configurable by SDK users)

**- How I did it**
* fix: added a catch in `_scheduleHeartbeat` to fix https://github.com/atsign-foundation/at_client_sdk/issues/741
  * [Added explicit tests](https://github.com/atsign-foundation/at_client_sdk/commit/e7f273f1ea43463e1f61601d295da04399da71b4) to prevent regression
* fix: make `Monitor.start()` catch Errors as well as Exceptions, so it calls `_handleError(e)` if it encounters any
* fix: Added guard condition in monitorRetry for situation where (1) when the retry function was called the monitor was not paused and therefore a future was created to call monitor.start but (2) by the time the future executes, the monitor has been paused and therefore monitor.start should NOT be called
  * Added test accordingly
* feat: Changed NotificationServiceImpl's retry delay (from when monitorRetry() is called to when Monitor.start() is called) from 15 seconds to 5 seconds
* test: Added some visible-for-testing instance variables to NotificationServiceImpl to make its monitor retry behaviour testable
* refactor: Removed _lastMonitorRetried from NotificationServiceImpl and added monitorRestartQueued variable instead - makes the logic more explicit and easier to follow
* test: Made NotificationServiceImpl's notificationServiceMap visible for testing, so we can isolate better isolate individual unit tests from each other
* test: made NotificationServiceImpl.monitorRetry visible for testing, added clear documentation of behaviour
* test: made NotificationServiceImpl.monitorRetry return a boolean for whether it actually queued a call to Monitor.start or not, so that behaviour can be asserted in tests
* test: tweaked Monitor tests to run a little bit faster test: added some assertions to the Monitor tests regarding its behaviour around retries upon failure
* test: added several tests to notification_service_test regarding monitorRetry:
  * Test initial state related to monitorRetry()
  * Test that monitorRetry() will queue a call to Monitor.start if monitorRestartQueued is false
  * Test that monitorRetry() will NOT queue a call to Monitor.start if monitorRestartQueued is true
  * Test that monitorRetry() will NOT queue a call to Monitor.start if the monitor has been paused
  * Test that the delayed future will NOT call Monitor.start if the monitor has since been paused
  * Test that monitorRetry() will reset monitorRestartQueued to false when it finally makes its call to Monitor.start


**- How to verify it**
Tests should all pass

**- Description for the changelog**
* fix: Ensure that we handle any and all exceptions related to sending heartbeat request
* feat: Made NotificationServiceImpl's retry delay public, so it can be set by application code
* feat: Changed NotificationServiceImpl's retry delay (from when monitorRetry() is called to when Monitor.start() is called) from 15 seconds to 5 seconds
