### PR TITLE
feat: add request options to exports

### DIFF
--- a/packages/at_client/lib/at_client.dart
+++ b/packages/at_client/lib/at_client.dart
@@ -23,3 +23,4 @@ export 'package:at_commons/at_commons.dart';
 export 'package:at_client/src/listener/sync_progress_listener.dart';
 @experimental
 export 'package:at_client/src/telemetry/at_client_telemetry.dart';
+export 'package:at_client/src/client/request_options.dart';


### PR DESCRIPTION
**The problem**
UMass students are unable to `bypassCache` in their Flutter projects when doing a `plookup` via the at_client sdk because `GetRequestOptions(bypassCache: true)` is an impossible object to create because they cannot import it since it is not exported by at_client.

**- What I did**
Exports `request_options.dart`

**- How I did it**
Modified `at_client.dart`

**- How to verify it**
See changes

**- Description for the changelog**
![image](https://user-images.githubusercontent.com/79019866/205112111-371ae6f4-fc47-491b-a12c-58afdd67338b.png)

```dart
final AtKey atKey = AtKey.public(key,
        namespace: 'group13', sharedBy: atSignPico)
    .build();
final AtValue atValue = await atClient.get(atKey,
    getRequestOptions: GetRequestOptions(bypassCache: true));
final String value = atValue.value;
print(value);
```
The above code cannot be ran because it is impossible to import the `GetRequestOptions` class from my Flutter project.