### PR TITLE
build(deps): Pin to Dart 2.19.6

### DIFF
--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -25,9 +25,9 @@ jobs:
       # Note: This workflow uses the latest stable version of the Dart SDK.
       # You can specify other versions if desired, see documentation here:
       # https://github.com/dart-lang/setup-dart/blob/main/README.md
-      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.4
+      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.5.0
         with:
-          sdk: stable
+          sdk: 2.19.6
 
       # Install dependencies in at_client library
       - name: Install dependencies in at_client
@@ -83,9 +83,9 @@ jobs:
       # Note: This workflow uses the latest stable version of the Dart SDK.
       # You can specify other versions if desired, see documentation here:
       # https://github.com/dart-lang/setup-dart/blob/main/README.md
-      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.4
+      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.5.0
         with:
-          sdk: stable
+          sdk: 2.19.6
 
       # Install dependencies in at_functional_test
       - name: Install dependencies in at_functional_test
@@ -157,9 +157,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.4
+      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.5.0
         with:
-          sdk: stable
+          sdk: 2.19.6
 
       - name: Install dependencies in at_client
         working-directory: packages/at_client
@@ -208,9 +208,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.4
+      - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f # v1.5.0
         with:
-          sdk: stable
+          sdk: 2.19.6
 
       - name: Install dependencies in at_client
         working-directory: packages/at_client


### PR DESCRIPTION
Tests are failing because `sdk: stable` now pulls in Dart 3.0.0, but our pubspec.yaml files generally say:

```
environment:
  sdk: '>=2.12.0 <3.0.0'
```

**- What I did**

Pinned to Dart 2.19.6

**- How I did it**

```diff
+sdk: 2.19.6
-sdk: stable
```

**- How to verify it**

Tests should start passing again

**- Description for the changelog**

build(deps): Pin to Dart 2.19.6