### PR TITLE
fix: Failing E2E test - verify cached key is deleted in sharedWith secondary when CCD is set to true

### DIFF
--- a/tests/at_end2end_test/lib/src/sync_initializer.dart
+++ b/tests/at_end2end_test/lib/src/sync_initializer.dart
@@ -7,7 +7,6 @@ import 'package:at_client/src/service/sync_service.dart';
 
 // ignore: implementation_imports
 import 'package:at_client/src/service/sync_service_impl.dart';
-import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_utils/at_logger.dart';
 
 /// The class represents the sync services for the end to end tests
@@ -24,7 +23,7 @@ class E2ESyncService {
   }
 
   Future<void> syncData(SyncService syncService,
-      {SyncParameters? syncParameters}) async {
+      {SyncOptions? syncOptions}) async {
     SyncServiceImpl.queueSize = 1;
     SyncServiceImpl.syncRequestThreshold = 1;
     SyncServiceImpl.syncRequestTriggerInSeconds = 1;
@@ -49,25 +48,26 @@ class E2ESyncService {
       // 1. If syncStatus is success && localCommitId is equal to serverCommitID (or)
       //    If syncStatus is failure
       // 2. When sync process exceeds the max timeout that is 30 seconds
-      if (syncParameters == null) {
+      if (syncOptions == null) {
         if (((syncProgress.syncStatus == SyncStatus.success) &&
                 (syncProgress.localCommitId == syncProgress.serverCommitId)) ||
             (syncProgress.syncStatus == SyncStatus.failure)) {
           isSyncInProgress = false;
         }
       } else {
-        print('Found SyncParameters...Waiting until the ${syncParameters.key} is synced to client');
+        print(
+            'Found SyncOptions...Waiting until the ${syncOptions.key} is synced to client');
         // Since the KeyInfoList is empty, wait until the required key is synced.
         // Hence call sync method to expedite the sync progress
-        if(syncProgress.keyInfoList == null || syncProgress.keyInfoList!.isEmpty){
+        if (syncProgress.keyInfoList == null ||
+            syncProgress.keyInfoList!.isEmpty) {
           syncService.sync();
         }
         for (KeyInfo keyInfo in syncProgress.keyInfoList!) {
           _logger.info(keyInfo);
-          if (syncParameters.key.isNotNull &&
-              (keyInfo.key == syncParameters.key)) {
+          if (syncOptions.key.isNotNull && (keyInfo.key == syncOptions.key)) {
             print(
-                'Found ${syncParameters.key} in key list info | ${syncProgress.syncStatus} | localCommitId: ${syncProgress.localCommitId} | ServerCommitId: ${syncProgress.serverCommitId}');
+                'Found ${syncOptions.key} in key list info | ${syncProgress.syncStatus} | localCommitId: ${syncProgress.localCommitId} | ServerCommitId: ${syncProgress.serverCommitId}');
             isSyncInProgress = false;
           }
         }
@@ -83,9 +83,10 @@ class E2ESyncService {
   }
 }
 
-class SyncParameters {
+/// Additional options for client to wait on sync
+class SyncOptions {
+  /// Waits until the key is sync'ed to the client
   String? key;
-  CommitOp? commitOp;
 }
 
 class E2ETestSyncProgressListener extends SyncProgressListener {

--- a/tests/at_end2end_test/lib/src/sync_initializer.dart
+++ b/tests/at_end2end_test/lib/src/sync_initializer.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
 import 'package:at_client/at_client.dart';
+
 // ignore: implementation_imports
 import 'package:at_client/src/service/sync_service.dart';
+
 // ignore: implementation_imports
 import 'package:at_client/src/service/sync_service_impl.dart';
 import 'package:at_utils/at_logger.dart';
@@ -25,16 +27,30 @@ class E2ESyncService {
     SyncServiceImpl.syncRequestThreshold = 1;
     SyncServiceImpl.syncRequestTriggerInSeconds = 1;
     SyncServiceImpl.syncRunIntervalSeconds = 1;
-
     var isSyncInProgress = true;
+
+    // Call to syncService.sync to expedite the sync progress
+    syncService.sync();
+
     var e2eTestSyncProgressListener = E2ETestSyncProgressListener();
     syncService.addProgressListener(e2eTestSyncProgressListener);
+
     e2eTestSyncProgressListener.streamController.stream
         .listen((SyncProgress syncProgress) async {
-    // Exit the sync process when either of the conditions are met,
-     // 1. If syncStatus is success && localCommitId is equal to serverCommitID (or) If syncStatus is failure
-      // 2. When sync process exceeds the max timeoutthat is 30 seconds
-        if (((syncProgress.syncStatus == SyncStatus.success) &&
+      // SyncProgress.localCommitId and SyncProgress.serverCommitId can be null
+      // In that case, we have continue to sync. Hence call sync and return.
+      if (syncProgress.localCommitId == null ||
+          syncProgress.serverCommitId == null) {
+        _logger.finer(
+            'SyncProgress localCommitId or serverCommitId is null. Hence continue to sync');
+        syncService.sync();
+        return;
+      }
+      // Exit the sync process when either of the conditions are met,
+      // 1. If syncStatus is success && localCommitId is equal to serverCommitID (or)
+      //    If syncStatus is failure
+      // 2. When sync process exceeds the max timeout that is 30 seconds
+      if (((syncProgress.syncStatus == SyncStatus.success) &&
               (syncProgress.localCommitId == syncProgress.serverCommitId)) ||
           (syncProgress.syncStatus == SyncStatus.failure)) {
         isSyncInProgress = false;
@@ -46,11 +62,11 @@ class E2ESyncService {
         }
       }
     });
-    syncService.sync();
-
     int started = DateTime.now().millisecondsSinceEpoch;
-    int waitUntilThis = started + 30000; // 30 seconds is more than enough time to wait
-    while (isSyncInProgress && DateTime.now().millisecondsSinceEpoch < waitUntilThis) {
+    int waitUntilThis =
+        started + 30000; // 30 seconds is more than enough time to wait
+    while (isSyncInProgress &&
+        DateTime.now().millisecondsSinceEpoch < waitUntilThis) {
       await Future.delayed(Duration(milliseconds: 100));
     }
   }

--- a/tests/at_end2end_test/lib/src/sync_initializer.dart
+++ b/tests/at_end2end_test/lib/src/sync_initializer.dart
@@ -59,7 +59,7 @@ class E2ESyncService {
         print('Found SyncParameters...Waiting until the ${syncParameters.key} is synced to client');
         // Since the KeyInfoList is empty, wait until the required key is synced.
         // Hence call sync method to expedite the sync progress
-        if(syncProgress.keyInfoList == null && syncProgress.keyInfoList!.isEmpty){
+        if(syncProgress.keyInfoList == null || syncProgress.keyInfoList!.isEmpty){
           syncService.sync();
         }
         for (KeyInfo keyInfo in syncProgress.keyInfoList!) {

--- a/tests/at_end2end_test/lib/src/sync_initializer.dart
+++ b/tests/at_end2end_test/lib/src/sync_initializer.dart
@@ -43,7 +43,7 @@ class E2ESyncService {
 
     e2eTestSyncProgressListener.streamController.stream
         .listen((SyncProgress syncProgress) async {
-      print('SyncService| $syncProgress');
+      _logger.info('SyncService| $syncProgress');
       // Exit the sync process when either of the conditions are met,
       // 1. If syncStatus is success && localCommitId is equal to serverCommitID (or)
       //    If syncStatus is failure
@@ -55,24 +55,25 @@ class E2ESyncService {
           isSyncInProgress = false;
         }
       } else {
-        print(
+        _logger.info(
             'Found SyncOptions...Waiting until the ${syncOptions.key} is synced to client');
         // Since the KeyInfoList is empty, wait until the required key is synced.
         // Hence call sync method to expedite the sync progress
         if (syncProgress.keyInfoList == null ||
             syncProgress.keyInfoList!.isEmpty) {
           syncService.sync();
+          return;
         }
         for (KeyInfo keyInfo in syncProgress.keyInfoList!) {
           _logger.info(keyInfo);
           if (syncOptions.key.isNotNull && (keyInfo.key == syncOptions.key)) {
-            print(
+            _logger.info(
                 'Found ${syncOptions.key} in key list info | ${syncProgress.syncStatus} | localCommitId: ${syncProgress.localCommitId} | ServerCommitId: ${syncProgress.serverCommitId}');
             isSyncInProgress = false;
           }
         }
       }
-      print(
+      _logger.info(
           'Completed sync| ${syncProgress.syncStatus} | localCommitId: ${syncProgress.localCommitId} | ServerCommitId: ${syncProgress.serverCommitId}');
     });
 

--- a/tests/at_end2end_test/lib/src/sync_initializer.dart
+++ b/tests/at_end2end_test/lib/src/sync_initializer.dart
@@ -55,7 +55,13 @@ class E2ESyncService {
             (syncProgress.syncStatus == SyncStatus.failure)) {
           isSyncInProgress = false;
         }
-      } else if (syncProgress.keyInfoList != null) {
+      } else {
+        print('Found SyncParameters...Waiting until the ${syncParameters.key} is synced to client');
+        // Since the KeyInfoList is empty, wait until the required key is synced.
+        // Hence call sync method to expedite the sync progress
+        if(syncProgress.keyInfoList == null && syncProgress.keyInfoList!.isEmpty){
+          syncService.sync();
+        }
         for (KeyInfo keyInfo in syncProgress.keyInfoList!) {
           _logger.info(keyInfo);
           if (syncParameters.key.isNotNull &&

--- a/tests/at_end2end_test/lib/src/sync_initializer.dart
+++ b/tests/at_end2end_test/lib/src/sync_initializer.dart
@@ -31,8 +31,12 @@ class E2ESyncService {
     syncService.addProgressListener(e2eTestSyncProgressListener);
     e2eTestSyncProgressListener.streamController.stream
         .listen((SyncProgress syncProgress) async {
-      if (syncProgress.syncStatus == SyncStatus.success ||
-          syncProgress.syncStatus == SyncStatus.failure) {
+    // Exit the sync process when either of the conditions are met,
+     // 1. If syncStatus is success && localCommitId is equal to serverCommitID (or) If syncStatus is failure
+      // 2. When sync process exceeds the max timeoutthat is 30 seconds
+        if (((syncProgress.syncStatus == SyncStatus.success) &&
+              (syncProgress.localCommitId == syncProgress.serverCommitId)) ||
+          (syncProgress.syncStatus == SyncStatus.failure)) {
         isSyncInProgress = false;
       }
       var keyInfoList = syncProgress.keyInfoList;

--- a/tests/at_end2end_test/test/deletion_key_test.dart
+++ b/tests/at_end2end_test/test/deletion_key_test.dart
@@ -4,6 +4,7 @@ import 'package:at_end2end_test/src/sync_initializer.dart';
 import 'package:at_end2end_test/src/test_initializers.dart';
 import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:test/test.dart';
+import 'package:at_utils/at_logger.dart';
 
 late AtClient sharedByAtClient;
 late AtClient sharedWithAtClient;
@@ -12,6 +13,7 @@ late String sharedWithAtSign;
 final namespace = 'wavi';
 
 void main() {
+  AtSignLogger.root_level = 'finer';
   setUpAll(() async {
     sharedByAtSign = ConfigUtil.getYaml()['atSign']['firstAtSign'];
     sharedWithAtSign = ConfigUtil.getYaml()['atSign']['secondAtSign'];

--- a/tests/at_end2end_test/test/deletion_key_test.dart
+++ b/tests/at_end2end_test/test/deletion_key_test.dart
@@ -80,13 +80,16 @@ void main() {
             namespace,
             TestPreferences.getInstance().getPreference(sharedWithAtSign)))
         .atClient;
-    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService);
 
     var cachedAtKey = AtKey()
       ..key = 'deletecachedkey'
       ..sharedWith = sharedWithAtSign
       ..sharedBy = sharedByAtSign
+      ..namespace = namespace
       ..metadata = (Metadata()..isCached = true);
+
+    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService, syncParameters: SyncParameters()..key = cachedAtKey.toString());
+
     var getResponse = await sharedWithAtClient.get(cachedAtKey);
     expect(getResponse.value, 'dummy_cached_value');
     // Delete the key

--- a/tests/at_end2end_test/test/deletion_key_test.dart
+++ b/tests/at_end2end_test/test/deletion_key_test.dart
@@ -108,7 +108,8 @@ void main() {
             namespace,
             TestPreferences.getInstance().getPreference(sharedWithAtSign)))
         .atClient;
-    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService);
+    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService,
+        syncOptions: SyncOptions()..key = cachedAtKey.toString());
 
     // Asserts cached key is deleted from the local storage in the sharedWith atSign
     expect(

--- a/tests/at_end2end_test/test/deletion_key_test.dart
+++ b/tests/at_end2end_test/test/deletion_key_test.dart
@@ -88,7 +88,8 @@ void main() {
       ..namespace = namespace
       ..metadata = (Metadata()..isCached = true);
 
-    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService, syncParameters: SyncParameters()..key = cachedAtKey.toString());
+    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService,
+        syncOptions: SyncOptions()..key = cachedAtKey.toString());
 
     var getResponse = await sharedWithAtClient.get(cachedAtKey);
     expect(getResponse.value, 'dummy_cached_value');

--- a/tests/at_end2end_test/test/deletion_key_test.dart
+++ b/tests/at_end2end_test/test/deletion_key_test.dart
@@ -4,7 +4,6 @@ import 'package:at_end2end_test/src/sync_initializer.dart';
 import 'package:at_end2end_test/src/test_initializers.dart';
 import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:test/test.dart';
-import 'package:at_utils/at_logger.dart';
 
 late AtClient sharedByAtClient;
 late AtClient sharedWithAtClient;
@@ -13,7 +12,6 @@ late String sharedWithAtSign;
 final namespace = 'wavi';
 
 void main() {
-  AtSignLogger.root_level = 'finer';
   setUpAll(() async {
     sharedByAtSign = ConfigUtil.getYaml()['atSign']['firstAtSign'];
     sharedWithAtSign = ConfigUtil.getYaml()['atSign']['secondAtSign'];
@@ -23,13 +21,17 @@ void main() {
     await TestSuiteInitializer.getInstance()
         .testInitializer(sharedWithAtSign, namespace);
     // Initialize sharedWithAtSign
-    sharedWithAtClient = (await AtClientManager.getInstance()
-        .setCurrentAtSign(sharedWithAtSign, namespace,
-            TestPreferences.getInstance().getPreference(sharedWithAtSign))).atClient;
+    sharedWithAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
+            sharedWithAtSign,
+            namespace,
+            TestPreferences.getInstance().getPreference(sharedWithAtSign)))
+        .atClient;
     // Setting sharedByAtSign atClient instance to context.
-    sharedByAtClient = (await AtClientManager.getInstance()
-        .setCurrentAtSign(sharedByAtSign, namespace,
-            TestPreferences.getInstance().getPreference(sharedByAtSign))).atClient;
+    sharedByAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
+            sharedByAtSign,
+            namespace,
+            TestPreferences.getInstance().getPreference(sharedByAtSign)))
+        .atClient;
   });
 
   test(
@@ -65,18 +67,20 @@ void main() {
           ..sharedWith(sharedWithAtSign)
           ..cache(-1, true))
         .build();
-    sharedByAtClient = (await AtClientManager.getInstance()
-        .setCurrentAtSign(sharedByAtSign, namespace,
-            TestPreferences.getInstance().getPreference(sharedByAtSign))).atClient;
+    sharedByAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
+            sharedByAtSign,
+            namespace,
+            TestPreferences.getInstance().getPreference(sharedByAtSign)))
+        .atClient;
     await sharedByAtClient.put(atKey, 'dummy_cached_value');
-    await E2ESyncService.getInstance()
-        .syncData(sharedByAtClient.syncService);
+    await E2ESyncService.getInstance().syncData(sharedByAtClient.syncService);
 
-    sharedWithAtClient = (await AtClientManager.getInstance()
-        .setCurrentAtSign(sharedWithAtSign, namespace,
-            TestPreferences.getInstance().getPreference(sharedWithAtSign))).atClient;
-    await E2ESyncService.getInstance()
-        .syncData(sharedWithAtClient.syncService);
+    sharedWithAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
+            sharedWithAtSign,
+            namespace,
+            TestPreferences.getInstance().getPreference(sharedWithAtSign)))
+        .atClient;
+    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService);
 
     var cachedAtKey = AtKey()
       ..key = 'deletecachedkey'
@@ -86,27 +90,26 @@ void main() {
     var getResponse = await sharedWithAtClient.get(cachedAtKey);
     expect(getResponse.value, 'dummy_cached_value');
     // Delete the key
-    sharedByAtClient =( await AtClientManager.getInstance()
-        .setCurrentAtSign(sharedByAtSign, namespace,
-            TestPreferences.getInstance().getPreference(sharedByAtSign))).atClient;
+    sharedByAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
+            sharedByAtSign,
+            namespace,
+            TestPreferences.getInstance().getPreference(sharedByAtSign)))
+        .atClient;
     await sharedByAtClient.delete(atKey);
-    await E2ESyncService.getInstance()
-        .syncData(sharedByAtClient.syncService);
+    await E2ESyncService.getInstance().syncData(sharedByAtClient.syncService);
 
     // Sync the deleted cached key commit entry to local secondary of sharedWith atSign
-    sharedWithAtClient = (await AtClientManager.getInstance()
-        .setCurrentAtSign(sharedWithAtSign, namespace,
-            TestPreferences.getInstance().getPreference(sharedWithAtSign))).atClient;
-    await E2ESyncService.getInstance()
-        .syncData(sharedWithAtClient.syncService);
+    sharedWithAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
+            sharedWithAtSign,
+            namespace,
+            TestPreferences.getInstance().getPreference(sharedWithAtSign)))
+        .atClient;
+    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService);
 
     // Asserts cached key is deleted from the local storage in the sharedWith atSign
     expect(
-        sharedWithAtClient
-            .getLocalSecondary()
-            ?.keyStore
-            ?.isKeyExists(
-                'cached:$sharedWithAtSign:deletecachedkey$sharedByAtSign}'),
+        sharedWithAtClient.getLocalSecondary()?.keyStore?.isKeyExists(
+            'cached:$sharedWithAtSign:deletecachedkey$sharedByAtSign}'),
         false);
     // When sync runs the test remains idle and timeout after 30 seconds
     // Adding timeout to allow sync to complete on current atSign and sharedWith atSign.
@@ -128,14 +131,12 @@ void main() {
         .atClient;
     // notifying a key with ttr to shared with atsign
     await currentAtClient.put(atKey, '$value');
-    await E2ESyncService.getInstance()
-        .syncData(sharedByAtClient.syncService);
+    await E2ESyncService.getInstance().syncData(sharedByAtClient.syncService);
     var sharedWithAtClient = (await AtClientManager.getInstance()
             .setCurrentAtSign(sharedWithAtSign, namespace,
                 TestPreferences.getInstance().getPreference(sharedWithAtSign)))
         .atClient;
-    await E2ESyncService.getInstance()
-        .syncData(sharedWithAtClient.syncService);
+    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService);
 
     var cachedAtKey = AtKey()
       ..key = key
@@ -159,10 +160,7 @@ void main() {
     var scanResultBeforeDelete = await sharedWithAtClient
         .getRemoteSecondary()!
         .executeCommand('scan\n', auth: true);
-    expect(
-        scanResultBeforeDelete!.contains(
-            serverCachedKey),
-        true);
+    expect(scanResultBeforeDelete!.contains(serverCachedKey), true);
     // Delete the cached key in the local secondary of sharedWith atSign
     var deleteResult = await sharedWithAtClient.delete(cachedAtKey);
     expect(deleteResult, true);
@@ -171,16 +169,15 @@ void main() {
     await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService);
     // Asserts cached key is deleted from the local storage in the sharedWith atSign
     expect(
-        sharedWithAtClient.getLocalSecondary()?.keyStore?.isKeyExists(
-            serverCachedKey),
+        sharedWithAtClient
+            .getLocalSecondary()
+            ?.keyStore
+            ?.isKeyExists(serverCachedKey),
         false);
     // Asserts cached key is deleted from the server in the sharedWith atSign
     var scanResultAfterDelete = await sharedWithAtClient
         .getRemoteSecondary()!
         .executeCommand('scan\n', auth: true);
-    expect(
-        scanResultAfterDelete!.contains(
-            serverCachedKey),
-        false);
+    expect(scanResultAfterDelete!.contains(serverCachedKey), false);
   }, timeout: Timeout(Duration(minutes: 1)));
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #1015 "

Please provide the following information:
-->

**- What I did**
Fix the following end2end test:
  * A test to verify cached key is deleted in sharedWith secondary when CCD is set to true

Root-Cause of the issue:
* On the sender's client, when a key is updated/deleted with a TTR set, a cached key gets created on the secondary server of the sharedWith atSign (receiver). 
* On the receiver's client, we check if a cached key is synced from the receiver's secondary server. The test fails because the assertions happen before the key gets synced to the receiver's client.
  
**- How I did it**

* Enhance the E2ESyncService follows:
   *  Run the sync service until localCommitId and serverCommitId are equal.
   *  But the above check alone would not suffice because, at the moment, the sync process waits until the client and server are in sync. But yet times, the client and server will be in sync when "test" runs the sync and then the cached key gets created in cloud secondary and  syncs to the client. 
   * To fix the above, an optional parameter - SyncOptions, is added to the syncData method in the E2ESyncService. 
   * The SyncOptions has a key of type String, when populated, the E2ESyncService waits until the key is synced to the client

**- How to verify it**
* All the e2e tests should pass

Pending-Work:
* Currently, SyncOptions has only a "key" field. There might be a need to wait for a specific key with a particular CommitOp. 
* For example, let's imagine the following scenario:
   * A key - "phone.wavi" is updated and then deleted and we have an assertion of "phone.wavi" with CommitOp.Delete.
   * The SyncService, sync only the CommitOp.Update, but yet to Sync "CommitOp.Delete". If an assertion happens at this point, the test will fail.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->