### PR TITLE
feat: Add AtClientParticulars to enhance logging

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -2,6 +2,7 @@
 - fix: Sync running into infinite loop when an invalid key is present in the entries to sync into client
 - fix: Redundant logs generated for an internal key[lastReceivedNotification] while sending notifications
 - chore: Reduced log_level of AtKey lower case enforcement message from INFO to FINER
+- feat: Introduce clientId, appName, appVersion and platform to distinguish requests from several clients in server logs.
 ## 3.0.58
 - chore: upgrade dependencies. at_commons to 3.0.43, at_utils to 3.0.12, at_lookup to 3.0.36 and at_chops to 1.0.3
 ## 3.0.57

--- a/packages/at_client/lib/src/client/remote_secondary.dart
+++ b/packages/at_client/lib/src/client/remote_secondary.dart
@@ -7,6 +7,7 @@ import 'package:at_client/src/manager/at_client_manager.dart';
 import 'package:at_client/src/preference/at_client_config.dart';
 import 'package:at_client/src/preference/at_client_preference.dart';
 import 'package:at_client/src/util/at_client_util.dart';
+import 'package:at_client/src/util/logger_util.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
@@ -73,11 +74,11 @@ class RemoteSecondary implements Secondary {
   Future<String> executeVerb(VerbBuilder builder, {sync = false}) async {
     try {
       String verbResult;
-      logger.finer(
-          '${_preference.atClientParticulars.clientId}|Command sent to server: ${builder.buildCommand()}');
+      logger.finer(logger.getLogMessageWithClientParticulars(_preference.atClientParticulars,
+          'Command sent to server: ${builder.buildCommand()}'));
       verbResult = await atLookUp.executeVerb(builder);
-      logger.finer(
-          '${_preference.atClientParticulars.clientId}|Response from server: $verbResult');
+      logger.finer(logger.getLogMessageWithClientParticulars(_preference.atClientParticulars,
+          'Response from server: $verbResult'));
       return verbResult;
     } on AtException catch (e) {
       throw e
@@ -95,12 +96,12 @@ class RemoteSecondary implements Secondary {
     // ignore: prefer_typing_uninitialized_variables
     var verbResult;
     try {
-      logger.finer(
-          '${_preference.atClientParticulars.clientId}|Command sent to server: ${builder.buildCommand()}');
+      logger.finer(logger.getLogMessageWithClientParticulars(_preference.atClientParticulars,
+          'Command sent to server: ${builder.buildCommand()}'));
       verbResult = await executeVerb(builder);
       verbResult = verbResult.replaceFirst('data:', '');
-      logger.finer(
-          '${_preference.atClientParticulars.clientId}|Response from server: $verbResult');
+      logger.finer(logger.getLogMessageWithClientParticulars(_preference.atClientParticulars,
+          'Response from server: $verbResult'));
     } on AtException catch (e) {
       throw e
         ..stack(AtChainedException(Intent.fetchData,

--- a/packages/at_client/lib/src/client/remote_secondary.dart
+++ b/packages/at_client/lib/src/client/remote_secondary.dart
@@ -95,8 +95,12 @@ class RemoteSecondary implements Secondary {
     // ignore: prefer_typing_uninitialized_variables
     var verbResult;
     try {
+      logger.finer(
+          '${_preference.atClientParticulars.clientId}|Command sent to server: ${builder.buildCommand()}');
       verbResult = await executeVerb(builder);
       verbResult = verbResult.replaceFirst('data:', '');
+      logger.finer(
+          '${_preference.atClientParticulars.clientId}|Response from server: $verbResult');
     } on AtException catch (e) {
       throw e
         ..stack(AtChainedException(Intent.fetchData,

--- a/packages/at_client/lib/src/client/remote_secondary.dart
+++ b/packages/at_client/lib/src/client/remote_secondary.dart
@@ -74,10 +74,12 @@ class RemoteSecondary implements Secondary {
   Future<String> executeVerb(VerbBuilder builder, {sync = false}) async {
     try {
       String verbResult;
-      logger.finer(logger.getLogMessageWithClientParticulars(_preference.atClientParticulars,
+      logger.finer(logger.getLogMessageWithClientParticulars(
+          _preference.atClientParticulars,
           'Command sent to server: ${builder.buildCommand()}'));
       verbResult = await atLookUp.executeVerb(builder);
-      logger.finer(logger.getLogMessageWithClientParticulars(_preference.atClientParticulars,
+      logger.finer(logger.getLogMessageWithClientParticulars(
+          _preference.atClientParticulars,
           'Response from server: $verbResult'));
       return verbResult;
     } on AtException catch (e) {
@@ -96,11 +98,13 @@ class RemoteSecondary implements Secondary {
     // ignore: prefer_typing_uninitialized_variables
     var verbResult;
     try {
-      logger.finer(logger.getLogMessageWithClientParticulars(_preference.atClientParticulars,
+      logger.finer(logger.getLogMessageWithClientParticulars(
+          _preference.atClientParticulars,
           'Command sent to server: ${builder.buildCommand()}'));
       verbResult = await executeVerb(builder);
       verbResult = verbResult.replaceFirst('data:', '');
-      logger.finer(logger.getLogMessageWithClientParticulars(_preference.atClientParticulars,
+      logger.finer(logger.getLogMessageWithClientParticulars(
+          _preference.atClientParticulars,
           'Response from server: $verbResult'));
     } on AtException catch (e) {
       throw e

--- a/packages/at_client/lib/src/client/remote_secondary.dart
+++ b/packages/at_client/lib/src/client/remote_secondary.dart
@@ -42,8 +42,25 @@ class RemoteSecondary implements Secondary {
         secondaryAddressFinder:
             AtClientManager.getInstance().secondaryAddressFinder,
         secureSocketConfig: secureSocketConfig,
-        clientConfig: {VERSION: AtClientConfig.getInstance().atClientVersion});
+        clientConfig: _getClientConfig());
+
     atLookUp.atChops = atChops;
+  }
+
+  Map<String, String> _getClientConfig() {
+    var clientConfig = <String, String>{};
+    clientConfig[VERSION] = AtClientConfig.getInstance().atClientVersion;
+    clientConfig[CLIENT_ID] = _preference.atClientParticulars.clientId;
+    if (_preference.atClientParticulars.appName.isNotNull) {
+      clientConfig[APP_NAME] = _preference.atClientParticulars.appName!;
+    }
+    if (_preference.atClientParticulars.appVersion.isNotNull) {
+      clientConfig[APP_VERSION] = _preference.atClientParticulars.appVersion!;
+    }
+    if (_preference.atClientParticulars.platform.isNotNull) {
+      clientConfig[PLATFORM] = _preference.atClientParticulars.platform!;
+    }
+    return clientConfig;
   }
 
   @experimental
@@ -56,7 +73,11 @@ class RemoteSecondary implements Secondary {
   Future<String> executeVerb(VerbBuilder builder, {sync = false}) async {
     try {
       String verbResult;
+      logger.finer(
+          '${_preference.atClientParticulars.clientId}|Command sent to server: ${builder.buildCommand()}');
       verbResult = await atLookUp.executeVerb(builder);
+      logger.finer(
+          '${_preference.atClientParticulars.clientId}|Response from server: $verbResult');
       return verbResult;
     } on AtException catch (e) {
       throw e

--- a/packages/at_client/lib/src/preference/at_client_particulars.dart
+++ b/packages/at_client/lib/src/preference/at_client_particulars.dart
@@ -4,7 +4,6 @@ import 'package:uuid/uuid.dart';
 
 @experimental
 class AtClientParticulars {
-
   final String _clientId = Uuid().v4();
 
   /// A unique identifier to distinguish clients on the server logs.

--- a/packages/at_client/lib/src/preference/at_client_particulars.dart
+++ b/packages/at_client/lib/src/preference/at_client_particulars.dart
@@ -4,13 +4,6 @@ import 'package:uuid/uuid.dart';
 
 @experimental
 class AtClientParticulars {
-  static final AtClientParticulars _singleton = AtClientParticulars._internal();
-
-  AtClientParticulars._internal();
-
-  factory AtClientParticulars.getInstance() {
-    return _singleton;
-  }
 
   final String _clientId = Uuid().v4();
 

--- a/packages/at_client/lib/src/preference/at_client_particulars.dart
+++ b/packages/at_client/lib/src/preference/at_client_particulars.dart
@@ -1,0 +1,29 @@
+import 'package:at_client/src/client/remote_secondary.dart';
+import 'package:meta/meta.dart';
+import 'package:uuid/uuid.dart';
+
+@experimental
+class AtClientParticulars {
+  static final AtClientParticulars _singleton = AtClientParticulars._internal();
+
+  AtClientParticulars._internal();
+
+  factory AtClientParticulars.getInstance() {
+    return _singleton;
+  }
+
+  final String _clientId = Uuid().v4();
+
+  /// A unique identifier to distinguish clients on the server logs.
+  String get clientId => _clientId.hashCode.toString();
+
+  /// The name of the app the [AtClient] is associated with. This helps in distinguish
+  /// the request sent from the apps in the [RemoteSecondary] logs.
+  String? appName;
+
+  /// The version of the app
+  String? appVersion;
+
+  /// The platform on which the app is running on.
+  String? platform;
+}

--- a/packages/at_client/lib/src/preference/at_client_preference.dart
+++ b/packages/at_client/lib/src/preference/at_client_preference.dart
@@ -1,4 +1,5 @@
 import 'package:at_client/at_client.dart';
+import 'package:at_client/src/preference/at_client_particulars.dart';
 import 'package:meta/meta.dart';
 import 'package:version/version.dart';
 
@@ -100,6 +101,9 @@ class AtClientPreference {
   /// This instance variable is experimental, for now
   @experimental
   Version atProtocolEmitted = Version(1, 5, 0);
+
+  @experimental
+  AtClientParticulars atClientParticulars = AtClientParticulars.getInstance();
 }
 
 @Deprecated("Use SyncService")

--- a/packages/at_client/lib/src/preference/at_client_preference.dart
+++ b/packages/at_client/lib/src/preference/at_client_preference.dart
@@ -103,7 +103,7 @@ class AtClientPreference {
   Version atProtocolEmitted = Version(1, 5, 0);
 
   @experimental
-  AtClientParticulars atClientParticulars = AtClientParticulars.getInstance();
+  AtClientParticulars atClientParticulars = AtClientParticulars();
 }
 
 @Deprecated("Use SyncService")

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -11,6 +11,7 @@ import 'package:at_client/src/response/json_utils.dart';
 import 'package:at_client/src/service/notification_service_impl.dart';
 import 'package:at_client/src/service/sync/sync_request.dart';
 import 'package:at_client/src/service/sync_service.dart';
+import 'package:at_client/src/util/logger_util.dart';
 import 'package:at_client/src/util/network_util.dart';
 import 'package:at_client/src/util/sync_util.dart';
 import 'package:at_commons/at_builders.dart';
@@ -139,8 +140,9 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     _statsNotificationListener
         .subscribe(regex: 'statsNotification')
         .listen((notification) async {
-      _logger.finer(
-          '${_atClient.getPreferences()!.atClientParticulars.clientId}|RCVD: stats notification in sync: ${notification.value}');
+      _logger.finer(_logger.getLogMessageWithClientParticulars(
+          _atClient.getPreferences()!.atClientParticulars,
+          'RCVD: stats notification in sync: ${notification.value}'));
       final serverCommitId = notification.value;
       if (serverCommitId != null &&
           int.parse(serverCommitId) > await _getLocalCommitId()) {
@@ -286,8 +288,9 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
 
   void _syncComplete(SyncRequest syncRequest) {
     syncRequest.result!.lastSyncedOn = DateTime.now().toUtc();
-    _logger.info(
-        '${_atClient.getPreferences()!.atClientParticulars.clientId}|Inside syncComplete. syncRequest.requestSource : ${syncRequest.requestSource} ; syncRequest.onDone : ${syncRequest.onDone}');
+    _logger.info(_logger.getLogMessageWithClientParticulars(
+        _atClient.getPreferences()!.atClientParticulars,
+        'Inside syncComplete. syncRequest.requestSource : ${syncRequest.requestSource}; syncRequest.onDone : ${syncRequest.onDone}'));
     // If specific onDone callback is set, call specific onDone callback,
     // else call the global onDone callback.
     if (syncRequest.onDone != null &&
@@ -324,8 +327,9 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   }
 
   void _clearQueue() {
-    _logger.finer(
-        '${_atClient.getPreferences()!.atClientParticulars.clientId}|Clearing sync queue');
+    _logger.finer(_logger.getLogMessageWithClientParticulars(
+        _atClient.getPreferences()!.atClientParticulars,
+        'Clearing sync queue'));
     _syncRequests.clear();
   }
 
@@ -507,8 +511,9 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       ..regex = _atClient.getPreferences()!.syncRegex
       ..limit = _atClient.getPreferences()!.syncPageLimit
       ..isPaginated = true;
-    _logger.finer(
-        '${_atClient.getPreferences()!.atClientParticulars.clientId} | syncBuilder ${syncBuilder.buildCommand()}');
+    _logger.finer(_logger.getLogMessageWithClientParticulars(
+        _atClient.getPreferences()!.atClientParticulars,
+        'syncBuilder ${syncBuilder.buildCommand()}'));
     List syncResponseJson = [];
     try {
       syncResponseJson = JsonUtils.decodeJson(DefaultResponseParser()
@@ -521,8 +526,9 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
           'Exception occurred in fetching sync response : ${e.getTraceMessage()}');
       rethrow;
     }
-    _logger.finest(
-        '${_atClient.getPreferences()!.atClientParticulars.clientId}|** syncResponse $syncResponseJson');
+    _logger.finest(_logger.getLogMessageWithClientParticulars(
+        _atClient.getPreferences()!.atClientParticulars,
+        'syncResponse $syncResponseJson'));
     return syncResponseJson;
   }
 
@@ -780,8 +786,9 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
         remoteSecondary, _atClient.getPreferences()!.syncRegex);
     // If server commit id is null, set to -1;
     _serverCommitId ??= -1;
-    _logger.info(
-        '${_atClient.getPreferences()!.atClientParticulars.clientId}| Returning serverCommitId $_serverCommitId');
+    _logger.info(_logger.getLogMessageWithClientParticulars(
+        _atClient.getPreferences()!.atClientParticulars,
+        'Returning serverCommitId $_serverCommitId'));
     return _serverCommitId;
   }
 
@@ -819,11 +826,13 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     var command = 'batch:';
     command += jsonEncode(requests);
     command += '\n';
-    _logger.finer(
-        '${_atClient.getPreferences()!.atClientParticulars.clientId}| Sending batch to sync: $command');
+    _logger.finer(_logger.getLogMessageWithClientParticulars(
+        _atClient.getPreferences()!.atClientParticulars,
+        'Sending batch to sync: $command'));
     var verbResult = await _remoteSecondary.executeCommand(command, auth: true);
-    _logger.finer(
-        '${_atClient.getPreferences()!.atClientParticulars.clientId}| batch result:$verbResult');
+    _logger.finer(_logger.getLogMessageWithClientParticulars(
+        _atClient.getPreferences()!.atClientParticulars,
+        'batch result:$verbResult'));
     if (verbResult != null) {
       verbResult = verbResult.replaceFirst('data:', '');
     }

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -139,7 +139,8 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     _statsNotificationListener
         .subscribe(regex: 'statsNotification')
         .listen((notification) async {
-      _logger.finer('${_atClient.getPreferences()!.atClientParticulars.clientId}|RCVD: stats notification in sync: ${notification.value}');
+      _logger.finer(
+          '${_atClient.getPreferences()!.atClientParticulars.clientId}|RCVD: stats notification in sync: ${notification.value}');
       final serverCommitId = notification.value;
       if (serverCommitId != null &&
           int.parse(serverCommitId) > await _getLocalCommitId()) {

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -505,7 +505,8 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       ..regex = _atClient.getPreferences()!.syncRegex
       ..limit = _atClient.getPreferences()!.syncPageLimit
       ..isPaginated = true;
-    _logger.finer('** syncBuilder ${syncBuilder.buildCommand()}');
+    _logger.finer(
+        '${_atClient.getPreferences()!.atClientParticulars.clientId} | syncBuilder ${syncBuilder.buildCommand()}');
     List syncResponseJson = [];
     try {
       syncResponseJson = JsonUtils.decodeJson(DefaultResponseParser()
@@ -518,7 +519,8 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
           'Exception occurred in fetching sync response : ${e.getTraceMessage()}');
       rethrow;
     }
-    _logger.finest('** syncResponse $syncResponseJson');
+    _logger.finest(
+        '${_atClient.getPreferences()!.atClientParticulars.clientId}|** syncResponse $syncResponseJson');
     return syncResponseJson;
   }
 
@@ -814,8 +816,11 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     var command = 'batch:';
     command += jsonEncode(requests);
     command += '\n';
+    _logger.finer(
+        '${_atClient.getPreferences()!.atClientParticulars.clientId}| Sending batch to sync: $command');
     var verbResult = await _remoteSecondary.executeCommand(command, auth: true);
-    _logger.finer('batch result:$verbResult');
+    _logger.finer(
+        '${_atClient.getPreferences()!.atClientParticulars.clientId}| batch result:$verbResult');
     if (verbResult != null) {
       verbResult = verbResult.replaceFirst('data:', '');
     }

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -139,7 +139,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     _statsNotificationListener
         .subscribe(regex: 'statsNotification')
         .listen((notification) async {
-      _logger.finer('got stats notification in sync: ${notification.value}');
+      _logger.finer('${_atClient.getPreferences()!.atClientParticulars.clientId}|RCVD: stats notification in sync: ${notification.value}');
       final serverCommitId = notification.value;
       if (serverCommitId != null &&
           int.parse(serverCommitId) > await _getLocalCommitId()) {
@@ -286,7 +286,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   void _syncComplete(SyncRequest syncRequest) {
     syncRequest.result!.lastSyncedOn = DateTime.now().toUtc();
     _logger.info(
-        'Inside syncComplete. syncRequest.requestSource : ${syncRequest.requestSource} ; syncRequest.onDone : ${syncRequest.onDone}');
+        '${_atClient.getPreferences()!.atClientParticulars.clientId}|Inside syncComplete. syncRequest.requestSource : ${syncRequest.requestSource} ; syncRequest.onDone : ${syncRequest.onDone}');
     // If specific onDone callback is set, call specific onDone callback,
     // else call the global onDone callback.
     if (syncRequest.onDone != null &&
@@ -323,7 +323,8 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   }
 
   void _clearQueue() {
-    _logger.finer('clearing sync queue');
+    _logger.finer(
+        '${_atClient.getPreferences()!.atClientParticulars.clientId}|Clearing sync queue');
     _syncRequests.clear();
   }
 
@@ -778,7 +779,8 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
         remoteSecondary, _atClient.getPreferences()!.syncRegex);
     // If server commit id is null, set to -1;
     _serverCommitId ??= -1;
-    _logger.info('Returning the serverCommitId $_serverCommitId');
+    _logger.info(
+        '${_atClient.getPreferences()!.atClientParticulars.clientId}| Returning serverCommitId $_serverCommitId');
     return _serverCommitId;
   }
 

--- a/packages/at_client/lib/src/util/logger_util.dart
+++ b/packages/at_client/lib/src/util/logger_util.dart
@@ -1,0 +1,22 @@
+import 'package:at_client/src/preference/at_client_particulars.dart';
+import 'package:at_client/src/util/at_client_util.dart';
+import 'package:at_utils/at_logger.dart';
+
+extension AtClientLogging on AtSignLogger {
+  String getLogMessageWithClientParticulars(
+      AtClientParticulars atClientParticulars, String logMessage) {
+    StringBuffer stringBuffer = StringBuffer();
+    stringBuffer.write('${atClientParticulars.clientId}|');
+    if (atClientParticulars.appName.isNotNull) {
+      stringBuffer.write('${atClientParticulars.appName}|');
+    }
+    if (atClientParticulars.appVersion.isNotNull) {
+      stringBuffer.write('${atClientParticulars.appVersion}|');
+    }
+    if (atClientParticulars.platform.isNotNull) {
+      stringBuffer.write('${atClientParticulars.platform}|');
+    }
+    stringBuffer.write(logMessage);
+    return stringBuffer.toString();
+  }
+}

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -39,6 +39,13 @@ dependencies:
   at_chops: ^1.0.3
   version: ^3.0.2
 
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: add_constants
+
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.21.4

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -33,18 +33,11 @@ dependencies:
   at_lookup: ^3.0.36
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
-  at_commons: ^3.0.43
+  at_commons: ^3.0.45
   at_utils: ^3.0.12
   meta: ^1.8.0
   at_chops: ^1.0.3
   version: ^3.0.2
-
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
-      ref: add_constants
 
 dev_dependencies:
   lints: ^2.0.0

--- a/packages/at_client/test/remote_secondary_test.dart
+++ b/packages/at_client/test/remote_secondary_test.dart
@@ -73,7 +73,9 @@ void main() {
 
     test('executeAndParse using llookup', () async {
       String fakeLookupData = 'data:lookup data stub';
-      LookupVerbBuilder lookupVerbBuilder = LookupVerbBuilder();
+      LookupVerbBuilder lookupVerbBuilder = LookupVerbBuilder()
+        ..atKey = 'dummy_key'
+        ..sharedBy = '@alice';
       when(() => mockAtLookUp.executeVerb(lookupVerbBuilder))
           .thenAnswer((_) async => fakeLookupData);
       RemoteSecondary remoteSecondary =

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -12,12 +12,12 @@ dependencies:
   at_client:
     path: ../../packages/at_client
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
-      ref: add_constants
+#dependency_overrides:
+#  at_commons:
+#    git:
+#      url: https://github.com/atsign-foundation/at_tools.git
+#      path: packages/at_commons
+#      ref: add_constants
 #  at_chops:
 #    git:
 #      url: https://github.com/atsign-foundation/at_libraries.git

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -12,7 +12,12 @@ dependencies:
   at_client:
     path: ../../packages/at_client
 
-#dependency_overrides:
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: add_constants
 #  at_chops:
 #    git:
 #      url: https://github.com/atsign-foundation/at_libraries.git

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -11,6 +11,13 @@ dependencies:
   at_client:
     path: ../../packages/at_client
 
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_tools.git
+      path: packages/at_commons
+      ref: add_constants
+
 #  at_chops:
 #    git:
 #      url: https://github.com/atsign-foundation/at_libraries.git

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -11,13 +11,13 @@ dependencies:
   at_client:
     path: ../../packages/at_client
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_tools.git
-      path: packages/at_commons
-      ref: add_constants
-
+#dependency_overrides:
+#  at_commons:
+#    git:
+#      url: https://github.com/atsign-foundation/at_tools.git
+#      path: packages/at_commons
+#      ref: add_constants
+#
 #  at_chops:
 #    git:
 #      url: https://github.com/atsign-foundation/at_libraries.git


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Introduce clientId, appName, appVersion and platform to distinguish requests from several clients
* Added clientId in the sync_service_impl and remote_secondary logs to compare with the server logs.

**- How I did it**
* Added a new class "AtClientParticulars" that contains the above-mentioned fields. Added "@‎experimental" tag to the class.
* The "AtClientParticulars" is exposed in the  "AtClientPreferences" for the apps to populate the appName, appVersion and platform.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->