### PR TITLE
fix: functionality of encryptedSharedKeySyncStatusCacheMap

### DIFF
--- a/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
@@ -1,5 +1,4 @@
 import 'dart:collection';
-import 'dart:io';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/client/secondary.dart';
@@ -31,7 +30,7 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
   }
 
   @visibleForTesting
-  static final HashMap<String, bool> encryptedSharedKeySyncStatusCacheMap = HashMap();
+  final HashMap<String, bool> encryptedSharedKeySyncStatusCacheMap = HashMap();
 
   SyncUtil syncUtil = SyncUtil();
 
@@ -232,8 +231,6 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
       ..sharedBy = atKey.sharedBy
       ..sharedWith = atKey.sharedWith;
     // If key is present in cache, return true
-    stdout.writeln('1-$encryptedSharedKeySyncStatusCacheMap');
-    stdout.writeln(encryptedSharedKeySyncStatusCacheMap.containsKey(llookupVerbBuilder.buildKey()));
     if (encryptedSharedKeySyncStatusCacheMap.containsKey(llookupVerbBuilder.buildKey())) {
       return encryptedSharedKeySyncStatusCacheMap[llookupVerbBuilder.buildKey()]!;
     }
@@ -243,7 +240,6 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
 
     CommitEntry sharedKeyCommitEntry = await syncUtil.getLatestCommitEntry(
         atCommitLog!, llookupVerbBuilder.buildKey());
-    stdout.writeln(sharedKeyCommitEntry);
     if (sharedKeyCommitEntry.commitId == null) {
       return false;
     }

--- a/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
@@ -226,18 +226,17 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
   ///
   /// If Synced, returns true; else returns false.
   Future<bool> isEncryptedSharedKeyInSync(AtKey atKey) async {
-    // If key is present in cache, return true
-    if (encryptedSharedKeySyncStatusCacheMap.containsKey(atKey.toString())) {
-      return encryptedSharedKeySyncStatusCacheMap[atKey.toString()]!;
-    }
-    // Set the commit log instance if not already set.
-    atCommitLog ??= await AtCommitLogManagerImpl.getInstance()
-        .getCommitLog(atKey.sharedBy!);
-
     var llookupVerbBuilder = LLookupVerbBuilder()
       ..atKey = AT_ENCRYPTION_SHARED_KEY
       ..sharedBy = atKey.sharedBy
       ..sharedWith = atKey.sharedWith;
+    // If key is present in cache, return true
+    if (encryptedSharedKeySyncStatusCacheMap.containsKey(llookupVerbBuilder.buildKey())) {
+      return encryptedSharedKeySyncStatusCacheMap[llookupVerbBuilder.buildKey()]!;
+    }
+    // Set the commit log instance if not already set.
+    atCommitLog ??= await AtCommitLogManagerImpl.getInstance()
+        .getCommitLog(atKey.sharedBy!);
 
     CommitEntry sharedKeyCommitEntry = await syncUtil.getLatestCommitEntry(
         atCommitLog!, llookupVerbBuilder.buildKey());

--- a/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
@@ -30,7 +30,8 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
   }
 
   @visibleForTesting
-  final HashMap<String, bool> encryptedSharedKeySyncStatusCacheMap = HashMap();
+  static final HashMap<String, bool> encryptedSharedKeySyncStatusCacheMap =
+      HashMap();
 
   SyncUtil syncUtil = SyncUtil();
 
@@ -231,8 +232,10 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
       ..sharedBy = atKey.sharedBy
       ..sharedWith = atKey.sharedWith;
     // If key is present in cache, return true
-    if (encryptedSharedKeySyncStatusCacheMap.containsKey(llookupVerbBuilder.buildKey())) {
-      return encryptedSharedKeySyncStatusCacheMap[llookupVerbBuilder.buildKey()]!;
+    if (encryptedSharedKeySyncStatusCacheMap
+        .containsKey(llookupVerbBuilder.buildKey())) {
+      return encryptedSharedKeySyncStatusCacheMap[
+          llookupVerbBuilder.buildKey()]!;
     }
     // Set the commit log instance if not already set.
     atCommitLog ??= await AtCommitLogManagerImpl.getInstance()

--- a/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
@@ -1,4 +1,5 @@
 import 'dart:collection';
+import 'dart:io';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/client/secondary.dart';
@@ -30,7 +31,7 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
   }
 
   @visibleForTesting
-  final HashMap<String, bool> encryptedSharedKeySyncStatusCacheMap = HashMap();
+  static final HashMap<String, bool> encryptedSharedKeySyncStatusCacheMap = HashMap();
 
   SyncUtil syncUtil = SyncUtil();
 
@@ -231,6 +232,8 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
       ..sharedBy = atKey.sharedBy
       ..sharedWith = atKey.sharedWith;
     // If key is present in cache, return true
+    stdout.writeln('1-$encryptedSharedKeySyncStatusCacheMap');
+    stdout.writeln(encryptedSharedKeySyncStatusCacheMap.containsKey(llookupVerbBuilder.buildKey()));
     if (encryptedSharedKeySyncStatusCacheMap.containsKey(llookupVerbBuilder.buildKey())) {
       return encryptedSharedKeySyncStatusCacheMap[llookupVerbBuilder.buildKey()]!;
     }
@@ -240,6 +243,7 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
 
     CommitEntry sharedKeyCommitEntry = await syncUtil.getLatestCommitEntry(
         atCommitLog!, llookupVerbBuilder.buildKey());
+    stdout.writeln(sharedKeyCommitEntry);
     if (sharedKeyCommitEntry.commitId == null) {
       return false;
     }

--- a/packages/at_client/test/encryption_service_test.dart
+++ b/packages/at_client/test/encryption_service_test.dart
@@ -94,6 +94,7 @@ void main() {
       assert(updateVerbBuilder.dataSignature != null);
     });
   });
+
   group('A group of test to validate the encryption service manager', () {
     test('Test to verify the encryption of shared key', () async {
       var currentAtSign = '@sitaram';
@@ -311,6 +312,7 @@ void main() {
       expect(
           await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), false);
       // assert the sync status is not added to cache map
+
       expect(
           AbstractAtKeyEncryption.encryptedSharedKeySyncStatusCacheMap
               .containsKey(atKey.toString()), false);
@@ -346,14 +348,17 @@ void main() {
               .containsKey('@bob:shared_key@alice'),
           true);
       //now change the commitId of the respective commitEntry to null
-      //this will make sure that when accessed from the commitLog it would appear that the entry is not synced
-      //for the  isEncryptedSharedKeyInSync() to return true, the cache must contain this key
+      //this will make sure that when accessed from the commitLog
+      // it would appear that the entry is not synced
+      //for isEncryptedSharedKeyInSync() to return true, the cache must contain this key
       keystoreToMap[1]?.commitId = null;
-      //the below assertion has to use the cache
+      //the below assertion will only return true if the key is present in the cache
       expect(await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), true);
     });
 
     tearDown(() async {
+      resetMocktailState();
+      AbstractAtKeyEncryption.encryptedSharedKeySyncStatusCacheMap.clear();
       await AtCommitLogManagerImpl.getInstance().close();
       var isExists = await Directory(storageDir).exists();
       if (isExists) {
@@ -481,6 +486,7 @@ void main() {
       when(() => mockLocalSecondary.executeVerb(
           any(that: UpdatedSharedKeyMatcher()),
           sync: true)).thenAnswer((_) => Future.value('data:1'));
+
       when(() => mockRemoteSecondary
               .executeVerb(any(that: UpdatedSharedKeyMatcher()), sync: true))
           .thenAnswer((_) => throw SecondaryConnectException(
@@ -500,6 +506,7 @@ void main() {
     });
 
     tearDown(() async {
+      AbstractAtKeyEncryption.encryptedSharedKeySyncStatusCacheMap.clear();
       await AtCommitLogManagerImpl.getInstance().close();
       var isExists = await Directory(storageDir).exists();
       if (isExists) {

--- a/packages/at_client/test/encryption_service_test.dart
+++ b/packages/at_client/test/encryption_service_test.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:at_client/at_client.dart';
-import 'package:at_client/src/encryption_service/abstract_atkey_encryption.dart';
 import 'package:at_client/src/encryption_service/encryption_manager.dart';
 import 'package:at_client/src/encryption_service/self_key_encryption.dart';
 import 'package:at_client/src/encryption_service/shared_key_encryption.dart';
@@ -91,7 +90,6 @@ void main() {
       assert(updateVerbBuilder.dataSignature != null);
     });
   });
-
   group('A group of test to validate the encryption service manager', () {
     test('Test to verify the encryption of shared key', () async {
       var currentAtSign = '@sitaram';
@@ -260,7 +258,7 @@ void main() {
           await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), false);
       // assert the sync status is not added to cache map when commit id is null.
       expect(
-          AbstractAtKeyEncryption.encryptedSharedKeySyncStatusCacheMap
+          sharedKeyEncryption.encryptedSharedKeySyncStatusCacheMap
               .containsKey(atKey.toString()),
           false);
     });
@@ -282,7 +280,7 @@ void main() {
       expect(await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), true);
       // assert the sync status is added to cache map
       expect(
-          AbstractAtKeyEncryption.encryptedSharedKeySyncStatusCacheMap
+          sharedKeyEncryption.encryptedSharedKeySyncStatusCacheMap
               .containsKey(atKey.toString()),
           true);
     });
@@ -312,23 +310,21 @@ void main() {
           await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), false);
       // assert the sync status is not added to cache map
       expect(
-          AbstractAtKeyEncryption.encryptedSharedKeySyncStatusCacheMap
+          sharedKeyEncryption.encryptedSharedKeySyncStatusCacheMap
               .containsKey(atKey.toString()),
           false);
     });
 
     test(
-        'A test to verify isEncryptedSharedKeyInSync is returned from the cache map',
+        'A test to verify isEncryptedSharedKeyInSync is return from the cache map',
         () async {
       var atKey = AtKey()
         ..key = AT_ENCRYPTION_SHARED_KEY
         ..sharedBy = '@alice'
         ..sharedWith = '@bob';
       var sharedKeyEncryption = SharedKeyEncryption(mockAtClient);
-
-      AbstractAtKeyEncryption.encryptedSharedKeySyncStatusCacheMap
+      sharedKeyEncryption.encryptedSharedKeySyncStatusCacheMap
           .putIfAbsent(atKey.toString(), () => true);
-
       expect(await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), true);
     });
 

--- a/packages/at_client/test/encryption_service_test.dart
+++ b/packages/at_client/test/encryption_service_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:at_client/at_client.dart';
+import 'package:at_client/src/encryption_service/abstract_atkey_encryption.dart';
 import 'package:at_client/src/encryption_service/encryption_manager.dart';
 import 'package:at_client/src/encryption_service/self_key_encryption.dart';
 import 'package:at_client/src/encryption_service/shared_key_encryption.dart';
@@ -90,6 +91,7 @@ void main() {
       assert(updateVerbBuilder.dataSignature != null);
     });
   });
+
   group('A group of test to validate the encryption service manager', () {
     test('Test to verify the encryption of shared key', () async {
       var currentAtSign = '@sitaram';
@@ -258,7 +260,7 @@ void main() {
           await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), false);
       // assert the sync status is not added to cache map when commit id is null.
       expect(
-          sharedKeyEncryption.encryptedSharedKeySyncStatusCacheMap
+          AbstractAtKeyEncryption.encryptedSharedKeySyncStatusCacheMap
               .containsKey(atKey.toString()),
           false);
     });
@@ -280,7 +282,7 @@ void main() {
       expect(await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), true);
       // assert the sync status is added to cache map
       expect(
-          sharedKeyEncryption.encryptedSharedKeySyncStatusCacheMap
+          AbstractAtKeyEncryption.encryptedSharedKeySyncStatusCacheMap
               .containsKey(atKey.toString()),
           true);
     });
@@ -310,21 +312,23 @@ void main() {
           await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), false);
       // assert the sync status is not added to cache map
       expect(
-          sharedKeyEncryption.encryptedSharedKeySyncStatusCacheMap
+          AbstractAtKeyEncryption.encryptedSharedKeySyncStatusCacheMap
               .containsKey(atKey.toString()),
           false);
     });
 
     test(
-        'A test to verify isEncryptedSharedKeyInSync is return from the cache map',
+        'A test to verify isEncryptedSharedKeyInSync is returned from the cache map',
         () async {
       var atKey = AtKey()
         ..key = AT_ENCRYPTION_SHARED_KEY
         ..sharedBy = '@alice'
         ..sharedWith = '@bob';
       var sharedKeyEncryption = SharedKeyEncryption(mockAtClient);
-      sharedKeyEncryption.encryptedSharedKeySyncStatusCacheMap
+
+      AbstractAtKeyEncryption.encryptedSharedKeySyncStatusCacheMap
           .putIfAbsent(atKey.toString(), () => true);
+
       expect(await sharedKeyEncryption.isEncryptedSharedKeyInSync(atKey), true);
     });
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes https://github.com/atsign-foundation/at_client_sdk/issues/891
**- What I did**
- fixed the encryptedSharedKeySyncStatusCacheMap which was previously unusable, which is now usable
- A new AbstractKeyEncryption instance is created every time, made sure that for each new instance the same cache map is used

**- How I did it**
- Previously the check for the key in existing cache was incorrect, the check is now fixed to be correct.
- Made the encryptedSharedKeySyncStatusCacheMap static so that each new instance of AbstractKeyEncryption returns only the same CacheMap.

**- How to verify it**
- Modified en existing test to accurately assert this functionality

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: functionality of encryptedSharedKeySyncStatusCacheMap