### PR TITLE
fix: at_client.putInternal() throws null error

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.56
+-fix: AtClient.put() throws null-check error when key's namespace is null
 ## 3.0.55
 - fix: Amend Monitor's socket message handler so that it separates multiple 'simultaneous' responses correctly.
 - fix: Sync to local fails to delete a cached key

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -474,8 +474,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       atKey.namespace ??= preference?.namespace;
     }
 
-    if (upperCaseRegex.hasMatch(atKey.key!) ||
-        upperCaseRegex.hasMatch(atKey.namespace!)) {
+    if (upperCaseRegex.hasMatch(atKey.key!)) {
       _logger.info(
           'AtKey: ${atKey.key}.${atKey.namespace} contains upper case characters,'
           'converting the key to lower case');

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -465,13 +465,12 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
   @visibleForTesting
   ensureLowerCase(AtKey atKey) {
-    if (
-    (atKey.key != null && upperCaseRegex.hasMatch(atKey.key!)) ||
-        (atKey.namespace != null && upperCaseRegex.hasMatch(atKey.namespace!))
-    ) {
-      _logger.info(
-          'AtKey: ${atKey.toString()} contains upper case characters,'
-              'key has been converted to lower case');
+    if ((atKey.key != null && upperCaseRegex.hasMatch(atKey.key!)) ||
+        (atKey.namespace != null &&
+            upperCaseRegex.hasMatch(atKey.namespace!))) {
+      _logger.info('AtKey: ${atKey.toString()} contains upper case characters,'
+          ' AtKey has been converted to lower case');
+      //AtKey.toString() in the above log will convert the entire key to lower case
     }
   }
 

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -474,7 +474,10 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       atKey.namespace ??= preference?.namespace;
     }
 
-    if (upperCaseRegex.hasMatch(atKey.toString())) {
+    if (
+        (atKey.key != null && upperCaseRegex.hasMatch(atKey.key!)) ||
+        (atKey.namespace != null && upperCaseRegex.hasMatch(atKey.namespace!))
+    ) {
       _logger.info(
           'AtKey: ${atKey.toString()} contains upper case characters,'
           'converting the key to lower case');

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -463,6 +463,18 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     }
   }
 
+  @visibleForTesting
+  ensureLowerCase(AtKey atKey) {
+    if (
+    (atKey.key != null && upperCaseRegex.hasMatch(atKey.key!)) ||
+        (atKey.namespace != null && upperCaseRegex.hasMatch(atKey.namespace!))
+    ) {
+      _logger.info(
+          'AtKey: ${atKey.toString()} contains upper case characters,'
+              'key has been converted to lower case');
+    }
+  }
+
   Future<AtResponse> _putInternal(AtKey atKey, dynamic value) async {
     // Performs the put request validations.
     AtClientValidation.validatePutRequest(atKey, value, preference!);
@@ -474,14 +486,8 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       atKey.namespace ??= preference?.namespace;
     }
 
-    if (
-        (atKey.key != null && upperCaseRegex.hasMatch(atKey.key!)) ||
-        (atKey.namespace != null && upperCaseRegex.hasMatch(atKey.namespace!))
-    ) {
-      _logger.info(
-          'AtKey: ${atKey.toString()} contains upper case characters,'
-          'key has been converted to lower case');
-    }
+    ensureLowerCase(atKey);
+
     // validate the atKey
     // * Setting the validateOwnership to true to perform KeyOwnerShip validation and KeyShare validation
     // * Setting enforceNamespace to true unless specifically set to false in the AtClientPreference

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -474,9 +474,9 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       atKey.namespace ??= preference?.namespace;
     }
 
-    if (upperCaseRegex.hasMatch(atKey.key!)) {
+    if (upperCaseRegex.hasMatch(atKey.toString())) {
       _logger.info(
-          'AtKey: ${atKey.key}.${atKey.namespace} contains upper case characters,'
+          'AtKey: ${atKey.toString()} contains upper case characters,'
           'converting the key to lower case');
     }
     // validate the atKey

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -477,7 +477,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     if (upperCaseRegex.hasMatch(atKey.toString())) {
       _logger.info(
           'AtKey: ${atKey.toString()} contains upper case characters,'
-          'converting the key to lower case');
+          'key has been converted to lower case');
     }
     // validate the atKey
     // * Setting the validateOwnership to true to perform KeyOwnerShip validation and KeyShare validation

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.55';
+  final String atClientVersion = '3.0.56';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.55
+version: 3.0.56
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/test/at_client_impl_test.dart
+++ b/packages/at_client/test/at_client_impl_test.dart
@@ -199,17 +199,19 @@ void main() {
   });
 
   group('AtClientImpl.ensureLowerCase() functionality checks', () {
+    late AtClientManager manager;
+    late AtClientImpl client;
     test(
-        'Test for AtClientImpl.ensureLowerCase() on an AtKey with no namespace',
+        'Test AtClientImpl.ensureLowerCase() on an AtKey with no namespace',
         () async {
       AtKey key = AtKey()
         ..key = 'dummy'
         ..sharedBy = '@sender'
         ..sharedWith = '@receiver';
 
-      var manager = await AtClientManager.getInstance()
+      manager = await AtClientManager.getInstance()
           .setCurrentAtSign('@sender', null, AtClientPreference());
-      var client = manager.atClient as AtClientImpl;
+      client = manager.atClient as AtClientImpl;
 
       //AtClientImpl.ensureLowerCase() has a void return type
       //this test is only to ensure that when this method is run
@@ -220,17 +222,27 @@ void main() {
     });
 
     test(
-        'Test for AtClientImpl.ensureLowerCase() of an AtKey with upper case chars in namespace',
+        'Test for AtClientImpl.ensureLowerCase() on an AtKey with upper case chars in namespace',
+            () async {
+          AtKey key = AtKey()
+            ..key = 'lowercase'
+            ..namespace = 'cAsEsEnSiTiVe'
+            ..sharedBy = '@sender'
+            ..sharedWith = '@receiver';
+
+          //AtClientImpl.ensureLowerCase() has a void return type
+          expect(client.ensureLowerCase(key), null); //errorless execution test
+          expect(key.namespace, 'casesensitive'); //namespace should be converted to lower case
+        });
+
+    test(
+        'Test AtClientImpl.ensureLowerCase() on an AtKey with upper case chars in key and namespace',
         () async {
       AtKey key = AtKey()
         ..key = 'uPpErCasE'
         ..namespace = 'cAsEsEnSiTiVe'
         ..sharedBy = '@sender'
         ..sharedWith = '@receiver';
-
-      var manager = await AtClientManager.getInstance()
-          .setCurrentAtSign('@sender', 'dummyNamespace', AtClientPreference());
-      var client = manager.atClient as AtClientImpl;
 
       //AtClientImpl.ensureLowerCase() has a void return type
       expect(client.ensureLowerCase(key), null); //errorless execution test

--- a/packages/at_client/test/at_client_impl_test.dart
+++ b/packages/at_client/test/at_client_impl_test.dart
@@ -197,4 +197,45 @@ void main() {
       expect(mockAtCompactionJob.isCronScheduled, false);
     });
   });
+
+  group('AtClientImpl.ensureLowerCase() functionality checks', () {
+    test(
+        'Test for AtClientImpl.ensureLowerCase() on an AtKey with no namespace',
+        () async {
+      AtKey key = AtKey()
+        ..key = 'dummy'
+        ..sharedBy = '@sender'
+        ..sharedWith = '@receiver';
+
+      var manager = await AtClientManager.getInstance()
+          .setCurrentAtSign('@sender', null, AtClientPreference());
+      var client = manager.atClient as AtClientImpl;
+
+      //AtClientImpl.ensureLowerCase() has a void return type
+      //this test is only to ensure that when this method is run
+      //with an AtKey with namespace 'null', it does not throw an exception
+      expect(client.ensureLowerCase(key), null);
+      //this test is considered to be passing when the method does not throw
+      // an exception/error while executing
+    });
+
+    test(
+        'Test for AtClientImpl.ensureLowerCase() of an AtKey with upper case chars in namespace',
+        () async {
+      AtKey key = AtKey()
+        ..key = 'uPpErCasE'
+        ..namespace = 'cAsEsEnSiTiVe'
+        ..sharedBy = '@sender'
+        ..sharedWith = '@receiver';
+
+      var manager = await AtClientManager.getInstance()
+          .setCurrentAtSign('@sender', 'dummyNamespace', AtClientPreference());
+      var client = manager.atClient as AtClientImpl;
+
+      //AtClientImpl.ensureLowerCase() has a void return type
+      expect(client.ensureLowerCase(key), null); //errorless execution test
+      expect(key.namespace, 'casesensitive'); //namespace should be converted to lower case
+      expect(key.key, 'uppercase'); //key should be converted to lower case
+    });
+  });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- AtKey.namespace has a null check in putInternal() that is throwing a null check error when a key is created without a namespace.
- Added a null check to the if-clause that checks for any upper case characters in AtKey's key and namespace.

**- How to verify it**
- when a key is created without namespace an exception should not be thrown.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: at_client.putInternal() throws null error