### PR TITLE
feat: add `useRemoteAtServer` to PutRequestOptions and (new) DeleteRequestOptions

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.60
+- feat: Add `useRemoteAtServer` to PutRequestOptions. When set, the update
+  request will be sent directly to the remote atServer
+- feat: Introduce DeleteRequestOptions
+  - Add new optional named parameter `deleteRequestOptions` to AtClient.delete
+  - Add `useRemoteAtServer` to DeleteRequestOptions. When set, the delete
+    request will be sent directly to the remote atServer
 ## 3.0.59
 - fix: Sync running into infinite loop when an invalid key is present in the entries to sync into client
 - fix: Redundant logs generated for an internal key[lastReceivedNotification] while sending notifications

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -273,17 +273,20 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   }
 
   @override
-  Future<bool> delete(AtKey atKey, {bool isDedicated = false, DeleteRequestOptions? deleteRequestOptions}) {
+  Future<bool> delete(AtKey atKey,
+      {bool isDedicated = false, DeleteRequestOptions? deleteRequestOptions}) {
     _telemetry?.controller.sink
         .add(AtTelemetryEvent('AtClient.delete called', {"key": atKey}));
     // ignore: no_leading_underscores_for_local_identifiers
-    var _deleteResult = _delete(atKey, deleteRequestOptions: deleteRequestOptions);
+    var _deleteResult =
+        _delete(atKey, deleteRequestOptions: deleteRequestOptions);
     _telemetry?.controller.sink.add(AtTelemetryEvent('AtClient.delete complete',
         {"key": atKey, "_deleteResult": _deleteResult}));
     return _deleteResult;
   }
 
-  Future<bool> _delete(AtKey atKey, {DeleteRequestOptions? deleteRequestOptions}) async {
+  Future<bool> _delete(AtKey atKey,
+      {DeleteRequestOptions? deleteRequestOptions}) async {
     // If metadata is null, initialize metadata
     atKey.metadata ??= Metadata();
     String keyWithNamespace;
@@ -302,7 +305,8 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       ..atKey = keyWithNamespace
       ..sharedBy = atKey.sharedBy;
     var secondary = getSecondary();
-    if (deleteRequestOptions != null && deleteRequestOptions.useRemoteAtServer) {
+    if (deleteRequestOptions != null &&
+        deleteRequestOptions.useRemoteAtServer) {
       secondary = getRemoteSecondary()!;
     }
     var deleteResult = await secondary.executeVerb(builder, sync: true);

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -58,6 +58,8 @@ abstract class AtClient {
   ///
   /// [isDedicated] is currently ignored and will be removed in next major version
   ///
+  /// [putRequestOptions] allows additional options to be provided. See [PutRequestOptions]
+  ///
   /// From at_client v3.0.55 lowercase will be enforced on all AtKey types
   /// AtKeys will now be actively converted to lowercase in at_client
   /// The values(AtValue) will however continue to be case-sensitive
@@ -109,6 +111,11 @@ abstract class AtClient {
   /// has to be shared with another atSign.
   /// By default namespace that is used to create the [AtClient] instance will be appended to the key. phone@alice will be saved as
   /// phone.persona@alice where 'persona' is the namespace.
+  ///
+  /// [isDedicated] is currently ignored and will be removed in next major version
+  ///
+  /// [putRequestOptions] allows additional options to be provided. See [PutRequestOptions]
+  ///
   /// From at_client v3.0.55 lowercase will be enforced on all AtKey types
   /// The values(AtValue) will however continue to be case-sensitive
   /// ```
@@ -140,7 +147,8 @@ abstract class AtClient {
   Future<AtResponse> putText(AtKey atKey, String value,
       {PutRequestOptions? putRequestOptions});
 
-  /// Used to store the binary data into the keystore. For example: images, files etc.
+  /// Used when storing binary data - e.g. images, files etc.
+  /// See also [AtClient.put] and [AtClient.putText]
   Future<AtResponse> putBinary(AtKey atKey, List<int> value,
       {PutRequestOptions? putRequestOptions});
 
@@ -258,6 +266,8 @@ abstract class AtClient {
   /// to false.
   ///
   /// [isDedicated] is currently ignored and will be removed in next major version
+  ///
+  /// [deleteRequestOptions] allows additional options to be provided. See [DeleteRequestOptions]
   /// ```
   /// e.g alice is current atsign
   /// delete:phone@alice

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -298,7 +298,7 @@ abstract class AtClient {
   ///             ..metadata = metaData
   ///   delete(key);
   ///```
-  Future<bool> delete(AtKey key, {bool isDedicated = false});
+  Future<bool> delete(AtKey key, {bool isDedicated = false, DeleteRequestOptions? deleteRequestOptions});
 
   /// Get all the keys stored in user's secondary in [AtKey] format. If [regex] is specified only matching keys are returned.
   /// If [sharedBy] is specified, then gets the keys from [sharedBy] user shared with current atClient user.

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -308,7 +308,8 @@ abstract class AtClient {
   ///             ..metadata = metaData
   ///   delete(key);
   ///```
-  Future<bool> delete(AtKey key, {bool isDedicated = false, DeleteRequestOptions? deleteRequestOptions});
+  Future<bool> delete(AtKey key,
+      {bool isDedicated = false, DeleteRequestOptions? deleteRequestOptions});
 
   /// Get all the keys stored in user's secondary in [AtKey] format. If [regex] is specified only matching keys are returned.
   /// If [sharedBy] is specified, then gets the keys from [sharedBy] user shared with current atClient user.

--- a/packages/at_client/lib/src/client/request_options.dart
+++ b/packages/at_client/lib/src/client/request_options.dart
@@ -1,11 +1,28 @@
-/// Holder for any parameters that has to be passed to at client methods from the app
-class RequestOptions {}
+/// Parameters that application code can optionally provide when calling
+/// `AtClient.get`, `AtClient.put` and `AtClient.delete` methods
+abstract class RequestOptions {}
 
-/// Request params for at client get method
+/// Parameters that application code can optionally provide when calling
+/// `AtClient.get`
 class GetRequestOptions extends RequestOptions {
+  /// Whether the `get` request should bypass this atSign's cache of data owned
+  /// by another atSign
   bool bypassCache = false;
 }
 
+/// Parameters that application code can optionally provide when calling
+/// `AtClient.put`
 class PutRequestOptions extends RequestOptions {
+  /// Whether to set the `sharedKeyEnc` and `pubKeyCS` properties on the
+  /// Metadata for this put request
   bool storeSharedKeyEncryptedMetadata = true;
+  /// Whether to send this update request directly to the remote atServer
+  bool useRemoteAtServer = false;
+}
+
+/// Parameters that application code can optionally provide when calling
+/// `AtClient.delete`
+class DeleteRequestOptions extends RequestOptions {
+  /// Whether to send this update request directly to the remote atServer
+  bool useRemoteAtServer = false;
 }

--- a/packages/at_client/lib/src/client/request_options.dart
+++ b/packages/at_client/lib/src/client/request_options.dart
@@ -16,6 +16,7 @@ class PutRequestOptions extends RequestOptions {
   /// Whether to set the `sharedKeyEnc` and `pubKeyCS` properties on the
   /// Metadata for this put request
   bool storeSharedKeyEncryptedMetadata = true;
+
   /// Whether to send this update request directly to the remote atServer
   bool useRemoteAtServer = false;
 }

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.59';
+  final String atClientVersion = '3.0.60';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.59
+version: 3.0.60
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -12,7 +12,7 @@ repository: https://github.com/atsign-foundation/at_client_sdk
 homepage: https://docs.atsign.com/
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.15.0 <3.0.0'
 
 dependencies:
   path: ^1.8.2

--- a/packages/at_client/test/full_stack_test.dart
+++ b/packages/at_client/test/full_stack_test.dart
@@ -340,7 +340,7 @@ void main() {
         PutRequestOptions pro = PutRequestOptions();
         expect(pro.useRemoteAtServer, false);
       });
-      checkPutBehaviour (bool useRemoteAtServer) async {
+      checkPutBehaviour(bool useRemoteAtServer) async {
         bool executedRemotely = false;
         var atKey = (AtKey.shared('test_put')..sharedWith('@bob')).build();
         when(() => mockRemoteSecondary.executeVerb(
@@ -348,20 +348,24 @@ void main() {
             sync: true)).thenAnswer((invocation) async {
           var builder = invocation.positionalArguments[0] as UpdateVerbBuilder;
           if (builder.atKeyObj.toString() == atKey.toString()) {
-            print ('mockRemoteSecondary.executeVerb with UpdateVerbBuilder for ${builder.atKeyObj.toString()} as expected');
+            print(
+                'mockRemoteSecondary.executeVerb with UpdateVerbBuilder for ${builder.atKeyObj.toString()} as expected');
             executedRemotely = true;
             return 'data:10';
-          } else if (builder.atKeyObj.toString() != '@bob:shared_key@alice'){
-            print (builder.buildCommand());
-            throw Exception('mockRemoteSecondary.executeVerb called with unexpected UpdateVerbBuilder');
+          } else if (builder.atKeyObj.toString() != '@bob:shared_key@alice') {
+            print(builder.buildCommand());
+            throw Exception(
+                'mockRemoteSecondary.executeVerb called with unexpected UpdateVerbBuilder');
           } else {
             return 'data:10';
           }
         });
         await atClient.put(atKey, clearText,
-            putRequestOptions: PutRequestOptions()..useRemoteAtServer = useRemoteAtServer);
-        expect (executedRemotely, useRemoteAtServer);
+            putRequestOptions: PutRequestOptions()
+              ..useRemoteAtServer = useRemoteAtServer);
+        expect(executedRemotely, useRemoteAtServer);
       }
+
       test('put behaviour when useRemoteAtServer set to true', () async {
         await checkPutBehaviour(true);
       });
@@ -378,8 +382,8 @@ void main() {
       checkDeleteBehaviour(bool useRemoteAtServer) async {
         bool executedRemotely = false;
         var atKey = (AtKey.shared('test_put',
-            namespace: namespace, sharedBy: atClient.getCurrentAtSign()!)
-          ..sharedWith('@bob'))
+                namespace: namespace, sharedBy: atClient.getCurrentAtSign()!)
+              ..sharedWith('@bob'))
             .build();
         print(atKey.toString());
         when(() => mockRemoteSecondary.executeVerb(
@@ -388,7 +392,8 @@ void main() {
           var builder = invocation.positionalArguments[0] as DeleteVerbBuilder;
           print('DeleteVerbBuilder: ${builder.buildCommand()}');
           if (builder.buildKey() == atKey.toString()) {
-            print ('mockRemoteSecondary.executeVerb with DeleteVerbBuilder for ${builder.atKeyObj.toString()} as expected');
+            print(
+                'mockRemoteSecondary.executeVerb with DeleteVerbBuilder for ${builder.atKeyObj.toString()} as expected');
             executedRemotely = true;
             return 'data:10';
           } else {
@@ -397,9 +402,12 @@ void main() {
                 'mockRemoteSecondary.executeVerb called with unexpected DeleteVerbBuilder');
           }
         });
-        await atClient.delete(atKey, deleteRequestOptions: DeleteRequestOptions()..useRemoteAtServer = useRemoteAtServer);
-        expect (executedRemotely, useRemoteAtServer);
+        await atClient.delete(atKey,
+            deleteRequestOptions: DeleteRequestOptions()
+              ..useRemoteAtServer = useRemoteAtServer);
+        expect(executedRemotely, useRemoteAtServer);
       }
+
       test('delete behaviour when useRemoteAtServer set to true', () async {
         await checkDeleteBehaviour(true);
       });

--- a/packages/at_client/test/put_request_test.dart
+++ b/packages/at_client/test/put_request_test.dart
@@ -130,7 +130,7 @@ void main() {
     });
   });
 
-  group('A group of test to validate value length', () {
+  group('A group of tests to validate value length', () {
     test(
         'A test to verify the exception is thrown when value exceeds the maxDataLimit',
         () async {


### PR DESCRIPTION
**- What I did**
- feat: Add `useRemoteAtServer` to PutRequestOptions. When set, the update
  request will be sent directly to the remote atServer
- feat: Introduce DeleteRequestOptions
  - Add new optional named parameter `deleteRequestOptions` to AtClient.delete
  - Add `useRemoteAtServer` to DeleteRequestOptions. When set, the delete
    request will be sent directly to the remote atServer
- test: Added tests for the above
- build: update pubspec.yaml and CHANGELOG.md
- docs: Documentation for GetRequestOptions, PutRequestOptions, DeleteRequestOptions

**- How to verify it**
Tests should pass
