### PR TITLE
fix: Sync to local fails to delete a cached key

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 3.0.54
+## 3.0.55
 - fix: Sync to local fails to delete a cached key
+## 3.0.54
 - fix: ensure forText notifications are decrypted successfully when using at_commons 3.0.35 or greater
 ## 3.0.53
 - feat: Introduce commit log compaction to keep size of commit log thin

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.54
+- fix: Sync to local fails to delete a cached key
 ## 3.0.53
 - feat: Introduce commit log compaction to keep size of commit log thin
 - fix: Fixed a bug where switch atSign event is notified multiple times

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.54';
+  final String atClientVersion = '3.0.55';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.53';
+  final String atClientVersion = '3.0.54';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -772,7 +772,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
         await _pullToLocal(builder, serverCommitEntry, CommitOp.UPDATE_ALL);
         break;
       case '-':
-        var builder = DeleteVerbBuilder()..atKey = serverCommitEntry['atKey'];
+        var builder = DeleteVerbBuilder()..atKeyObj = AtKey.fromString(serverCommitEntry['atKey']);
         _logger.finest(
             'syncing to local delete: ${serverCommitEntry['atKey']}  commitId:${serverCommitEntry['commitId']}');
         await _pullToLocal(builder, serverCommitEntry, CommitOp.DELETE);

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.53
+version: 3.0.54
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.54
+version: 3.0.55
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/test/sync_new_test.dart
+++ b/packages/at_client/test/sync_new_test.dart
@@ -44,6 +44,8 @@ class MockNotificationServiceImpl extends Mock
 
 class MockNetworkUtil extends Mock implements NetworkUtil {}
 
+class MockSyncUtil extends Mock implements SyncUtil {}
+
 class FakeSyncVerbBuilder extends Fake implements SyncVerbBuilder {}
 
 class FakeUpdateVerbBuilder extends Fake implements UpdateVerbBuilder {}
@@ -56,6 +58,10 @@ class FakeUpdateVerbBuilder extends Fake implements UpdateVerbBuilder {}
 /// 3. Recreate = A key that exists previously got deleted and it is being created again
 
 void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeSyncVerbBuilder());
+    registerFallbackValue(FakeUpdateVerbBuilder());
+  });
   // (Client) How items are added to the 'uncommitted' queue on the client side (upon data store operations)
   // (Client) How the client processes that uncommitted queue (while sending updates to server) - e.g. how is the queue ordered, how is it de-duped, etc
   // (Client) How the client processes updates from the server - can the client reject? under what conditions? what happens upon a rejection?
@@ -2206,17 +2212,23 @@ void main() {
   });
 
   group('A group of tests when server is ahead of local commit id', () {
+    late AtClient mockAtClient;
+    late AtClientManager mockAtClientManager;
+    late NotificationServiceImpl mockNotificationService;
+    late RemoteSecondary mockRemoteSecondary;
+    late NetworkUtil mockNetworkUtil;
+    late SyncUtil mockSyncUtil;
+
     setUp(() async {
       TestResources.atsign = '@gandalf';
       await TestResources.setupLocalStorage(TestResources.atsign);
+      mockAtClient = MockAtClient();
+      mockAtClientManager = MockAtClientManager();
+      mockNotificationService = MockNotificationServiceImpl();
+      mockRemoteSecondary = MockRemoteSecondary();
+      mockNetworkUtil = MockNetworkUtil();
+      mockSyncUtil = MockSyncUtil();
     });
-
-    AtClient mockAtClient = MockAtClient();
-    AtClientManager mockAtClientManager = MockAtClientManager();
-    NotificationServiceImpl mockNotificationService =
-        MockNotificationServiceImpl();
-    RemoteSecondary mockRemoteSecondary = MockRemoteSecondary();
-    NetworkUtil mockNetworkUtil = MockNetworkUtil();
 
     /// The test should contain all types of keys - public key, shared key, self key
     ///
@@ -2419,37 +2431,61 @@ void main() {
     });
 
     /// Preconditions:
-    /// 1. There should be an entry for the same key in the key store
-    /// 2. There should be an entry for the same key in the commit log
+    /// 1. There should be an entry of keys in the keystore
+    /// 2. The server response should contain the same keys with CommitOp.DELETE
     ///
     /// Operation:
     /// CommitOp.DELETE
     ///
     /// Assertions:
     /// 1. The key should be deleted from the key store
-    /// 2. CommitLog should have an entry for the key with commitOp.DELETE
     test(
         'A test to verify existing key is deleted when delete commit operation is received',
         () async {
       // --------------------- Setup ---------------------
+      LocalSecondary? localSecondary = LocalSecondary(mockAtClient,
+          keyStore: TestResources.getHiveKeyStore(TestResources.atsign));
+
+      SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
+          atClientManager: mockAtClientManager,
+          notificationService: mockNotificationService,
+          remoteSecondary: mockRemoteSecondary) as SyncServiceImpl;
+      syncService.networkUtil = mockNetworkUtil;
+      syncService.syncUtil = mockSyncUtil;
+
       HiveKeystore? keystore =
           TestResources.getHiveKeyStore(TestResources.atsign);
-      //------------------Operation-------------
-      //  creating a key in the keystore
-      String atKey = (AtKey.public('message',
-              namespace: 'wavi', sharedBy: TestResources.atsign))
-          .build()
-          .toString();
-      await keystore!.put(atKey, AtData()..data = 'hello');
-      int? removeId = await keystore.remove(atKey);
+      await keystore?.put(
+          '@alice:contact@gandalf', AtData()..data = 'dummy_value');
+      await keystore?.put(
+          'cached:@gandalf:aboutme@bob', AtData()..data = 'dummy_value');
+
+      // Mock Responses
+      when(() => mockSyncUtil.getLastSyncedEntry(null,
+          atSign:
+              TestResources.atsign)).thenAnswer((_) => Future.value(CommitEntry(
+          '@bob:phone@${TestResources.atsign}', CommitOp.UPDATE, DateTime.now())
+        ..commitId = 2));
+      when(() => mockSyncUtil.getChangesSinceLastCommit(null, null,
+          atSign: TestResources.atsign)).thenAnswer((_) => Future.value([]));
+      when(() => mockSyncUtil.getCommitEntry(any(), TestResources.atsign))
+          .thenAnswer((_) => Future.value(null));
+
+      when(() => mockRemoteSecondary.executeVerb(
+          any(
+              that: SyncVerbBuilderMatcher()))).thenAnswer((_) => Future.value(
+          'data:[{"atKey":"@alice:contact@gandalf","value":null,"metadata":null,"commitId":3,"operation":"-"},{"atKey":"cached:@gandalf:aboutme@bob","value":null,"metadata":null,"commitId":4,"operation":"-"}]'));
+
+      when(() => mockAtClient.getLocalSecondary())
+          .thenAnswer((_) => localSecondary);
+
+      var syncRequest = SyncRequest()..result = SyncResult();
+      await syncService.syncInternal(4, syncRequest);
       //------------------Assertions-------------
-      expect(() async => await keystore.get(atKey),
+      expect(() async => await keystore?.get('cached:@gandalf:aboutme@bob'),
           throwsA(predicate((dynamic e) => e is KeyNotFoundException)));
-      // verifying the key in the commit log
-      var commitEntryResult =
-          await SyncUtil(atCommitLog: TestResources.commitLog)
-              .getCommitEntry(removeId!, TestResources.atsign);
-      expect(commitEntryResult!.operation, CommitOp.DELETE);
+      expect(() async => await keystore?.get('@alice:contact@gandalf'),
+          throwsA(predicate((dynamic e) => e is KeyNotFoundException)));
     });
 
     test(
@@ -3576,6 +3612,7 @@ void onDoneCallback(syncResult) {
 
 class CustomSyncProgressListener extends SyncProgressListener {
   SyncProgress? localSyncProgress;
+
   @override
   void onSyncProgressEvent(SyncProgress syncProgress) {
     localSyncProgress = syncProgress;
@@ -3587,6 +3624,7 @@ class TestResources {
   static AtCommitLog? commitLog;
   static SecondaryPersistenceStore? secondaryPersistenceStore;
   static var storageDir = '${Directory.current.path}/test/hive';
+
   //an object that will be used to assert change of state
   static bool switchState = false;
 

--- a/tests/at_end2end_test/test/deletion_key_test.dart
+++ b/tests/at_end2end_test/test/deletion_key_test.dart
@@ -1,10 +1,12 @@
 import 'package:at_client/at_client.dart';
 import 'package:at_end2end_test/config/config_util.dart';
+import 'package:at_end2end_test/src/sync_initializer.dart';
 import 'package:at_end2end_test/src/test_initializers.dart';
 import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:test/test.dart';
 
 late AtClientManager currentAtClientManager;
+late AtClientManager sharedWithAtClientManager;
 late String currentAtSign;
 late String sharedWithAtSign;
 final namespace = 'wavi';
@@ -18,6 +20,10 @@ void main() {
         .testInitializer(currentAtSign, namespace);
     await TestSuiteInitializer.getInstance()
         .testInitializer(sharedWithAtSign, namespace);
+    // Initialize sharedWithAtSign
+    sharedWithAtClientManager = await AtClientManager.getInstance()
+        .setCurrentAtSign(sharedWithAtSign, namespace,
+            TestPreferences.getInstance().getPreference(sharedWithAtSign));
     // Setting currentAtSign atClient instance to context.
     currentAtClientManager = await AtClientManager.getInstance()
         .setCurrentAtSign(currentAtSign, namespace,
@@ -49,4 +55,55 @@ void main() {
             .isKeyExists(atKey.toString()),
         false);
   });
+
+  test(
+      'A test to verify cached key is deleted in sharedWith secondary when CCD is set to true',
+      () async {
+    var atKey = (AtKey.shared('deletecachedkey', sharedBy: currentAtSign)
+          ..sharedWith(sharedWithAtSign)
+          ..cache(-1, true))
+        .build();
+    await currentAtClientManager.atClient.put(atKey, 'dummy_cached_value');
+    await E2ESyncService.getInstance()
+        .syncData(currentAtClientManager.atClient.syncService);
+
+    sharedWithAtClientManager = await AtClientManager.getInstance()
+        .setCurrentAtSign(sharedWithAtSign, namespace,
+            TestPreferences.getInstance().getPreference(sharedWithAtSign));
+    await E2ESyncService.getInstance()
+        .syncData(sharedWithAtClientManager.atClient.syncService);
+
+    var cachedAtKey = AtKey()
+      ..key = 'deletecachedkey'
+      ..sharedWith = sharedWithAtSign
+      ..sharedBy = currentAtSign
+      ..metadata = (Metadata()..isCached = true);
+    var getResponse = await sharedWithAtClientManager.atClient.get(cachedAtKey);
+    expect(getResponse.value, 'dummy_cached_value');
+    // Delete the key
+    currentAtClientManager = await AtClientManager.getInstance()
+        .setCurrentAtSign(currentAtSign, namespace,
+            TestPreferences.getInstance().getPreference(currentAtSign));
+    await currentAtClientManager.atClient.delete(atKey);
+    await E2ESyncService.getInstance()
+        .syncData(currentAtClientManager.atClient.syncService);
+
+    // Sync the deleted cached key commit entry to local secondary of sharedWith atSign
+    sharedWithAtClientManager = await AtClientManager.getInstance()
+        .setCurrentAtSign(sharedWithAtSign, namespace,
+            TestPreferences.getInstance().getPreference(sharedWithAtSign));
+    await E2ESyncService.getInstance()
+        .syncData(sharedWithAtClientManager.atClient.syncService);
+
+    // Asserts cached key is deleted from the local storage in the sharedWith atSign
+    expect(
+        sharedWithAtClientManager.atClient
+            .getLocalSecondary()
+            ?.keyStore
+            ?.isKeyExists(
+                'cached:$sharedWithAtSign:deletecachedkey$currentAtSign}'),
+        false);
+    // When sync runs the test remains idle and timeout after 30 seconds
+    // Adding timeout to allow sync to complete on current atSign and sharedWith atSign.
+  }, timeout: Timeout(Duration(minutes: 1)));
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
[Problem]
* The cached key in the local secondary is not deleted when a sync response contains a delete operation.

[Root Cause]
* In sync_service_impl.dart, the string representation of the AtKey instance (received from the server via the sync response) is set to DeleteVerbBuilder.AtKey. When a "toString" is called on the "DeleteVerbBuilder", the "cached:<sharedWith>" is duplicated causing the incorrect key.

**- How I did it**
* Before calling "toString" on "DeleteVerbBuilder", convert the string representation of "AtKey" to "AtKey" object and set it to atKeyObj

**- How to verify it**
* Tested manually and cached keys get deleted in local secondary.
* Updated the unit tests and end2end tests to asset the changes.

**- Description for the changelog**
* Sync to local fails to delete a cached key
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->