### PR TITLE
fix: invalid pad block issue

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.49
+- fix: Fixed a bug where initial notifications fails to decrypt - invalid pad block issue
 ## 3.0.48
 - feat: Added `lib/src/client/request_options.dart` to provide access to the `RequestOptions` and `GetRequestOptions` classes.
 ## 3.0.47

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.47
+- fix: Fixed a bug where initial notifications fails to decrypt - invalid pad block issue 
 ## 3.0.46
 - fix: Ensure that we handle any and all exceptions related to sending heartbeat request
 - feat: Made NotificationServiceImpl's retry delay into a public instance variable, so it can be set by application code

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -878,7 +878,7 @@ class AtClientImpl implements AtClient {
       if (notificationParams.atKey.sharedWith != null &&
           notificationParams.atKey.sharedWith != currentAtSign) {
         try {
-          final atKeyEncryption = AtKeyEncryptionManager()
+          final atKeyEncryption = AtKeyEncryptionManager.getInstance(this)
               .get(notificationParams.atKey, currentAtSign!);
           builder.value = await atKeyEncryption.encrypt(
               notificationParams.atKey, notificationParams.value!);
@@ -891,7 +891,7 @@ class AtClientImpl implements AtClient {
       if (notificationParams.atKey.sharedWith == null ||
           notificationParams.atKey.sharedWith == currentAtSign) {
         try {
-          final atKeyEncryption = AtKeyEncryptionManager()
+          final atKeyEncryption = AtKeyEncryptionManager.getInstance(this)
               .get(notificationParams.atKey, currentAtSign!);
           builder.value = await atKeyEncryption.encrypt(
               notificationParams.atKey, notificationParams.value!);

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -882,7 +882,7 @@ class AtClientImpl implements AtClient {
       if (notificationParams.atKey.sharedWith != null &&
           notificationParams.atKey.sharedWith != currentAtSign) {
         try {
-          final atKeyEncryption = AtKeyEncryptionManager()
+          final atKeyEncryption = AtKeyEncryptionManager.getInstance(this)
               .get(notificationParams.atKey, currentAtSign!);
           builder.value = await atKeyEncryption.encrypt(
               notificationParams.atKey, notificationParams.value!);
@@ -895,7 +895,7 @@ class AtClientImpl implements AtClient {
       if (notificationParams.atKey.sharedWith == null ||
           notificationParams.atKey.sharedWith == currentAtSign) {
         try {
-          final atKeyEncryption = AtKeyEncryptionManager()
+          final atKeyEncryption = AtKeyEncryptionManager.getInstance(this)
               .get(notificationParams.atKey, currentAtSign!);
           builder.value = await atKeyEncryption.encrypt(
               notificationParams.atKey, notificationParams.value!);

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -882,7 +882,7 @@ class AtClientImpl implements AtClient {
       if (notificationParams.atKey.sharedWith != null &&
           notificationParams.atKey.sharedWith != currentAtSign) {
         try {
-          final atKeyEncryption = AtKeyEncryptionManager.getInstance(this)
+          final atKeyEncryption = AtKeyEncryptionManager(this)
               .get(notificationParams.atKey, currentAtSign!);
           builder.value = await atKeyEncryption.encrypt(
               notificationParams.atKey, notificationParams.value!);
@@ -895,7 +895,7 @@ class AtClientImpl implements AtClient {
       if (notificationParams.atKey.sharedWith == null ||
           notificationParams.atKey.sharedWith == currentAtSign) {
         try {
-          final atKeyEncryption = AtKeyEncryptionManager.getInstance(this)
+          final atKeyEncryption = AtKeyEncryptionManager(this)
               .get(notificationParams.atKey, currentAtSign!);
           builder.value = await atKeyEncryption.encrypt(
               notificationParams.atKey, notificationParams.value!);

--- a/packages/at_client/lib/src/decryption_service/decryption_manager.dart
+++ b/packages/at_client/lib/src/decryption_service/decryption_manager.dart
@@ -1,13 +1,25 @@
+import 'package:at_client/at_client.dart';
 import 'package:at_client/src/decryption_service/decryption.dart';
 import 'package:at_client/src/decryption_service/local_key_decryption.dart';
 import 'package:at_client/src/decryption_service/self_key_decryption.dart';
 import 'package:at_client/src/decryption_service/shared_key_decryption.dart';
-import 'package:at_commons/at_commons.dart';
 
 ///The manager class for [AtKeyDecryption]
 class AtKeyDecryptionManager {
+  late AtClient _atClient;
+
+  static final AtKeyDecryptionManager _singleton =
+      AtKeyDecryptionManager._internal();
+
+  AtKeyDecryptionManager._internal();
+
+  factory AtKeyDecryptionManager.getInstance(AtClient atClient) {
+    _singleton._atClient = atClient;
+    return _singleton;
+  }
+
   /// Return the relevant instance of [AtKeyDecryption] for the given [AtKey]
-  static AtKeyDecryption get(AtKey atKey, String currentAtSign) {
+  AtKeyDecryption get(AtKey atKey, String currentAtSign) {
     // If sharedBy not equals currentAtSign, return SharedKeyDecryption
     // Eg: currentAtSign is @bob and key is phone@alice
     if (atKey.sharedBy != currentAtSign) {
@@ -23,6 +35,6 @@ class AtKeyDecryptionManager {
     // Returns LocalKeyDecryption to for the keys present in local storage
     // that are sharedWith other atSign's.
     // @alice:phone@bob
-    return LocalKeyDecryption();
+    return LocalKeyDecryption(_atClient);
   }
 }

--- a/packages/at_client/lib/src/decryption_service/decryption_manager.dart
+++ b/packages/at_client/lib/src/decryption_service/decryption_manager.dart
@@ -6,17 +6,9 @@ import 'package:at_client/src/decryption_service/shared_key_decryption.dart';
 
 ///The manager class for [AtKeyDecryption]
 class AtKeyDecryptionManager {
-  late AtClient _atClient;
+  late final AtClient _atClient;
 
-  static final AtKeyDecryptionManager _singleton =
-      AtKeyDecryptionManager._internal();
-
-  AtKeyDecryptionManager._internal();
-
-  factory AtKeyDecryptionManager.getInstance(AtClient atClient) {
-    _singleton._atClient = atClient;
-    return _singleton;
-  }
+  AtKeyDecryptionManager(this._atClient);
 
   /// Return the relevant instance of [AtKeyDecryption] for the given [AtKey]
   AtKeyDecryption get(AtKey atKey, String currentAtSign) {

--- a/packages/at_client/lib/src/decryption_service/local_key_decryption.dart
+++ b/packages/at_client/lib/src/decryption_service/local_key_decryption.dart
@@ -7,8 +7,11 @@ import 'package:at_utils/at_logger.dart';
 /// Example of local keys:
 /// CurrentAtSign: @bob
 /// llookup:@alice:phone@bob
-class LocalKeyDecryption implements AtKeyDecryption {
+class LocalKeyDecryption extends AbstractAtKeyEncryption
+    implements AtKeyDecryption {
   final _logger = AtSignLogger('LocalKeyDecryption');
+
+  LocalKeyDecryption(AtClient atClient) : super(atClient);
 
   @override
   Future<String> decrypt(AtKey atKey, dynamic encryptedValue) async {
@@ -18,7 +21,7 @@ class LocalKeyDecryption implements AtKeyDecryption {
           exceptionScenario: ExceptionScenario.decryptionFailed);
     }
     // Get the shared key.
-    var sharedKey = await AbstractAtKeyEncryption.getSharedKey(atKey);
+    var sharedKey = await getSharedKey(atKey);
 
     if (sharedKey.isEmpty) {
       _logger.severe('Decryption failed. SharedKey is null');

--- a/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
@@ -1,27 +1,33 @@
+import 'package:at_client/at_client.dart';
+import 'package:at_client/src/client/secondary.dart';
 import 'package:at_client/src/encryption_service/encryption.dart';
 import 'package:at_client/src/encryption_service/shared_key_encryption.dart';
 import 'package:at_client/src/encryption_service/stream_encryption.dart';
-import 'package:at_client/src/manager/at_client_manager.dart';
 import 'package:at_client/src/response/default_response_parser.dart';
-import 'package:at_client/src/util/encryption_util.dart';
 import 'package:at_commons/at_builders.dart';
-import 'package:at_commons/at_commons.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_utils/at_logger.dart';
 
 /// Contains the common code for [SharedKeyEncryption] and [StreamEncryption]
 abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
   final _logger = AtSignLogger('AbstractAtKeyEncryption');
   late String _sharedKey;
+  final AtClient _atClient;
+  AtCommitLog? atCommitLog;
+
+  DefaultResponseParser defaultResponseParser = DefaultResponseParser();
 
   String get sharedKey => _sharedKey;
 
+  AbstractAtKeyEncryption(this._atClient);
+
   @override
   Future<dynamic> encrypt(AtKey atKey, dynamic value) async {
-    // Get AES Key from the local storage
-    _sharedKey = await getSharedKey(atKey);
-    late String encryptedSharedKey;
-    // Get SharedWith encryption public key
     String sharedWithPublicKey = '';
+    String encryptedSharedKey = '';
+    // 1. Get AES Key from the local storage
+    _sharedKey = await getSharedKey(atKey);
+    // Fetch the encryption public key of the sharedWith atSign
     try {
       sharedWithPublicKey = await _getSharedWithPublicKey(atKey);
     } on AtPublicKeyNotFoundException catch (e) {
@@ -32,23 +38,18 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
     // If sharedKey is empty, then -
     // Generate a new sharedKey
     // Encrypt the sharedKey with sharedWith public key
-    // Notify the encryptedSharedKey with sharedWith user
-    // Store the sharedKey for future use.
     if (_sharedKey.isEmpty) {
       // Generate sharedKey
       _sharedKey = EncryptionUtil.generateAESKey();
-      //Encrypt shared key with public key of sharedWith atSign.
+      // Encrypt shared key with public key of sharedWith atSign.
       encryptedSharedKey =
           EncryptionUtil.encryptKey(sharedKey, sharedWithPublicKey);
-      // Store the encryptedSharedWith Key. Set ttr to enable sharedWith atSign
-      // to cache the encryptedSharedKey.
-      await _notifyEncryptedSharedKey(atKey, encryptedSharedKey);
-      // Store the sharedKey for future retrieval.
+      // Update the encrypted sharedKey to local secondary with TTR
+      await updateEncryptedSharedKeyToSecondary(atKey, encryptedSharedKey);
       // Encrypt the sharedKey with currentAtSignPublicKey and store it for future use.
       String? currentAtSignEncryptionPublicKey;
       try {
-        currentAtSignEncryptionPublicKey = await AtClientManager.getInstance()
-            .atClient
+        currentAtSignEncryptionPublicKey = await _atClient
             .getLocalSecondary()!
             .getEncryptionPublicKey(atKey.sharedBy!);
       } on KeyNotFoundException catch (e) {
@@ -61,9 +62,18 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
       var encryptedSharedKeyForCurrentAtSign = EncryptionUtil.encryptKey(
           sharedKey, currentAtSignEncryptionPublicKey!);
       _storeSharedKey(atKey, encryptedSharedKeyForCurrentAtSign);
-    } else {
+    }
+    // For the existing shared_key, the encryptedSharedKey has to be fetched
+    // from the local secondary
+    if (encryptedSharedKey.isNull) {
       encryptedSharedKey =
           EncryptionUtil.encryptKey(sharedKey, sharedWithPublicKey);
+    }
+    // Check if the encryptedSharedKey is synced to remote secondary
+    // If not synced, update the key to remote secondary directly
+    if (!(await isEncryptedSharedKeyInSync(atKey))) {
+      await updateEncryptedSharedKeyToSecondary(atKey, encryptedSharedKey,
+          secondary: _atClient.getRemoteSecondary());
     }
     atKey.metadata!.sharedKeyEnc = encryptedSharedKey;
     atKey.metadata!.pubKeyCS = EncryptionUtil.md5CheckSum(sharedWithPublicKey);
@@ -72,166 +82,147 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
   /// Fetches the shared key in the local secondary
   /// If not found, fetches in the remote secondary
   /// If found, returns the decrypted sharedKey.
-  static Future<String> getSharedKey(AtKey atKey) async {
-    String? key = '';
-    var llookupVerbBuilder = LLookupVerbBuilder()
-      ..atKey =
-          '$AT_ENCRYPTION_SHARED_KEY.${atKey.sharedWith?.replaceAll('@', '')}'
-      ..sharedBy = atKey.sharedBy;
+  ///
+  /// If shared_key is not found in local secondary and remote secondary, returns an empty string
+  ///
+  /// Throws [KeyNotFoundException] if the encryptionPrivateKey is not found.
+  Future<String> getSharedKey(AtKey atKey) async {
+    String? encryptedSharedKey;
     try {
-      key = await _getCachedSharedKey(llookupVerbBuilder);
+      // 1. Look for shared key in local secondary
+      encryptedSharedKey =
+          await _getEncryptedSharedKey(_atClient.getLocalSecondary()!, atKey);
     } on KeyNotFoundException {
-      AtSignLogger('AbstractAtKeyEncryption').finer(
-          '${atKey.key}${atKey.sharedBy} not found in local secondary. Fetching from cloud secondary.');
+      _logger.finer(
+          '${atKey.key}${atKey.sharedBy} not found in local secondary. Fetching from remote secondary');
     }
-    // If sharedKey is not found in localSecondary, fetch from remote secondary.
     try {
-      if (key == null || key.isEmpty || key == 'data:null') {
-        key = await _getSharedKeyFromRemote(atKey);
+      // 2. If sharedKey is not found in localSecondary, fetch from remote secondary.
+      if (encryptedSharedKey.isNull || encryptedSharedKey == 'data:null') {
+        encryptedSharedKey = await _getEncryptedSharedKey(
+            _atClient.getRemoteSecondary()!, atKey);
       }
     } on KeyNotFoundException {
-      AtSignLogger('AbstractAtKeyEncryption').finer(
-          '${llookupVerbBuilder.atKey}${atKey.sharedBy} not found in remote secondary. Generating a new shared key');
+      _logger.finer(
+          '${atKey.key}${atKey.sharedBy} not found in remote secondary. Generating a new shared key');
     }
-    // If sharedKey is found, decrypt the shared key and return.
-    if (key != null && key.isNotEmpty && key != 'data:null') {
-      key = DefaultResponseParser().parse(key).response;
-      String? encryptionPrivateKey;
-      try {
-        encryptionPrivateKey = await AtClientManager.getInstance()
-            .atClient
-            .getLocalSecondary()!
-            .getEncryptionPrivateKey();
-      } on KeyNotFoundException catch (e) {
-        e.stack(AtChainedException(
-            Intent.fetchEncryptionPrivateKey,
-            ExceptionScenario.encryptionFailed,
-            'Failed to decrypt the encrypted shared key'));
-        rethrow;
-      }
-      return EncryptionUtil.decryptKey(key, encryptionPrivateKey!);
+    if (encryptedSharedKey.isNull || encryptedSharedKey == 'data:null') {
+      return '';
     }
-    return key!;
-  }
-
-  ///Get cached shared key from local storage
-  static Future<String?> _getCachedSharedKey(
-      LLookupVerbBuilder llookupVerbBuilder) async {
-    return await AtClientManager.getInstance()
-        .atClient
-        .getLocalSecondary()!
-        .executeVerb(llookupVerbBuilder);
-  }
-
-  /// Get shared key from cloud secondary and caches it local secondary for
-  /// further use.
-  static Future<String> _getSharedKeyFromRemote(AtKey atKey) async {
-    var llookupVerbBuilder = LLookupVerbBuilder()
-      ..atKey =
-          '$AT_ENCRYPTION_SHARED_KEY.${atKey.sharedWith?.replaceAll('@', '')}'
-      ..sharedBy = atKey.sharedBy;
-
-    var encryptedSharedKey = await AtClientManager.getInstance()
-        .atClient
-        .getRemoteSecondary()!
-        .executeVerb(llookupVerbBuilder);
-    if (encryptedSharedKey.isNotEmpty && encryptedSharedKey != 'data:null') {
-      // Cached the encryptedSharedKey in local secondary for further use.
-      // Setting shouldSync to false because the key is retrieved from cloud secondary
-      // and need to sync back again.
-      encryptedSharedKey = encryptedSharedKey.replaceAll('data:', '');
-      _storeSharedKey(atKey, encryptedSharedKey, shouldSync: false);
+    encryptedSharedKey =
+        defaultResponseParser.parse(encryptedSharedKey!).response;
+    String? encryptionPrivateKey;
+    try {
+      encryptionPrivateKey =
+          await _atClient.getLocalSecondary()!.getEncryptionPrivateKey();
+    } on KeyNotFoundException catch (e) {
+      e.stack(AtChainedException(
+          Intent.fetchEncryptionPrivateKey,
+          ExceptionScenario.encryptionFailed,
+          'Failed to decrypt the encrypted shared key'));
+      rethrow;
     }
-    return encryptedSharedKey;
+    return EncryptionUtil.decryptKey(encryptedSharedKey, encryptionPrivateKey!);
   }
 
   /// Returns sharedWith atSign publicKey.
   /// Throws [KeyNotFoundException] if sharedWith atSign publicKey is not found.
   Future<String> _getSharedWithPublicKey(AtKey atKey) async {
-    //local lookup the cached public key of sharedWith atsign.
-    String sharedWithPublicKey = '';
-    var cachedPublicKeyBuilder = LLookupVerbBuilder()
-      ..atKey = 'publickey.${atKey.sharedWith?.replaceAll('@', '')}'
-      ..sharedBy = atKey.sharedBy;
+    String? sharedWithPublicKey;
     try {
-      sharedWithPublicKey = (await AtClientManager.getInstance()
-          .atClient
+      // 1. Get the cached public key
+      var cachedEncryptionPublicKeyBuilder = LLookupVerbBuilder()
+        ..atKey = 'publickey'
+        ..sharedBy = atKey.sharedWith
+        ..isPublic = true
+        ..isCached = true;
+
+      sharedWithPublicKey = await _atClient
           .getLocalSecondary()!
-          .executeVerb(cachedPublicKeyBuilder))!;
+          .executeVerb(cachedEncryptionPublicKeyBuilder);
     } on KeyNotFoundException {
-      _logger.finer(
-          '${cachedPublicKeyBuilder.atKey}@${atKey.sharedBy} not found in local secondary. Fetching from cloud secondary');
+      _logger.finer('${atKey.sharedWith} encryption public key is not found');
     }
-    if (sharedWithPublicKey.isNotEmpty && sharedWithPublicKey != 'data:null') {
-      return sharedWithPublicKey.replaceAll('data:', '');
-    }
-
-    // Lookup public key of sharedWith atSign in cloud secondary
-    var plookupBuilder = PLookupVerbBuilder()
-      ..atKey = 'publickey'
-      ..sharedBy = atKey.sharedWith?.replaceAll('@', '');
-
     try {
-      sharedWithPublicKey = await AtClientManager.getInstance()
-          .atClient
-          .getRemoteSecondary()!
-          .executeVerb(plookupBuilder);
-    } on AtException catch (e) {
+      if (sharedWithPublicKey.isNull || sharedWithPublicKey == 'data:null') {
+        var encryptionPublicKeyBuilder = PLookupVerbBuilder()
+          ..atKey = 'publickey'
+          ..sharedBy = atKey.sharedWith;
+        sharedWithPublicKey = await _atClient
+            .getRemoteSecondary()!
+            .executeVerb(encryptionPublicKeyBuilder);
+      }
+    } on AtException catch (exception) {
       throw AtPublicKeyNotFoundException(
           'Failed to fetch public key of ${atKey.sharedWith}')
-        ..fromException(e)
-        ..stack(AtChainedException(
-            Intent.shareData, ExceptionScenario.keyNotFound, e.message));
+        ..fromException(exception)
+        ..stack(AtChainedException(Intent.shareData,
+            ExceptionScenario.keyNotFound, exception.message));
     }
-    sharedWithPublicKey =
-        DefaultResponseParser().parse(sharedWithPublicKey).response;
-
-    // If SharedWith PublicKey is not found throw KeyNotFoundException.
-    if (sharedWithPublicKey.isEmpty || sharedWithPublicKey == 'data:null') {
-      throw AtPublicKeyNotFoundException(
-          'public key not found. data sharing is forbidden.');
+    if (sharedWithPublicKey.isNull || sharedWithPublicKey == 'data:null') {
+      return throw AtPublicKeyNotFoundException(
+          'Failed to fetch public key of ${atKey.sharedWith}');
     }
-    //Cache the sharedWithPublicKey and return public key of sharedWith atSign
-    var sharedWithPublicKeyBuilder = UpdateVerbBuilder()
-      ..atKey = 'publickey.${atKey.sharedWith?.replaceAll('@', '')}'
-      ..sharedBy = atKey.sharedBy
-      ..value = sharedWithPublicKey;
-    await AtClientManager.getInstance()
-        .atClient
-        .getLocalSecondary()!
-        .executeVerb(sharedWithPublicKeyBuilder, sync: true);
-    return sharedWithPublicKey;
+    return defaultResponseParser.parse(sharedWithPublicKey!).response;
   }
 
   /// Stores the encryptedSharedKey for future use.
   /// Optionally set shouldSync parameter to false to avoid the key to sync to cloud secondary
   /// Defaulted to sync the key to cloud secondary.
-  static void _storeSharedKey(AtKey atKey, String encryptedSharedKey,
+  void _storeSharedKey(AtKey atKey, String encryptedSharedKey,
       {bool shouldSync = true}) async {
     var updateSharedKeyForCurrentAtSignBuilder = UpdateVerbBuilder()
       ..atKey =
           '$AT_ENCRYPTION_SHARED_KEY.${atKey.sharedWith?.replaceAll('@', '')}'
       ..sharedBy = atKey.sharedBy
       ..value = encryptedSharedKey;
-    await AtClientManager.getInstance()
-        .atClient
+    await _atClient
         .getLocalSecondary()!
         .executeVerb(updateSharedKeyForCurrentAtSignBuilder, sync: shouldSync);
   }
 
-  /// Stores the encryptedSharedKey in local secondary
-  /// and cache's in the [atKey.sharedWith] atSign.
-  Future<void> _notifyEncryptedSharedKey(
-      AtKey atKey, String encryptedSharedKey) async {
+  /// Gets the encrypted shared key from the given secondary instance - Local Secondary or Remote Secondary
+  ///
+  /// Throws [KeyNotFoundException] is key is not found the secondary
+  Future<String?> _getEncryptedSharedKey(
+      Secondary secondary, AtKey atKey) async {
+    var llookupVerbBuilder = LLookupVerbBuilder()
+      ..atKey =
+          '$AT_ENCRYPTION_SHARED_KEY.${atKey.sharedWith?.replaceAll('@', '')}'
+      ..sharedBy = atKey.sharedBy;
+    return await secondary.executeVerb(llookupVerbBuilder);
+  }
+
+  /// Checks if the encryptedSharedKey is synced to the cloud secondary
+  ///
+  /// If Synced, returns true; else returns false.
+  Future<bool> isEncryptedSharedKeyInSync(AtKey atKey) async {
+    atCommitLog ??= await AtCommitLogManagerImpl.getInstance()
+        .getCommitLog(atKey.sharedBy!);
+
+    var llookupVerbBuilder = LLookupVerbBuilder()
+      ..atKey = AT_ENCRYPTION_SHARED_KEY
+      ..sharedBy = atKey.sharedBy
+      ..sharedWith = atKey.sharedWith;
+
+    CommitEntry? sharedKeyCommitEntry =
+        await atCommitLog!.getLatestCommitEntry(llookupVerbBuilder.buildKey());
+    if (sharedKeyCommitEntry?.commitId == null) {
+      return false;
+    }
+    return true;
+  }
+
+  Future<String?> updateEncryptedSharedKeyToSecondary(
+      AtKey atKey, String encryptedSharedKeyValue,
+      {Secondary? secondary}) async {
+    secondary ??= _atClient.getLocalSecondary()!;
     var updateSharedKeyBuilder = UpdateVerbBuilder()
       ..atKey = AT_ENCRYPTION_SHARED_KEY
       ..sharedWith = atKey.sharedWith
       ..sharedBy = atKey.sharedBy
       ..ttr = 3888000
-      ..value = encryptedSharedKey;
-    await AtClientManager.getInstance()
-        .atClient
-        .getLocalSecondary()!
-        .executeVerb(updateSharedKeyBuilder, sync: true);
+      ..value = encryptedSharedKeyValue;
+    return await secondary.executeVerb(updateSharedKeyBuilder, sync: true);
   }
 }

--- a/packages/at_client/lib/src/encryption_service/encryption_manager.dart
+++ b/packages/at_client/lib/src/encryption_service/encryption_manager.dart
@@ -1,12 +1,24 @@
+import 'package:at_client/at_client.dart';
 import 'package:at_client/src/encryption_service/encryption.dart';
 import 'package:at_client/src/encryption_service/self_key_encryption.dart';
 import 'package:at_client/src/encryption_service/shared_key_encryption.dart';
-import 'package:at_commons/at_commons.dart';
 
 /// The manager class for [AtKeyEncryption]
 class AtKeyEncryptionManager {
   /// Accepts the [AtKey] and currentAtSign and returns the relevant
   /// [AtKeyEncryption] subclass.
+  late AtClient _atClient;
+
+  static final AtKeyEncryptionManager _singleton =
+      AtKeyEncryptionManager._internal();
+
+  AtKeyEncryptionManager._internal();
+
+  factory AtKeyEncryptionManager.getInstance(AtClient atClient) {
+    _singleton._atClient = atClient;
+    return _singleton;
+  }
+
   AtKeyEncryption get(AtKey atKey, String currentAtSign) {
     // If atKey is sharedKey, return sharedKeyEncryption
     // Eg. @bob:phone.wavi@alice. and @alice is currentAtSign.
@@ -19,7 +31,7 @@ class AtKeyEncryptionManager {
             atKey.sharedWith != null &&
             atKey.sharedWith != currentAtSign) ||
         atKey.sharedWith != null && atKey.sharedWith != currentAtSign) {
-      return SharedKeyEncryption();
+      return SharedKeyEncryption(_atClient);
     }
     return SelfKeyEncryption();
   }

--- a/packages/at_client/lib/src/encryption_service/encryption_manager.dart
+++ b/packages/at_client/lib/src/encryption_service/encryption_manager.dart
@@ -7,17 +7,9 @@ import 'package:at_client/src/encryption_service/shared_key_encryption.dart';
 class AtKeyEncryptionManager {
   /// Accepts the [AtKey] and currentAtSign and returns the relevant
   /// [AtKeyEncryption] subclass.
-  late AtClient _atClient;
+  late final AtClient _atClient;
 
-  static final AtKeyEncryptionManager _singleton =
-      AtKeyEncryptionManager._internal();
-
-  AtKeyEncryptionManager._internal();
-
-  factory AtKeyEncryptionManager.getInstance(AtClient atClient) {
-    _singleton._atClient = atClient;
-    return _singleton;
-  }
+  AtKeyEncryptionManager(this._atClient);
 
   AtKeyEncryption get(AtKey atKey, String currentAtSign) {
     // If atKey is sharedKey, return sharedKeyEncryption

--- a/packages/at_client/lib/src/encryption_service/shared_key_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/shared_key_encryption.dart
@@ -1,9 +1,10 @@
+import 'package:at_client/at_client.dart';
 import 'package:at_client/src/encryption_service/abstract_atkey_encryption.dart';
-import 'package:at_client/src/util/encryption_util.dart';
-import 'package:at_commons/at_commons.dart';
 
 ///Class responsible for encrypting the value of the SharedKey's
 class SharedKeyEncryption extends AbstractAtKeyEncryption {
+  SharedKeyEncryption(AtClient atClient) : super(atClient);
+
   @override
   Future<dynamic> encrypt(AtKey atKey, dynamic value) async {
     if (value is! String) {

--- a/packages/at_client/lib/src/encryption_service/stream_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/stream_encryption.dart
@@ -1,9 +1,12 @@
+import 'package:at_client/src/client/at_client_spec.dart';
 import 'package:at_client/src/encryption_service/abstract_atkey_encryption.dart';
 import 'package:at_client/src/util/encryption_util.dart';
 import 'package:at_commons/at_commons.dart';
 
 /// Class responsible for encrypting the stream data.
 class StreamEncryption extends AbstractAtKeyEncryption {
+  StreamEncryption(AtClient atClient) : super(atClient);
+
   @override
   Future<dynamic> encrypt(AtKey atKey, dynamic value) async {
     if (value is! List<int>) {

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -103,7 +103,7 @@ class NotificationServiceImpl
             _atClientManager.atClient.getCurrentAtSign()!,
             namespace: _atClientManager.atClient.getPreferences()!.namespace)
         .build();
-    atKeyEncryptionManager = AtKeyEncryptionManager.getInstance(_atClient);
+    atKeyEncryptionManager = AtKeyEncryptionManager(_atClient);
   }
 
   /// Simple state to prevent _init() running more than once *concurrently*

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -49,7 +49,7 @@ class NotificationServiceImpl
 
   late AtClientManager _atClientManager;
   AtClientValidation atClientValidation = AtClientValidation();
-  AtKeyEncryptionManager atKeyEncryptionManager = AtKeyEncryptionManager();
+  late AtKeyEncryptionManager atKeyEncryptionManager;
 
   /// The delay between when a call is made to monitorRetry() - i.e. a monitorRestart is queued -
   /// and when Monitor.start() is subsequently called
@@ -103,6 +103,7 @@ class NotificationServiceImpl
             _atClientManager.atClient.getCurrentAtSign()!,
             namespace: _atClientManager.atClient.getPreferences()!.namespace)
         .build();
+    atKeyEncryptionManager = AtKeyEncryptionManager.getInstance(_atClient);
   }
 
   /// Simple state to prevent _init() running more than once *concurrently*
@@ -246,9 +247,10 @@ class NotificationServiceImpl
         _streamListeners.forEach((notificationConfig, streamController) async {
           try {
             var transformedNotification =
-                await NotificationResponseTransformer().transform(Tuple()
-                  ..one = atNotification
-                  ..two = notificationConfig);
+                await NotificationResponseTransformer(_atClient)
+                    .transform(Tuple()
+                      ..one = atNotification
+                      ..two = notificationConfig);
 
             if (notificationConfig.regex != emptyRegex) {
               if (hasRegexMatch(atNotification.key, notificationConfig.regex)) {

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -531,7 +531,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       final serverEncryptedValue = serverCommitEntry['value'];
       final serverMetaData = serverCommitEntry['metadata'];
       if (serverMetaData != null && serverMetaData[IS_ENCRYPTED] == "true") {
-        final decryptionManager = AtKeyDecryptionManager.getInstance(_atClient)
+        final decryptionManager = AtKeyDecryptionManager(_atClient)
             .get(atKey, _atClient.getCurrentAtSign()!);
 
         // ignore: prefer_typing_uninitialized_variables

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -531,8 +531,8 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       final serverEncryptedValue = serverCommitEntry['value'];
       final serverMetaData = serverCommitEntry['metadata'];
       if (serverMetaData != null && serverMetaData[IS_ENCRYPTED] == "true") {
-        final decryptionManager =
-            AtKeyDecryptionManager.get(atKey, _atClient.getCurrentAtSign()!);
+        final decryptionManager = AtKeyDecryptionManager.getInstance(_atClient)
+            .get(atKey, _atClient.getCurrentAtSign()!);
 
         // ignore: prefer_typing_uninitialized_variables
         var serverDecryptedValue;

--- a/packages/at_client/lib/src/transformer/request_transformer/put_request_transformer.dart
+++ b/packages/at_client/lib/src/transformer/request_transformer/put_request_transformer.dart
@@ -31,7 +31,7 @@ class PutRequestTransformer
     updateVerbBuilder.value = tuple.two;
     //Encrypt the data for non public keys
     if (!tuple.one.metadata!.isPublic!) {
-      var encryptionService = AtKeyEncryptionManager()
+      var encryptionService = AtKeyEncryptionManager.getInstance(_atClient)
           .get(tuple.one, _atClient.getCurrentAtSign()!);
       try {
         updateVerbBuilder.value =

--- a/packages/at_client/lib/src/transformer/request_transformer/put_request_transformer.dart
+++ b/packages/at_client/lib/src/transformer/request_transformer/put_request_transformer.dart
@@ -31,7 +31,7 @@ class PutRequestTransformer
     updateVerbBuilder.value = tuple.two;
     //Encrypt the data for non public keys
     if (!tuple.one.metadata!.isPublic!) {
-      var encryptionService = AtKeyEncryptionManager.getInstance(_atClient)
+      var encryptionService = AtKeyEncryptionManager(_atClient)
           .get(tuple.one, _atClient.getCurrentAtSign()!);
       try {
         updateVerbBuilder.value =

--- a/packages/at_client/lib/src/transformer/response_transformer/get_response_transformer.dart
+++ b/packages/at_client/lib/src/transformer/response_transformer/get_response_transformer.dart
@@ -40,7 +40,7 @@ class GetResponseTransformer
     if (!(decodedResponse['key'].startsWith('public:')) &&
         !(decodedResponse['key'].startsWith('cached:public:'))) {
       var decryptionService =
-          AtKeyDecryptionManager.getInstance(_atClient).get(tuple.one, _atClient.getCurrentAtSign()!);
+          AtKeyDecryptionManager(_atClient).get(tuple.one, _atClient.getCurrentAtSign()!);
       try {
         atValue.value =
             await decryptionService.decrypt(tuple.one, atValue.value) as String;

--- a/packages/at_client/lib/src/transformer/response_transformer/get_response_transformer.dart
+++ b/packages/at_client/lib/src/transformer/response_transformer/get_response_transformer.dart
@@ -40,7 +40,7 @@ class GetResponseTransformer
     if (!(decodedResponse['key'].startsWith('public:')) &&
         !(decodedResponse['key'].startsWith('cached:public:'))) {
       var decryptionService =
-          AtKeyDecryptionManager.get(tuple.one, _atClient.getCurrentAtSign()!);
+          AtKeyDecryptionManager.getInstance(_atClient).get(tuple.one, _atClient.getCurrentAtSign()!);
       try {
         atValue.value =
             await decryptionService.decrypt(tuple.one, atValue.value) as String;

--- a/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
+++ b/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
@@ -50,7 +50,7 @@ class NotificationResponseTransformer
   }
 
   Future<String> _getDecryptedValue(AtKey atKey, String encryptedValue) async {
-    atKeyDecryption ??= AtKeyDecryptionManager.getInstance(_atClient)
+    atKeyDecryption ??= AtKeyDecryptionManager(_atClient)
         .get(atKey, atKey.sharedWith!);
     var decryptedValue = await atKeyDecryption?.decrypt(atKey, encryptedValue);
     // Return decrypted value

--- a/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
+++ b/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
@@ -10,8 +10,12 @@ import 'package:meta/meta.dart';
 class NotificationResponseTransformer
     implements
         Transformer<Tuple<AtNotification, NotificationConfig>, AtNotification> {
+  late AtClient _atClient;
+
   @visibleForTesting
   AtKeyDecryption? atKeyDecryption;
+
+  NotificationResponseTransformer(this._atClient);
 
   @override
   Future<AtNotification> transform(
@@ -46,7 +50,8 @@ class NotificationResponseTransformer
   }
 
   Future<String> _getDecryptedValue(AtKey atKey, String encryptedValue) async {
-    atKeyDecryption ??= AtKeyDecryptionManager.get(atKey, atKey.sharedWith!);
+    atKeyDecryption ??= AtKeyDecryptionManager.getInstance(_atClient)
+        .get(atKey, atKey.sharedWith!);
     var decryptedValue = await atKeyDecryption?.decrypt(atKey, encryptedValue);
     // Return decrypted value
     return decryptedValue.toString().trim();

--- a/packages/at_client/lib/src/util/sync_util.dart
+++ b/packages/at_client/lib/src/util/sync_util.dart
@@ -124,4 +124,34 @@ class SyncUtil {
     }
     return true;
   }
+
+  /// Returns the latest [CommitEntry] of the given key from the given atCommitLog instance
+  /// If the key is not found [NullCommitEntry] is returned.
+  Future<CommitEntry> getLatestCommitEntry(
+      AtCommitLog atCommitLog, String key) async {
+    var values = (await atCommitLog.commitLogKeyStore.toMap()).values.toList()
+      ..sort(_compareCommitId);
+    for (CommitEntry commitEntry in values) {
+      if (commitEntry.atKey == key) {
+        return commitEntry;
+      }
+    }
+    return NullCommitEntry();
+  }
+
+  /// Sorts the commit entries in descending order.
+  ///
+  /// The CommitEntries with commitId 'null' comes before the commit entries with commitId
+  int _compareCommitId(commitEntry1, commitEntry2) {
+    if (commitEntry1.commitId == null && commitEntry2.commitId == null) {
+      return 0;
+    }
+    if (commitEntry1.commitId == null && commitEntry2.commitId != null) {
+      return -1;
+    }
+    if (commitEntry1.commitId != null && commitEntry2.commitId == null) {
+      return 1;
+    }
+    return commitEntry2.commitId!.compareTo(commitEntry1.commitId!);
+  }
 }

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -37,12 +37,6 @@ dependencies:
   at_utils: ^3.0.11
   meta: ^1.8.0
 
-dependency_overrides:
-  at_persistence_secondary_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server
-      path: packages/at_persistence_secondary_server
-      ref: refactor_commit_log
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.21.4

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -37,6 +37,12 @@ dependencies:
   at_utils: ^3.0.11
   meta: ^1.8.0
 
+dependency_overrides:
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server
+      path: packages/at_persistence_secondary_server
+      ref: refactor_commit_log
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.21.4

--- a/packages/at_client/test/decryption_service_test.dart
+++ b/packages/at_client/test/decryption_service_test.dart
@@ -173,7 +173,9 @@ void main() {
         ..key = 'phone.wavi'
         ..sharedBy = '@alice';
 
-      var decryptionService = AtKeyDecryptionManager.get(atKey, currentAtSign);
+      var decryptionService =
+          AtKeyDecryptionManager.getInstance(mockAtClientImpl)
+              .get(atKey, currentAtSign);
       expect(decryptionService, isA<SharedKeyDecryption>());
     });
 
@@ -187,7 +189,9 @@ void main() {
         ..sharedBy = '@bob'
         ..metadata = Metadata();
 
-      var decryptionService = AtKeyDecryptionManager.get(atKey, currentAtSign);
+      var decryptionService =
+          AtKeyDecryptionManager.getInstance(mockAtClientImpl)
+              .get(atKey, currentAtSign);
       expect(decryptionService, isA<LocalKeyDecryption>());
     });
 
@@ -201,7 +205,9 @@ void main() {
         ..sharedBy = '@alice'
         ..metadata = Metadata();
 
-      var decryptionService = AtKeyDecryptionManager.get(atKey, currentAtSign);
+      var decryptionService =
+          AtKeyDecryptionManager.getInstance(mockAtClientImpl)
+              .get(atKey, currentAtSign);
       expect(decryptionService, isA<SelfKeyDecryption>());
     });
 
@@ -214,7 +220,9 @@ void main() {
         ..sharedBy = '@alice'
         ..metadata = Metadata();
 
-      var decryptionService = AtKeyDecryptionManager.get(atKey, currentAtSign);
+      var decryptionService =
+          AtKeyDecryptionManager.getInstance(mockAtClientImpl)
+              .get(atKey, currentAtSign);
       expect(decryptionService, isA<SelfKeyDecryption>());
     });
   });
@@ -246,7 +254,7 @@ void main() {
         'Test to verify IllegalArgumentException is thrown when encrypted value is null - LocalKeyDecryption',
         () {
       expect(
-          () => LocalKeyDecryption().decrypt(AtKey(), ''),
+          () => LocalKeyDecryption(mockAtClientImpl).decrypt(AtKey(), ''),
           throwsA(predicate((dynamic e) =>
               e is AtDecryptionException &&
               e.message == 'Decryption failed. Encrypted value is null')));

--- a/packages/at_client/test/decryption_service_test.dart
+++ b/packages/at_client/test/decryption_service_test.dart
@@ -174,7 +174,7 @@ void main() {
         ..sharedBy = '@alice';
 
       var decryptionService =
-          AtKeyDecryptionManager.getInstance(mockAtClientImpl)
+          AtKeyDecryptionManager(mockAtClientImpl)
               .get(atKey, currentAtSign);
       expect(decryptionService, isA<SharedKeyDecryption>());
     });
@@ -190,7 +190,7 @@ void main() {
         ..metadata = Metadata();
 
       var decryptionService =
-          AtKeyDecryptionManager.getInstance(mockAtClientImpl)
+          AtKeyDecryptionManager(mockAtClientImpl)
               .get(atKey, currentAtSign);
       expect(decryptionService, isA<LocalKeyDecryption>());
     });
@@ -206,7 +206,7 @@ void main() {
         ..metadata = Metadata();
 
       var decryptionService =
-          AtKeyDecryptionManager.getInstance(mockAtClientImpl)
+          AtKeyDecryptionManager(mockAtClientImpl)
               .get(atKey, currentAtSign);
       expect(decryptionService, isA<SelfKeyDecryption>());
     });
@@ -221,7 +221,7 @@ void main() {
         ..metadata = Metadata();
 
       var decryptionService =
-          AtKeyDecryptionManager.getInstance(mockAtClientImpl)
+          AtKeyDecryptionManager(mockAtClientImpl)
               .get(atKey, currentAtSign);
       expect(decryptionService, isA<SelfKeyDecryption>());
     });

--- a/packages/at_client/test/encryption_service_test.dart
+++ b/packages/at_client/test/encryption_service_test.dart
@@ -100,8 +100,8 @@ void main() {
       when(() => mockAtClientManager.atClient).thenAnswer((_) => mockAtClient);
       when(() => mockAtClient.getCurrentAtSign()).thenAnswer((_) => '@sitaram');
 
-      var encryptionService = AtKeyEncryptionManager(mockAtClient)
-          .get(atKey, currentAtSign);
+      var encryptionService =
+          AtKeyEncryptionManager(mockAtClient).get(atKey, currentAtSign);
       expect(encryptionService, isA<SharedKeyEncryption>());
     });
 
@@ -113,8 +113,8 @@ void main() {
         ..sharedBy = '@alice'
         ..metadata = Metadata();
 
-      var encryptionService = AtKeyEncryptionManager(mockAtClient)
-          .get(atKey, currentAtSign);
+      var encryptionService =
+          AtKeyEncryptionManager(mockAtClient).get(atKey, currentAtSign);
       expect(encryptionService, isA<SelfKeyEncryption>());
     });
   });
@@ -130,8 +130,8 @@ void main() {
         ..metadata = (Metadata()..isPublic = false);
       var value = 918078908676;
 
-      var encryptionService = AtKeyEncryptionManager(mockAtClient)
-          .get(atKey, currentAtSign);
+      var encryptionService =
+          AtKeyEncryptionManager(mockAtClient).get(atKey, currentAtSign);
 
       expect(
           () => encryptionService.encrypt(atKey, value),
@@ -255,6 +255,11 @@ void main() {
         ..sharedWith = '@bob';
       expect(
           await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), false);
+      // assert the sync status is not added to cache map when commit id is null.
+      expect(
+          sharedKeyEncryption.encryptedSharedKeySyncStatusCacheMap
+              .containsKey(atKey.toString()),
+          false);
     });
 
     test(
@@ -272,6 +277,11 @@ void main() {
         ..sharedBy = '@alice'
         ..sharedWith = '@bob';
       expect(await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), true);
+      // assert the sync status is added to cache map
+      expect(
+          sharedKeyEncryption.encryptedSharedKeySyncStatusCacheMap
+              .containsKey(atKey.toString()),
+          true);
     });
 
     test(
@@ -297,6 +307,24 @@ void main() {
         ..sharedWith = '@bob';
       expect(
           await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), false);
+      // assert the sync status is not added to cache map
+      expect(
+          sharedKeyEncryption.encryptedSharedKeySyncStatusCacheMap
+              .containsKey(atKey.toString()),
+          false);
+    });
+
+    test(
+        'A test to verify isEncryptedSharedKeyInSync is return from the cache map',
+        () async {
+      var atKey = AtKey()
+        ..key = AT_ENCRYPTION_SHARED_KEY
+        ..sharedBy = '@alice'
+        ..sharedWith = '@bob';
+      var sharedKeyEncryption = SharedKeyEncryption(mockAtClient);
+      sharedKeyEncryption.encryptedSharedKeySyncStatusCacheMap
+          .putIfAbsent(atKey.toString(), () => true);
+      expect(await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), true);
     });
 
     tearDown(() async {
@@ -350,10 +378,10 @@ void main() {
       var value = 'hello';
 
       when(() => mockLocalSecondary
-          .executeVerb(any(that: EncryptedSharedKeyMatcher())))
+              .executeVerb(any(that: EncryptedSharedKeyMatcher())))
           .thenAnswer((_) => Future.value(encryptedSharedKey));
       when(() => mockLocalSecondary
-          .executeVerb(any(that: EncryptionPublicKeyMatcher())))
+              .executeVerb(any(that: EncryptionPublicKeyMatcher())))
           .thenAnswer((_) => Future.value(encryptionPublicKey));
 
       var encryptedValue = await sharedKeyEncryption.encrypt(atKey, value);

--- a/packages/at_client/test/encryption_service_test.dart
+++ b/packages/at_client/test/encryption_service_test.dart
@@ -1,17 +1,20 @@
-import 'package:at_client/src/client/at_client_spec.dart';
-import 'package:at_client/src/client/local_secondary.dart';
+import 'dart:io';
+
+import 'package:at_client/at_client.dart';
 import 'package:at_client/src/encryption_service/encryption_manager.dart';
 import 'package:at_client/src/encryption_service/self_key_encryption.dart';
 import 'package:at_client/src/encryption_service/shared_key_encryption.dart';
 import 'package:at_client/src/transformer/request_transformer/put_request_transformer.dart';
-import 'package:at_client/src/preference/at_client_preference.dart';
-import 'package:at_client/src/util/at_client_util.dart';
-import 'package:at_client/src/util/encryption_util.dart';
-import 'package:at_commons/at_commons.dart';
-import 'package:test/test.dart';
+import 'package:at_commons/at_builders.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockAtClientManager extends Mock implements AtClientManager {}
 
 class MockLocalSecondary extends Mock implements LocalSecondary {}
+
+class MockRemoteSecondary extends Mock implements RemoteSecondary {}
 
 class MockAtClient extends Mock implements AtClient {
   @override
@@ -20,10 +23,16 @@ class MockAtClient extends Mock implements AtClient {
   }
 }
 
+class FakeLocalLookUpVerbBuilder extends Fake implements LLookupVerbBuilder {}
+
 void main() {
   LocalSecondary mockLocalSecondary = MockLocalSecondary();
 
+  RemoteSecondary mockRemoteSecondary = MockRemoteSecondary();
+
   AtClient mockAtClient = MockAtClient();
+
+  AtClientManager mockAtClientManager = MockAtClientManager();
 
   group('A group of test to validate self key encryption exceptions', () {
     test(
@@ -88,8 +97,11 @@ void main() {
         ..sharedWith = '@bob'
         ..sharedBy = '@alice';
 
-      var encryptionService =
-          AtKeyEncryptionManager().get(atKey, currentAtSign);
+      when(() => mockAtClientManager.atClient).thenAnswer((_) => mockAtClient);
+      when(() => mockAtClient.getCurrentAtSign()).thenAnswer((_) => '@sitaram');
+
+      var encryptionService = AtKeyEncryptionManager.getInstance(mockAtClient)
+          .get(atKey, currentAtSign);
       expect(encryptionService, isA<SharedKeyEncryption>());
     });
 
@@ -101,8 +113,8 @@ void main() {
         ..sharedBy = '@alice'
         ..metadata = Metadata();
 
-      var encryptionService =
-          AtKeyEncryptionManager().get(atKey, currentAtSign);
+      var encryptionService = AtKeyEncryptionManager.getInstance(mockAtClient)
+          .get(atKey, currentAtSign);
       expect(encryptionService, isA<SelfKeyEncryption>());
     });
   });
@@ -118,8 +130,8 @@ void main() {
         ..metadata = (Metadata()..isPublic = false);
       var value = 918078908676;
 
-      var encryptionService =
-          AtKeyEncryptionManager().get(atKey, currentAtSign);
+      var encryptionService = AtKeyEncryptionManager.getInstance(mockAtClient)
+          .get(atKey, currentAtSign);
 
       expect(
           () => encryptionService.encrypt(atKey, value),
@@ -129,4 +141,358 @@ void main() {
                   'Invalid value type found: ${value.runtimeType}. Valid value type is String')));
     });
   });
+
+  group(
+      'A group of tests to related to fetch and decrypt the encrypted shared key',
+      () {
+    test(
+        'A test to verify encrypted shared key is fetched from local secondary and decrypted successfully',
+        () async {
+      registerFallbackValue(FakeLocalLookUpVerbBuilder());
+      var sharedKeyEncryption = SharedKeyEncryption(mockAtClient);
+
+      var originalSharedKey = 'WwOn34SJaEQUHvmaY5haGtVAfHp1eBzLk8239uRGnhw=';
+      var encryptedSharedKey =
+          'T3VaG/MMd7ZFnKMCCQUqIOM4dDiLiZXeIZkXJ3p13jn4EXU6FWgygCbG/8aUrMr3riPO+Il4CwIvGrulGXsKzx9sjBxsFAhTDczzvOt0a52UJFxIjJGkC7mAuprLa23dRI/zUfvxEd6fgXVDT5k8itOO0ykOcb9syEtvzg+vZhniVODz7yu9gh0R1iQDxebM5mCPbGKNlEkdGJq6wGBvn26p2fq5CaPyIBHRU2B+DIaBEKnVmK2WomJnrCbLtYFlGGmtsMkCVfllBJSW3i6SZ1m080Yt07qtjnsWobK1FT+2i07Q+uGEaSjIr5eUyPeN4V5L1ZmsnXk92w+vhD0k0w==';
+      var encryptionPrivateKey =
+          'MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCrGPCsZtFf1xhALzrtnfjRlr9p6RdKMNPd2Z5RkOvUsvZuK56aR2Sc7Yl6HqPFi5rr1Xd4SwNXTfZIgVxpU4QoTyNjyFUWrWHoo2NQ0lUX75HAWYIzQf706HfkGmmDBOGoUEVJPLvQv9vPMpIofZYj9WTiWo9zBTRT8EbPNTF1RJHWQNfgs3xYkX16FfutBvS/B5TYZWDXpwVFwuGh0FF2gL3/wZvp6Qq5PXnV/iiF3mrF46kXXE04WAeizsF1u2nP8OuwdLkSk0I1zka81Xrpey/yRcbOEwK9zG5c6XsgqwCILEhLIBvYX/LRacllkxBci5ivZaSBsx41Jsc+Hw69AgMBAAECggEAOO8jpzrPkUTSHQmaYlee5J91MpkN1vJIjhpMRHglAbJLrn11WYFISbABf1GSzbmW48M07iKIChU3Twk85w+TepZbAGk5Z0Jqwi8cbViQWFav+YHPgZ8EaBqzSoQ/eAm3zXpok+ZR2TT+wAPj/vVLcMvHtkrMUUn6D7R0256nxo1u+fdJ5vsBefhSKR23zNfp+ynU54s20Gc4ejqDujbIow+aiJZv9y/asPG5UdSWN6ykhoPlOCv+VqAlGT7OWFKAMTUfIZb1UsqCIYKN+BNbwFBkFcuzr8AM5Xxd1DoNcBVdLOY6j+6k2kd4U0XxvLAhE0FZDVt5J82jGtmDJQyRQQKBgQDjFixG3XnXArYnM8667+LrdIK2UGbxu94pMjRR16g7v+miShASdcxzmBr/oDAHJrSwYg4t6QIyarj0nIfUqUNefQS28qjDBuQRMHwAcYcZZ5QwynJZsyHu5KP/Hqm2V4C7mU84jpKygiDQl9GSXIsIldQ+5ADrAvpFVkyNOwGFpwKBgQDA4dCHpFFmW2BcFIHXn3fpg2JPNSnXBmVl64QRVKUj30As5KMpgULiP5qP9KfogYArm+S+p6uK5s6kqdLDNOMwqCGLD21n8EOzOjtd1bbzxuC/OUu1SCmmqMd64Y+StNj5lxx1FmkbGT96kAM20QnvUdz1U1KeCODprL5z4L9c+wKBgQCztaBklHEPjr3IWF+J4L2byCCJVyegtiQiRfDRs/EXF9E09ZeyhDbAY+c51PMtNZxY2cCO5I8whvTH3/g+e5Us+ZL5lR+o95MVZ2E6mJ1ppWbJFe1Yv0JjY93Ez+dOvgDKdZEUGQBO9Fwzt3HKeiItMSU+gAGZ+klFBf6e5ctWkQKBgFckbpspwOD2vaU8WqE5Weq1QjA4+6s7J4qRijxuOqHnVk4yCglRbg9b3w/U4BtqjqalKwZ8KEN8HbZFR4SMG2y7OVRjZvGDmoKZ94JgcOTYYGfkkfDYJoE2VdGNoNkOPc0d2WyI8HmewZA1Ck60yMFIAgUQXQ4rQrowImemDa8LAoGAYc8Tp8LUNj4fYzTA0zE7YwBga0eTB8F9eHYhimAhBRScG5FYQHlGgNvwfAATclJfX2ikBRHidWUYGM/4+z10ZX+98uwGEwPgUWJCy8mLJ6CJb88a0j7LQjOYd5ZT+Qi96X5Y4RRYj7/2CHaq1KvoywqsGoaVaiTK1opj33c7F64=';
+
+      when(() => mockAtClient.getLocalSecondary())
+          .thenAnswer((_) => mockLocalSecondary);
+
+      when(() => mockLocalSecondary
+              .executeVerb(any(that: EncryptedSharedKeyMatcher())))
+          .thenAnswer((_) => Future.value(encryptedSharedKey));
+      when(() => mockLocalSecondary.getEncryptionPrivateKey())
+          .thenAnswer((_) => Future.value(encryptionPrivateKey));
+
+      var atKey = AtKey()
+        ..sharedBy = '@alice'
+        ..sharedWith = '@bob'
+        ..key = 'phone';
+      expect(await sharedKeyEncryption.getSharedKey(atKey), originalSharedKey);
+    });
+
+    test(
+        'A test to verify encrypted shared key is fetched from remote secondary and decrypted successfully',
+        () async {
+      registerFallbackValue(FakeLocalLookUpVerbBuilder());
+      var sharedKeyEncryption = SharedKeyEncryption(mockAtClient);
+
+      var originalSharedKey = 'WwOn34SJaEQUHvmaY5haGtVAfHp1eBzLk8239uRGnhw=';
+      var encryptedSharedKey =
+          'T3VaG/MMd7ZFnKMCCQUqIOM4dDiLiZXeIZkXJ3p13jn4EXU6FWgygCbG/8aUrMr3riPO+Il4CwIvGrulGXsKzx9sjBxsFAhTDczzvOt0a52UJFxIjJGkC7mAuprLa23dRI/zUfvxEd6fgXVDT5k8itOO0ykOcb9syEtvzg+vZhniVODz7yu9gh0R1iQDxebM5mCPbGKNlEkdGJq6wGBvn26p2fq5CaPyIBHRU2B+DIaBEKnVmK2WomJnrCbLtYFlGGmtsMkCVfllBJSW3i6SZ1m080Yt07qtjnsWobK1FT+2i07Q+uGEaSjIr5eUyPeN4V5L1ZmsnXk92w+vhD0k0w==';
+      var encryptionPrivateKey =
+          'MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCrGPCsZtFf1xhALzrtnfjRlr9p6RdKMNPd2Z5RkOvUsvZuK56aR2Sc7Yl6HqPFi5rr1Xd4SwNXTfZIgVxpU4QoTyNjyFUWrWHoo2NQ0lUX75HAWYIzQf706HfkGmmDBOGoUEVJPLvQv9vPMpIofZYj9WTiWo9zBTRT8EbPNTF1RJHWQNfgs3xYkX16FfutBvS/B5TYZWDXpwVFwuGh0FF2gL3/wZvp6Qq5PXnV/iiF3mrF46kXXE04WAeizsF1u2nP8OuwdLkSk0I1zka81Xrpey/yRcbOEwK9zG5c6XsgqwCILEhLIBvYX/LRacllkxBci5ivZaSBsx41Jsc+Hw69AgMBAAECggEAOO8jpzrPkUTSHQmaYlee5J91MpkN1vJIjhpMRHglAbJLrn11WYFISbABf1GSzbmW48M07iKIChU3Twk85w+TepZbAGk5Z0Jqwi8cbViQWFav+YHPgZ8EaBqzSoQ/eAm3zXpok+ZR2TT+wAPj/vVLcMvHtkrMUUn6D7R0256nxo1u+fdJ5vsBefhSKR23zNfp+ynU54s20Gc4ejqDujbIow+aiJZv9y/asPG5UdSWN6ykhoPlOCv+VqAlGT7OWFKAMTUfIZb1UsqCIYKN+BNbwFBkFcuzr8AM5Xxd1DoNcBVdLOY6j+6k2kd4U0XxvLAhE0FZDVt5J82jGtmDJQyRQQKBgQDjFixG3XnXArYnM8667+LrdIK2UGbxu94pMjRR16g7v+miShASdcxzmBr/oDAHJrSwYg4t6QIyarj0nIfUqUNefQS28qjDBuQRMHwAcYcZZ5QwynJZsyHu5KP/Hqm2V4C7mU84jpKygiDQl9GSXIsIldQ+5ADrAvpFVkyNOwGFpwKBgQDA4dCHpFFmW2BcFIHXn3fpg2JPNSnXBmVl64QRVKUj30As5KMpgULiP5qP9KfogYArm+S+p6uK5s6kqdLDNOMwqCGLD21n8EOzOjtd1bbzxuC/OUu1SCmmqMd64Y+StNj5lxx1FmkbGT96kAM20QnvUdz1U1KeCODprL5z4L9c+wKBgQCztaBklHEPjr3IWF+J4L2byCCJVyegtiQiRfDRs/EXF9E09ZeyhDbAY+c51PMtNZxY2cCO5I8whvTH3/g+e5Us+ZL5lR+o95MVZ2E6mJ1ppWbJFe1Yv0JjY93Ez+dOvgDKdZEUGQBO9Fwzt3HKeiItMSU+gAGZ+klFBf6e5ctWkQKBgFckbpspwOD2vaU8WqE5Weq1QjA4+6s7J4qRijxuOqHnVk4yCglRbg9b3w/U4BtqjqalKwZ8KEN8HbZFR4SMG2y7OVRjZvGDmoKZ94JgcOTYYGfkkfDYJoE2VdGNoNkOPc0d2WyI8HmewZA1Ck60yMFIAgUQXQ4rQrowImemDa8LAoGAYc8Tp8LUNj4fYzTA0zE7YwBga0eTB8F9eHYhimAhBRScG5FYQHlGgNvwfAATclJfX2ikBRHidWUYGM/4+z10ZX+98uwGEwPgUWJCy8mLJ6CJb88a0j7LQjOYd5ZT+Qi96X5Y4RRYj7/2CHaq1KvoywqsGoaVaiTK1opj33c7F64=';
+
+      when(() => mockAtClient.getLocalSecondary())
+          .thenAnswer((_) => mockLocalSecondary);
+      when(() => mockAtClient.getRemoteSecondary())
+          .thenAnswer((_) => mockRemoteSecondary);
+
+      when(() => mockLocalSecondary
+              .executeVerb(any(that: EncryptedSharedKeyMatcher())))
+          .thenAnswer((_) => Future.value('data:null'));
+      when(() => mockRemoteSecondary
+              .executeVerb(any(that: EncryptedSharedKeyMatcher())))
+          .thenAnswer((_) => Future.value(encryptedSharedKey));
+      when(() => mockLocalSecondary.getEncryptionPrivateKey())
+          .thenAnswer((_) => Future.value(encryptionPrivateKey));
+
+      var atKey = AtKey()
+        ..sharedBy = '@alice'
+        ..sharedWith = '@bob'
+        ..key = 'phone';
+      expect(await sharedKeyEncryption.getSharedKey(atKey), originalSharedKey);
+    });
+
+    test(
+        'A test to verify empty string is returned when shared key is not found in local and remote secondary',
+        () async {
+      registerFallbackValue(FakeLocalLookUpVerbBuilder());
+      var sharedKeyEncryption = SharedKeyEncryption(mockAtClient);
+
+      when(() => mockAtClient.getLocalSecondary())
+          .thenAnswer((_) => mockLocalSecondary);
+      when(() => mockAtClient.getRemoteSecondary())
+          .thenAnswer((_) => mockRemoteSecondary);
+
+      when(() => mockLocalSecondary
+              .executeVerb(any(that: EncryptedSharedKeyMatcher())))
+          .thenAnswer((_) => Future.value('data:null'));
+      when(() => mockRemoteSecondary
+              .executeVerb(any(that: EncryptedSharedKeyMatcher())))
+          .thenAnswer((_) => Future.value('data:null'));
+
+      var atKey = AtKey()
+        ..sharedBy = '@alice'
+        ..sharedWith = '@bob'
+        ..key = 'phone';
+      expect(await sharedKeyEncryption.getSharedKey(atKey), '');
+    });
+  });
+
+  group('A group of test related to shared_key is synced to cloud secondary',
+      () {
+    String storageDir = '${Directory.current.path}/test/hive';
+    AtCommitLog? atCommitLog;
+
+    test(
+        'A test to verify isEncryptedSharedKeyInSync method returns false when commit id null',
+        () async {
+      atCommitLog = await AtCommitLogManagerImpl.getInstance().getCommitLog(
+          '@alice',
+          commitLogPath: storageDir,
+          enableCommitId: false);
+      await atCommitLog?.commit('@bob:shared_key@alice', CommitOp.UPDATE);
+
+      var sharedKeyEncryption = SharedKeyEncryption(mockAtClient);
+      sharedKeyEncryption.atCommitLog = atCommitLog;
+
+      var atKey = AtKey()
+        ..key = AT_ENCRYPTION_SHARED_KEY
+        ..sharedBy = '@alice'
+        ..sharedWith = '@bob';
+      expect(
+          await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), false);
+    });
+
+    test(
+        'A test to verify isEncryptedSharedKeyInSync method returns true when commit is not null',
+        () async {
+      var commitLogInstance = await AtCommitLogManagerImpl.getInstance()
+          .getCommitLog('@alice', commitLogPath: storageDir);
+      await commitLogInstance?.commit('@bob:shared_key@alice', CommitOp.UPDATE);
+
+      var sharedKeyEncryption = SharedKeyEncryption(mockAtClient);
+      sharedKeyEncryption.atCommitLog = commitLogInstance;
+
+      var atKey = AtKey()
+        ..key = AT_ENCRYPTION_SHARED_KEY
+        ..sharedBy = '@alice'
+        ..sharedWith = '@bob';
+      expect(await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), true);
+    });
+
+    test(
+        'A test to verify isEncryptedSharedKeyInSync method returns false when two commit entries exist with commit id null and not null',
+        () async {
+      var commitLogInstance = await AtCommitLogManagerImpl.getInstance()
+          .getCommitLog('@alice',
+              commitLogPath: storageDir, enableCommitId: false);
+      // Null commit id
+      await commitLogInstance?.commitLogKeyStore.add(CommitEntry(
+          '@bob:shared_key@alice', CommitOp.UPDATE, DateTime.now()));
+      // Populated commit id to mock commit entry is synced from server
+      await commitLogInstance?.commitLogKeyStore.add(
+          CommitEntry('@bob:shared_key@alice', CommitOp.UPDATE, DateTime.now())
+            ..commitId = 1);
+
+      var sharedKeyEncryption = SharedKeyEncryption(mockAtClient);
+      sharedKeyEncryption.atCommitLog = commitLogInstance;
+
+      var atKey = AtKey()
+        ..key = AT_ENCRYPTION_SHARED_KEY
+        ..sharedBy = '@alice'
+        ..sharedWith = '@bob';
+      expect(
+          await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), false);
+    });
+
+    tearDown(() async {
+      await AtCommitLogManagerImpl.getInstance().close();
+      var isExists = await Directory(storageDir).exists();
+      if (isExists) {
+        Directory(storageDir).deleteSync(recursive: true);
+      }
+    });
+  });
+
+  group('A group of test related shared key encryption', () {
+    String storageDir = '${Directory.current.path}/test/hive';
+    SharedKeyEncryption sharedKeyEncryption;
+    AtCommitLog? atCommitLog;
+
+    var encryptionPrivateKey =
+        'MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQCJ+42pSjfJ5DSe7jCh7RWSH9MlTiG3PPrYdEGHDoSNhtPflSiL6BhpEpodNMLSaYpWsoV9ad2vRgXqgN0qM3LufflkgAigpAU8ukzCUWs+7sHQZBPfiz/clO1GuajF7iV0CaOe7tJA7Hyod9StALDi/56kwhGqLi84rimLeNKxv7qCfOJowePJCrs5++KXQozQXWYoeeBrj1HGEWMCbuoaw3ihvwJPBo76GkR7seYcq9AlrFivf2HcvDaPx0fSMXejTS5aL0Kogz7hBrNNGi1WyjD51hZEvMssh1OYy6TKtYsj3veMO1zd9fBZT+9yXXNCZ3cXXnZqOHAetWEPsjoNAgMBAAECggEAQ7Bp4ECOebY/si+7H9SEnniKRmS72X5KuGDfvHd8w0j/K1Gq4Gdtgi4j+Gvnnv0zZjCRl+KVY+SABnhNBuTSXvjhnVHJ6bRM9WuXOERkziymW6qcrS9MltNgSy/NAbxAF1qbL96MuljJFoQiivQp0lH/62dg7xFVDQMzUj5lbdid0CIV9r9Jp6SxXCG8OTjhU8RupXyqWiIgg3xVr/Y2ayYnO2O8cnm9V8C0zTvX5290IijTfHXkbarGg0vY7sg2Krs1uk1sQ+70yHJSppTOfa+cfYLuoj4k+emqJWWn7TZKkTlfnc6ON566XN5eiH+t2AmKttW9MxWQhaWv50I7KQKBgQDH4yh3u8f+Pbj3L3SJMN0aQ/ZHMApJ96C+iAJRgYp0aYuVpHscQPRxS7p3JwT758cKdrUTHSji/t7PrtsLDlp9rLw8WHEng7rfA/hlL9Ghoks/3gxaX90+dCXMo1odKbCxTEEBGxUC0aFIOOQGJ8Ot47fNE15IuaoPDO/On1X36wKBgQCwt6H02nLxKY0ILdu8HRVGXcqOOcBQiMIrjjhmt7llAfB5cJKuwq29apyJdRglqWSHXuK3B42reiF3I0fm3+QfihqFUfchU+2N8LcCciNR1BM0l1t/Xkw/FW18lTld0WoTAI/EOE+VEOzzdO542f2m7EBjQZy9hVg4XtlKi1pP5wKBgCXrqVS1siZAbWOvhAs20utVs1Yj/f+0U7FxugbebXbSQyHbd2OPyw/nTvOl2mMzwGXyyT1cDdKqiXia8oExcudeqsNEAAuACSaf6TLBFKL2WBJAvNU0VJOxky40WzcnHpc0ISzlh2HmhRNff5rPVmcZyVfFceCYIHQEf0YSokuLAoGAFqnmXnWpqh4vFS50cOK1+MlMkgL8FBgF9voNZ7cGUtr10U1LspgLGjDTFJns19+qoeXcY6bXV3eZVSM0NHrgUd8vWYvSivatj7egcPLcbsEpGWST+njIhIql+QVWTx7tYLSAu6SRKEf8a5jCgMNMUZ0ZAOHITVINp2UarwHCOl8CgYBenz32mGQapDgw7fyw3aWe5e4i2rC3jHOxJOHSHTAcLzBZ7JrKOIoNtiHU9XWIjRB0kng4a0rDffywxM4YHI+ZMXgvYzHE1Ob2ei3Q/Q52bxkLEwEGrqwXl1kdmCb69imp1T92JBZ3ls2dX7+uJtJiy5KlZilGN61AwMgOxyg7Mg==';
+    var encryptionPublicKey =
+        'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAifuNqUo3yeQ0nu4woe0Vkh/TJU4htzz62HRBhw6EjYbT35Uoi+gYaRKaHTTC0mmKVrKFfWndr0YF6oDdKjNy7n35ZIAIoKQFPLpMwlFrPu7B0GQT34s/3JTtRrmoxe4ldAmjnu7SQOx8qHfUrQCw4v+epMIRqi4vOK4pi3jSsb+6gnziaMHjyQq7Ofvil0KM0F1mKHnga49RxhFjAm7qGsN4ob8CTwaO+hpEe7HmHKvQJaxYr39h3Lw2j8dH0jF3o00uWi9CqIM+4QazTRotVsow+dYWRLzLLIdTmMukyrWLI973jDtc3fXwWU/vcl1zQmd3F152ajhwHrVhD7I6DQIDAQAB';
+    var sharedKey = 'Q58MkV2KwLNZAVS6SxKEzw1okYHtf/9k9EegctSyCqo=';
+    var encryptedSharedKey =
+        'JZ3fjGxobojMytMhslfcBsJ5R0f5oVFwV7Qyyko1PMB3DhWMWRhlCQFUIZlyGyX0gIBrDBkYGRHDkj00DYAoF1VVJ3jaHL1d45VPpYpPG0QxhA7A8BriU8PnX+3wbUk8LMD7GscW3sOJPJ2mduCM2UKs1TUO3D4AKR7vrEZXRi11ddgQZet6JgTcKG+/uG7ftdMxs1Y+jHvwfHCYlW+w/IfERzoyfPlAyyGAuY/ucZea/9JvSXtgp5Oxk7MKn3IMBa3N6vCb0zYpg+6SUdee0t47zeTaMcPJ9wCOJQ6p5b5ltK7kJxX2ILGHDFUeMUISKG2eMrEeR9HlVKQ3e3eLRw==';
+    var publicKeyCheckSum = '745a800133171a170121e8040e3ebfe7';
+
+    setUp(() async {
+      registerFallbackValue(FakeLocalLookUpVerbBuilder());
+      when(() => mockAtClient.getLocalSecondary())
+          .thenAnswer((_) => mockLocalSecondary);
+      when(() => mockAtClient.getRemoteSecondary())
+          .thenAnswer((_) => mockRemoteSecondary);
+      when(() => mockLocalSecondary.getEncryptionPrivateKey())
+          .thenAnswer((_) => Future.value(encryptionPrivateKey));
+
+      atCommitLog = await AtCommitLogManagerImpl.getInstance().getCommitLog(
+          '@alice',
+          commitLogPath: storageDir,
+          enableCommitId: false);
+    });
+
+    test('test to verify encryption when shared key is available', () async {
+      sharedKeyEncryption = SharedKeyEncryption(mockAtClient);
+      await atCommitLog?.commitLogKeyStore.add(
+          // Adding commit id to mock commit entry is synced from server
+          CommitEntry('@bob:shared_key@alice', CommitOp.UPDATE, DateTime.now())
+            ..commitId = 0);
+      sharedKeyEncryption.atCommitLog = atCommitLog;
+      var atKey = (AtKey.shared('phone', namespace: 'wavi', sharedBy: '@alice')
+            ..sharedWith('@bob'))
+          .build();
+      var value = 'hello';
+
+      when(() => mockLocalSecondary
+          .executeVerb(any(that: EncryptedSharedKeyMatcher())))
+          .thenAnswer((_) => Future.value(encryptedSharedKey));
+      when(() => mockLocalSecondary
+          .executeVerb(any(that: EncryptionPublicKeyMatcher())))
+          .thenAnswer((_) => Future.value(encryptionPublicKey));
+
+      var encryptedValue = await sharedKeyEncryption.encrypt(atKey, value);
+      var decryptedSharedKey =
+          EncryptionUtil.decryptKey(encryptedSharedKey, encryptionPrivateKey);
+      expect(decryptedSharedKey, sharedKey);
+      var decryptedValue =
+          EncryptionUtil.decryptValue(encryptedValue, decryptedSharedKey);
+      expect(decryptedValue, value);
+      expect(atKey.metadata?.sharedKeyEnc.isNotNull, true);
+      expect(atKey.metadata?.pubKeyCS.isNotNull, true);
+    });
+
+    test('test to verify encryption when a new shared key is generated',
+        () async {
+      sharedKeyEncryption = SharedKeyEncryption(mockAtClient);
+      // Adding commit id to mock that commit entry is synced from server
+      await atCommitLog?.commitLogKeyStore.add(
+          CommitEntry('@bob:shared_key@alice', CommitOp.UPDATE, DateTime.now())
+            ..commitId = 0);
+      sharedKeyEncryption.atCommitLog = atCommitLog;
+
+      when(() => mockLocalSecondary
+              .executeVerb(any(that: EncryptedSharedKeyMatcher())))
+          .thenAnswer((_) => Future.value('data:null'));
+      when(() => mockRemoteSecondary
+              .executeVerb(any(that: EncryptedSharedKeyMatcher())))
+          .thenAnswer((_) => Future.value('data:null'));
+      when(() => mockLocalSecondary
+              .executeVerb(any(that: EncryptionPublicKeyMatcher())))
+          .thenAnswer((_) => Future.value(encryptionPublicKey));
+      when(() => mockLocalSecondary.executeVerb(
+          any(that: UpdatedSharedKeyMatcher()),
+          sync: true)).thenAnswer((_) => Future.value('data:1'));
+      when(() => mockLocalSecondary.getEncryptionPublicKey('@alice'))
+          .thenAnswer((_) => Future.value(encryptionPublicKey));
+
+      var atKey = (AtKey.shared('phone', namespace: 'wavi', sharedBy: '@alice')
+            ..sharedWith('@bob'))
+          .build();
+      var originalValue = 'hello';
+
+      var encryptedValue =
+          await sharedKeyEncryption.encrypt(atKey, originalValue);
+      expect(
+          EncryptionUtil.decryptValue(
+              encryptedValue, sharedKeyEncryption.sharedKey),
+          originalValue);
+      expect(atKey.metadata?.sharedKeyEnc.isNotNull, true);
+      expect(atKey.metadata?.pubKeyCS.isNotNull, true);
+    });
+
+    test(
+        'test to verify exception is thrown when update command fails to store shared_key to remote secondary',
+        () async {
+      atCommitLog!.commitLogKeyStore.add(CommitEntry(
+          '@bob:shared_key@alice', CommitOp.UPDATE, DateTime.now()));
+
+      sharedKeyEncryption = SharedKeyEncryption(mockAtClient);
+      sharedKeyEncryption.atCommitLog = atCommitLog;
+
+      when(() => mockLocalSecondary
+              .executeVerb(any(that: EncryptedSharedKeyMatcher())))
+          .thenAnswer((_) => Future.value('data:null'));
+      when(() => mockRemoteSecondary
+              .executeVerb(any(that: EncryptedSharedKeyMatcher())))
+          .thenAnswer((_) => Future.value('data:null'));
+      when(() => mockLocalSecondary
+              .executeVerb(any(that: EncryptionPublicKeyMatcher())))
+          .thenAnswer((_) => Future.value(encryptionPublicKey));
+      when(() => mockLocalSecondary.executeVerb(
+          any(that: UpdatedSharedKeyMatcher()),
+          sync: true)).thenAnswer((_) => Future.value('data:1'));
+      when(() => mockRemoteSecondary
+              .executeVerb(any(that: UpdatedSharedKeyMatcher()), sync: true))
+          .thenAnswer((_) => throw SecondaryConnectException(
+              'unable to connect to remote secondary'));
+      when(() => mockLocalSecondary.getEncryptionPublicKey('@alice'))
+          .thenAnswer((_) => Future.value(encryptionPublicKey));
+
+      var atKey = (AtKey.shared('phone', namespace: 'wavi', sharedBy: '@alice')
+            ..sharedWith('@bob'))
+          .build();
+      var originalValue = 'hello';
+      expect(
+          () async => await sharedKeyEncryption.encrypt(atKey, originalValue),
+          throwsA(predicate((dynamic e) =>
+              e is SecondaryConnectException &&
+              e.message == 'unable to connect to remote secondary')));
+    });
+
+    tearDown(() async {
+      await AtCommitLogManagerImpl.getInstance().close();
+      var isExists = await Directory(storageDir).exists();
+      if (isExists) {
+        Directory(storageDir).deleteSync(recursive: true);
+      }
+    });
+  });
+}
+
+class EncryptedSharedKeyMatcher extends Matcher {
+  @override
+  Description describe(Description description) =>
+      description.add('A custom matcher to match the encrypted shared key');
+
+  @override
+  bool matches(item, Map matchState) {
+    if (item is LLookupVerbBuilder && item.atKey!.contains('shared_key')) {
+      return true;
+    }
+    return false;
+  }
+}
+
+class EncryptionPublicKeyMatcher extends Matcher {
+  @override
+  Description describe(Description description) =>
+      description.add('A custom matcher to match the encrypted public key');
+
+  @override
+  bool matches(item, Map matchState) {
+    if (item is LLookupVerbBuilder && item.atKey!.contains('publickey')) {
+      return true;
+    }
+    return false;
+  }
+}
+
+class UpdatedSharedKeyMatcher extends Matcher {
+  @override
+  Description describe(Description description) => description.add(
+      'A custom matcher to match the encrypted shared key for update verb builder');
+
+  @override
+  bool matches(item, Map matchState) {
+    if (item is UpdateVerbBuilder) {
+      return true;
+    }
+    return false;
+  }
 }

--- a/packages/at_client/test/encryption_service_test.dart
+++ b/packages/at_client/test/encryption_service_test.dart
@@ -100,7 +100,7 @@ void main() {
       when(() => mockAtClientManager.atClient).thenAnswer((_) => mockAtClient);
       when(() => mockAtClient.getCurrentAtSign()).thenAnswer((_) => '@sitaram');
 
-      var encryptionService = AtKeyEncryptionManager.getInstance(mockAtClient)
+      var encryptionService = AtKeyEncryptionManager(mockAtClient)
           .get(atKey, currentAtSign);
       expect(encryptionService, isA<SharedKeyEncryption>());
     });
@@ -113,7 +113,7 @@ void main() {
         ..sharedBy = '@alice'
         ..metadata = Metadata();
 
-      var encryptionService = AtKeyEncryptionManager.getInstance(mockAtClient)
+      var encryptionService = AtKeyEncryptionManager(mockAtClient)
           .get(atKey, currentAtSign);
       expect(encryptionService, isA<SelfKeyEncryption>());
     });
@@ -130,7 +130,7 @@ void main() {
         ..metadata = (Metadata()..isPublic = false);
       var value = 918078908676;
 
-      var encryptionService = AtKeyEncryptionManager.getInstance(mockAtClient)
+      var encryptionService = AtKeyEncryptionManager(mockAtClient)
           .get(atKey, currentAtSign);
 
       expect(

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -118,8 +118,10 @@ void main() {
       var notificationParams = NotificationParams.forUpdate(
           (AtKey.shared('phone', namespace: 'wavi')..sharedWith('@bob'))
               .build());
-      var notifyVerbBuilder = await NotificationRequestTransformer('@alice',
-              AtClientPreference()..namespace = 'wavi', SharedKeyEncryption())
+      var notifyVerbBuilder = await NotificationRequestTransformer(
+              '@alice',
+              AtClientPreference()..namespace = 'wavi',
+              SharedKeyEncryption(mockAtClientImpl))
           .transform(notificationParams);
       expect(notifyVerbBuilder.atKey, 'phone.wavi');
       expect(notifyVerbBuilder.sharedWith, '@bob');
@@ -184,6 +186,30 @@ void main() {
       expect(notifyVerbBuilder.priority, PriorityEnum.low);
       expect(notifyVerbBuilder.strategy, StrategyEnum.all);
     });
+
+    test(
+        'A test to verify notification is not sent when encryption service throws exception',
+        () async {
+      registerFallbackValue(FakeAtKey());
+      SharedKeyEncryption mockSharedKeyEncryption = MockSharedKeyEncryption();
+      when(() => mockSharedKeyEncryption.encrypt(any(), any())).thenAnswer(
+          (_) => throw SecondaryConnectException(
+              'Unable to connect to secondary server'));
+      var notificationParams = NotificationParams.forText(
+          'Hi How are you', '@bob',
+          shouldEncrypt: true);
+
+      var notificationRequestTransformer = NotificationRequestTransformer(
+          '@alice',
+          AtClientPreference()..namespace = 'wavi',
+          mockSharedKeyEncryption);
+      expect(
+          () async => await notificationRequestTransformer
+              .transform(notificationParams),
+          throwsA(predicate((dynamic e) =>
+              e is SecondaryConnectException &&
+              e.message == 'Unable to connect to secondary server')));
+    });
   });
 
   group('A group of test to validate notification response transformer', () {
@@ -204,7 +230,8 @@ void main() {
           DateTime.now().millisecondsSinceEpoch,
           MessageTypeEnum.text.toString(),
           isEncrypted);
-      var notificationResponseTransformer = NotificationResponseTransformer();
+      var notificationResponseTransformer =
+          NotificationResponseTransformer(mockAtClientImpl);
       notificationResponseTransformer.atKeyDecryption = mockSharedKeyDecryption;
 
       var transformedNotification =
@@ -228,7 +255,8 @@ void main() {
           DateTime.now().millisecondsSinceEpoch,
           MessageTypeEnum.text.toString(),
           isEncrypted);
-      var notificationResponseTransformer = NotificationResponseTransformer();
+      var notificationResponseTransformer =
+          NotificationResponseTransformer(mockAtClientImpl);
       notificationResponseTransformer.atKeyDecryption = mockSharedKeyDecryption;
 
       var transformedNotification =
@@ -253,7 +281,8 @@ void main() {
           MessageTypeEnum.key.toString(),
           isEncrypted,
           value: 'encryptedValue');
-      var notificationResponseTransformer = NotificationResponseTransformer();
+      var notificationResponseTransformer =
+          NotificationResponseTransformer(mockAtClientImpl);
       notificationResponseTransformer.atKeyDecryption = mockSharedKeyDecryption;
 
       var transformedNotification =
@@ -278,7 +307,8 @@ void main() {
           MessageTypeEnum.key.toString(),
           isEncrypted,
           value: 'encryptedValue');
-      var notificationResponseTransformer = NotificationResponseTransformer();
+      var notificationResponseTransformer =
+          NotificationResponseTransformer(mockAtClientImpl);
       notificationResponseTransformer.atKeyDecryption = mockSharedKeyDecryption;
 
       var transformedNotification =
@@ -300,7 +330,8 @@ void main() {
           DateTime.now().millisecondsSinceEpoch,
           MessageTypeEnum.key.toString(),
           isEncrypted);
-      var notificationResponseTransformer = NotificationResponseTransformer();
+      var notificationResponseTransformer =
+          NotificationResponseTransformer(mockAtClientImpl);
       notificationResponseTransformer.atKeyDecryption = mockSharedKeyDecryption;
 
       var transformedNotification =
@@ -322,7 +353,8 @@ void main() {
           MessageTypeEnum.key.toString(),
           isEncrypted,
           value: 'encryptedValue');
-      var notificationResponseTransformer = NotificationResponseTransformer();
+      var notificationResponseTransformer =
+          NotificationResponseTransformer(mockAtClientImpl);
       notificationResponseTransformer.atKeyDecryption = mockSharedKeyDecryption;
 
       var transformedNotification =

--- a/tests/at_end2end_test/test/notify_test.dart
+++ b/tests/at_end2end_test/test/notify_test.dart
@@ -102,13 +102,13 @@ void main() async {
         expect(notificationResult.notificationStatusEnum,
             NotificationStatusEnum.delivered);
 
-        await AtClientManager.getInstance().setCurrentAtSign(sharedWithAtSign,
+        sharedWithAtClientManager = await AtClientManager.getInstance().setCurrentAtSign(sharedWithAtSign,
             namespace, TestPreferences.getInstance().getPreference(sharedWithAtSign));
         var atNotification = await AtClientManager.getInstance()
             .notificationService
             .fetch(notificationResult.notificationID);
         atNotification.isEncrypted = input.atKey.metadata!.isEncrypted;
-        await NotificationResponseTransformer().transform(Tuple()
+        await NotificationResponseTransformer(sharedWithAtClientManager.atClient).transform(Tuple()
           ..one = atNotification
           ..two = (NotificationConfig()
             ..shouldDecrypt = input.atKey.metadata!.isEncrypted!));

--- a/tests/at_end2end_test/test/sharing_key_test.dart
+++ b/tests/at_end2end_test/test/sharing_key_test.dart
@@ -123,7 +123,8 @@ void main() async {
       ..metadata = Metadata();
     var value = 'New Jersey';
     var encryptionService =
-        AtKeyEncryptionManager().get(locationKey, currentAtSign);
+        AtKeyEncryptionManager.getInstance(currentAtClientManager.atClient)
+            .get(locationKey, currentAtSign);
     var encryptedValue = await encryptionService.encrypt(locationKey, value);
     var result = await currentAtClientManager.atClient
         .getRemoteSecondary()!

--- a/tests/at_end2end_test/test/sharing_key_test.dart
+++ b/tests/at_end2end_test/test/sharing_key_test.dart
@@ -123,7 +123,7 @@ void main() async {
       ..metadata = Metadata();
     var value = 'New Jersey';
     var encryptionService =
-        AtKeyEncryptionManager.getInstance(currentAtClientManager.atClient)
+        AtKeyEncryptionManager(currentAtClientManager.atClient)
             .get(locationKey, currentAtSign);
     var encryptedValue = await encryptionService.encrypt(locationKey, value);
     var result = await currentAtClientManager.atClient

--- a/tests/at_functional_test/test/atclient_notify_test.dart
+++ b/tests/at_functional_test/test/atclient_notify_test.dart
@@ -11,6 +11,7 @@ void main() {
   var currentAtSign = '@alice🛠';
   var sharedWithAtSign = '@bob🛠';
   late AtClientManager atClientManager;
+  String namespace = 'wavi';
   setUpAll(() async {
     var preference = TestUtils.getPreference(currentAtSign);
     atClientManager = await AtClientManager.getInstance()
@@ -24,7 +25,7 @@ void main() {
     var phoneKey = AtKey()
       ..key = 'phone'
       ..sharedWith = sharedWithAtSign
-      ..namespace = '.wavi';
+      ..namespace = namespace;
     var value = '+1 100 200 300';
 
     var result = await atClientManager.notificationService
@@ -51,7 +52,7 @@ void main() {
     var landlineKey = AtKey()
       ..key = 'landline'
       ..sharedWith = sharedWithAtSign
-      ..namespace = '.wavi';
+      ..namespace = namespace;
     var value = '040-238989$lastNumber';
 
     var result = await atClientManager.notificationService
@@ -72,7 +73,7 @@ void main() {
     var phoneKey = AtKey()
       ..key = 'phone'
       ..sharedWith = sharedWithAtSign
-      ..namespace = '.wavi';
+      ..namespace = namespace;
     var value = '+1 100 200 300';
     await atClientManager.notificationService
         .notify(NotificationParams.forUpdate(phoneKey, value: value));
@@ -82,7 +83,7 @@ void main() {
     var phoneKey = AtKey()
       ..key = 'phone'
       ..sharedWith = sharedWithAtSign
-      ..namespace = '.wavi';
+      ..namespace = namespace;
     var notificationResult = await atClientManager.notificationService
         .notify(NotificationParams.forDelete(phoneKey));
     expect(notificationResult.notificationStatusEnum.toString(),
@@ -95,7 +96,7 @@ void main() {
     var phoneKey = AtKey()
       ..key = 'phone'
       ..sharedWith = '@bob🛠'
-      ..namespace = '.wavi';
+      ..namespace = namespace;
     await atClientManager.notificationService.notify(
         NotificationParams.forDelete(phoneKey),
         onSuccess: onSuccessCallback);
@@ -129,12 +130,12 @@ void main() {
     await Future.delayed(Duration(seconds: 10));
   });
 
-  test('notify - test deprecated method using notificationservice', () async {
+  test('notify - test deprecated method using notification service', () async {
     // phone.me@alice🛠
     var phoneKey = AtKey()
       ..key = 'phone'
       ..sharedWith = sharedWithAtSign
-      ..namespace = '.wavi';
+      ..namespace = namespace;
     var value = '+1 100 200 300';
     final atClient = atClientManager.atClient;
     final notifyResult =
@@ -165,7 +166,7 @@ void main() {
     var phoneKey = AtKey()
       ..key = 'phone'
       ..sharedWith = sharedWithAtSign
-      ..namespace = '.wavi';
+      ..namespace = namespace;
     var value = '+1 100 200 300';
     await atClientManager.notificationService
         .notify(NotificationParams.forUpdate(phoneKey, value: value));

--- a/tests/at_functional_test/test/atclient_sharedkey_test.dart
+++ b/tests/at_functional_test/test/atclient_sharedkey_test.dart
@@ -40,7 +40,7 @@ void main() {
       ..sharedBy = currentAtSign
       ..metadata = (Metadata()..ttl = 120000);
     var value = '+91 887 888 3435';
-    var encryptionService = AtKeyEncryptionManager.getInstance(atClient)
+    var encryptionService = AtKeyEncryptionManager(atClient)
         .get(phoneKey, currentAtSign);
     var encryptedValue = await encryptionService.encrypt(phoneKey, value);
     var result = await atClient.getRemoteSecondary()!.executeCommand(

--- a/tests/at_functional_test/test/atclient_sharedkey_test.dart
+++ b/tests/at_functional_test/test/atclient_sharedkey_test.dart
@@ -40,8 +40,8 @@ void main() {
       ..sharedBy = currentAtSign
       ..metadata = (Metadata()..ttl = 120000);
     var value = '+91 887 888 3435';
-    var encryptionService =
-        AtKeyEncryptionManager().get(phoneKey, currentAtSign);
+    var encryptionService = AtKeyEncryptionManager.getInstance(atClient)
+        .get(phoneKey, currentAtSign);
     var encryptedValue = await encryptionService.encrypt(phoneKey, value);
     var result = await atClient.getRemoteSecondary()!.executeCommand(
         'update:sharedKeyEnc:${phoneKey.metadata?.sharedKeyEnc}:pubKeyCS:${phoneKey.metadata?.pubKeyCS}:${phoneKey.sharedWith}:${phoneKey.key}.$namespace$currentAtSign $encryptedValue\n',


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Refactor the `getSharedKey` method in `AbstractAtKeyEncryption` to sync the `encryptedSharedKey` to the cloud secondary if not already synced before sending the notifications.
2. Write unit tests to assert the above functionality
3. Refactor the classes to initialize fields with mock objects when writing unit tests.

**- How I did it**
1. Introduce `isEncryptedSharedKeyInSync` which verifies if the `shared_key` is synced to the cloud secondary. If not synced, runs the update verb to store the shared_key in the cloud secondary.

2. Refactor the `_getSharedWithPublicKey` method which fetches the encryption public key of the sharedWith atSign. 
    - Earlier (prior to caching of public keys) we store to sharedWith atSign's encryption public key as `public.bob@alice` to store the encryption public key of @‎bob in @‎alice atSign. 
    - Now with caching of the public key, upon initial look up the encryption public key, a cached key will be created automatically (cached:public:publickey@‎bob).      
    -  So, instead of creating a new key (public.bob@alice), we can utilize the cached key(cached:public:publickey@bob). Therefore, removed the piece of code that creates the key (public.bob@alice) and refactor the method that fetches the encryption public key to first look for a cached public key, if not then run a lookup verb to sharedWith atSign.

3. Following are the changes to enable writing unit tests:

   1. Refactor AtKeyEncryptionManager and AtKeyDecryptionManager classes to accept the at_client object 
   2. Add a constructor to LocalKeyDecryption, SharedKeyEncryption and StreamEncryption classes that accept AtClient instance to enable passing mock objects in unit testing.
   3. Remove the static nature of the getSharedKey method and write unit tests around getting the shared key from the local secondary and remote secondary.
   4. Since, LocalKeyDecryption also needs a shared_key to decrypt the value, mark LocalKeyDecryption as a child of AbstractAtKeyEncryption to make the getSharedKey method available for LocalKeyDecryption.
   5. Refactor the existing unit tests to accommodate the above changes.

**- How to verify it**

Following are the unit tests written to assert the above changes:

Tests in encryption_service_test.dart

1. A group of tests related to fetching and decrypting the encrypted shared key
- A test to verify encrypted shared key is fetched from the local secondary and decrypted successfully
- A test to verify encrypted shared key is fetched from remote secondary and decrypted successfully
- A test to verify empty string is returned when the shared key is not found in local and remote secondary

2. A group of tests related to shared_key is synced to the cloud secondary
- A test to verify isEncryptedSharedKeyInSync method returns false when commit id null
- A test to verify isEncryptedSharedKeyInSync method returns true when commit is not null
- A test to verify isEncryptedSharedKeyInSync method returns false when two commit entries exist with commit id null and not null

3. A group of tests related to shared key encryption
- test to verify encryption when the shared key is available
- test to verify encryption when a new shared key is generated
- test to verify exception is thrown when update command fails to store shared_key to remote secondary

Test in notification_service_test.dart
1. A test to verify notification is not sent when the encryption service throws an exception

**- Description for the changelog**

Fix initial notifications throwing pad block issue because "encryptedSharedKey" is not synced to cloud secondary.

ToDo's

- Initial plan was to fetch the sharedWith encryption public key only if a new shared_key is generated. If the shared_key is already available, then fetch the encrypted shared key from the @‎bob:shared_key@alice key. 

Below are items for discussion:

1. The checksum of encryption public key of sharedWith atSign is added to AtKey metadata. At the moment, the checksum data is not stored; needs to compute every time. For this, we need an encryption public key of the shared With atSign. So irrespective of IF the shared_key is existing or a new one, we might need to fetch the encryption public key of sharedWith atSign.

2. If the shared_key is generated, we need an additional IF block that will search for the shared_key (@‎bob:shared_key@‎alice) availability in the local and remote. So, since we anyways have to fetch the encryption public key for # 1, Can we directly encrypt the shared key each time or should it be fetched from the key (@‎bob:shared_key@‎alice)?

<!--‎
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->