### PR TITLE
feat: Inject AtChops instance (if any) so that it is available everywhere that it can be used

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.52
 - feat: Introduce AtServiceFactory to make AtClientManager more reusable and more testable
+- feat: Make AtChops instance (if any) available everywhere that it can/should be used
 ## 3.0.51
 - feat: Add atSign to AtSignLoggers' names when relevant, so that log messages are clearer
 - feat: Made notificationService and syncService available via AtClient to enable cleaner simpler code elsewhere

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -168,7 +168,7 @@ class AtClientImpl implements AtClient {
     }
 
     // Now using ??= because we may be injecting a RemoteSecondary
-    _remoteSecondary ??= RemoteSecondary(_atSign, _preference!,
+    _remoteSecondary ??= RemoteSecondary(_atSign, _preference!, atChops: atChops,
         privateKey: _preference!.privateKey);
 
     // Now using ??= because we may be injecting an EncryptionService
@@ -613,7 +613,7 @@ class AtClientImpl implements AtClient {
     var command =
         'stream:init$sharedWith namespace:$namespace $streamId $fileName ${encryptedData.length}\n';
     _logger.finer('sending stream init:$command');
-    var remoteSecondary = RemoteSecondary(_atSign, _preference!);
+    var remoteSecondary = RemoteSecondary(_atSign, _preference!, atChops: atChops);
     var result = await remoteSecondary.executeCommand(command, auth: true);
     _logger.finer('ack message:$result');
     if (result != null && result.startsWith('stream:ack')) {

--- a/packages/at_client/lib/src/client/remote_secondary.dart
+++ b/packages/at_client/lib/src/client/remote_secondary.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:at_chops/at_chops.dart';
 import 'package:at_client/src/client/secondary.dart';
 import 'package:at_client/src/manager/at_client_manager.dart';
 import 'package:at_client/src/preference/at_client_config.dart';
@@ -23,8 +24,10 @@ class RemoteSecondary implements Secondary {
 
   late AtLookupImpl atLookUp;
 
+  final AtChops? atChops;
+
   RemoteSecondary(String atSign, AtClientPreference preference,
-      {String? privateKey}) {
+      {String? privateKey, this.atChops}) {
     _atSign = AtUtils.formatAtSign(atSign)!;
     logger = AtSignLogger('RemoteSecondary ($_atSign)');
     _preference = preference;
@@ -40,6 +43,7 @@ class RemoteSecondary implements Secondary {
             AtClientManager.getInstance().secondaryAddressFinder,
         secureSocketConfig: secureSocketConfig,
         clientConfig: {VERSION: AtClientConfig.getInstance().atClientVersion});
+    atLookUp.atChops = atChops;
   }
 
   @experimental

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -1,3 +1,4 @@
+import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/listener/at_sign_change_listener.dart';
 import 'package:at_client/src/listener/switch_at_sign_event.dart';
@@ -53,7 +54,7 @@ class AtClientManager {
   }
 
   Future<AtClientManager> setCurrentAtSign(String atSign, String? namespace, AtClientPreference preference,
-      {AtServiceFactory? serviceFactory}) async {
+      {AtServiceFactory? serviceFactory, AtChops? atChops}) async {
 
     serviceFactory ??= DefaultAtServiceFactory();
 
@@ -73,6 +74,7 @@ class AtClientManager {
     _atSign = atSign;
     var previousAtClient = _currentAtClient;
     _currentAtClient = await serviceFactory.atClient(_atSign, namespace, preference, this);
+    _currentAtClient!.atChops = atChops;
 
     final switchAtSignEvent =
         SwitchAtSignEvent(previousAtClient, _currentAtClient!);

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -53,6 +53,10 @@ class AtClientManager {
     }
   }
 
+  /// * Can provide an [AtServiceFactory] to control what types of AtClients, NotificationServices and SyncServices get created
+  /// by this method.
+  /// * Can provide an [AtChops] instance if available; setCurrentAtSign will ensure that it is injected into objects that
+  /// can use it
   Future<AtClientManager> setCurrentAtSign(String atSign, String? namespace, AtClientPreference preference,
       {AtServiceFactory? serviceFactory, AtChops? atChops}) async {
 

--- a/packages/at_client/lib/src/manager/monitor.dart
+++ b/packages/at_client/lib/src/manager/monitor.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/preference/monitor_preference.dart';
 import 'package:at_client/src/response/default_response_parser.dart';
@@ -81,6 +82,8 @@ class Monitor {
 
   get heartbeatInterval => _heartbeatInterval;
 
+  final AtChops? atChops;
+
   ///
   /// Creates a [Monitor] object.
   ///
@@ -124,7 +127,9 @@ class Monitor {
       {RemoteSecondary? remoteSecondary,
       MonitorConnectivityChecker? monitorConnectivityChecker,
       MonitorOutboundConnectionFactory? monitorOutboundConnectionFactory,
-      Duration? monitorHeartbeatInterval}) {
+      Duration? monitorHeartbeatInterval,
+      this.atChops,
+      }) {
     _logger = AtSignLogger('Monitor ($atSign)');
     _onResponse = onResponse;
     _onError = onError;
@@ -133,7 +138,7 @@ class Monitor {
     _regex = monitorPreference.regex;
     _keepAlive = monitorPreference.keepAlive;
     _lastNotificationTime = monitorPreference.lastNotificationTime;
-    _remoteSecondary = remoteSecondary ?? RemoteSecondary(atSign, preference);
+    _remoteSecondary = remoteSecondary ?? RemoteSecondary(atSign, preference, atChops: atChops);
     _retryCallBack = retryCallBack;
     _monitorConnectivityChecker =
         monitorConnectivityChecker ?? MonitorConnectivityChecker();

--- a/packages/at_client/lib/src/manager/monitor.dart
+++ b/packages/at_client/lib/src/manager/monitor.dart
@@ -263,6 +263,7 @@ class Monitor {
     _logger.finer(
         'Authenticating the monitor connection: from result:$fromResponse');
     if (_preference.useAtChops) {
+      _logger.finer('Using AtChops to do the PKAM signing');
       var signingResult =
       atChops!.signString(fromResponse, SigningKeyType.pkamSha256);
       _logger.finer('Sending command pkam:${signingResult.result}');

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -94,7 +94,8 @@ class NotificationServiceImpl
             _atClient.getCurrentAtSign()!,
             _atClient.getPreferences()!,
             MonitorPreference()..keepAlive = true,
-            monitorRetry);
+            monitorRetry,
+            atChops: atClient.atChops);
     _atClientManager.listenToAtSignChange(this);
     lastReceivedNotificationAtKey = AtKey.local(lastReceivedNotificationKey,
             _atClient.getCurrentAtSign()!,

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -64,7 +64,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       required NotificationService notificationService,
       RemoteSecondary? remoteSecondary}) async {
     remoteSecondary ??= RemoteSecondary(
-        atClient.getCurrentAtSign()!, atClient.getPreferences()!);
+        atClient.getCurrentAtSign()!, atClient.getPreferences()!, atChops: atClient.atChops);
     final syncService = SyncServiceImpl._(
         atClientManager, atClient, notificationService, remoteSecondary);
     await syncService._statsServiceListener();
@@ -667,7 +667,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     late RemoteSecondary remoteSecondary;
     try {
       remoteSecondary = RemoteSecondary(
-          _atClient.getCurrentAtSign()!, _atClient.getPreferences()!);
+          _atClient.getCurrentAtSign()!, _atClient.getPreferences()!, atChops: _atClient.atChops);
       var serverCommitId =
           await _getServerCommitId(remoteSecondary: remoteSecondary);
 


### PR DESCRIPTION
Fixes #888 

**- What I did**
This PR is required so that as the onboarding packages take up use of AtChops, as is happening now with at_onboarding_cli, then can pass their constructed atChops when calling AtClientManager.setCurrentAtSign so that all of the core at_client package objects can then use that same atChops object for their cryptographic operations which require use of private keys

* Ensure that when we wish to use an AtChops instance (typically constructed by one of either the flutter or dart onboarding package) then it is injected to wherever needs it - notably, the RemoteSecondary and Monitor objects.
* Because SyncServiceImpl.create constructs its RemoteSecondary right away, this means that atChops needs to be available to SyncServiceImpl.create
* To make this possible, AtClientManager.setCurrentAtSign now accepts an optional AtChops? parameter which is injected into the constructed AtClient before the NotificationService and SyncService are created.
* As a result, SyncServiceImpl.create can get its AtChops from the AtClient which is passed, and can pass it to any RemoteSecondary it creates
* And, likewise, NotificationServiceImpl.create can get its AtChops from the AtClient which is passed, and can pass it to any Monitor it creates.

**- How I did it**
* RemoteSecondary constructor now accepts optional AtChops? parameter. In turn, RemoteSecondary sets atChops on the AtLookupsImpls it creates
* When creating RemoteSecondary objects, AtClientImpl provides its atChops to the RemoteSecondary constructor
* AtClientManager.setCurrentAtSign accepts optional AtChops? parameter, and thus can immediately set the atChops on the AtClient it creates
* Monitor constructor now accepts optional AtChops? parameter and uses it when authenticating, if AtClientPreference.useAtChops is true
* NotificationServiceImpl passes atClient.atChops when calling the Monitor constructor
* SyncServiceImpl passes atClient.atChops when calling the RemoteSecondary constructor

**- How to verify it**
Tests pass.

**- Description for the changelog**
feat: Inject AtChops instance (if any) so that it is available everywhere that it can be used