### PR TITLE
fix: delete local key

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.47
+- fix: Enable deletion of local keys
 ## 3.0.46
 - fix: Ensure that we handle any and all exceptions related to sending heartbeat request
 - feat: Made NotificationServiceImpl's retry delay into a public instance variable, so it can be set by application code

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -225,7 +225,8 @@ class AtClientImpl implements AtClient {
         sharedBy: atKey.sharedBy,
         isPublic: isPublic,
         isCached: isCached,
-        namespaceAware: isNamespaceAware);
+        namespaceAware: isNamespaceAware,
+        isLocal: atKey.isLocal);
     _telemetry?.controller.sink.add(AtTelemetryEvent('AtClient.delete complete', {"key":atKey, "_deleteResult":_deleteResult}));
     return _deleteResult;
   }
@@ -235,7 +236,8 @@ class AtClientImpl implements AtClient {
       String? sharedBy,
       bool isPublic = false,
       bool isCached = false,
-      bool namespaceAware = true}) async {
+      bool namespaceAware = true,
+      bool isLocal = false}) async {
     String keyWithNamespace;
     if (namespaceAware) {
       keyWithNamespace = _getKeyWithNamespace(key);
@@ -244,6 +246,7 @@ class AtClientImpl implements AtClient {
     }
     sharedBy ??= currentAtSign;
     var builder = DeleteVerbBuilder()
+      ..isLocal = isLocal
       ..isCached = isCached
       ..isPublic = isPublic
       ..sharedWith = sharedWith

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -132,23 +132,7 @@ class LocalSecondary implements Secondary {
 
   Future<String> _delete(DeleteVerbBuilder builder) async {
     try {
-      var deleteKey = '';
-      if (builder.isCached) {
-        deleteKey += 'cached:';
-      }
-      if (builder.isPublic) {
-        deleteKey += 'public:';
-      }
-      if (builder.sharedWith != null && builder.sharedWith!.isNotEmpty) {
-        deleteKey += '${AtUtils.formatAtSign(builder.sharedWith!)}:';
-      }
-      if (builder.sharedBy != null && builder.sharedBy!.isNotEmpty) {
-        deleteKey +=
-            '${builder.atKey}${AtUtils.formatAtSign(builder.sharedBy!)}';
-      } else {
-        deleteKey += builder.atKey!;
-      }
-      var deleteResult = await keyStore!.remove(deleteKey);
+      var deleteResult = await keyStore!.remove(builder.buildKey());
       return 'data:$deleteResult';
     } on DataStoreException catch (e) {
       _logger.severe('exception in delete:${e.toString()}');

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,5 +10,5 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.46';
+  final String atClientVersion = '3.0.47';
 }

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.46
+version: 3.0.47
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 
@@ -33,7 +33,7 @@ dependencies:
   at_lookup: ^3.0.32
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
-  at_commons: ^3.0.31
+  at_commons: ^3.0.32
   at_utils: ^3.0.11
   meta: ^1.8.0
 

--- a/tests/at_functional_test/test/delete_key_test.dart
+++ b/tests/at_functional_test/test/delete_key_test.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+
+import 'package:at_client/at_client.dart';
+import 'package:test/test.dart';
+import 'at_demo_credentials.dart' as demo_credentials;
+import 'set_encryption_keys.dart';
+
+void main() {
+  late AtClientManager atClientManager;
+  late AtClient atClient;
+  var currentAtSign = '@alice🛠';
+  var namespace = 'wavi';
+  setUpAll(() async {
+    var preference = getPreference(currentAtSign);
+    atClientManager = await AtClientManager.getInstance()
+        .setCurrentAtSign(currentAtSign, namespace, preference);
+    atClient = atClientManager.atClient;
+    // To setup encryption keys
+    await setEncryptionKeys(currentAtSign, preference);
+  });
+
+  group('A group of tests related to deletion of a key', () {
+    test(
+        'A test to verify the deletion of a local key - create a local key using a static factory method',
+            () async {
+          var localKey = AtKey.local('local-key', currentAtSign).build();
+          // Create local key
+          var putResponse = await atClient.put(localKey, 'dummy-local-value');
+          expect(putResponse, true);
+          // Fetch the key
+          AtValue getResponse = await atClient.get(localKey);
+          expect(getResponse.value, 'dummy-local-value');
+          // Delete the key
+          var deleteResponse = await atClient.delete(localKey);
+          expect(deleteResponse, true);
+          // Verify key is deleted
+          var isLocalKeyExist = atClient
+              .getLocalSecondary()
+              ?.keyStore
+              ?.isKeyExists(localKey.toString());
+          expect(isLocalKeyExist, false);
+        });
+
+    test(
+        'A test to verify the deletion of a local key - create a local key setting isLocal to true',
+            () async {
+          var localKey = AtKey()
+            ..key = 'local-key'
+            ..isLocal = true
+            ..sharedBy = currentAtSign;
+          // Create local key
+          var putResponse = await atClient.put(localKey, 'dummy-local-value');
+          expect(putResponse, true);
+          // Fetch the key
+          AtValue getResponse = await atClient.get(localKey);
+          expect(getResponse.value, 'dummy-local-value');
+          // Delete the key
+          var deleteResponse = await atClient.delete(localKey);
+          expect(deleteResponse, true);
+          // Verify key is deleted
+          var isLocalKeyExist = atClient
+              .getLocalSecondary()
+              ?.keyStore
+              ?.isKeyExists(localKey.toString());
+          expect(isLocalKeyExist, false);
+        });
+  });
+}
+
+Future<void> tearDownFunc() async {
+  var isExists = await Directory('test/hive').exists();
+  if (isExists) {
+    Directory('test/hive').deleteSync(recursive: true);
+  }
+}
+
+AtClientPreference getPreference(String atsign) {
+  var preference = AtClientPreference();
+  preference.hiveStoragePath = 'test/hive/client';
+  preference.commitLogPath = 'test/hive/client/commit';
+  preference.isLocalStoreRequired = true;
+  preference.privateKey = demo_credentials.pkamPrivateKeyMap[atsign];
+  preference.rootDomain = 'vip.ve.atsign.zone';
+  preference.syncRegex = 'wavi';
+  return preference;
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
1. Enable the deletion of a local key.

**- How I did it**
1. In the delete method, when a user set, "isLocal" to true on AtKey, populated the "isLocal" flag in the delete verb builder to remove the key from Keystore.
2. Following [PR](https://github.com/atsign-foundation/at_tools/pull/253) contains changes adding "isLocal" field to delete_verb_bulder.dart

**- How to verify it**
1. Added a functional test that deletes a local key 
 - Local key created using the AtKey factory method
 - Local key creation using the AtKey concrete class, setting isLocal field to true.

**- Description for the changelog**
1. fix: Deletion of a local key.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->