### PR TITLE
build: prep for release at_client v 3.0.55

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 3.0.55
+- fix: Amend Monitor's socket message handler so that it separates multiple 'simultaneous' responses correctly.
 - fix: Sync to local fails to delete a cached key
 - feat: Introduce CommitOp(CommitOperation) to the KeyInfo to describe key update or delete upon sync
-- build: consume changes in at_commons v3.0.35 that enforce lowercase on AtKey
+- feat: consume changes in at_commons v3.0.35 that enforce lowercase on AtKey
 - build: upgrade dependency at_persistence_secondary_server to v3.0.46
 ## 3.0.54
 - fix: ensure forText notifications are decrypted successfully when using at_commons 3.0.35 or greater

--- a/packages/at_client/test/sync_service_test.dart
+++ b/packages/at_client/test/sync_service_test.dart
@@ -2,9 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:at_client/at_client.dart';
-import 'package:at_client/src/response/at_notification.dart'
-    // ignore: no_leading_underscores_for_library_prefixes
-    as _at_notification;
+import 'package:at_client/src/response/at_notification.dart' as at_notification;
 import 'package:at_client/src/service/sync/sync_request.dart';
 import 'package:at_client/src/service/sync_service_impl.dart';
 import 'package:at_client/src/service/notification_service_impl.dart';
@@ -58,9 +56,9 @@ class MockAtClientManager extends Mock implements AtClientManager {}
 class MockNotificationServiceImpl extends Mock
     implements NotificationServiceImpl {
   @override
-  Stream<_at_notification.AtNotification> subscribe(
+  Stream<at_notification.AtNotification> subscribe(
       {String? regex, bool shouldDecrypt = false}) {
-    return StreamController<_at_notification.AtNotification>().stream;
+    return StreamController<at_notification.AtNotification>().stream;
   }
 }
 


### PR DESCRIPTION
**- What I did**
* build: update CHANGELOG to include all merged PRs for 3.0.55
* style: changed an imported package name in sync_service_test.dart to meet Dart style guidelines

