### PR TITLE
fix: Invalid key in sync causes infinite loop

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.59
+- fix: Sync running into infinite loop when an invalid key is present in the entries to sync into client
 ## 3.0.58
 - chore: upgrade dependencies. at_commons to 3.0.43, at_utils to 3.0.12, at_lookup to 3.0.36 and at_chops to 1.0.3
 ## 3.0.57

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.58';
+  final String atClientVersion = '3.0.59';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -775,17 +775,14 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   Future<int> _getLastReceivedServerCommitId() async {
     // If "lastReceivedServerCommitId" key exists, fetch the data and return the
     // last received server commit id.
-    var isLastReceivedServerKeyExists = _atClient
-        .getLocalSecondary()!
-        .keyStore!
-        .isKeyExists(_lastReceivedServerCommitIdAtKey.toString());
-    if (isLastReceivedServerKeyExists) {
+    try {
       var response = await _atClient.get(_lastReceivedServerCommitIdAtKey);
       return int.parse(response.value);
+    } on KeyNotFoundException {
+      // If the key does not exist, fall back to previous logic, which is
+      // return last synced commit id.
+      return _getLocalCommitId();
     }
-    // If the key does not exist, fall back to previous logic, which is
-    // return last synced commit id.
-    return _getLocalCommitId();
   }
 
   /// Returns the local commit id. If null, returns -1.

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -778,7 +778,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     try {
       var response = await _atClient.get(_lastReceivedServerCommitIdAtKey);
       return int.parse(response.value);
-    } on KeyNotFoundException {
+    } on AtKeyNotFoundException {
       // If the key does not exist, fall back to previous logic, which is
       // return last synced commit id.
       return _getLocalCommitId();

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -59,6 +59,9 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   /// Returns the currentAtSign associated with the SyncService
   String get currentAtSign => _atClient.getCurrentAtSign()!;
 
+  /// A local AtKey to persist the last received server commitId
+  late AtKey _lastReceivedServerCommitIdAtKey;
+
   static Future<SyncService> create(AtClient atClient,
       {required AtClientManager atClientManager,
       required NotificationService notificationService,
@@ -83,6 +86,8 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     _logger = AtSignLogger('SyncService (${_atClient.getCurrentAtSign()})');
     _remoteSecondary = remoteSecondary;
     _statsNotificationListener = notificationService as NotificationServiceImpl;
+    _lastReceivedServerCommitIdAtKey =
+        AtKey.local('lastreceivedservercommitid', currentAtSign).build();
     _atClientManager.listenToAtSignChange(this);
   }
 
@@ -335,15 +340,14 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     var unCommittedEntries = await syncUtil.getChangesSinceLastCommit(
         lastSyncedLocalSeq, _atClient.getPreferences()!.syncRegex,
         atSign: _atClient.getCurrentAtSign()!);
-    var localCommitId = await _getLocalCommitId();
-    if (serverCommitId > localCommitId) {
+    var lastReceivedServerCommitId = await _getLastReceivedServerCommitId();
+    if (serverCommitId > lastReceivedServerCommitId) {
       _logger.finer(
-          'syncing to local: localCommitId $localCommitId serverCommitId $serverCommitId');
+          'syncing to local: localCommitId $lastReceivedServerCommitId serverCommitId $serverCommitId');
 
-      // Hint to casual reader: This is where we sync new changes from the server to this this client
+      // Hint to casual reader: This is where we sync new changes from the server to this client
       final keyInfoList = await _syncFromServer(
-          serverCommitId, localCommitId, unCommittedEntries);
-
+          serverCommitId, lastReceivedServerCommitId, unCommittedEntries);
       syncResult.keyInfoList.addAll(keyInfoList);
     }
     if (unCommittedEntries.isNotEmpty) {
@@ -352,7 +356,6 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
 
       // Hint to casual reader: This is where we sync new changes from this client to the server
       final keyInfoList = await _syncToRemote(unCommittedEntries);
-
       syncResult.keyInfoList.addAll(keyInfoList);
     }
     syncResult.lastSyncedOn = DateTime.now().toUtc();
@@ -406,91 +409,109 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   }
 
   /// Syncs the cloud secondary changes to local secondary.
-  Future<List<KeyInfo>> _syncFromServer(int serverCommitId, int localCommitId,
+  Future<List<KeyInfo>> _syncFromServer(
+      int serverCommitId,
+      int lastReceivedServerCommitId,
       List<CommitEntry> uncommittedEntries) async {
     // Iterates until serverCommitId is greater than lastReceivedServerCommitId.
     // replacing localCommitId with lastReceivedServerCommitId fixes infinite loop issue
     // in certain scenarios e.g server has a commit entry that need not be synced on client side,
     // server has delete commit entry and the key is not present on local keystore
     List<KeyInfo> keyInfoList = [];
-    int lastReceivedServerCommitId = localCommitId;
-    while (serverCommitId > lastReceivedServerCommitId) {
-      _sendTelemetry('_syncFromServer.whileLoop', {
-        "serverCommitId": serverCommitId,
-        "lastReceivedServerCommitId": lastReceivedServerCommitId
-      });
-
-      var syncBuilder = SyncVerbBuilder()
-        ..commitId = localCommitId
-        ..regex = _atClient.getPreferences()!.syncRegex
-        ..limit = _atClient.getPreferences()!.syncPageLimit
-        ..isPaginated = true;
-      _logger.finer('** syncBuilder ${syncBuilder.buildCommand()}');
-      List syncResponseJson = [];
-      try {
-        syncResponseJson = JsonUtils.decodeJson(DefaultResponseParser()
-            .parse(await _remoteSecondary.executeVerb(syncBuilder))
-            .response);
-      } on AtException catch (e) {
-        e.stack(AtChainedException(Intent.syncData,
-            ExceptionScenario.remoteVerbExecutionFailed, e.message));
-        _logger.severe(
-            'Exception occurred in fetching sync response : ${e.getTraceMessage()}');
-        rethrow;
-      }
-      _logger.finest('** syncResponse $syncResponseJson');
-
-      if (syncResponseJson.isEmpty) {
-        _logger.finer(
-            'sync response is empty: local commitID: $localCommitId server commitID: $serverCommitId');
-        break;
-      }
-      // Iterates over each commit
-      for (dynamic serverCommitEntry in syncResponseJson) {
-        _sendTelemetry('_syncFromServer.forEachEntry.start', {
-          "atKey": serverCommitEntry['atKey'],
-          "operation": serverCommitEntry['operation'],
-          "commitId": serverCommitEntry['commitId'],
+    try {
+      while (serverCommitId > lastReceivedServerCommitId) {
+        _sendTelemetry('_syncFromServer.whileLoop', {
+          "serverCommitId": serverCommitId,
+          "lastReceivedServerCommitId": lastReceivedServerCommitId
         });
-        if (serverCommitEntry['commitId'] is int) {
-          lastReceivedServerCommitId = serverCommitEntry['commitId'];
-        } else {
-          lastReceivedServerCommitId = int.parse(serverCommitEntry['commitId']);
+        List<dynamic> listOfCommitEntriesToSync =
+            await _getEntriesToSyncFromServer(lastReceivedServerCommitId);
+        if (listOfCommitEntriesToSync.isEmpty) {
+          _logger.finer(
+              'sync response is empty: local commitID: $lastReceivedServerCommitId server commitID: $serverCommitId');
+          break;
         }
-        try {
-          final keyInfo = KeyInfo(
-              serverCommitEntry['atKey'],
-              SyncDirection.remoteToLocal,
-              convertCommitOpSymbolToEnum(serverCommitEntry['operation']));
-          ConflictInfo? conflictInfo =
-              await _checkConflict(serverCommitEntry, uncommittedEntries);
-          keyInfo.conflictInfo = conflictInfo;
-          await _syncLocal(serverCommitEntry);
-          keyInfoList.add(keyInfo);
-          _sendTelemetry('_syncFromServer.forEachEntry.end', {
-            'atKey': keyInfo.key,
-            'syncDirection': keyInfo.syncDirection,
-            'errorOrExceptionMessage':
-                keyInfo.conflictInfo?.errorOrExceptionMessage
+        // Iterates over each commit entry
+        for (dynamic serverCommitEntry in listOfCommitEntriesToSync) {
+          _sendTelemetry('_syncFromServer.forEachEntry.start', {
+            "atKey": serverCommitEntry['atKey'],
+            "operation": serverCommitEntry['operation'],
+            "commitId": serverCommitEntry['commitId'],
           });
-        } on Exception catch (e, stacktrace) {
-          _sendTelemetry('_syncFromServer.forEachEntry.exception',
-              {"e": e, "st": stacktrace});
-          _logger.severe(
-              'exception syncing entry to local $serverCommitEntry Exception: ${e.toString()} - stacktrace: $stacktrace');
-        } on Error catch (e, stacktrace) {
-          _sendTelemetry(
-              '_syncFromServer.forEachEntry.error', {"e": e, "st": stacktrace});
-          _logger.severe(
-              'error syncing entry to local $serverCommitEntry - Exception: ${e.toString()} - stacktrace: $stacktrace');
+          // Convert the commit-id to "int" if in "String" data type.
+          lastReceivedServerCommitId =
+              _parseToInteger(serverCommitEntry['commitId']);
+          await _processServerCommitEntry(
+              serverCommitEntry, uncommittedEntries, keyInfoList);
+          _logger.finest(
+              '**lastReceivedServerCommitId $lastReceivedServerCommitId');
         }
       }
-      // assigning the lastSynced local commit id.
-      localCommitId = await _getLocalCommitId();
-      _logger
-          .finest('**lastReceivedServerCommitId $lastReceivedServerCommitId');
+    } finally {
+      // The put method persists the lastReceivedServerCommitId which will be used to
+      // fetch the next set of entries to sync from server
+      // Adding this piece in finally block to ensure lastReceivedServerCommitId state
+      // is persisted even if there occurs any exception during sync to local.
+      await _atClient.put(_lastReceivedServerCommitIdAtKey,
+          lastReceivedServerCommitId.toString());
     }
     return keyInfoList;
+  }
+
+  Future<void> _processServerCommitEntry(serverCommitEntry,
+      List<CommitEntry> uncommittedEntries, List<KeyInfo> keyInfoList) async {
+    try {
+      final keyInfo = KeyInfo(
+          serverCommitEntry['atKey'],
+          SyncDirection.remoteToLocal,
+          convertCommitOpSymbolToEnum(serverCommitEntry['operation']));
+      ConflictInfo? conflictInfo =
+          await _checkConflict(serverCommitEntry, uncommittedEntries);
+      keyInfo.conflictInfo = conflictInfo;
+      await _syncLocal(serverCommitEntry);
+      keyInfoList.add(keyInfo);
+      _sendTelemetry('_syncFromServer.forEachEntry.end', {
+        'atKey': keyInfo.key,
+        'syncDirection': keyInfo.syncDirection,
+        'errorOrExceptionMessage': keyInfo.conflictInfo?.errorOrExceptionMessage
+      });
+    } on Exception catch (e, stacktrace) {
+      _sendTelemetry(
+          '_syncFromServer.forEachEntry.exception', {"e": e, "st": stacktrace});
+      _logger.severe(
+          'exception syncing entry to local $serverCommitEntry Exception: ${e.toString()} - stacktrace: $stacktrace');
+    } on Error catch (e, stacktrace) {
+      _sendTelemetry(
+          '_syncFromServer.forEachEntry.error', {"e": e, "st": stacktrace});
+      _logger.severe(
+          'error syncing entry to local $serverCommitEntry - Exception: ${e.toString()} - stacktrace: $stacktrace');
+    }
+  }
+
+  /// Takes the last received server commit id and fetches the entries that are above the given
+  /// commit-id to sync into the local keystore.
+  Future<List<dynamic>> _getEntriesToSyncFromServer(
+      int lastReceivedServerCommitId) async {
+    var syncBuilder = SyncVerbBuilder()
+      ..commitId = lastReceivedServerCommitId
+      ..regex = _atClient.getPreferences()!.syncRegex
+      ..limit = _atClient.getPreferences()!.syncPageLimit
+      ..isPaginated = true;
+    _logger.finer('** syncBuilder ${syncBuilder.buildCommand()}');
+    List syncResponseJson = [];
+    try {
+      syncResponseJson = JsonUtils.decodeJson(DefaultResponseParser()
+          .parse(await _remoteSecondary.executeVerb(syncBuilder))
+          .response);
+    } on AtException catch (e) {
+      e.stack(AtChainedException(Intent.syncData,
+          ExceptionScenario.remoteVerbExecutionFailed, e.message));
+      _logger.severe(
+          'Exception occurred in fetching sync response : ${e.getTraceMessage()}');
+      rethrow;
+    }
+    _logger.finest('** syncResponse $syncResponseJson');
+    return syncResponseJson;
   }
 
   Future<ConflictInfo?> _checkConflict(
@@ -692,6 +713,8 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       var serverCommitId =
           await _getServerCommitId(remoteSecondary: remoteSecondary);
 
+      var lastReceivedServerCommitId = await _getLastReceivedServerCommitId();
+
       var lastSyncedEntry = await syncUtil.getLastSyncedEntry(
           _atClient.getPreferences()!.syncRegex,
           atSign: _atClient.getCurrentAtSign()!);
@@ -704,7 +727,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
           lastSyncedLocalSeq, _atClient.getPreferences()!.syncRegex,
           atSign: _atClient.getCurrentAtSign()!);
       return SyncUtil.isInSync(
-          unCommittedEntries, serverCommitId, lastSyncedCommitId);
+          unCommittedEntries, serverCommitId, lastReceivedServerCommitId);
     } on Exception catch (e) {
       var cause = (e is AtException) ? e.getTraceMessage() : e.toString();
       _logger.severe('exception in isInSync $cause');
@@ -721,6 +744,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     }
     var serverCommitId =
         await _getServerCommitId(remoteSecondary: _remoteSecondary);
+    var lastReceivedServerCommitId = await _getLastReceivedServerCommitId();
     var lastSyncedEntry = await syncUtil.getLastSyncedEntry(
         _atClient.getPreferences()!.syncRegex,
         atSign: _atClient.getCurrentAtSign()!);
@@ -732,7 +756,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
         lastSyncedLocalSeq, _atClient.getPreferences()!.syncRegex,
         atSign: _atClient.getCurrentAtSign()!);
     return SyncUtil.isInSync(
-        unCommittedEntries, serverCommitId, lastSyncedCommitId);
+        unCommittedEntries, serverCommitId, lastReceivedServerCommitId);
   }
 
   /// Returns the cloud secondary latest commit id. if null, returns -1.
@@ -746,6 +770,22 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     _serverCommitId ??= -1;
     _logger.info('Returning the serverCommitId $_serverCommitId');
     return _serverCommitId;
+  }
+
+  Future<int> _getLastReceivedServerCommitId() async {
+    // If "lastReceivedServerCommitId" key exists, fetch the data and return the
+    // last received server commit id.
+    var isLastReceivedServerKeyExists = _atClient
+        .getLocalSecondary()!
+        .keyStore!
+        .isKeyExists(_lastReceivedServerCommitIdAtKey.toString());
+    if (isLastReceivedServerKeyExists) {
+      var response = await _atClient.get(_lastReceivedServerCommitIdAtKey);
+      return int.parse(response.value);
+    }
+    // If the key does not exist, fall back to previous logic, which is
+    // return last synced commit id.
+    return _getLocalCommitId();
   }
 
   /// Returns the local commit id. If null, returns -1.
@@ -931,6 +971,13 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   void clearSyncEntities() {
     _syncRequests.clear();
     _syncProgressListeners.clear();
+  }
+
+  int _parseToInteger(dynamic arg1) {
+    if (arg1 is String) {
+      return int.parse(arg1);
+    }
+    return arg1;
   }
 }
 

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -60,7 +60,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   String get currentAtSign => _atClient.getCurrentAtSign()!;
 
   /// A local AtKey to persist the last received server commitId
-  late AtKey _lastReceivedServerCommitIdAtKey;
+  late final AtKey _lastReceivedServerCommitIdAtKey;
 
   static Future<SyncService> create(AtClient atClient,
       {required AtClientManager atClientManager,

--- a/packages/at_client/lib/src/util/sync_util.dart
+++ b/packages/at_client/lib/src/util/sync_util.dart
@@ -64,12 +64,12 @@ class SyncUtil {
 
   //#TODO change return type to enum which says in sync, local ahead or server ahead
   static bool isInSync(List<CommitEntry?>? unCommittedEntries,
-      int? serverCommitId, int? lastSyncedCommitId) {
-    logger.finer('localCommitId:$lastSyncedCommitId');
+      int? serverCommitId, int? lastReceivedServerCommitId) {
+    logger.finer('localCommitId:$lastReceivedServerCommitId');
     logger.finer('serverCommitId:$serverCommitId');
     logger.finer('changed entries: ${unCommittedEntries?.length}');
     return (unCommittedEntries == null || unCommittedEntries.isEmpty) &&
-        _checkCommitIdsEqual(lastSyncedCommitId, serverCommitId);
+        _checkCommitIdsEqual(lastReceivedServerCommitId, serverCommitId);
   }
 
   static bool _checkCommitIdsEqual(lastSyncedCommitId, serverCommitId) {

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.58
+version: 3.0.59
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/test/sync_new_test.dart
+++ b/packages/at_client/test/sync_new_test.dart
@@ -1165,6 +1165,7 @@ void main() {
     ///     a. The keystore should have test4_key0 with value: +445-446-4847
     test('A test to verify when an existing key is deleted and then created',
         () async {
+      registerFallbackValue(FakeAtKey());
       //----------------------------------setup---------------------------------
       LocalSecondary? localSecondary = LocalSecondary(mockAtClient,
           keyStore: TestResources.getHiveKeyStore(TestResources.atsign));
@@ -1182,6 +1183,10 @@ void main() {
           .thenAnswer((invocation) =>
               Future.value('data:[{"id":1,"response":{"data":"21"}},'
                   '{"id":2,"response":{"data":"22"}}]'));
+      when(() =>
+              mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((invocation) =>
+              throw KeyNotFoundException('key is not found in keystore'));
 
       //instantiate sync service using mocks
       SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
@@ -1255,6 +1260,7 @@ void main() {
     /// 2. When fetching uncommitted entries only entries with hive_seq 6,7,8 should be returned.
     test('A test to verify batch requests does not sync entries with commitId',
         () async {
+      registerFallbackValue(FakeAtKey());
       //----------------------------------setup---------------------------------
       HiveKeystore? keystore =
           TestResources.getHiveKeyStore(TestResources.atsign);
@@ -1301,6 +1307,10 @@ void main() {
       when(() => mockAtClient.put(
               any(that: LastReceivedServerCommitIdMatcher()), any()))
           .thenAnswer((_) => Future.value(true));
+      when(() =>
+              mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((invocation) =>
+              throw KeyNotFoundException('key is not found in keystore'));
 
       SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
           atClientManager: mockAtClientManager,
@@ -1545,6 +1555,7 @@ void main() {
 
       registerFallbackValue(FakeSyncVerbBuilder());
       registerFallbackValue(FakeUpdateVerbBuilder());
+      registerFallbackValue(FakeAtKey());
 
       when(() => mockNetworkUtil.isNetworkAvailable())
           .thenAnswer((_) => Future.value(true));
@@ -1557,6 +1568,10 @@ void main() {
                   '{"id":3,"response":{"data":"23"}},'
                   '{"id":4,"response":{"data":"24"}},'
                   '{"id":5,"response":{"data":"25"}}]'));
+      when(() =>
+              mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((invocation) =>
+              throw KeyNotFoundException('key is not found in keystore'));
 
       SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
           atClientManager: mockAtClientManager,
@@ -2003,6 +2018,7 @@ void main() {
 
       registerFallbackValue(FakeSyncVerbBuilder());
       registerFallbackValue(FakeUpdateVerbBuilder());
+      registerFallbackValue(FakeAtKey());
 
       mockAtClient.setPreferences(preference);
       when(() => mockNetworkUtil.isNetworkAvailable())
@@ -2016,6 +2032,10 @@ void main() {
               '{"id":3,"response":{"data":"103"}},'
               '{"id":4,"response":{"data":"104"}},'
               '{"id":5,"response":{"data":"105"}}]'));
+      when(() =>
+              mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((invocation) =>
+              throw KeyNotFoundException('key is not found in keystore'));
 
       SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
           atClientManager: mockAtClientManager,
@@ -2305,6 +2325,10 @@ void main() {
       when(() => mockAtClient.put(
               any(that: LastReceivedServerCommitIdMatcher()), any()))
           .thenAnswer((_) => Future.value(true));
+      when(() =>
+              mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((invocation) =>
+              throw KeyNotFoundException('key is not found in keystore'));
 
       SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
           atClientManager: mockAtClientManager,
@@ -2502,6 +2526,10 @@ void main() {
       when(() => mockAtClient.put(
               any(that: LastReceivedServerCommitIdMatcher()), any()))
           .thenAnswer((_) => Future.value(true));
+      when(() =>
+              mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((invocation) =>
+              throw KeyNotFoundException('key is not found in keystore'));
 
       when(() => mockAtClient.getLocalSecondary())
           .thenAnswer((_) => localSecondary);
@@ -2620,6 +2648,10 @@ void main() {
       when(() => mockAtClient.put(
               any(that: LastReceivedServerCommitIdMatcher()), any()))
           .thenAnswer((_) => Future.value(true));
+      when(() =>
+              mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((invocation) =>
+              throw KeyNotFoundException('key is not found in keystore'));
 
       // --------------------- preconditions setup -----------------------------
       await localSecondary.putValue('public:conflict_key1@bob', 'localValue');
@@ -2823,6 +2855,10 @@ void main() {
         when(() => mockAtClient.put(
                 any(that: LastReceivedServerCommitIdMatcher()), any()))
             .thenAnswer((_) => Future.value(true));
+        when(() => mockAtClient
+                .get(any(that: LastReceivedServerCommitIdMatcher())))
+            .thenAnswer((invocation) =>
+                throw KeyNotFoundException('key is not found in keystore'));
 
         //----------------------------Preconditions setup ----------------------
         await localSecondary.putValue(
@@ -2922,6 +2958,7 @@ void main() {
 
         registerFallbackValue(FakeSyncVerbBuilder());
         registerFallbackValue(FakeUpdateVerbBuilder());
+        registerFallbackValue(FakeAtKey());
 
         when(() => mockNetworkUtil.isNetworkAvailable())
             .thenAnswer((_) => Future.value(true));
@@ -2952,6 +2989,10 @@ void main() {
             .thenAnswer((invocation) =>
                 Future.value('data:[{"id":1,"response":{"data":"4"}},'
                     '{"id":2,"response":{"data":"5"}}]'));
+        when(() => mockAtClient
+                .get(any(that: LastReceivedServerCommitIdMatcher())))
+            .thenAnswer((invocation) =>
+                throw KeyNotFoundException('key is not found in keystore'));
 
         //------------------Assertions -------------------
         //onDoneCallback when triggered, flips the switch in TestResources
@@ -3044,6 +3085,10 @@ void main() {
         when(() => mockAtClient.put(
                 any(that: LastReceivedServerCommitIdMatcher()), any()))
             .thenAnswer((_) => Future.value(true));
+        when(() => mockAtClient
+                .get(any(that: LastReceivedServerCommitIdMatcher())))
+            .thenAnswer((invocation) =>
+                throw KeyNotFoundException('key is not found in keystore'));
 
         SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
             atClientManager: mockAtClientManager,
@@ -3233,6 +3278,10 @@ void main() {
         when(() => mockAtClient.put(
                 any(that: LastReceivedServerCommitIdMatcher()), any()))
             .thenAnswer((_) => Future.value(true));
+        when(() => mockAtClient
+                .get(any(that: LastReceivedServerCommitIdMatcher())))
+            .thenAnswer((invocation) =>
+                throw KeyNotFoundException('key is not found in keystore'));
 
         //-----------------preconditions setup-----------------
         await localSecondary.putValue(
@@ -3374,6 +3423,10 @@ void main() {
         when(() => mockAtClient.put(
                 any(that: LastReceivedServerCommitIdMatcher()), any()))
             .thenAnswer((_) => Future.value(true));
+        when(() => mockAtClient
+                .get(any(that: LastReceivedServerCommitIdMatcher())))
+            .thenAnswer((invocation) =>
+                throw KeyNotFoundException('key is not found in keystore'));
 
         //------------------------ preconditions setup ------------------------
         await localSecondary.putValue(
@@ -3461,6 +3514,10 @@ void main() {
         when(() => mockAtClient.put(
                 any(that: LastReceivedServerCommitIdMatcher()), any()))
             .thenAnswer((_) => Future.value(true));
+        when(() => mockAtClient
+                .get(any(that: LastReceivedServerCommitIdMatcher())))
+            .thenAnswer((invocation) =>
+                throw KeyNotFoundException('key is not found in keystore'));
 
         // ----------------- preconditions setup and operation -----------------
         CustomSyncProgressListener progressListener =
@@ -3556,6 +3613,10 @@ void main() {
         when(() => mockLocalSecondary.keyStore?.isKeyExists(
                 any(that: startsWith('local:lastreceivedservercommitid'))))
             .thenAnswer((invocation) => false);
+        when(() => mockAtClient
+                .get(any(that: LastReceivedServerCommitIdMatcher())))
+            .thenAnswer((invocation) =>
+                throw KeyNotFoundException('key is not found in keystore'));
 
         var syncServiceImpl = await SyncServiceImpl.create(mockAtClient,
             atClientManager: mockAtClientManager,
@@ -3647,6 +3708,10 @@ void main() {
         when(() => mockLocalSecondary.keyStore
                 ?.isKeyExists(any(that: startsWith('local:'))))
             .thenAnswer((invocation) => false);
+        when(() => mockAtClient
+                .get(any(that: LastReceivedServerCommitIdMatcher())))
+            .thenAnswer((invocation) =>
+                throw KeyNotFoundException('key is not found in keystore'));
 
         var syncServiceImpl = await SyncServiceImpl.create(mockAtClient,
             atClientManager: mockAtClientManager,

--- a/packages/at_client/test/sync_new_test.dart
+++ b/packages/at_client/test/sync_new_test.dart
@@ -1186,7 +1186,7 @@ void main() {
       when(() =>
               mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
           .thenAnswer((invocation) =>
-              throw KeyNotFoundException('key is not found in keystore'));
+              throw AtKeyNotFoundException('key is not found in keystore'));
 
       //instantiate sync service using mocks
       SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
@@ -1310,7 +1310,7 @@ void main() {
       when(() =>
               mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
           .thenAnswer((invocation) =>
-              throw KeyNotFoundException('key is not found in keystore'));
+              throw AtKeyNotFoundException('key is not found in keystore'));
 
       SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
           atClientManager: mockAtClientManager,
@@ -1571,7 +1571,7 @@ void main() {
       when(() =>
               mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
           .thenAnswer((invocation) =>
-              throw KeyNotFoundException('key is not found in keystore'));
+              throw AtKeyNotFoundException('key is not found in keystore'));
 
       SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
           atClientManager: mockAtClientManager,
@@ -2035,7 +2035,7 @@ void main() {
       when(() =>
               mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
           .thenAnswer((invocation) =>
-              throw KeyNotFoundException('key is not found in keystore'));
+              throw AtKeyNotFoundException('key is not found in keystore'));
 
       SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
           atClientManager: mockAtClientManager,
@@ -2328,7 +2328,7 @@ void main() {
       when(() =>
               mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
           .thenAnswer((invocation) =>
-              throw KeyNotFoundException('key is not found in keystore'));
+              throw AtKeyNotFoundException('key is not found in keystore'));
 
       SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
           atClientManager: mockAtClientManager,
@@ -2529,7 +2529,7 @@ void main() {
       when(() =>
               mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
           .thenAnswer((invocation) =>
-              throw KeyNotFoundException('key is not found in keystore'));
+              throw AtKeyNotFoundException('key is not found in keystore'));
 
       when(() => mockAtClient.getLocalSecondary())
           .thenAnswer((_) => localSecondary);
@@ -2651,7 +2651,7 @@ void main() {
       when(() =>
               mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
           .thenAnswer((invocation) =>
-              throw KeyNotFoundException('key is not found in keystore'));
+              throw AtKeyNotFoundException('key is not found in keystore'));
 
       // --------------------- preconditions setup -----------------------------
       await localSecondary.putValue('public:conflict_key1@bob', 'localValue');
@@ -2858,7 +2858,7 @@ void main() {
         when(() => mockAtClient
                 .get(any(that: LastReceivedServerCommitIdMatcher())))
             .thenAnswer((invocation) =>
-                throw KeyNotFoundException('key is not found in keystore'));
+                throw AtKeyNotFoundException('key is not found in keystore'));
 
         //----------------------------Preconditions setup ----------------------
         await localSecondary.putValue(
@@ -2992,7 +2992,7 @@ void main() {
         when(() => mockAtClient
                 .get(any(that: LastReceivedServerCommitIdMatcher())))
             .thenAnswer((invocation) =>
-                throw KeyNotFoundException('key is not found in keystore'));
+                throw AtKeyNotFoundException('key is not found in keystore'));
 
         //------------------Assertions -------------------
         //onDoneCallback when triggered, flips the switch in TestResources
@@ -3088,7 +3088,7 @@ void main() {
         when(() => mockAtClient
                 .get(any(that: LastReceivedServerCommitIdMatcher())))
             .thenAnswer((invocation) =>
-                throw KeyNotFoundException('key is not found in keystore'));
+                throw AtKeyNotFoundException('key is not found in keystore'));
 
         SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
             atClientManager: mockAtClientManager,
@@ -3281,7 +3281,7 @@ void main() {
         when(() => mockAtClient
                 .get(any(that: LastReceivedServerCommitIdMatcher())))
             .thenAnswer((invocation) =>
-                throw KeyNotFoundException('key is not found in keystore'));
+                throw AtKeyNotFoundException('key is not found in keystore'));
 
         //-----------------preconditions setup-----------------
         await localSecondary.putValue(
@@ -3426,7 +3426,7 @@ void main() {
         when(() => mockAtClient
                 .get(any(that: LastReceivedServerCommitIdMatcher())))
             .thenAnswer((invocation) =>
-                throw KeyNotFoundException('key is not found in keystore'));
+                throw AtKeyNotFoundException('key is not found in keystore'));
 
         //------------------------ preconditions setup ------------------------
         await localSecondary.putValue(
@@ -3517,7 +3517,7 @@ void main() {
         when(() => mockAtClient
                 .get(any(that: LastReceivedServerCommitIdMatcher())))
             .thenAnswer((invocation) =>
-                throw KeyNotFoundException('key is not found in keystore'));
+                throw AtKeyNotFoundException('key is not found in keystore'));
 
         // ----------------- preconditions setup and operation -----------------
         CustomSyncProgressListener progressListener =
@@ -3616,7 +3616,7 @@ void main() {
         when(() => mockAtClient
                 .get(any(that: LastReceivedServerCommitIdMatcher())))
             .thenAnswer((invocation) =>
-                throw KeyNotFoundException('key is not found in keystore'));
+                throw AtKeyNotFoundException('key is not found in keystore'));
 
         var syncServiceImpl = await SyncServiceImpl.create(mockAtClient,
             atClientManager: mockAtClientManager,
@@ -3711,7 +3711,7 @@ void main() {
         when(() => mockAtClient
                 .get(any(that: LastReceivedServerCommitIdMatcher())))
             .thenAnswer((invocation) =>
-                throw KeyNotFoundException('key is not found in keystore'));
+                throw AtKeyNotFoundException('key is not found in keystore'));
 
         var syncServiceImpl = await SyncServiceImpl.create(mockAtClient,
             atClientManager: mockAtClientManager,

--- a/packages/at_client/test/sync_new_test.dart
+++ b/packages/at_client/test/sync_new_test.dart
@@ -62,6 +62,8 @@ class FakeDeleteVerbBuilder extends Fake implements DeleteVerbBuilder {}
 
 class FakeRemoteSecondary extends Fake implements RemoteSecondary {}
 
+class FakeAtKey extends Fake implements AtKey {}
+
 ///Notes:
 /// Description of terminology used in the test cases:
 ///
@@ -1261,6 +1263,7 @@ void main() {
 
       registerFallbackValue(FakeSyncVerbBuilder());
       registerFallbackValue(FakeUpdateVerbBuilder());
+      registerFallbackValue(FakeAtKey());
 
       when(() => mockNetworkUtil.isNetworkAvailable())
           .thenAnswer((_) => Future.value(true));
@@ -1294,6 +1297,10 @@ void main() {
           (invocation) => Future.value('data:[{"id":1,"response":{"data":"6"}},'
               '{"id":2,"response":{"data":"7"}},'
               '{"id":3,"response":{"data":"8"}}]'));
+
+      when(() => mockAtClient.put(
+              any(that: LastReceivedServerCommitIdMatcher()), any()))
+          .thenAnswer((_) => Future.value(true));
 
       SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
           atClientManager: mockAtClientManager,
@@ -2255,6 +2262,7 @@ void main() {
     /// Server and local should be in sync and 5 entries from the server must be synced to local
     test('A test to verify server commit entries are synced to local',
         () async {
+      registerFallbackValue(FakeAtKey());
       //----------------------------------Setup---------------------------------
       LocalSecondary? localSecondary = LocalSecondary(mockAtClient,
           keyStore: TestResources.getHiveKeyStore(TestResources.atsign));
@@ -2294,6 +2302,9 @@ void main() {
               '"value":"dummy",'
               '"metadata":{"createdAt":"2022-11-07 13:42:02.703Z"},'
               '"commitId":15,"operation":"*"}]'));
+      when(() => mockAtClient.put(
+              any(that: LastReceivedServerCommitIdMatcher()), any()))
+          .thenAnswer((_) => Future.value(true));
 
       SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
           atClientManager: mockAtClientManager,
@@ -2454,6 +2465,7 @@ void main() {
     test(
         'A test to verify existing key is deleted when delete commit operation is received',
         () async {
+      registerFallbackValue(FakeAtKey());
       // --------------------- Setup ---------------------
       LocalSecondary? localSecondary = LocalSecondary(mockAtClient,
           keyStore: TestResources.getHiveKeyStore(TestResources.atsign));
@@ -2487,6 +2499,9 @@ void main() {
           any(
               that: SyncVerbBuilderMatcher()))).thenAnswer((_) => Future.value(
           'data:[{"atKey":"@alice:contact@gandalf","value":null,"metadata":null,"commitId":3,"operation":"-"},{"atKey":"cached:@gandalf:aboutme@bob","value":null,"metadata":null,"commitId":4,"operation":"-"}]'));
+      when(() => mockAtClient.put(
+              any(that: LastReceivedServerCommitIdMatcher()), any()))
+          .thenAnswer((_) => Future.value(true));
 
       when(() => mockAtClient.getLocalSecondary())
           .thenAnswer((_) => localSecondary);
@@ -2571,6 +2586,7 @@ void main() {
 
       registerFallbackValue(FakeSyncVerbBuilder());
       registerFallbackValue(FakeUpdateVerbBuilder());
+      registerFallbackValue(FakeAtKey());
 
       when(() => mockNetworkUtil.isNetworkAvailable())
           .thenAnswer((_) => Future.value(true));
@@ -2601,6 +2617,9 @@ void main() {
               auth: any(named: "auth"))).thenAnswer(
           (invocation) => Future.value('data:[{"id":1,"response":{"data":"3"}},'
               '{"id":2,"response":{"data":"4"}}]'));
+      when(() => mockAtClient.put(
+              any(that: LastReceivedServerCommitIdMatcher()), any()))
+          .thenAnswer((_) => Future.value(true));
 
       // --------------------- preconditions setup -----------------------------
       await localSecondary.putValue('public:conflict_key1@bob', 'localValue');
@@ -2770,6 +2789,7 @@ void main() {
 
         registerFallbackValue(FakeSyncVerbBuilder());
         registerFallbackValue(FakeUpdateVerbBuilder());
+        registerFallbackValue(FakeAtKey());
 
         when(() => mockNetworkUtil.isNetworkAvailable())
             .thenAnswer((_) => Future.value(false));
@@ -2800,6 +2820,9 @@ void main() {
             .thenAnswer((invocation) =>
                 Future.value('data:[{"id":1,"response":{"data":"4"}},'
                     '{"id":2,"response":{"data":"5"}}]'));
+        when(() => mockAtClient.put(
+                any(that: LastReceivedServerCommitIdMatcher()), any()))
+            .thenAnswer((_) => Future.value(true));
 
         //----------------------------Preconditions setup ----------------------
         await localSecondary.putValue(
@@ -2986,6 +3009,7 @@ void main() {
 
         registerFallbackValue(FakeSyncVerbBuilder());
         registerFallbackValue(FakeUpdateVerbBuilder());
+        registerFallbackValue(FakeAtKey());
 
         when(() => mockNetworkUtil.isNetworkAvailable())
             .thenAnswer((_) => Future.value(true));
@@ -3017,6 +3041,9 @@ void main() {
                 '"value":"dummy",'
                 '"metadata":{"createdAt":"2022-11-07 13:42:02.703Z"},'
                 '"commitId":4,"operation":"*"}]'));
+        when(() => mockAtClient.put(
+                any(that: LastReceivedServerCommitIdMatcher()), any()))
+            .thenAnswer((_) => Future.value(true));
 
         SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
             atClientManager: mockAtClientManager,
@@ -3162,6 +3189,7 @@ void main() {
         syncService.syncUtil = SyncUtil(atCommitLog: TestResources.commitLog);
         registerFallbackValue(FakeSyncVerbBuilder());
         registerFallbackValue(FakeUpdateVerbBuilder());
+        registerFallbackValue(FakeAtKey());
 
         when(() => mockNetworkUtil.isNetworkAvailable())
             .thenAnswer((_) => Future.value(true));
@@ -3202,6 +3230,9 @@ void main() {
             .thenAnswer((invocation) =>
                 Future.value('data:[{"id":1,"response":{"data":"3"}},'
                     '{"id":2,"response":{"data":"4"}}]'));
+        when(() => mockAtClient.put(
+                any(that: LastReceivedServerCommitIdMatcher()), any()))
+            .thenAnswer((_) => Future.value(true));
 
         //-----------------preconditions setup-----------------
         await localSecondary.putValue(
@@ -3299,6 +3330,7 @@ void main() {
         syncService.syncUtil = SyncUtil(atCommitLog: TestResources.commitLog);
         registerFallbackValue(FakeSyncVerbBuilder());
         registerFallbackValue(FakeUpdateVerbBuilder());
+        registerFallbackValue(FakeAtKey());
 
         when(() => mockNetworkUtil.isNetworkAvailable())
             .thenAnswer((_) => Future.value(true));
@@ -3339,6 +3371,9 @@ void main() {
             .thenAnswer((invocation) =>
                 Future.value('data:[{"id":1,"response":{"data":"4"}},'
                     '{"id":2,"response":{"data":"5"}}]'));
+        when(() => mockAtClient.put(
+                any(that: LastReceivedServerCommitIdMatcher()), any()))
+            .thenAnswer((_) => Future.value(true));
 
         //------------------------ preconditions setup ------------------------
         await localSecondary.putValue(
@@ -3397,6 +3432,7 @@ void main() {
         syncService.syncUtil = SyncUtil(atCommitLog: TestResources.commitLog);
         registerFallbackValue(FakeSyncVerbBuilder());
         registerFallbackValue(FakeUpdateVerbBuilder());
+        registerFallbackValue(FakeAtKey());
 
         when(() => mockNetworkUtil.isNetworkAvailable())
             .thenAnswer((_) => Future.value(true));
@@ -3422,6 +3458,9 @@ void main() {
                 '"value":"dummy",'
                 '"metadata":{"createdAt":"2022-11-07 13:42:02.703Z"},'
                 '"commitId":3,"operation":"*"}]'));
+        when(() => mockAtClient.put(
+                any(that: LastReceivedServerCommitIdMatcher()), any()))
+            .thenAnswer((_) => Future.value(true));
 
         // ----------------- preconditions setup and operation -----------------
         CustomSyncProgressListener progressListener =
@@ -3480,6 +3519,7 @@ void main() {
         registerFallbackValue(FakeSyncVerbBuilder());
         registerFallbackValue(FakeUpdateVerbBuilder());
         registerFallbackValue(FakeDeleteVerbBuilder());
+        registerFallbackValue(FakeAtKey());
 
         LocalSecondary mockLocalSecondary = MockLocalSecondary();
         SyncUtil mockSyncUtil = MockSyncUtil();
@@ -3510,6 +3550,12 @@ void main() {
         when(() => mockLocalSecondary.executeVerb(
             any(that: UpdateDeleteVerbBuilderMatcher()),
             sync: false)).thenAnswer((_) => Future.value('data:5'));
+        when(() => mockAtClient.put(
+                any(that: LastReceivedServerCommitIdMatcher()), any()))
+            .thenAnswer((_) => Future.value(true));
+        when(() => mockLocalSecondary.keyStore?.isKeyExists(
+                any(that: startsWith('local:lastreceivedservercommitid'))))
+            .thenAnswer((invocation) => false);
 
         var syncServiceImpl = await SyncServiceImpl.create(mockAtClient,
             atClientManager: mockAtClientManager,
@@ -3549,6 +3595,7 @@ void main() {
         registerFallbackValue(FakeSyncVerbBuilder());
         registerFallbackValue(FakeUpdateVerbBuilder());
         registerFallbackValue(FakeDeleteVerbBuilder());
+        registerFallbackValue(FakeAtKey());
 
         SecondaryKeyStore mockSecondaryKeyStore = MockSecondaryKeyStore();
         LocalSecondary mockLocalSecondary = MockLocalSecondary();
@@ -3594,6 +3641,12 @@ void main() {
             mockRemoteSecondary.executeCommand(any(),
                 auth: any(named: "auth"))).thenAnswer((_) => Future.value(
             'data:[{"id":1,"response":{"data":"21"}},{"id":2,"response":{"data":"22"}},{"id":3,"response":{"data":"23"}},{"id":4,"response":{"data":"24"}}]'));
+        when(() => mockAtClient.put(
+                any(that: LastReceivedServerCommitIdMatcher()), any()))
+            .thenAnswer((_) => Future.value(true));
+        when(() => mockLocalSecondary.keyStore
+                ?.isKeyExists(any(that: startsWith('local:'))))
+            .thenAnswer((invocation) => false);
 
         var syncServiceImpl = await SyncServiceImpl.create(mockAtClient,
             atClientManager: mockAtClientManager,
@@ -3744,6 +3797,21 @@ class RemoteSecondaryMatcher extends Matcher {
   @override
   bool matches(item, Map matchState) {
     if (item is RemoteSecondary) {
+      return true;
+    }
+    return false;
+  }
+}
+
+class LastReceivedServerCommitIdMatcher extends Matcher {
+  @override
+  Description describe(Description description) {
+    return description;
+  }
+
+  @override
+  bool matches(item, Map matchState) {
+    if (item is AtKey && item.key!.startsWith('lastreceivedservercommitid')) {
       return true;
     }
     return false;

--- a/packages/at_client/test/sync_service_test.dart
+++ b/packages/at_client/test/sync_service_test.dart
@@ -162,9 +162,9 @@ void main() async {
               CommitEntry('phone.wavi', CommitOp.UPDATE, DateTime.now())
                 ..commitId = localCommitId));
       when(() =>
-          mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+              mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
           .thenAnswer((invocation) =>
-      throw KeyNotFoundException('key is not found in keystore'));
+              throw AtKeyNotFoundException('key is not found in keystore'));
 
       var serverCommitId = 2;
       var syncRequest = SyncRequest()..result = SyncResult();
@@ -204,9 +204,9 @@ void main() async {
                     {"id": "3", "name": "lastCommitID", "value": "5"}
                   ])}'));
       when(() =>
-          mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+              mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
           .thenAnswer((invocation) =>
-      throw KeyNotFoundException('key is not found in keystore'));
+              throw AtKeyNotFoundException('key is not found in keystore'));
 
       syncServiceImpl.networkUtil = mockNetworkUtil;
 
@@ -293,9 +293,9 @@ void main() async {
               CommitEntry('phone.wavi', CommitOp.UPDATE, DateTime.now())
                 ..commitId = localCommitId));
       when(() =>
-          mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+              mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
           .thenAnswer((invocation) =>
-      throw KeyNotFoundException('key is not found in keystore'));
+              throw AtKeyNotFoundException('key is not found in keystore'));
 
       var serverCommitId = 2;
       var syncRequest = SyncRequest()..result = SyncResult();

--- a/packages/at_client/test/sync_service_test.dart
+++ b/packages/at_client/test/sync_service_test.dart
@@ -31,7 +31,7 @@ class MockSecondaryKeyStore extends Mock implements SecondaryKeyStore {
 
   @override
   bool isKeyExists(String key) {
-    if(key.startsWith('local:lastreceivedservercommitid')){
+    if (key.startsWith('local:lastreceivedservercommitid')) {
       return false;
     }
     return true;
@@ -92,6 +92,7 @@ class FakeUpdateVerbBuilder extends Fake implements UpdateVerbBuilder {}
 class FakeStatsVerbBuilder extends Fake implements StatsVerbBuilder {}
 
 class FakeAtKey extends Fake implements AtKey {}
+
 void main() async {
   AtClient mockAtClient = MockAtClient();
   AtClientManager mockAtClientManager = MockAtClientManager();
@@ -120,7 +121,7 @@ void main() async {
       registerFallbackValue(FakeAtKey());
 
       when(() => mockAtClient.put(
-          any(that: LastReceivedServerCommitIdMatcher()), any()))
+              any(that: LastReceivedServerCommitIdMatcher()), any()))
           .thenAnswer((_) => Future.value(true));
       when(() => mockRemoteSecondary.executeVerb(any()))
           .thenAnswer((_) => Future.value('data:${jsonEncode([
@@ -179,7 +180,7 @@ void main() async {
       when(() => mockAtClient.getLocalSecondary())
           .thenAnswer((_) => mockLocalSecondary);
       when(() => mockAtClient.put(
-          any(that: LastReceivedServerCommitIdMatcher()), any()))
+              any(that: LastReceivedServerCommitIdMatcher()), any()))
           .thenAnswer((_) => Future.value(true));
       when(() => mockAtCommitLog.lastSyncedEntry()).thenAnswer((_) =>
           Future.value(
@@ -233,7 +234,7 @@ void main() async {
       when(() => mockAtClient.getLocalSecondary())
           .thenAnswer((_) => mockLocalSecondary);
       when(() => mockAtClient.put(
-          any(that: LastReceivedServerCommitIdMatcher()), any()))
+              any(that: LastReceivedServerCommitIdMatcher()), any()))
           .thenAnswer((_) => Future.value(true));
       when(() => mockRemoteSecondary.executeVerb(any()))
           .thenAnswer((_) => Future.value('data:${jsonEncode([

--- a/packages/at_client/test/sync_service_test.dart
+++ b/packages/at_client/test/sync_service_test.dart
@@ -161,6 +161,10 @@ void main() async {
           Future.value(
               CommitEntry('phone.wavi', CommitOp.UPDATE, DateTime.now())
                 ..commitId = localCommitId));
+      when(() =>
+          mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((invocation) =>
+      throw KeyNotFoundException('key is not found in keystore'));
 
       var serverCommitId = 2;
       var syncRequest = SyncRequest()..result = SyncResult();
@@ -199,6 +203,10 @@ void main() async {
           .thenAnswer((_) => Future.value('data:${jsonEncode([
                     {"id": "3", "name": "lastCommitID", "value": "5"}
                   ])}'));
+      when(() =>
+          mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((invocation) =>
+      throw KeyNotFoundException('key is not found in keystore'));
 
       syncServiceImpl.networkUtil = mockNetworkUtil;
 
@@ -284,6 +292,10 @@ void main() async {
           Future.value(
               CommitEntry('phone.wavi', CommitOp.UPDATE, DateTime.now())
                 ..commitId = localCommitId));
+      when(() =>
+          mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((invocation) =>
+      throw KeyNotFoundException('key is not found in keystore'));
 
       var serverCommitId = 2;
       var syncRequest = SyncRequest()..result = SyncResult();


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Fix sync running into an infinite loop when an invalid key is sent from the server in the sync response.

**- How I did it**
* Introduce a new variable "lastReceivedServerCommitId" which keeps track of the last commit entry sent by the server. When fetching the next sent of entries to sync, the client sends the "lastReceivedServerCommitId" instead of "lastSyncedCommitId" into the local keystore.

**- How to verify it**
* Updated the unit tests to accommodate the changes.

**- Description for the changelog**
* Fix: Sync running into infinite loop when an invalid key is present in the entries to sync into client
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->