### PR TITLE
test: Added e2e test for syncing cached key deletion

### DIFF
--- a/packages/at_client_mobile/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/at_client_mobile/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -9,7 +9,7 @@ import at_file_saver
 import biometric_storage
 import file_selector_macos
 import package_info_plus_macos
-import path_provider_macos
+import path_provider_foundation
 import share_plus_macos
 import url_launcher_macos
 

--- a/tests/at_end2end_test/test/deletion_key_test.dart
+++ b/tests/at_end2end_test/test/deletion_key_test.dart
@@ -63,6 +63,9 @@ void main() {
           ..sharedWith(sharedWithAtSign)
           ..cache(-1, true))
         .build();
+    currentAtClientManager = await AtClientManager.getInstance()
+        .setCurrentAtSign(currentAtSign, namespace,
+            TestPreferences.getInstance().getPreference(currentAtSign));
     await currentAtClientManager.atClient.put(atKey, 'dummy_cached_value');
     await E2ESyncService.getInstance()
         .syncData(currentAtClientManager.atClient.syncService);
@@ -110,15 +113,16 @@ void main() {
   test(
       'A test to verify cached key is deleted when receiver deletes the cached key in the local',
       () async {
-    var atKey = AtKey()
-      ..key = 'testcachedkey'
-      ..sharedWith = sharedWithAtSign
-      ..sharedBy = currentAtSign
-      ..metadata = (Metadata()..ttr = -1);
+    var atKey = (AtKey.shared('testcachedkey', sharedBy: currentAtSign)
+          ..sharedWith(sharedWithAtSign)
+          ..cache(-1, true))
+        .build();
     var value = 'test_cached_value';
+    currentAtClientManager = await AtClientManager.getInstance()
+        .setCurrentAtSign(currentAtSign, namespace,
+            TestPreferences.getInstance().getPreference(currentAtSign));
     // notifying a key with ttr to shared with atsign
-    await currentAtClientManager.atClient.notificationService
-        .notify(NotificationParams.forUpdate(atKey, value: '$value'));
+    await currentAtClientManager.atClient.put(atKey,'$value');
     await E2ESyncService.getInstance()
         .syncData(currentAtClientManager.atClient.syncService);
 

--- a/tests/at_end2end_test/test/deletion_key_test.dart
+++ b/tests/at_end2end_test/test/deletion_key_test.dart
@@ -5,29 +5,29 @@ import 'package:at_end2end_test/src/test_initializers.dart';
 import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:test/test.dart';
 
-late AtClientManager currentAtClientManager;
-late AtClientManager sharedWithAtClientManager;
-late String currentAtSign;
+late AtClient sharedByAtClient;
+late AtClient sharedWithAtClient;
+late String sharedByAtSign;
 late String sharedWithAtSign;
 final namespace = 'wavi';
 
 void main() {
   setUpAll(() async {
-    currentAtSign = ConfigUtil.getYaml()['atSign']['firstAtSign'];
+    sharedByAtSign = ConfigUtil.getYaml()['atSign']['firstAtSign'];
     sharedWithAtSign = ConfigUtil.getYaml()['atSign']['secondAtSign'];
 
     await TestSuiteInitializer.getInstance()
-        .testInitializer(currentAtSign, namespace);
+        .testInitializer(sharedByAtSign, namespace);
     await TestSuiteInitializer.getInstance()
         .testInitializer(sharedWithAtSign, namespace);
     // Initialize sharedWithAtSign
-    sharedWithAtClientManager = await AtClientManager.getInstance()
+    sharedWithAtClient = (await AtClientManager.getInstance()
         .setCurrentAtSign(sharedWithAtSign, namespace,
-            TestPreferences.getInstance().getPreference(sharedWithAtSign));
-    // Setting currentAtSign atClient instance to context.
-    currentAtClientManager = await AtClientManager.getInstance()
-        .setCurrentAtSign(currentAtSign, namespace,
-            TestPreferences.getInstance().getPreference(currentAtSign));
+            TestPreferences.getInstance().getPreference(sharedWithAtSign))).atClient;
+    // Setting sharedByAtSign atClient instance to context.
+    sharedByAtClient = (await AtClientManager.getInstance()
+        .setCurrentAtSign(sharedByAtSign, namespace,
+            TestPreferences.getInstance().getPreference(sharedByAtSign))).atClient;
   });
 
   test(
@@ -35,21 +35,21 @@ void main() {
       () async {
     // The namespace in the preference is "wavi". Overriding the namespace in the atKey to "buzz"
     var atKey = (AtKey.shared('keyNamespaceOverriding',
-            namespace: 'buzz', sharedBy: currentAtSign)
+            namespace: 'buzz', sharedBy: sharedByAtSign)
           ..sharedWith(sharedWithAtSign))
         .build();
-    await currentAtClientManager.atClient.put(atKey, 'dummy_value');
+    await sharedByAtClient.put(atKey, 'dummy_value');
     expect(
-        currentAtClientManager.atClient
+        sharedByAtClient
             .getLocalSecondary()!
             .keyStore!
             .isKeyExists(atKey.toString()),
         true);
 
     // Delete the key
-    await currentAtClientManager.atClient.delete(atKey);
+    await sharedByAtClient.delete(atKey);
     expect(
-        currentAtClientManager.atClient
+        sharedByAtClient
             .getLocalSecondary()!
             .keyStore!
             .isKeyExists(atKey.toString()),
@@ -59,52 +59,52 @@ void main() {
   test(
       'A test to verify cached key is deleted in sharedWith secondary when CCD is set to true',
       () async {
-    var atKey = (AtKey.shared('deletecachedkey', sharedBy: currentAtSign)
+    var atKey = (AtKey.shared('deletecachedkey', sharedBy: sharedByAtSign)
           ..sharedWith(sharedWithAtSign)
           ..cache(-1, true))
         .build();
-    currentAtClientManager = await AtClientManager.getInstance()
-        .setCurrentAtSign(currentAtSign, namespace,
-            TestPreferences.getInstance().getPreference(currentAtSign));
-    await currentAtClientManager.atClient.put(atKey, 'dummy_cached_value');
+    sharedByAtClient = (await AtClientManager.getInstance()
+        .setCurrentAtSign(sharedByAtSign, namespace,
+            TestPreferences.getInstance().getPreference(sharedByAtSign))).atClient;
+    await sharedByAtClient.put(atKey, 'dummy_cached_value');
     await E2ESyncService.getInstance()
-        .syncData(currentAtClientManager.atClient.syncService);
+        .syncData(sharedByAtClient.syncService);
 
-    sharedWithAtClientManager = await AtClientManager.getInstance()
+    sharedWithAtClient = (await AtClientManager.getInstance()
         .setCurrentAtSign(sharedWithAtSign, namespace,
-            TestPreferences.getInstance().getPreference(sharedWithAtSign));
+            TestPreferences.getInstance().getPreference(sharedWithAtSign))).atClient;
     await E2ESyncService.getInstance()
-        .syncData(sharedWithAtClientManager.atClient.syncService);
+        .syncData(sharedWithAtClient.syncService);
 
     var cachedAtKey = AtKey()
       ..key = 'deletecachedkey'
       ..sharedWith = sharedWithAtSign
-      ..sharedBy = currentAtSign
+      ..sharedBy = sharedByAtSign
       ..metadata = (Metadata()..isCached = true);
-    var getResponse = await sharedWithAtClientManager.atClient.get(cachedAtKey);
+    var getResponse = await sharedWithAtClient.get(cachedAtKey);
     expect(getResponse.value, 'dummy_cached_value');
     // Delete the key
-    currentAtClientManager = await AtClientManager.getInstance()
-        .setCurrentAtSign(currentAtSign, namespace,
-            TestPreferences.getInstance().getPreference(currentAtSign));
-    await currentAtClientManager.atClient.delete(atKey);
+    sharedByAtClient =( await AtClientManager.getInstance()
+        .setCurrentAtSign(sharedByAtSign, namespace,
+            TestPreferences.getInstance().getPreference(sharedByAtSign))).atClient;
+    await sharedByAtClient.delete(atKey);
     await E2ESyncService.getInstance()
-        .syncData(currentAtClientManager.atClient.syncService);
+        .syncData(sharedByAtClient.syncService);
 
     // Sync the deleted cached key commit entry to local secondary of sharedWith atSign
-    sharedWithAtClientManager = await AtClientManager.getInstance()
+    sharedWithAtClient = (await AtClientManager.getInstance()
         .setCurrentAtSign(sharedWithAtSign, namespace,
-            TestPreferences.getInstance().getPreference(sharedWithAtSign));
+            TestPreferences.getInstance().getPreference(sharedWithAtSign))).atClient;
     await E2ESyncService.getInstance()
-        .syncData(sharedWithAtClientManager.atClient.syncService);
+        .syncData(sharedWithAtClient.syncService);
 
     // Asserts cached key is deleted from the local storage in the sharedWith atSign
     expect(
-        sharedWithAtClientManager.atClient
+        sharedWithAtClient
             .getLocalSecondary()
             ?.keyStore
             ?.isKeyExists(
-                'cached:$sharedWithAtSign:deletecachedkey$currentAtSign}'),
+                'cached:$sharedWithAtSign:deletecachedkey$sharedByAtSign}'),
         false);
     // When sync runs the test remains idle and timeout after 30 seconds
     // Adding timeout to allow sync to complete on current atSign and sharedWith atSign.
@@ -113,71 +113,72 @@ void main() {
   test(
       'A test to verify cached key is deleted when receiver deletes the cached key in the local',
       () async {
-    var atKey = (AtKey.shared('testcachedkey', sharedBy: currentAtSign)
+    var key = 'testcachedkey';
+    var atKey = (AtKey.shared(key, sharedBy: sharedByAtSign)
           ..sharedWith(sharedWithAtSign)
           ..cache(-1, true))
         .build();
     var value = 'test_cached_value';
-    currentAtClientManager = await AtClientManager.getInstance()
-        .setCurrentAtSign(currentAtSign, namespace,
-            TestPreferences.getInstance().getPreference(currentAtSign));
+    var currentAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
+            sharedByAtSign,
+            namespace,
+            TestPreferences.getInstance().getPreference(sharedByAtSign)))
+        .atClient;
     // notifying a key with ttr to shared with atsign
-    await currentAtClientManager.atClient.put(atKey,'$value');
+    await currentAtClient.put(atKey, '$value');
     await E2ESyncService.getInstance()
-        .syncData(currentAtClientManager.atClient.syncService);
-
-    sharedWithAtClientManager = await AtClientManager.getInstance()
-        .setCurrentAtSign(sharedWithAtSign, namespace,
-            TestPreferences.getInstance().getPreference(sharedWithAtSign));
+        .syncData(sharedByAtClient.syncService);
+    var sharedWithAtClient = (await AtClientManager.getInstance()
+            .setCurrentAtSign(sharedWithAtSign, namespace,
+                TestPreferences.getInstance().getPreference(sharedWithAtSign)))
+        .atClient;
     await E2ESyncService.getInstance()
-        .syncData(sharedWithAtClientManager.atClient.syncService);
+        .syncData(sharedWithAtClient.syncService);
 
     var cachedAtKey = AtKey()
-      ..key = 'testcachedkey'
+      ..key = key
       ..sharedWith = sharedWithAtSign
-      ..sharedBy = currentAtSign
+      ..sharedBy = sharedByAtSign
       ..metadata = (Metadata()..isCached = true);
     // Assert cached key is present in the local storage of the sharedWith atSign
-    var getResponse = await sharedWithAtClientManager.atClient.get(cachedAtKey);
+    var getResponse = await sharedWithAtClient.get(cachedAtKey);
     expect(getResponse.value, 'test_cached_value');
 
     // creating another atkey instance to delete the cached key
     // due to the following bug - https://github.com/atsign-foundation/at_client_sdk/issues/939
     cachedAtKey = AtKey()
-      ..key = 'testcachedkey'
+      ..key = key
       ..sharedWith = sharedWithAtSign
-      ..sharedBy = currentAtSign
+      ..sharedBy = sharedByAtSign
       ..metadata = (Metadata()..isCached = true);
-    var scanResultBeforeDelete = await sharedWithAtClientManager.atClient
+    // cached key to be fetched from secondary
+    var serverCachedKey =
+        'cached:$sharedWithAtSign:$key.$namespace$sharedByAtSign';
+    var scanResultBeforeDelete = await sharedWithAtClient
         .getRemoteSecondary()!
         .executeCommand('scan\n', auth: true);
     expect(
         scanResultBeforeDelete!.contains(
-            'cached:$sharedWithAtSign:testcachedkey.wavi$currentAtSign'),
+            serverCachedKey),
         true);
     // Delete the cached key in the local secondary of sharedWith atSign
-    var deleteResult =
-        await sharedWithAtClientManager.atClient.delete(cachedAtKey);
+    var deleteResult = await sharedWithAtClient.delete(cachedAtKey);
     expect(deleteResult, true);
 
     // Sync the deleted cached key commit entry to secondary of sharedWith atSign
-    await E2ESyncService.getInstance()
-        .syncData(sharedWithAtClientManager.atClient.syncService);
+    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService);
     // Asserts cached key is deleted from the local storage in the sharedWith atSign
     expect(
-        sharedWithAtClientManager.atClient
-            .getLocalSecondary()
-            ?.keyStore
-            ?.isKeyExists(
-                'cached:$sharedWithAtSign:testcachedkey.wavi$currentAtSign}'),
+        sharedWithAtClient.getLocalSecondary()?.keyStore?.isKeyExists(
+            serverCachedKey),
         false);
     // Asserts cached key is deleted from the server in the sharedWith atSign
-    var scanResultAfterDelete = await sharedWithAtClientManager.atClient
+    var scanResultAfterDelete = await sharedWithAtClient
         .getRemoteSecondary()!
         .executeCommand('scan\n', auth: true);
     expect(
         scanResultAfterDelete!.contains(
-            'cached:$sharedWithAtSign:testcachedkey.wavi$currentAtSign'),
+            serverCachedKey),
         false);
   }, timeout: Timeout(Duration(minutes: 1)));
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #932 "

Please provide the following information:
-->

**- What I did**
Added an e2e test 
**- How I did it**
Created a cached key and deleted that cached key at the receiver's local secondary and verified the key in the remote secondary after sync
**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->