### PR TITLE
fix: sync deleted cached keys 

### DIFF
--- a/packages/at_client_mobile/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/at_client_mobile/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,7 +9,7 @@ import at_file_saver
 import biometric_storage
 import file_selector_macos
 import package_info_plus_macos
-import path_provider_macos
+import path_provider_foundation
 import share_plus_macos
 import url_launcher_macos
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
I Modified the `getBatchRequests()` method in `sync_service_impl.dart` file to allow deleted cached keys to sync to cloud secondary.

**- How I did it**
Added `entry.operation != CommitOp.DELETE` to the IF statement of the `getBatchRequests()` method in `sync_service_impl.dart`

**- How to verify it**
A test should be written for this. This PR goes to a 932-sync-deleted... branch so someone can write a test before merging with trunk.

I verified it by deleting my data on the dude app, uninstalling the app and reinstalling the app and the data remained deleted. Without this fix the deleted data reappeared. You can read about this issue in #932.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Allow deleted cached keys to sync to cloud secondary