### PR TITLE
test: (IGNORE) run tests with dependency override for at_persistence_secondary_server

### DIFF
--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -14,6 +14,13 @@ homepage: https://docs.atsign.com/
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
+dependency_overrides:
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: packages/at_persistence_secondary_server
+      ref: gkc-fix-AtMetaData.fromJson
+
 dependencies:
   path: ^1.8.2
   hive: ^2.2.3

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -8,21 +8,16 @@ publish_to: none
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
+dependency_overrides:
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: packages/at_persistence_secondary_server
+      ref: gkc-fix-AtMetaData.fromJson
+
 dependencies:
   at_client:
     path: ../../packages/at_client
-
-#dependency_overrides:
-#  at_chops:
-#    git:
-#      url: https://github.com/atsign-foundation/at_libraries.git
-#      path: packages/at_chops
-#      ref: at_chops
-#  at_lookup:
-#    git:
-#      url: https://github.com/atsign-foundation/at_libraries.git
-#      path: packages/at_lookup
-#      ref: publish_atlookup
 
 dev_dependencies:
   pedantic: ^1.11.1

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -6,26 +6,17 @@ version: 1.0.0
 environment:
   sdk: '>=2.14.4 <3.0.0'
 
+dependency_overrides:
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      path: packages/at_persistence_secondary_server
+      ref: gkc-fix-AtMetaData.fromJson
+
 dependencies:
   uuid: 3.0.7
   at_client:
     path: ../../packages/at_client
-
-#  at_chops:
-#    git:
-#      url: https://github.com/atsign-foundation/at_libraries.git
-#      path: packages/at_chops
-#      ref: at_chops
-#  at_client:
-#    git:
-#      url: https://github.com/atsign-foundation/at_client_sdk.git
-#      path: packages/at_client
-#      ref: uptake_atchops
-#  at_lookup:
-#    git:
-#      url: https://github.com/atsign-foundation/at_libraries.git
-#      path: packages/at_lookup
-#      ref: publish_atlookup
 
 dev_dependencies:
   test: ^1.21.4


### PR DESCRIPTION
DRAFT PR only

Run tests with dependency override in order to ensure that it is safe to merge & publish at_persistence_secondary_server v3.0.50
