### PR TITLE
fix: Invalid atKey in notification_response_transformer.dart

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,5 +1,7 @@
+## 3.0.57
+- fix: Incorrect atKey.toString() in notification_response_transformation.dart
 ## 3.0.56
--fix: AtClient.put() throws null-check error when key's namespace is null
+- fix: AtClient.put() throws null-check error when key's namespace is null
 ## 3.0.55
 - fix: Amend Monitor's socket message handler so that it separates multiple 'simultaneous' responses correctly.
 - fix: Sync to local fails to delete a cached key

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.56';
+  final String atClientVersion = '3.0.57';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
+++ b/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
@@ -22,8 +22,32 @@ class NotificationResponseTransformer
       Tuple<AtNotification, NotificationConfig> tuple) async {
     // prepare the atKey from the atNotification object.
     var atNotification = tuple.one;
+    String sharedBy = tuple.one.from;
+    String sharedWith = tuple.one.to;
+    var key = tuple.one.key;
+    // AtKeys when sharedBy and sharedWith are populated look like
+    // @alice:something.something.namespace@bob
+    // where @bob is sharedBy and @alice is sharedWith
+
+    // Because of history, the 'key' here sometimes (always?) also contains
+    // the sharedBy and sharedWith and we will end up creating AtKeys which look like
+    // '@alice@alice:something.something.namespace@bob@bob' unless we prevent it here.
+
+    // If we've already got sharedBy in the 'key' part, then strip it off
+    // before creating the AtKey
+    // e.g. ends with '@bob' (note no colon preceding)
+    if (sharedBy.trim().isNotEmpty && key.endsWith(sharedBy)) {
+      key = key.substring(0, key.length - sharedBy.length);
+    }
+    // If we've already got sharedWith in the 'key' part, then strip it off
+    // before creating the AtKey
+    // e.g. starts with '@alice:' (note the colon)
+    if (sharedWith.trim().isNotEmpty && key.startsWith(sharedWith)) {
+      key = key.substring(
+          sharedWith.length + 1); // substring from just after '@alice:'
+    }
     AtKey atKey = AtKey()
-      ..key = tuple.one.key
+      ..key = key
       ..sharedWith = tuple.one.to
       ..sharedBy = tuple.one.from;
 

--- a/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
+++ b/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
@@ -55,10 +55,7 @@ class NotificationResponseTransformer
         tuple.one.messageType!.toLowerCase().contains('text') &&
         (tuple.one.isEncrypted != null && tuple.one.isEncrypted!)) {
       // decrypt the text message;
-      // the encrypted text message is a part of notification key. for example
-      // @alice:<text-message>. So split with : to get the encrypted message
-      var encryptedValue = atKey.key!.split(':')[1];
-      var decryptedValue = await _getDecryptedValue(atKey, encryptedValue);
+      var decryptedValue = await _getDecryptedValue(atKey, atKey.key);
       atNotification.key = '${tuple.one.to}:$decryptedValue';
       return atNotification;
     } else if ((tuple.one.value.isNotNull) &&
@@ -74,10 +71,10 @@ class NotificationResponseTransformer
     return atNotification;
   }
 
-  Future<String> _getDecryptedValue(AtKey atKey, String encryptedValue) async {
+  Future<String> _getDecryptedValue(AtKey atKey, String? encryptedValue) async {
     atKeyDecryption ??=
         AtKeyDecryptionManager(_atClient).get(atKey, atKey.sharedWith!);
-    var decryptedValue = await atKeyDecryption?.decrypt(atKey, encryptedValue);
+    var decryptedValue = await atKeyDecryption?.decrypt(atKey, encryptedValue?.trim());
     // Return decrypted value
     return decryptedValue.toString().trim();
   }

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.56
+version: 3.0.57
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- The PR fixes the git issue: https://github.com/atsign-foundation/at_client_sdk/issues/772

**- How I did it**
- Trim the sharedWith and sharedBy from the atKey.key received in the notification call back

**- How to verify it**
- Manually tested the changes and looks good.
- The existing unit and e2e tests should pass.

**- Description for the changelog**
- Incorrect atKey.toString() in notification_response_transformation.dart
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->