### PR TITLE
fix: add atChops as optional argument in AtServiceFactory.atClient

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.53
 - feat: Introduce commit log compaction to keep size of commit log thin
 - fix: Fixed a bug where switch atSign event is notified multiple times
+- fix: Add AtChops as optional argument to AtServiceFactory.atClient
 ## 3.0.52
 - feat: Introduce AtServiceFactory to make AtClientManager more reusable and more testable
 - feat: Make AtChops instance (if any) available everywhere that it can/should be used

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -29,6 +29,7 @@ class AtClientManager {
 
   @Deprecated('Use atClientManager.atClient.syncService')
   SyncService get syncService => atClient.syncService;
+
   @Deprecated('Use atClientManager.atClient.notificationService')
   NotificationService get notificationService => atClient.notificationService;
 
@@ -77,9 +78,8 @@ class AtClientManager {
         'Switching atSigns from ${_currentAtClient?.getCurrentAtSign()} to $atSign');
     _atSign = atSign;
     var previousAtClient = _currentAtClient;
-    _currentAtClient =
-        await serviceFactory.atClient(_atSign, namespace, preference, this);
-    _currentAtClient!.atChops = atChops;
+    _currentAtClient = await serviceFactory
+        .atClient(_atSign, namespace, preference, this, atChops: atChops);
 
     final switchAtSignEvent =
         SwitchAtSignEvent(previousAtClient, _currentAtClient!);
@@ -142,9 +142,12 @@ class AtClientManager {
 
 abstract class AtServiceFactory {
   Future<AtClient> atClient(String atSign, String? namespace,
-      AtClientPreference preference, AtClientManager atClientManager);
+      AtClientPreference preference, AtClientManager atClientManager,
+      {AtChops? atChops});
+
   Future<NotificationService> notificationService(
       AtClient atClient, AtClientManager atClientManager);
+
   Future<SyncService> syncService(AtClient atClient,
       AtClientManager atClientManager, NotificationService notificationService);
 }
@@ -152,9 +155,10 @@ abstract class AtServiceFactory {
 class DefaultAtServiceFactory implements AtServiceFactory {
   @override
   Future<AtClient> atClient(String atSign, String? namespace,
-      AtClientPreference preference, AtClientManager atClientManager) async {
+      AtClientPreference preference, AtClientManager atClientManager,
+      {AtChops? atChops}) async {
     return await AtClientImpl.create(atSign, namespace, preference,
-        atClientManager: atClientManager);
+        atClientManager: atClientManager, atChops: atChops);
   }
 
   @override


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did** 
[Problem]
* When AtClient is initialized through the "DefaultAtServiceFactory", we do not have a way to pass the AtChops instance. As a result, in the AtClientImpl constructor, when initializing the RemoteSecondary and AtLookUp, the AtChops instance inside the classes is set to null.

**- How I did it**
[Solution]
* In "AtServiceFactory" and "DefaultAtServiceFactory" add AtChops as an optional parameter.
  * When creating the AtClient instance, the atChops is passed as an optional argument to the "AtClient.create" method, which is subsequently passed to the constructor. So, the AtChops instances in the "RemoteSecondary" and "AtLookUp" are set to the instance that is injected into the AtClient.create method instead of null.

**- Description for the changelog**
* Add AtChops as an optional argument to the "DefaultAtServiceFactory".
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->