### PR TITLE
feat: Add new method to check sync

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.50
+- fix: Add `checkIfClientAndServerInSync` in `SyncService` and deprecate `isInSync`
 ## 3.0.49
 - fix: Enable AtKey.namespace overrides the namespace in AtClientPreference in AtClient delete method
 - fix: Fixed a bug where initial notifications fails to decrypt - invalid pad block issue

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,5 +10,5 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.49';
+  final String atClientVersion = '3.0.50';
 }

--- a/packages/at_client/lib/src/service/sync/sync_result.dart
+++ b/packages/at_client/lib/src/service/sync/sync_result.dart
@@ -9,6 +9,8 @@ class SyncResult {
   DateTime? lastSyncedOn;
   bool dataChange = true;
   List<KeyInfo> keyInfoList = [];
+  late int localCommitId;
+  late int serverCommitId;
 
   @override
   String toString() {

--- a/packages/at_client/lib/src/service/sync/sync_status.dart
+++ b/packages/at_client/lib/src/service/sync/sync_status.dart
@@ -1,7 +1,15 @@
 import 'package:at_client/src/service/sync_service_impl.dart';
 
 ///Enum to represent the sync status
-enum SyncStatus { started, notStarted, success, failure }
+enum SyncStatus {
+  started,
+  notStarted,
+  success,
+  failure,
+  clientAhead,
+  serverAhead,
+  inSync
+}
 
 class SyncProgress {
   SyncStatus? syncStatus;

--- a/packages/at_client/lib/src/service/sync_service.dart
+++ b/packages/at_client/lib/src/service/sync_service.dart
@@ -1,4 +1,6 @@
+import 'package:at_client/at_client.dart';
 import 'package:at_client/src/listener/sync_progress_listener.dart';
+import 'package:at_client/src/service/sync/sync_result.dart';
 import 'package:at_client/src/service/sync/sync_status.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:meta/meta.dart';
@@ -38,6 +40,7 @@ abstract class SyncService {
   void setOnDone(Function onDone);
 
   /// Returns true if local and cloud secondary are in sync. false otherwise
+  @Deprecated('Use [SyncService.checkIfClientAndServerInSync]')
   Future<bool> isInSync();
 
   /// Returns true if sync is in-progress; else false.
@@ -48,6 +51,22 @@ abstract class SyncService {
 
   /// Removes a sync progress listener
   void removeProgressListener(SyncProgressListener listener);
+
+  /// Check if the [RemoteSecondary] and [LocalSecondary] are in sync.
+  ///
+  /// Returns [SyncResult] which encapsulates [SyncStatus]
+  ///
+  /// [SyncStatus.serverAhead] is set when server commit id higher than client commit id
+  ///
+  /// [SyncStatus.clientAhead] is set when server commit id and client commit id
+  /// are equal AND client have uncommitted entries.
+  ///
+  /// [SyncStatus.inSync] is set when server commit and client commit id are equal
+  /// AND client do not have uncommitted entries.
+  ///
+  /// Sets [SyncResult.localCommitId] and [SyncResult.serverCommitId] with
+  /// latest commit-id of client and server respectively.
+  Future<SyncResult> checkIfClientAndServerInSync();
 }
 
 @experimental

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.49
+version: 3.0.50
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Replace `isInSync` with `checkIfClientAndServerInSync` in `SyncService` and deprecate `isInSync`. 
* The `checkIfClientAndServerInSync` returns `Future<SyncResult>` which has `syncStatus`, `localCommitId` and `serverCommitId`
* Add the following states to syncStatus
  * serverAhead
  * clientAhead
  * inSync
* Add `localCommitId` and `serverCommitId` to `SyncResult` class; where localCommitId and serverCommitId are set and returned along with SyncStatus

**- How I did it**
* Added a new method in `SyncService` class

**- How to verify it**
* Added the following unit tests:
  * The test to verify the method returns server-Ahead when the server commit-id is greater than the client commit-id
  * The test to verify the method returns client-Ahead when the client commit-id is greater than the server commit-id
  * The test to verify the method returns server-Ahead when the server commit-id is greater than the client commit-id and the client has uncommitted entries.
  * The test to verify the method returns inSync when the client and server are in sync and the client does not have uncommitted entries.

**- Description for the changelog**
* Deprecate isInSync and add `checkClientAndServerInSync` to check if server and client are in sync.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->