### PR TITLE
chore: Exclude some deprecated & unused code files from test coverage reporting

### DIFF
--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -180,7 +180,17 @@ jobs:
         # Needs a secret, so don't run for Dependabot PRs
         if: ${{ github.actor != 'dependabot[bot]' }}
         working-directory: tests/at_end2end_test
-        run: dart test --concurrency=1
+        run: dart test --concurrency=1 --coverage="coverage"
+
+      - name: Convert coverage to LCOV format
+        working-directory: tests/at_end2end_test
+        run: dart run coverage:format_coverage --check-ignore --lcov --in=coverage --out=end2end_test_coverage.lcov --report-on=lib
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
+        with:
+          file: tests/at_end2end_test/end2end_test_coverage.lcov
+          flags: end2end_tests
 
   # The Job runs end-to-end tests between server code running on trunk branch and canary (production ready) server
   end2end_test_14:

--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Convert coverage to LCOV format
         working-directory: packages/at_client
-        run: dart run coverage:format_coverage --lcov --in=coverage --out=unit_test_coverage.lcov --report-on=lib
+        run: dart run coverage:format_coverage --check-ignore --lcov --in=coverage --out=unit_test_coverage.lcov --report-on=lib
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1
@@ -113,7 +113,7 @@ jobs:
 
       - name: Convert coverage to LCOV format
         working-directory: tests/at_functional_test
-        run: dart run coverage:format_coverage --lcov --in=coverage --out=functional_test_coverage.lcov --report-on=../../packages/at_client/lib
+        run: dart run coverage:format_coverage --check-ignore --lcov --in=coverage --out=functional_test_coverage.lcov --report-on=../../packages/at_client/lib
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3.1.1

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -219,6 +219,7 @@ class AtClientImpl implements AtClient {
     var isCached = atKey.metadata != null ? atKey.metadata!.isCached : false;
     var isNamespaceAware =
         atKey.metadata != null ? atKey.metadata!.namespaceAware : true;
+    // ignore: no_leading_underscores_for_local_identifiers
     var _deleteResult = _delete(atKey.key!,
         sharedWith: atKey.sharedWith,
         sharedBy: atKey.sharedBy,
@@ -772,12 +773,12 @@ class AtClientImpl implements AtClient {
       throw Exception('json decode exception in download file ${e.toString()}');
     }
     var downloadedFiles = <File>[];
-    var fileDownloadReponse = await FileTransferService()
+    var fileDownloadResponse = await FileTransferService()
         .downloadFromFileBin(fileTransferObject, downloadPath);
-    if (fileDownloadReponse.isError) {
+    if (fileDownloadResponse.isError) {
       throw Exception('download fail');
     }
-    var encryptedFileList = Directory(fileDownloadReponse.filePath!).listSync();
+    var encryptedFileList = Directory(fileDownloadResponse.filePath!).listSync();
     try {
       for (var encryptedFile in encryptedFileList) {
         var decryptedFile = await _encryptionService!.decryptFileInChunks(
@@ -793,7 +794,7 @@ class AtClientImpl implements AtClient {
         decryptedFile.deleteSync();
       }
       // deleting temp directory
-      Directory(fileDownloadReponse.filePath!).deleteSync(recursive: true);
+      Directory(fileDownloadResponse.filePath!).deleteSync(recursive: true);
       return downloadedFiles;
     } catch (e) {
       print('error in downloadFile: $e');

--- a/packages/at_client/lib/src/manager/sync_isolate_manager.dart
+++ b/packages/at_client/lib/src/manager/sync_isolate_manager.dart
@@ -6,6 +6,9 @@ import 'package:at_client/src/client/remote_secondary.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_utils/at_logger.dart';
 
+// coverage:ignore-file
+
+@Deprecated("Only used by deprecated SyncManager")
 class SyncIsolateManager {
   static final SyncIsolateManager _singleton = SyncIsolateManager._internal();
 

--- a/packages/at_client/lib/src/manager/sync_manager.dart
+++ b/packages/at_client/lib/src/manager/sync_manager.dart
@@ -17,8 +17,10 @@ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.
 import 'package:at_utils/at_logger.dart';
 import 'package:cron/cron.dart';
 
+// coverage:ignore-file
+
 /// [Deprecate] Use [SyncService]
-@Deprecated("Use SyncService.Sync")
+@Deprecated("Use SyncService")
 class SyncManager {
   var logger = AtSignLogger('SyncManager');
 


### PR DESCRIPTION
**- What I did**
* Excluded some deprecated & unused code files from test coverage reporting
* Added actions to also gather and upload the end-to-end tests coverage info
* Fixed some miscellaneous typos I noticed

**- How I did it**
* added the `// coverage:ignore-file` incantation to a couple of files
* Added actions to also gather and upload the end-to-end tests coverage info

**- How to verify it**
* See https://app.codecov.io/gh/atsign-foundation/at_client_sdk/tree/gkc-tidy-up-test-coverage-reports?displayType=list