### PR TITLE
test: Fix failing functional tests due to sync race conditions

### DIFF
--- a/tests/at_functional_test/lib/src/sync_service.dart
+++ b/tests/at_functional_test/lib/src/sync_service.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/service/sync_service.dart';
-import 'package:at_client/src/service/sync_service_impl.dart';
 import 'package:at_utils/at_logger.dart';
 
 /// The class represents the sync services for the functional tests
@@ -20,40 +19,35 @@ class FunctionalTestSyncService {
 
   Future<void> syncData(SyncService syncService) async {
     // Setting sync request threshold to 1 to expedite sync process
-    SyncServiceImpl.syncRequestThreshold = 1;
-    bool isInSyncProgress = true;
-    int startTimeInMs = DateTime.now().millisecondsSinceEpoch;
-    // Setting max wait time to 30000 milli seconds (30 seconds)
-    int maxWaitTime = startTimeInMs + 30000;
-
+    var isInSyncProgress = true;
     var functionalTestSyncProgressListener =
         FunctionalTestSyncProgressListener();
-
+    // initialise sync and add listener
+    syncService.addProgressListener(functionalTestSyncProgressListener);
     // Calling sync method to expedite sync process
     syncService.sync();
-
-    syncService.addProgressListener(functionalTestSyncProgressListener);
-
     functionalTestSyncProgressListener.streamController.stream
         .listen((syncProgress) async {
       // Exit the sync process when either of the conditions are met,
       // 1. If syncStatus is success && localCommitId is equal to serverCommitID (or) If syncStatus is failure
-      // 2. When sync process exceeds the max timeout.
-      //
+      // 2. When sync process exceeds the max timeout (30 seconds)
       if (((syncProgress.syncStatus == SyncStatus.success) &&
               (syncProgress.localCommitId == syncProgress.serverCommitId)) ||
           (syncProgress.syncStatus == SyncStatus.failure)) {
         _logger.info('sync completed');
         isInSyncProgress = false;
       }
-// When localCommitId and serverCommitId are not equal, calling sync method to expedite sync process
-      syncService.sync();
     });
+    // When localCommitId and serverCommitId are not equal, calling sync method to expedite sync process
+    syncService.sync();
+    int startTimeInMS = DateTime.now().millisecondsSinceEpoch;
+    //  start time plus 30 seconds (30000 milliseconds)
+    int maxWaitTime = startTimeInMS + 30000;
     while (isInSyncProgress &&
-        DateTime.now().millisecondsSinceEpoch < maxWaitTime) {
-      // 30000 milliseconds(30 seconds) from the current time
-      _logger.info('sync in progress');
-      await Future.delayed(Duration(seconds: 100));
+        DateTime.now().millisecondsSinceEpoch <
+            maxWaitTime) //  time is less than 30 seconds
+    {
+      await Future.delayed(Duration(milliseconds: 100));
     }
   }
 }

--- a/tests/at_functional_test/lib/src/sync_service.dart
+++ b/tests/at_functional_test/lib/src/sync_service.dart
@@ -19,30 +19,41 @@ class FunctionalTestSyncService {
   }
 
   Future<void> syncData(SyncService syncService) async {
+    // Setting sync request threshold to 1 to expedite sync process
     SyncServiceImpl.syncRequestThreshold = 1;
-    var isInSyncProgress = true;
+    bool isInSyncProgress = true;
+    int startTimeInMs = DateTime.now().millisecondsSinceEpoch;
+    // Setting max wait time to 30000 milli seconds (30 seconds)
+    int maxWaitTime = startTimeInMs + 30000;
+
     var functionalTestSyncProgressListener =
         FunctionalTestSyncProgressListener();
-    // initialise sync and add listener
-    syncService.addProgressListener(functionalTestSyncProgressListener);
+
+    // Calling sync method to expedite sync process
     syncService.sync();
+
+    syncService.addProgressListener(functionalTestSyncProgressListener);
+
     functionalTestSyncProgressListener.streamController.stream
         .listen((syncProgress) async {
-      // if syncStatus is success && localCommitId is equal to serverCommitID
-      // or if syncStatus is failure, then sync is false.
+      // Exit the sync process when either of the conditions are met,
+      // 1. If syncStatus is success && localCommitId is equal to serverCommitID (or) If syncStatus is failure
+      // 2. When sync process exceeds the max timeout.
+      //
       if (((syncProgress.syncStatus == SyncStatus.success) &&
               (syncProgress.localCommitId == syncProgress.serverCommitId)) ||
           (syncProgress.syncStatus == SyncStatus.failure)) {
         _logger.info('sync completed');
         isInSyncProgress = false;
       }
+// When localCommitId and serverCommitId are not equal, calling sync method to expedite sync process
+      syncService.sync();
     });
-    int startTimeInMS = DateTime.now().millisecondsSinceEpoch;
-    int maxWaitTime = startTimeInMS + 30000;
     while (isInSyncProgress &&
         DateTime.now().millisecondsSinceEpoch < maxWaitTime) {
+      // 30000 milliseconds(30 seconds) from the current time
       _logger.info('sync in progress');
-      await Future.delayed(Duration(milliseconds: 100));
+      await Future.delayed(Duration(seconds: 100));
     }
   }
 }

--- a/tests/at_functional_test/lib/src/sync_service.dart
+++ b/tests/at_functional_test/lib/src/sync_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/service/sync_service.dart';
+import 'package:at_client/src/service/sync_service_impl.dart';
 import 'package:at_utils/at_logger.dart';
 
 /// The class represents the sync services for the functional tests
@@ -19,6 +20,10 @@ class FunctionalTestSyncService {
 
   Future<void> syncData(SyncService syncService) async {
     // Setting sync request threshold to 1 to expedite sync process
+    SyncServiceImpl.syncRequestThreshold = 1;
+    SyncServiceImpl.queueSize = 1;
+    SyncServiceImpl.syncRequestTriggerInSeconds = 1;
+    SyncServiceImpl.syncRunIntervalSeconds = 1;
     var isInSyncProgress = true;
     var functionalTestSyncProgressListener =
         FunctionalTestSyncProgressListener();

--- a/tests/at_functional_test/lib/src/sync_service.dart
+++ b/tests/at_functional_test/lib/src/sync_service.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/service/sync_service.dart';
+import 'package:at_client/src/service/sync_service_impl.dart';
 import 'package:at_utils/at_logger.dart';
 
 /// The class represents the sync services for the functional tests
@@ -18,6 +19,7 @@ class FunctionalTestSyncService {
   }
 
   Future<void> syncData(SyncService syncService) async {
+    SyncServiceImpl.syncRequestThreshold = 1;
     var isInSyncProgress = true;
     var functionalTestSyncProgressListener =
         FunctionalTestSyncProgressListener();

--- a/tests/at_functional_test/lib/src/sync_service.dart
+++ b/tests/at_functional_test/lib/src/sync_service.dart
@@ -18,13 +18,19 @@ class FunctionalTestSyncService {
     return _singleton;
   }
 
-  Future<void> syncData(SyncService syncService) async {
+  Future<void> syncData(SyncService syncService,
+      {SyncOptions? syncOptions}) async {
     // Setting sync request threshold to 1 to expedite sync process
     SyncServiceImpl.syncRequestThreshold = 1;
     SyncServiceImpl.queueSize = 1;
     SyncServiceImpl.syncRequestTriggerInSeconds = 1;
     SyncServiceImpl.syncRunIntervalSeconds = 1;
     var isInSyncProgress = true;
+
+    int startTimeInMS = DateTime.now().millisecondsSinceEpoch;
+    //  start time plus 30 seconds (30000 milliseconds)
+    int maxWaitTime = startTimeInMS + 30000;
+
     var functionalTestSyncProgressListener =
         FunctionalTestSyncProgressListener();
     // initialise sync and add listener
@@ -36,18 +42,36 @@ class FunctionalTestSyncService {
       // Exit the sync process when either of the conditions are met,
       // 1. If syncStatus is success && localCommitId is equal to serverCommitID (or) If syncStatus is failure
       // 2. When sync process exceeds the max timeout (30 seconds)
-      if (((syncProgress.syncStatus == SyncStatus.success) &&
-              (syncProgress.localCommitId == syncProgress.serverCommitId)) ||
-          (syncProgress.syncStatus == SyncStatus.failure)) {
-        _logger.info('sync completed');
-        isInSyncProgress = false;
+      if (syncOptions == null) {
+        if (((syncProgress.syncStatus == SyncStatus.success) &&
+                (syncProgress.localCommitId == syncProgress.serverCommitId)) ||
+            (syncProgress.syncStatus == SyncStatus.failure)) {
+          isInSyncProgress = false;
+        }
+      } else {
+        _logger.info(
+            'Found SyncOptions...Waiting until the ${syncOptions.key} is synced to client');
+        // Since the KeyInfoList is empty, wait until the required key is synced.
+        // Hence call sync method to expedite the sync progress
+        if (syncProgress.keyInfoList == null ||
+            syncProgress.keyInfoList!.isEmpty) {
+          syncService.sync();
+          return;
+        }
+        for (KeyInfo keyInfo in syncProgress.keyInfoList!) {
+          _logger.info(keyInfo);
+          if (syncOptions.key.isNotNull && (keyInfo.key == syncOptions.key)) {
+            _logger.info(
+                'Found ${syncOptions.key} in key list info | ${syncProgress.syncStatus} | localCommitId: ${syncProgress.localCommitId} | ServerCommitId: ${syncProgress.serverCommitId}');
+            isInSyncProgress = false;
+          }
+        }
       }
+      _logger.info(
+          'Completed sync| ${syncProgress.syncStatus} | localCommitId: ${syncProgress.localCommitId} | ServerCommitId: ${syncProgress.serverCommitId}');
     });
     // When localCommitId and serverCommitId are not equal, calling sync method to expedite sync process
-    syncService.sync();
-    int startTimeInMS = DateTime.now().millisecondsSinceEpoch;
-    //  start time plus 30 seconds (30000 milliseconds)
-    int maxWaitTime = startTimeInMS + 30000;
+
     while (isInSyncProgress &&
         DateTime.now().millisecondsSinceEpoch <
             maxWaitTime) //  time is less than 30 seconds
@@ -55,6 +79,12 @@ class FunctionalTestSyncService {
       await Future.delayed(Duration(milliseconds: 100));
     }
   }
+}
+
+/// Additional options for client to wait on sync
+class SyncOptions {
+  /// Waits until the key is sync'ed to the client
+  String? key;
 }
 
 class FunctionalTestSyncProgressListener extends SyncProgressListener {

--- a/tests/at_functional_test/test/atclient_sync_callback_test.dart
+++ b/tests/at_functional_test/test/atclient_sync_callback_test.dart
@@ -183,11 +183,10 @@ void main() {
           expect(keyInfo.commitOp, CommitOp.UPDATE);
         }
       });
-
       atClientManager.atClient.syncService
           .removeProgressListener(progressListener);
     }));
-  }, timeout: Timeout(Duration(minutes: 5)));
+  });
   tearDown(() async => await tearDownFunc());
 }
 

--- a/tests/at_functional_test/test/atclient_sync_callback_test.dart
+++ b/tests/at_functional_test/test/atclient_sync_callback_test.dart
@@ -173,16 +173,21 @@ void main() {
         .listen(expectAsync1((SyncProgress syncProgress) {
       print('SyncProgress: $syncProgress');
       expect(syncProgress.syncStatus, SyncStatus.success);
-      expect(syncProgress.keyInfoList, isNotEmpty);
-      expect(syncProgress.localCommitId,
-          greaterThan(syncProgress.localCommitIdBeforeSync!));
-      expect(syncProgress.localCommitId, equals(syncProgress.serverCommitId));
-      syncProgress.keyInfoList?.forEach((keyInfo) {
-        if (keyInfo.key.contains('fb_username-$uniqueId')) {
-          expect(keyInfo.syncDirection, SyncDirection.remoteToLocal);
-          expect(keyInfo.commitOp, CommitOp.UPDATE);
-        }
-      });
+      // If localCommitIdBeforeSync and localCommitId (local commitId after sync)
+      // are equal, it means there is not nothing to sync. So do not assert below conditions.
+      // The sync callback gets triggered twice, and the below conditions will be asserted
+      // on either of the sync process callback.
+      if (syncProgress.localCommitIdBeforeSync != syncProgress.localCommitId) {
+        expect(syncProgress.keyInfoList, isNotEmpty);
+        expect(syncProgress.localCommitId,
+            greaterThan(syncProgress.localCommitIdBeforeSync!));
+        syncProgress.keyInfoList?.forEach((keyInfo) {
+          if (keyInfo.key.contains('fb_username-$uniqueId')) {
+            expect(keyInfo.syncDirection, SyncDirection.remoteToLocal);
+            expect(keyInfo.commitOp, CommitOp.UPDATE);
+          }
+        });
+      }
       atClientManager.atClient.syncService
           .removeProgressListener(progressListener);
     }));

--- a/tests/at_functional_test/test/atclient_sync_callback_test.dart
+++ b/tests/at_functional_test/test/atclient_sync_callback_test.dart
@@ -166,58 +166,28 @@ void main() {
         await atClient.getRemoteSecondary()!.executeVerb(updateVerbBuilder);
     expect(updateResponse.isNotEmpty, true);
 
-    // Calling sync 3 times to met the threshold.
-    atClientManager.atClient.syncService.sync();
-    atClientManager.atClient.syncService.sync();
-    atClientManager.atClient.syncService.sync();
     await FunctionalTestSyncService.getInstance()
         .syncData(atClientManager.atClient.syncService);
 
-    // Calling sync 3 times to met the threshold.
-    atClientManager.atClient.syncService.sync();
-    atClientManager.atClient.syncService.sync();
-    atClientManager.atClient.syncService.sync();
-    await FunctionalTestSyncService.getInstance()
-        .syncData(atClientManager.atClient.syncService);
-
-    int progressCallbacksReceived = 0;
-    int requiredProgressCallbacks = 2;
-    var isLocalCommitIdEqualServerCommitId = false;
     progressListener.streamController.stream
         .listen(expectAsync1((SyncProgress syncProgress) {
       print('SyncProgress: $syncProgress');
       expect(syncProgress.syncStatus, SyncStatus.success);
-      // If localCommitIdBeforeSync and localCommitId (local commitId after sync)
-      // are equal, it means there is not nothing to sync. So do not assert below conditions.
-      // The sync callback gets triggered twice, and the below conditions will be asserted
-      // on either of the sync process callback.
-      if (syncProgress.localCommitIdBeforeSync != syncProgress.localCommitId) {
-        expect(syncProgress.keyInfoList, isNotEmpty);
-        expect(syncProgress.localCommitId,
-            greaterThan(syncProgress.localCommitIdBeforeSync!));
-        syncProgress.keyInfoList?.forEach((keyInfo) {
-          if (keyInfo.key.contains('fb_username-$uniqueId')) {
-            expect(keyInfo.commitOp, CommitOp.UPDATE);
-            expect(keyInfo.syncDirection, SyncDirection.remoteToLocal);
-          }
-        });
-      }
-      // At the end of the test (either in first run or by end of second run),
-      // localCommitId should be equal to serverCommitId
-      if (isLocalCommitIdEqualServerCommitId == false) {
-        if (syncProgress.localCommitId == syncProgress.serverCommitId) {
-          isLocalCommitIdEqualServerCommitId = true;
+      expect(syncProgress.keyInfoList, isNotEmpty);
+      expect(syncProgress.localCommitId,
+          greaterThan(syncProgress.localCommitIdBeforeSync!));
+      expect(syncProgress.localCommitId, equals(syncProgress.serverCommitId));
+      syncProgress.keyInfoList?.forEach((keyInfo) {
+        if (keyInfo.key.contains('fb_username-$uniqueId')) {
+          expect(keyInfo.syncDirection, SyncDirection.remoteToLocal);
+          expect(keyInfo.commitOp, CommitOp.UPDATE);
         }
-      }
-      // Assert only on the completion of second sync run.
-      if (progressCallbacksReceived == requiredProgressCallbacks) {
-        expect(isLocalCommitIdEqualServerCommitId, true);
-      }
+      });
 
       atClientManager.atClient.syncService
           .removeProgressListener(progressListener);
-    }, count: 2));
-  });
+    }));
+  }, timeout: Timeout(Duration(minutes: 5)));
   tearDown(() async => await tearDownFunc());
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #840 "

Please provide the following information:
-->

**- What I did**
I added a check to see if syncStatus is a success && localCommitId equals serverCommitID. If both are equal, Exit the code as sync completed.
Exit if sync process exceeds 30 seconds
Call sync again if localCommitId is not equal to server commit id.
**- How I did it**
Added a condition to see if localCommiId equals serverCommitI

**- How to verify it**
all the functional tests should pass
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->