### PR TITLE
fix: onboard when the device is offline

### DIFF
--- a/packages/at_client_mobile/test/at_client_service_test.dart
+++ b/packages/at_client_mobile/test/at_client_service_test.dart
@@ -264,6 +264,24 @@ void main() {
       expect(onboardResult, true);
     });
 
+    test('A test to verify onboard method when device is offline', () async {
+      var atClientService = AtClientService();
+      atClientService.atLookupImpl = mockAtLookupImpl;
+      atClientService.keyChainManager = mockKeyChainManager;
+      atClientService.atClientManager = mockAtClientManager;
+
+      when(() => mockKeyChainManager.getPkamPrivateKey(any()))
+          .thenAnswer((_) => Future.value('dummy_private_key'));
+      // When device is offline, it fails to fetch the encryption public key from
+      // server and throws network not reachable exceptions
+      when(() => mockAtLookupImpl.executeCommand(any()))
+          .thenAnswer((_) => throw Exception('Network not reachable'));
+
+      var onboardResult = await atClientService.onboard(
+          atClientPreference: atClientPreference, atsign: atSign);
+      expect(onboardResult, true);
+    });
+
     test(
         'A test to verify onboard method when atSign is fetched from keychain manager',
         () async {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
[Problem]
 * Onboarding an atSign paired to a device fails when the network is down, This prevents fetching the data from the local storage when the device is offline.

[Root Cause]
  * During onboarding, the "OnBoardingStatus" is determined for which the encryption public key is fetched from the cloud secondary server. When the network is not reachable, fetching of encryption public key returns an exception causing the onboard process to fail.

**- How I did it**
[Solution]
 * Added a try-catch block around the code that fetches the encryption public key from the server. Upon exception, the error is logged and "null" is returned. 
 * Refactored the code in "_getServerEncryptionPublicKey" method as below:
      * Currently, the lookup verb command is used to fetch the encryption public key. On an authenticated connection, the lookup verb fails to fetch the data and returns "data:null". In this case, llookup verb is used to fetch the encryption public key. In a worst-case scenario, two calls to remote secondary are sent.
      * Modified the code such that If the connection is authenticated, then set the command to llookup verb, else set to command to lookup verb and run executeCommand to fetch the data.
 * Modified the condition to check the OnboardingStatus in the "getKeyRestorePolicy" method:
      * If the encryption public key is NULL on the cloud and local secondary (OR) encryption public key is NULL in cloud secondary and NOT-NULL is local secondary, then Onboarding Status is set to "Activate".
      * Also, if the encryption public key is NULL in cloud secondary and NOT-NULL is local secondary, then Onboarding Status is set to "SyncToServer".
      * Since the condition to check "SyncToSever" is the same as the condition after OR in the condition to check "Activate" the "SyncToServer" will not be returned.
      * Also the condition encryptionPublicKey NOT NULL in local secondary does not seem correct for "ACTIVATE", because if we generate encryption key pair only after activating the atSign. Hence removed the later part of the condition to check the "OnboardingStatus.ACTIVATE"
       
**- How to verify it**
  * Ran wavi app and atmosphere app with the changes and able to onboard the app.
  * Added a new unit test to onboard an app when remote secondary returns an exception.

**- Description for the changelog**
* Onboard a paired atSign when the device is offline
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->