### PR TITLE
fix: Replace deprecated methods with new methods

### DIFF
--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -80,7 +80,7 @@ class LocalSecondary implements Secondary {
             ..sharedKeyEnc = builder.sharedKeyEncrypted
             ..pubKeyCS = builder.pubKeyChecksum
             ..encoding = builder.encoding;
-          var atMetadata = AtMetadataAdapter(metadata);
+          var atMetadata = AtMetaData.fromCommonsMetadata(metadata);
           updateResult = await keyStore!.putMeta(updateKey, atMetadata);
           break;
         default:
@@ -98,7 +98,7 @@ class LocalSecondary implements Secondary {
             ..sharedKeyEnc = builder.sharedKeyEncrypted
             ..pubKeyCS = builder.pubKeyChecksum
             ..encoding = builder.encoding;
-          var atMetadata = AtMetadataAdapter(metadata);
+          var atMetadata = AtMetaData.fromCommonsMetadata(metadata);
           updateResult = await keyStore!.putAll(updateKey, atData, atMetadata);
           break;
       }

--- a/packages/at_client/lib/src/manager/storage_manager.dart
+++ b/packages/at_client/lib/src/manager/storage_manager.dart
@@ -39,7 +39,7 @@ class StorageManager {
     var keyStoreManager = SecondaryPersistenceStoreFactory.getInstance()
         .getSecondaryPersistenceStore(currentAtSign)!
         .getSecondaryKeyStoreManager()!;
-    await hiveKeyStore.init();
+    await hiveKeyStore.initialize();
     keyStoreManager.keyStore = hiveKeyStore;
     isStorageInitialized = true;
   }

--- a/tests/at_functional_test/test/atclient_sync_callback_test.dart
+++ b/tests/at_functional_test/test/atclient_sync_callback_test.dart
@@ -169,7 +169,8 @@ void main() {
     atClientManager.atClient.syncService.sync();
     atClientManager.atClient.syncService.sync();
     atClientManager.atClient.syncService.sync();
-    await FunctionalTestSyncService.getInstance().syncData(atClientManager.atClient.syncService);
+    await FunctionalTestSyncService.getInstance()
+        .syncData(atClientManager.atClient.syncService);
     progressListener.streamController.stream
         .listen(expectAsync1((SyncProgress syncProgress) {
       expect(syncProgress.syncStatus, SyncStatus.success);
@@ -179,7 +180,7 @@ void main() {
       expect(syncProgress.localCommitId, equals(syncProgress.serverCommitId));
       syncProgress.keyInfoList?.forEach((keyInfo) {
         if (keyInfo.key.contains('fb_username-$uniqueId')) {
-          expect(keyInfo.commitOp, CommitOp.UPDATE_ALL);
+          expect(keyInfo.commitOp, CommitOp.UPDATE);
           expect(keyInfo.syncDirection, SyncDirection.remoteToLocal);
         }
       });


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* dart analyze throws a warning on deprecated methods in use. Replaced deprecated methods from local_secondary and storage manager
* Fix a failing "sync server ahead" functional test.
   * The test is failing because the key does not have metadata but the commit operation is being asserted on "CommitOp.UpdateALL". Changed the assertion to "CommitOp.Update"
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->