### PR TITLE
fix: Refactor e2e tests

### DIFF
--- a/tests/at_end2end_test/test/deletion_key_test.dart
+++ b/tests/at_end2end_test/test/deletion_key_test.dart
@@ -4,6 +4,7 @@ import 'package:at_end2end_test/src/sync_initializer.dart';
 import 'package:at_end2end_test/src/test_initializers.dart';
 import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
 
 late AtClient sharedByAtClient;
 late AtClient sharedWithAtClient;
@@ -63,46 +64,50 @@ void main() {
   test(
       'A test to verify cached key is deleted in sharedWith secondary when CCD is set to true',
       () async {
-    var atKey = (AtKey.shared('deletecachedkey', sharedBy: sharedByAtSign)
-          ..sharedWith(sharedWithAtSign)
-          ..cache(-1, true))
-        .build();
+    // Create a key with TTR set
+    var key = 'deletecachedkey-${Uuid().v4().hashCode}';
+    var atKey =
+        (AtKey.shared(key, namespace: namespace, sharedBy: sharedByAtSign)
+              ..sharedWith(sharedWithAtSign)
+              ..cache(-1, true))
+            .build();
     sharedByAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
             sharedByAtSign,
             namespace,
             TestPreferences.getInstance().getPreference(sharedByAtSign)))
         .atClient;
     await sharedByAtClient.put(atKey, 'dummy_cached_value');
-    await E2ESyncService.getInstance().syncData(sharedByAtClient.syncService);
+    await E2ESyncService.getInstance().syncData(sharedByAtClient.syncService,
+        syncOptions: SyncOptions()..key = atKey.toString());
 
+    // Switch to sharedWith AtSign and fetch the cached key
     sharedWithAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
             sharedWithAtSign,
             namespace,
             TestPreferences.getInstance().getPreference(sharedWithAtSign)))
         .atClient;
-
     var cachedAtKey = AtKey()
-      ..key = 'deletecachedkey'
+      ..key = key
       ..sharedWith = sharedWithAtSign
       ..sharedBy = sharedByAtSign
       ..namespace = namespace
       ..metadata = (Metadata()..isCached = true);
-
     await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService,
         syncOptions: SyncOptions()..key = cachedAtKey.toString());
-
     var getResponse = await sharedWithAtClient.get(cachedAtKey);
     expect(getResponse.value, 'dummy_cached_value');
-    // Delete the key
+
+    // Switch back to sharedBy AtSign and delete the key
     sharedByAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
             sharedByAtSign,
             namespace,
             TestPreferences.getInstance().getPreference(sharedByAtSign)))
         .atClient;
     await sharedByAtClient.delete(atKey);
-    await E2ESyncService.getInstance().syncData(sharedByAtClient.syncService);
+    await E2ESyncService.getInstance().syncData(sharedByAtClient.syncService,
+        syncOptions: SyncOptions()..key = atKey.toString());
 
-    // Sync the deleted cached key commit entry to local secondary of sharedWith atSign
+    // Switch to sharedWith AtSign and let the deleted cached key sync to local Secondary
     sharedWithAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
             sharedWithAtSign,
             namespace,
@@ -110,11 +115,11 @@ void main() {
         .atClient;
     await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService,
         syncOptions: SyncOptions()..key = cachedAtKey.toString());
-
-    // Asserts cached key is deleted from the local storage in the sharedWith atSign
     expect(
-        sharedWithAtClient.getLocalSecondary()?.keyStore?.isKeyExists(
-            'cached:$sharedWithAtSign:deletecachedkey$sharedByAtSign}'),
+        sharedWithAtClient
+            .getLocalSecondary()
+            ?.keyStore
+            ?.isKeyExists(cachedAtKey.toString()),
         false);
     // When sync runs the test remains idle and timeout after 30 seconds
     // Adding timeout to allow sync to complete on current atSign and sharedWith atSign.
@@ -123,66 +128,63 @@ void main() {
   test(
       'A test to verify cached key is deleted when receiver deletes the cached key in the local',
       () async {
-    var key = 'testcachedkey';
-    var atKey = (AtKey.shared(key, sharedBy: sharedByAtSign)
-          ..sharedWith(sharedWithAtSign)
-          ..cache(-1, true))
-        .build();
+    var key = 'testcachedkey-${Uuid().v4().hashCode}';
+    var atKey =
+        (AtKey.shared(key, namespace: namespace, sharedBy: sharedByAtSign)
+              ..sharedWith(sharedWithAtSign)
+              ..cache(-1, true))
+            .build();
     var value = 'test_cached_value';
+
     var currentAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
             sharedByAtSign,
             namespace,
             TestPreferences.getInstance().getPreference(sharedByAtSign)))
         .atClient;
-    // notifying a key with ttr to shared with atsign
-    await currentAtClient.put(atKey, '$value');
-    await E2ESyncService.getInstance().syncData(sharedByAtClient.syncService);
+    // notifying a key with ttr to shared with atSign
+    await currentAtClient.put(atKey, value);
+    await E2ESyncService.getInstance().syncData(sharedByAtClient.syncService,
+        syncOptions: SyncOptions()..key = atKey.toString());
+
     var sharedWithAtClient = (await AtClientManager.getInstance()
             .setCurrentAtSign(sharedWithAtSign, namespace,
                 TestPreferences.getInstance().getPreference(sharedWithAtSign)))
         .atClient;
-    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService);
-
     var cachedAtKey = AtKey()
       ..key = key
       ..sharedWith = sharedWithAtSign
       ..sharedBy = sharedByAtSign
+      ..namespace = namespace
       ..metadata = (Metadata()..isCached = true);
+    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService,
+        syncOptions: SyncOptions()..key = cachedAtKey.toString());
+
     // Assert cached key is present in the local storage of the sharedWith atSign
     var getResponse = await sharedWithAtClient.get(cachedAtKey);
     expect(getResponse.value, 'test_cached_value');
 
-    // creating another atkey instance to delete the cached key
-    // due to the following bug - https://github.com/atsign-foundation/at_client_sdk/issues/939
-    cachedAtKey = AtKey()
-      ..key = key
-      ..sharedWith = sharedWithAtSign
-      ..sharedBy = sharedByAtSign
-      ..metadata = (Metadata()..isCached = true);
-    // cached key to be fetched from secondary
-    var serverCachedKey =
-        'cached:$sharedWithAtSign:$key.$namespace$sharedByAtSign';
     var scanResultBeforeDelete = await sharedWithAtClient
         .getRemoteSecondary()!
-        .executeCommand('scan\n', auth: true);
-    expect(scanResultBeforeDelete!.contains(serverCachedKey), true);
+        .executeCommand('scan $key\n', auth: true);
+    expect(scanResultBeforeDelete!.contains(cachedAtKey.toString()), true);
     // Delete the cached key in the local secondary of sharedWith atSign
     var deleteResult = await sharedWithAtClient.delete(cachedAtKey);
     expect(deleteResult, true);
 
     // Sync the deleted cached key commit entry to secondary of sharedWith atSign
-    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService);
+    await E2ESyncService.getInstance().syncData(sharedWithAtClient.syncService,
+        syncOptions: SyncOptions()..key = cachedAtKey.toString());
     // Asserts cached key is deleted from the local storage in the sharedWith atSign
     expect(
         sharedWithAtClient
             .getLocalSecondary()
             ?.keyStore
-            ?.isKeyExists(serverCachedKey),
+            ?.isKeyExists(cachedAtKey.toString()),
         false);
     // Asserts cached key is deleted from the server in the sharedWith atSign
     var scanResultAfterDelete = await sharedWithAtClient
         .getRemoteSecondary()!
-        .executeCommand('scan\n', auth: true);
-    expect(scanResultAfterDelete!.contains(serverCachedKey), false);
+        .executeCommand('scan $key\n', auth: true);
+    expect(scanResultAfterDelete!.contains(cachedAtKey.toString()), false);
   }, timeout: Timeout(Duration(minutes: 1)));
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Refactor the sharing_key_test and deletion_key_test in E2E tests
* Refactor the E2E sync logic

**- How I did it**
* The result would be inconsistent if the same key name is used in multiple tests. Hence appended a uniqueId for each key in the test to distinguish the keys.
* In sharing_key_test.dart, use SyncOptions to wait for a specific key to sync before performing the assertations.
* In E2E Sync Server, refactored the sync logic to have totalWaitTime that waits for 2 minutes and transientWaitTime of 30 seconds.

**- How to verify it**
* All the existing tests should pass.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->