### PR TITLE
build: at_client use new versions of at_commons and at_persistence_secondary_server

### DIFF
--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -22,10 +22,10 @@ import 'package:meta/meta.dart';
 
 ///A [SyncService] object is used to ensure data in local secondary(e.g mobile device) and cloud secondary are in sync.
 class SyncServiceImpl implements SyncService, AtSignChangeListener {
-  static const _syncRequestThreshold = 3,
-      _syncRequestTriggerInSeconds = 3,
-      _syncRunIntervalSeconds = 5,
-      _queueSize = 5;
+  static int syncRequestThreshold = 3,
+      syncRequestTriggerInSeconds = 3,
+      syncRunIntervalSeconds = 5,
+      queueSize = 5;
   late final AtClient _atClient;
   late final RemoteSecondary _remoteSecondary;
   late final NotificationServiceImpl _statsNotificationListener;
@@ -41,7 +41,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
 
   final List<SyncProgressListener> _syncProgressListeners = [];
   late final Cron _cron;
-  final _syncRequests = ListQueue<SyncRequest>(_queueSize);
+  final _syncRequests = ListQueue<SyncRequest>(queueSize);
   bool _syncInProgress = false;
 
   @override
@@ -89,7 +89,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   void _scheduleSyncRun() {
     _cron = Cron();
 
-    _cron.schedule(Schedule.parse('*/$_syncRunIntervalSeconds * * * * *'),
+    _cron.schedule(Schedule.parse('*/$syncRunIntervalSeconds * * * * *'),
         () async {
       try {
         await processSyncRequests();
@@ -181,13 +181,13 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     }
     if (respectSyncRequestQueueSizeAndRequestTriggerDuration) {
       if (_syncRequests.isEmpty ||
-          (_syncRequests.length < _syncRequestThreshold &&
+          (_syncRequests.length < syncRequestThreshold &&
               (_syncRequests.isNotEmpty &&
                   DateTime.now()
                           .toUtc()
                           .difference(_syncRequests.elementAt(0).requestedOn)
                           .inSeconds <
-                      _syncRequestTriggerInSeconds))) {
+                      syncRequestTriggerInSeconds))) {
         _logger.finest('skipping sync - queue length ${_syncRequests.length}');
         return;
       }
@@ -311,7 +311,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
 
   void _addSyncRequestToQueue(SyncRequest syncRequest) {
     hasHadNoSyncRequests = false;
-    if (_syncRequests.length == _queueSize) {
+    if (_syncRequests.length == queueSize) {
       _syncRequests.removeLast();
     }
     _syncRequests.addLast(syncRequest);

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -29,21 +29,14 @@ dependencies:
   internet_connection_checker: ^1.0.0+1
   async: ^2.9.0
   at_persistence_spec: ^2.0.10
-  at_persistence_secondary_server: ^3.0.45
+  at_persistence_secondary_server: ^3.0.51
   at_lookup: ^3.0.35
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
-  at_commons: ^3.0.35
+  at_commons: ^3.0.42
   at_utils: ^3.0.11
   meta: ^1.8.0
   at_chops: ^1.0.0
-
-#dependency_overrides:
-#  at_commons:
-#    git:
-#      url: https://github.com/atsign-foundation/at_tools.git
-#      path: packages/at_commons
-#      ref: trunk
 
 dev_dependencies:
   lints: ^2.0.0

--- a/tests/at_end2end_test/analysis_options.yaml
+++ b/tests/at_end2end_test/analysis_options.yaml
@@ -1,16 +1,14 @@
-# Defines a default set of lint rules enforced for projects at Google. For
-# details and rationale, see
-# https://github.com/dart-lang/pedantic#enabled-lints.
-
-include: package:pedantic/analysis_options.yaml
+# Defines a default set of lint rules enforced for
+# projects at Google. For details and rationale,
+# see https://pub.dev/packages/lints.
+include: package:lints/recommended.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
-
 # Uncomment to specify additional rules.
-# linter:
-#   rules:
-#     - camel_case_types
-
-# analyzer:
-#   exclude:
-#     - path/to/excluded/files/**
+linter:
+  rules:
+    camel_case_types : true
+    unnecessary_string_interpolations : true
+    await_only_futures : true
+    unawaited_futures: true
+    depend_on_referenced_packages : false

--- a/tests/at_end2end_test/lib/src/sync_initializer.dart
+++ b/tests/at_end2end_test/lib/src/sync_initializer.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/service/sync_service.dart';
+import 'package:at_client/src/service/sync_service_impl.dart';
 import 'package:at_utils/at_logger.dart';
 
 /// The class represents the sync services for the end to end tests
@@ -17,6 +18,10 @@ class E2ESyncService {
   }
 
   Future<void> syncData(SyncService syncService) async {
+    SyncServiceImpl.syncRequestThreshold = 1;
+    SyncServiceImpl.syncRequestTriggerInSeconds = 1;
+    SyncServiceImpl.syncRunIntervalSeconds = 1;
+
     var _isSyncInProgress = true;
     var e2eTestSyncProgressListener = E2ETestSyncProgressListener();
     syncService.addProgressListener(e2eTestSyncProgressListener);
@@ -26,6 +31,7 @@ class E2ESyncService {
       if (syncProgress.syncStatus == SyncStatus.success ||
           syncProgress.syncStatus == SyncStatus.failure) {
         _isSyncInProgress = false;
+        print (syncProgress);
       }
     });
     while (_isSyncInProgress) {

--- a/tests/at_end2end_test/lib/src/sync_initializer.dart
+++ b/tests/at_end2end_test/lib/src/sync_initializer.dart
@@ -31,7 +31,6 @@ class E2ESyncService {
       if (syncProgress.syncStatus == SyncStatus.success ||
           syncProgress.syncStatus == SyncStatus.failure) {
         _isSyncInProgress = false;
-        print (syncProgress);
       }
     });
     while (_isSyncInProgress) {

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -27,3 +27,5 @@ dependencies:
 dev_dependencies:
   pedantic: ^1.11.1
   test: ^1.21.4
+  version: 3.0.2
+  lints: ^2.0.0

--- a/tests/at_end2end_test/test/bypasscache_test.dart
+++ b/tests/at_end2end_test/test/bypasscache_test.dart
@@ -7,21 +7,37 @@ import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:test/test.dart';
 
 void main() async {
-  late AtClientManager currentAtClientManager;
-  late AtClientManager sharedWithAtClientManager;
-  late String currentAtSign;
-  late String sharedWithAtSign;
+  late AtClient clientOne;
+  late AtClient clientTwo;
+  late String atSignOne;
+  late String atSignTwo;
   final namespace = 'wavi';
 
   setUpAll(() async {
-    currentAtSign = ConfigUtil.getYaml()['atSign']['firstAtSign'];
-    sharedWithAtSign = ConfigUtil.getYaml()['atSign']['secondAtSign'];
+    atSignOne = ConfigUtil.getYaml()['atSign']['firstAtSign'];
+    atSignTwo = ConfigUtil.getYaml()['atSign']['secondAtSign'];
 
     await TestSuiteInitializer.getInstance()
-        .testInitializer(currentAtSign, namespace);
+        .testInitializer(atSignOne, namespace);
     await TestSuiteInitializer.getInstance()
-        .testInitializer(sharedWithAtSign, namespace);
+        .testInitializer(atSignTwo, namespace);
   });
+
+  Future<void> setAtSignOneAutoNotify(bool autoNotify) async {
+    //  reset the autoNotify to true
+    clientOne = (await AtClientManager.getInstance().setCurrentAtSign(
+        atSignOne,
+        namespace,
+        TestPreferences.getInstance().getPreference(atSignOne))).atClient;
+
+    var configResult = await clientOne
+        .getRemoteSecondary()!
+        .executeCommand('config:set:autoNotify=$autoNotify\n', auth: true);
+    if (configResult == null) {
+      fail('failed to set auto config to $autoNotify');
+    }
+    expect(configResult.contains('data:ok'), true);
+  }
 
   /// The purpose of this test is to verify the following:
   /// 1. Share a key from atsign_1 to atsign_2 with ttr, with autoNotify:true
@@ -33,93 +49,98 @@ void main() async {
   test('bypass cache test', () async {
     var verificationKey = AtKey()
       ..key = 'verificationNumber'
-      ..sharedWith = sharedWithAtSign
+      ..sharedWith = atSignTwo
       ..metadata = (Metadata()..ttr = 1000);
-    var oldValue = '0873';
-    // updating the key to the currentAtSign
-    currentAtClientManager = await AtClientManager.getInstance()
-        .setCurrentAtSign(currentAtSign, namespace,
-            TestPreferences.getInstance().getPreference(currentAtSign));
+    var initialValue = '0873';
+
+    // Ensure autoNotify is set to true to begin with
+    await setAtSignOneAutoNotify(true);
+
+    // As atSignOne: Put the initial value
+    clientOne = (await AtClientManager.getInstance()
+        .setCurrentAtSign(atSignOne, namespace,
+            TestPreferences.getInstance().getPreference(atSignOne))).atClient;
     var putResult =
-        await currentAtClientManager.atClient.put(verificationKey, oldValue);
+        await clientOne.put(verificationKey, initialValue);
     expect(putResult, true);
     // Sync the data to the remote secondary
     await E2ESyncService.getInstance()
-        .syncData(currentAtClientManager.atClient.syncService);
+        .syncData(clientOne.syncService);
 
-    // Setting sharedWithAtSign atClient instance to context.
-    sharedWithAtClientManager = await AtClientManager.getInstance()
-        .setCurrentAtSign(sharedWithAtSign, namespace,
-            TestPreferences.getInstance().getPreference(sharedWithAtSign));
+    // Give it a couple of seconds to propagate from one atServer to the other
+    await Future.delayed(Duration(seconds: 2));
+
+    // As atSignTwo: do a sync, and do the get, to verify we have the initial value
+    clientTwo = (await AtClientManager.getInstance()
+        .setCurrentAtSign(atSignTwo, namespace,
+            TestPreferences.getInstance().getPreference(atSignTwo))).atClient;
     await E2ESyncService.getInstance()
-        .syncData(sharedWithAtClientManager.atClient.syncService);
+        .syncData(clientTwo.syncService);
     var getKey = AtKey()
       ..key = 'verificationNumber'
-      ..sharedBy = currentAtSign;
-    var getResult = await sharedWithAtClientManager.atClient.get(getKey);
-    expect(getResult.value, oldValue);
+      ..sharedBy = atSignOne;
+    var getResult = await clientTwo.get(getKey);
+    expect(getResult.value, initialValue);
     print('get Result is $getResult');
 
-    // Setting currentAtSign atClient instance to context.
-    await AtClientManager.getInstance().setCurrentAtSign(currentAtSign,
-        namespace, TestPreferences.getInstance().getPreference(currentAtSign));
+    // As atSignOne
+    clientOne = (await AtClientManager.getInstance().setCurrentAtSign(atSignOne,
+        namespace, TestPreferences.getInstance().getPreference(atSignOne))).atClient;
     try {
-      // set auto notify to false
-      var configResult = await currentAtClientManager.atClient
-          .getRemoteSecondary()!
-          .executeCommand('config:set:autoNotify=false\n', auth: true);
-      expect(configResult, contains('data:ok'));
-      // adding a delay for 2 seconds till the config value gets updated
-      await Future.delayed(Duration(seconds: 3));
-      // Updating the same key with a new value
+      // Set autoNotify to false so that the update doesn't propagate to atSignTwo automatically
+      await setAtSignOneAutoNotify(false);
+
+      // Put a new value
       var verificationKeyNew = AtKey()
         ..key = 'verificationNumber'
-        ..sharedWith = sharedWithAtSign;
+        ..sharedWith = atSignTwo;
       var newValue = '9900';
-      var newPutResult = await currentAtClientManager.atClient
+      var newPutResult = await clientOne
           .put(verificationKeyNew, newValue);
       expect(newPutResult, true);
-      await E2ESyncService.getInstance()
-          .syncData(currentAtClientManager.atClient.syncService);
 
-      // Setting sharedWithAtSign atClient instance to context.
-      sharedWithAtClientManager = await AtClientManager.getInstance()
-          .setCurrentAtSign(sharedWithAtSign, namespace,
-              TestPreferences.getInstance().getPreference(sharedWithAtSign));
+      // Sync the data to the remote secondary
       await E2ESyncService.getInstance()
-          .syncData(sharedWithAtClientManager.atClient.syncService);
-      //  get result with bypassCache set to true
-      // should return the newly updated value
-      getResult = await sharedWithAtClientManager.atClient.get(getKey,
+          .syncData(clientOne.syncService);
+
+
+      // As atSignTwo
+      clientTwo = (await AtClientManager.getInstance()
+          .setCurrentAtSign(atSignTwo, namespace,
+              TestPreferences.getInstance().getPreference(atSignTwo))).atClient;
+
+      // Sync - after this we still should have the old value
+      await E2ESyncService.getInstance()
+          .syncData(clientTwo.syncService);
+
+      // get result with bypassCache set to false
+      // should still return the initial value
+      getResult = await clientTwo.get(getKey,
+          getRequestOptions: GetRequestOptions()..bypassCache = false);
+      print('get result with bypass cache false $getResult');
+      expect(getResult.value, initialValue);
+
+      // get result with bypassCache set to true
+      // should return the new value
+      getResult = await clientTwo.get(getKey,
           getRequestOptions: GetRequestOptions()..bypassCache = true);
       print('get result with bypass cache true $getResult');
       expect(getResult.value, newValue);
-      // get Result with byPassCache set to false
-      // should return the old value
-      // adding a delay
-      await Future.delayed(Duration(seconds: 5));
-      var getResultWithFalse = await sharedWithAtClientManager.atClient.get(
+
+      // Sync - after this we should now have the new value
+      await E2ESyncService.getInstance()
+          .syncData(clientTwo.syncService);
+
+      // get Result with byPassCache set to false again
+      // should also now return the new value, since cached value will have been updated with the
+      // results of the remote lookup, and the cached value will have been synced to the client
+      var getResultWithFalse = await clientTwo.get(
           getKey,
           getRequestOptions: GetRequestOptions()..bypassCache = false);
       print('get result with bypass cache false $getResultWithFalse');
-      expect(getResultWithFalse.value, oldValue);
-      //  reset the autoNotify to false
-      await AtClientManager.getInstance().setCurrentAtSign(
-          currentAtSign,
-          namespace,
-          TestPreferences.getInstance().getPreference(currentAtSign));
+      expect(getResultWithFalse.value, newValue);
     } finally {
-      // Moving the config:set:autoNotify=true to finally block because if
-      // test fails in between the autoNotify on the atSign remains false.
-      var configResult = await currentAtClientManager.atClient
-          .getRemoteSecondary()!
-          .executeCommand('config:set:autoNotify=true\n', auth: true);
-      if (configResult == null) {
-        assert(fail('failed to set auto config to true'));
-      }
-      assert(configResult!.contains('data:ok'), true);
+      await setAtSignOneAutoNotify(true);
     }
-    //Setting the timeout to prevent termination of test, since we have Future.delayed
-    // for 30 Seconds.
-  }, timeout: Timeout(Duration(minutes: 5)));
+  });
 }

--- a/tests/at_end2end_test/test/commit_log_compaction_test.dart
+++ b/tests/at_end2end_test/test/commit_log_compaction_test.dart
@@ -60,7 +60,7 @@ void main() {
       firstAtClient = atClientManager.atClient as AtClientImpl;
       expect(firstAtClient.atClientCommitLogCompaction?.isCompactionJobRunning(), true);
       expect(secondAtClient.atClientCommitLogCompaction?.isCompactionJobRunning(), false);
-    });
+    }, timeout: Timeout(Duration(minutes: 5)));
   } catch (e, s) {
     print(s);
   }

--- a/tests/at_end2end_test/test/key_stream_test.dart
+++ b/tests/at_end2end_test/test/key_stream_test.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: prefer_typing_uninitialized_variables
+
 import 'dart:async';
 
 import 'package:at_client/at_client.dart';
@@ -13,8 +15,7 @@ import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
 
 void main() async {
-  late AtClientManager currentAtClientManager;
-  late AtClientManager sharedWithAtClientManager;
+  late AtClientManager atClientManager;
   late String currentAtSign;
   late String sharedWithAtSign;
   final namespace = 'wavi';
@@ -79,15 +80,17 @@ void main() async {
     });
 
     test('getKeys', () async {
-      currentAtClientManager = await AtClientManager.getInstance()
+      atClientManager = await AtClientManager.getInstance()
           .setCurrentAtSign(currentAtSign, namespace,
               TestPreferences.getInstance().getPreference(currentAtSign));
       await Future.wait([
-        currentAtClientManager.atClient.put(key, randomValue),
-        currentAtClientManager.atClient.put(key2, randomValue2)
+        atClientManager.atClient.put(key, randomValue),
+        atClientManager.atClient.put(key2, randomValue2)
       ]);
+
       await E2ESyncService.getInstance()
-          .syncData(currentAtClientManager.atClient.syncService);
+          .syncData(atClientManager.atClient.syncService);
+
       await AtClientManager.getInstance().setCurrentAtSign(
           sharedWithAtSign,
           namespace,
@@ -96,7 +99,7 @@ void main() async {
           sharedWithAtSign);
       await keyStream.getKeys();
       expect(keyStream, emitsInAnyOrder([randomValue, randomValue2]));
-    }, timeout: Timeout(Duration(minutes: 5)));
+    });
 
     test('dispose', () async {
       await keyStream.dispose();
@@ -123,7 +126,7 @@ void main() async {
           namespace,
           TestPreferences.getInstance().getPreference(sharedWithAtSign));
       keyStream = KeyStreamImpl(
-        regex: namespace + '@',
+        regex: '$namespace@',
         convert: (key, value) => value.value ?? '',
         sharedBy: currentAtSign,
         sharedWith: sharedWithAtSign,
@@ -169,7 +172,7 @@ void main() async {
           namespace,
           TestPreferences.getInstance().getPreference(sharedWithAtSign));
       keyStream = IterableKeyStream<String>(
-        regex: namespace + '@',
+        regex: '$namespace@',
         convert: (key, value) => value.value ?? '',
         sharedBy: currentAtSign,
         sharedWith: sharedWithAtSign,
@@ -221,7 +224,7 @@ void main() async {
           namespace,
           TestPreferences.getInstance().getPreference(sharedWithAtSign));
       keyStream = MapKeyStream<String, String>(
-        regex: namespace + '@',
+        regex: '$namespace@',
         convert: (key, value) => MapEntry(key.key!, value.value),
         sharedBy: currentAtSign,
         sharedWith: sharedWithAtSign,
@@ -257,7 +260,6 @@ void main() async {
 
   group('Switch atsigns group', () {
     var currentAtSign, sharedWithAtSign;
-    AtClientManager? currentAtSignClientManager, sharedWithAtSignClientManager;
     var namespace = 'keyStream';
     late KeyStreamImpl<String> keyStream, keyStream2, keyStream3;
     var uuid;
@@ -281,17 +283,17 @@ void main() async {
       currentAtSign = ConfigUtil.getYaml()['atSign']['firstAtSign'];
       sharedWithAtSign = ConfigUtil.getYaml()['atSign']['secondAtSign'];
       // Create atClient instance for currentAtSign
-      currentAtSignClientManager = await AtClientManager.getInstance()
+      await AtClientManager.getInstance()
           .setCurrentAtSign(currentAtSign, namespace,
               TestPreferences.getInstance().getPreference(currentAtSign));
 
       // Create atClient instance for atSign2
-      sharedWithAtSignClientManager = await AtClientManager.getInstance()
+      await AtClientManager.getInstance()
           .setCurrentAtSign(sharedWithAtSign, namespace,
               TestPreferences.getInstance().getPreference(sharedWithAtSign));
       // Set Encryption Keys for sharedWithAtSign
       keyStream = KeyStreamImpl(
-        regex: namespace + '@',
+        regex: '$namespace@',
         convert: (key, value) => value.value ?? '',
         sharedBy: currentAtSign,
         sharedWith: sharedWithAtSign,
@@ -313,7 +315,7 @@ void main() async {
       expect(keyStream.controller.isClosed, true);
 
       keyStream2 = KeyStreamImpl(
-        regex: namespace + '@',
+        regex: '$namespace@',
         convert: (key, value) => value.value ?? '',
         sharedBy: sharedWithAtSign,
         sharedWith: currentAtSign,
@@ -332,7 +334,7 @@ void main() async {
       expect(keyStream.controller.isClosed, true);
 
       keyStream3 = KeyStreamImpl(
-        regex: namespace + '@',
+        regex: '$namespace@',
         convert: (key, value) => value.value ?? '',
         sharedBy: currentAtSign,
         sharedWith: sharedWithAtSign,


### PR DESCRIPTION
**- What I did**
at_client now uses at_persistence_secondary_server ^3.0.51 (previously ^3.0.45) and at_commons ^3.0.42 (previously ^3.0.35)

**- How I did it**
test: Made some static variables public in SyncServiceImpl so that tests etc. can modify them
refactor: Cleaned up bypasscache_test.dart to make it more readable
test: Added another assertion to bypasscache_test to verify the initial value is still returned, and corrected another assertion
test: Added a version check for an assertion in bypasscache_test which won't work until version 3.0.29
test: Added logging of KeyInfos when SyncProgress listener is called in E2ESyncService
test: Added a 30-second timeout for sync to complete in E2ESyncService
chore: various de-linting

**- How to verify it**
Tests pass
