### PR TITLE
test: Fixed some assertions re decryption

### DIFF
--- a/packages/at_client/test/encryption_util_test.dart
+++ b/packages/at_client/test/encryption_util_test.dart
@@ -3,6 +3,24 @@ import 'package:at_commons/at_commons.dart';
 import 'package:crypton/crypton.dart';
 import 'package:test/test.dart';
 
+bool wrappedDecryptSucceeds(
+    {required String cipherText,
+      required String aesKey,
+      required String? ivBase64,
+      required String clearText}) {
+  try {
+    var deciphered =
+    EncryptionUtil.decryptValue(cipherText, aesKey, ivBase64: ivBase64);
+    if (deciphered != clearText) {
+      return false;
+    } else {
+      return true;
+    }
+  } catch (e) {
+    return false;
+  }
+}
+
 void main() {
   group('A group of encryption util tests', () {
     test('generate aes key test', () {
@@ -28,22 +46,11 @@ void main() {
           EncryptionUtil.decryptValue(encryptedValue, aesKey, ivBase64: iv);
       expect(decryptedValue, valueToEncrypt);
 
-      expect(
-          () => EncryptionUtil.decryptValue(encryptedValue, aesKey),
-          throwsA(predicate((e) =>
-              e is AtKeyException &&
-              e.message ==
-                  'Invalid argument(s): Invalid or corrupted pad block')));
+      expect(wrappedDecryptSucceeds(cipherText: encryptedValue, aesKey: aesKey, ivBase64: null, clearText: valueToEncrypt), false);
 
       for (int i = 0; i < 10; i++) {
         var otherIV = EncryptionUtil.generateIV();
-        expect(
-            () => EncryptionUtil.decryptValue(encryptedValue, aesKey,
-                ivBase64: otherIV),
-            throwsA(predicate((e) =>
-                e is AtKeyException &&
-                e.message ==
-                    'Invalid argument(s): Invalid or corrupted pad block')));
+        expect(wrappedDecryptSucceeds(cipherText: encryptedValue, aesKey: aesKey, ivBase64: otherIV, clearText: valueToEncrypt), false);
       }
     });
 

--- a/packages/at_client/test/encryption_util_test.dart
+++ b/packages/at_client/test/encryption_util_test.dart
@@ -5,12 +5,12 @@ import 'package:test/test.dart';
 
 bool wrappedDecryptSucceeds(
     {required String cipherText,
-      required String aesKey,
-      required String? ivBase64,
-      required String clearText}) {
+    required String aesKey,
+    required String? ivBase64,
+    required String clearText}) {
   try {
     var deciphered =
-    EncryptionUtil.decryptValue(cipherText, aesKey, ivBase64: ivBase64);
+        EncryptionUtil.decryptValue(cipherText, aesKey, ivBase64: ivBase64);
     if (deciphered != clearText) {
       return false;
     } else {
@@ -46,11 +46,23 @@ void main() {
           EncryptionUtil.decryptValue(encryptedValue, aesKey, ivBase64: iv);
       expect(decryptedValue, valueToEncrypt);
 
-      expect(wrappedDecryptSucceeds(cipherText: encryptedValue, aesKey: aesKey, ivBase64: null, clearText: valueToEncrypt), false);
+      expect(
+          wrappedDecryptSucceeds(
+              cipherText: encryptedValue,
+              aesKey: aesKey,
+              ivBase64: null,
+              clearText: valueToEncrypt),
+          false);
 
       for (int i = 0; i < 10; i++) {
         var otherIV = EncryptionUtil.generateIV();
-        expect(wrappedDecryptSucceeds(cipherText: encryptedValue, aesKey: aesKey, ivBase64: otherIV, clearText: valueToEncrypt), false);
+        expect(
+            wrappedDecryptSucceeds(
+                cipherText: encryptedValue,
+                aesKey: aesKey,
+                ivBase64: otherIV,
+                clearText: valueToEncrypt),
+            false);
       }
     });
 

--- a/packages/at_client/test/full_stack_test.dart
+++ b/packages/at_client/test/full_stack_test.dart
@@ -14,14 +14,14 @@ class MockRemoteSecondary extends Mock implements RemoteSecondary {}
 class MockSecondaryAddressFinder extends Mock
     implements SecondaryAddressFinder {}
 
-bool wrappedDecryptSucceeds({
-  required String cipherText,
-  required String aesKey,
-  required String? ivBase64,
-  required String clearText
-}) {
+bool wrappedDecryptSucceeds(
+    {required String cipherText,
+    required String aesKey,
+    required String? ivBase64,
+    required String clearText}) {
   try {
-    var deciphered = EncryptionUtil.decryptValue(cipherText, aesKey, ivBase64: ivBase64);
+    var deciphered =
+        EncryptionUtil.decryptValue(cipherText, aesKey, ivBase64: ivBase64);
     if (deciphered != clearText) {
       return false;
     } else {
@@ -31,6 +31,7 @@ bool wrappedDecryptSucceeds({
     return false;
   }
 }
+
 void main() {
   group('Test with full client stack except mockRemoteSecondary', () {
     final fullStackPrefs = AtClientPreference()
@@ -249,8 +250,7 @@ void main() {
       test('Test put shared, then get, with IV, 2.0 to 2.0', () async {
         fullStackPrefs.atProtocolEmitted = Version(2, 0, 0);
 
-        var atKey = (AtKey.shared('test_put')
-          ..sharedWith('@bob')).build();
+        var atKey = (AtKey.shared('test_put')..sharedWith('@bob')).build();
         await atClient.put(atKey, clearText);
         expect(atKey.metadata?.ivNonce, isNotNull);
 
@@ -292,8 +292,7 @@ void main() {
       test('Test put shared, then get, with IV, 2.0 to 1.5', () async {
         fullStackPrefs.atProtocolEmitted = Version(2, 0, 0);
 
-        var atKey = (AtKey.shared('test_put')
-          ..sharedWith('@bob')).build();
+        var atKey = (AtKey.shared('test_put')..sharedWith('@bob')).build();
         await atClient.put(atKey, clearText);
         expect(atKey.metadata?.ivNonce, isNotNull);
 

--- a/packages/at_client/test/full_stack_test.dart
+++ b/packages/at_client/test/full_stack_test.dart
@@ -14,6 +14,23 @@ class MockRemoteSecondary extends Mock implements RemoteSecondary {}
 class MockSecondaryAddressFinder extends Mock
     implements SecondaryAddressFinder {}
 
+bool wrappedDecryptSucceeds({
+  required String cipherText,
+  required String aesKey,
+  required String? ivBase64,
+  required String clearText
+}) {
+  try {
+    var deciphered = EncryptionUtil.decryptValue(cipherText, aesKey, ivBase64: ivBase64);
+    if (deciphered != clearText) {
+      return false;
+    } else {
+      return true;
+    }
+  } catch (e) {
+    return false;
+  }
+}
 void main() {
   group('Test with full client stack except mockRemoteSecondary', () {
     final fullStackPrefs = AtClientPreference()
@@ -142,8 +159,13 @@ void main() {
             .keyStore!
             .get(atKey.toString()));
         var cipherText = atData.data;
-        expect(() => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey),
-            throwsException);
+        expect(
+            wrappedDecryptSucceeds(
+                cipherText: cipherText,
+                aesKey: selfEncryptionKey,
+                ivBase64: null,
+                clearText: clearText),
+            false);
         expect(
             EncryptionUtil.decryptValue(cipherText, selfEncryptionKey,
                 ivBase64: atKey.metadata?.ivNonce),
@@ -167,8 +189,13 @@ void main() {
             .keyStore!
             .get(atKey.toString()));
         var cipherText = atData.data;
-        expect(() => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey),
-            throwsException);
+        expect(
+            wrappedDecryptSucceeds(
+                cipherText: cipherText,
+                aesKey: selfEncryptionKey,
+                ivBase64: null,
+                clearText: clearText),
+            false);
         expect(
             EncryptionUtil.decryptValue(cipherText, selfEncryptionKey,
                 ivBase64: atKey.metadata?.ivNonce),
@@ -222,7 +249,8 @@ void main() {
       test('Test put shared, then get, with IV, 2.0 to 2.0', () async {
         fullStackPrefs.atProtocolEmitted = Version(2, 0, 0);
 
-        var atKey = (AtKey.shared('test_put')..sharedWith('@bob')).build();
+        var atKey = (AtKey.shared('test_put')
+          ..sharedWith('@bob')).build();
         await atClient.put(atKey, clearText);
         expect(atKey.metadata?.ivNonce, isNotNull);
 
@@ -231,14 +259,27 @@ void main() {
             .keyStore!
             .get(atKey.toString()));
         var cipherText = atData.data;
-        expect(() => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey),
-            throwsException);
         expect(
-            () => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey,
-                ivBase64: atKey.metadata?.ivNonce),
-            throwsException);
-        expect(() => EncryptionUtil.decryptValue(cipherText, bobSharedKey),
-            throwsException);
+            wrappedDecryptSucceeds(
+                cipherText: cipherText,
+                aesKey: selfEncryptionKey,
+                ivBase64: null,
+                clearText: clearText),
+            false);
+        expect(
+            wrappedDecryptSucceeds(
+                cipherText: cipherText,
+                aesKey: selfEncryptionKey,
+                ivBase64: atKey.metadata?.ivNonce,
+                clearText: clearText),
+            false);
+        expect(
+            wrappedDecryptSucceeds(
+                cipherText: cipherText,
+                aesKey: bobSharedKey,
+                ivBase64: null,
+                clearText: clearText),
+            false);
         expect(
             EncryptionUtil.decryptValue(cipherText, bobSharedKey,
                 ivBase64: atKey.metadata?.ivNonce),
@@ -251,7 +292,8 @@ void main() {
       test('Test put shared, then get, with IV, 2.0 to 1.5', () async {
         fullStackPrefs.atProtocolEmitted = Version(2, 0, 0);
 
-        var atKey = (AtKey.shared('test_put')..sharedWith('@bob')).build();
+        var atKey = (AtKey.shared('test_put')
+          ..sharedWith('@bob')).build();
         await atClient.put(atKey, clearText);
         expect(atKey.metadata?.ivNonce, isNotNull);
 
@@ -261,14 +303,27 @@ void main() {
             .keyStore!
             .get(atKey.toString()));
         var cipherText = atData.data;
-        expect(() => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey),
-            throwsException);
         expect(
-            () => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey,
-                ivBase64: atKey.metadata?.ivNonce),
-            throwsException);
-        expect(() => EncryptionUtil.decryptValue(cipherText, bobSharedKey),
-            throwsException);
+            wrappedDecryptSucceeds(
+                cipherText: cipherText,
+                aesKey: selfEncryptionKey,
+                ivBase64: null,
+                clearText: clearText),
+            false);
+        expect(
+            wrappedDecryptSucceeds(
+                cipherText: cipherText,
+                aesKey: selfEncryptionKey,
+                ivBase64: atKey.metadata?.ivNonce,
+                clearText: clearText),
+            false);
+        expect(
+            wrappedDecryptSucceeds(
+                cipherText: cipherText,
+                aesKey: bobSharedKey,
+                ivBase64: null,
+                clearText: clearText),
+            false);
         expect(
             EncryptionUtil.decryptValue(cipherText, bobSharedKey,
                 ivBase64: atKey.metadata?.ivNonce),


### PR DESCRIPTION
**- What I did**
test: Changed assertions regarding decryption in full_stack_test.dart and encryption_util_test.dart to resolve the problem where, every now and again when calling AES decrypt without an IV on a value which was encrypted with an IV, an exception isn't thrown and we get an actual decryption result. (But don't worry, the decryption result is still nonsense.)

**- How I did it**
Created a local function `wrappedDecryptionSucceeds` which wraps EncryptionUtil.decryptValue(). The local wrapper returns true if and only if the decryption succeeds and the decrypted value is the same as the original clearText. If an exception is thrown, the wrapper returns false. If an exception is not thrown, but the decrypted value is not the same as the original clearText, the wrapper returns false.

**- How to verify it**
Tests pass

