### PR TITLE
fix: Update lastReceivedServerCommitId when uncommitted entries are synced

### DIFF
--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -392,8 +392,13 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
             await syncUtil.updateCommitEntry(
                 commitEntry, commitId, _atClient.getCurrentAtSign()!);
             // update the last received server commit id
-            await _atClient.put(
-                _lastReceivedServerCommitIdAtKey, commitId.toString());
+            // When an invalid key is received, the commit-id is -1, and in this
+            // case the "lastReceivedServerCommitId" must NOT be updated, because
+            // we do not want lose the track of latest server commit id.
+            if (commitId != -1) {
+              await _atClient.put(
+                  _lastReceivedServerCommitIdAtKey, commitId.toString());
+            }
             keyInfoList.add(KeyInfo(commitEntry.atKey,
                 SyncDirection.localToRemote, commitEntry.operation));
           } on Exception catch (e) {

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -340,7 +340,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     var unCommittedEntries = await syncUtil.getChangesSinceLastCommit(
         lastSyncedLocalSeq, _atClient.getPreferences()!.syncRegex,
         atSign: _atClient.getCurrentAtSign()!);
-    var lastReceivedServerCommitId = await _getLastReceivedServerCommitId();
+    var lastReceivedServerCommitId = await getLastReceivedServerCommitId();
     if (serverCommitId > lastReceivedServerCommitId) {
       _logger.finer(
           'syncing to local: localCommitId $lastReceivedServerCommitId serverCommitId $serverCommitId');
@@ -391,6 +391,9 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
             _logger.finer('***batchId:$batchId key: ${commitEntry.atKey}');
             await syncUtil.updateCommitEntry(
                 commitEntry, commitId, _atClient.getCurrentAtSign()!);
+            // update the last received server commit id
+            await _atClient.put(
+                _lastReceivedServerCommitIdAtKey, commitId.toString());
             keyInfoList.add(KeyInfo(commitEntry.atKey,
                 SyncDirection.localToRemote, commitEntry.operation));
           } on Exception catch (e) {
@@ -713,7 +716,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       var serverCommitId =
           await _getServerCommitId(remoteSecondary: remoteSecondary);
 
-      var lastReceivedServerCommitId = await _getLastReceivedServerCommitId();
+      var lastReceivedServerCommitId = await getLastReceivedServerCommitId();
 
       var lastSyncedEntry = await syncUtil.getLastSyncedEntry(
           _atClient.getPreferences()!.syncRegex,
@@ -744,7 +747,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     }
     var serverCommitId =
         await _getServerCommitId(remoteSecondary: _remoteSecondary);
-    var lastReceivedServerCommitId = await _getLastReceivedServerCommitId();
+    var lastReceivedServerCommitId = await getLastReceivedServerCommitId();
     var lastSyncedEntry = await syncUtil.getLastSyncedEntry(
         _atClient.getPreferences()!.syncRegex,
         atSign: _atClient.getCurrentAtSign()!);
@@ -772,7 +775,8 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     return _serverCommitId;
   }
 
-  Future<int> _getLastReceivedServerCommitId() async {
+  @visibleForTesting
+  Future<int> getLastReceivedServerCommitId() async {
     // If "lastReceivedServerCommitId" key exists, fetch the data and return the
     // last received server commit id.
     try {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Fix the issue: https://github.com/atsign-foundation/at_client_sdk/issues/990

**- How I did it**
* Update the "lastReceivedServerCommitId" when uncommitted entries are synced to the server and the respective entries in the client are updated. This fixes the issue-990 mentioned above.

**- How to verify it**
* Added unit test to verify the "lastReceivedServerCommitId" is updated when an uncommitted entry is synced to the server

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->