### PR TITLE
fix: set ttr for public key

### DIFF
--- a/packages/at_client_mobile/lib/src/at_client_service.dart
+++ b/packages/at_client_mobile/lib/src/at_client_service.dart
@@ -139,10 +139,6 @@ class AtClientService {
       ..value = encryptPublicKey
       ..metadata.ttr = -1;
 
-    void updateBUilder(){
-      return;
-    }
-
     await _atClient!
         .getLocalSecondary()!
         .executeVerb(updateBuilder, sync: true);

--- a/packages/at_client_mobile/lib/src/at_client_service.dart
+++ b/packages/at_client_mobile/lib/src/at_client_service.dart
@@ -123,7 +123,7 @@ class AtClientService {
     await _atClient!
         .getLocalSecondary()!
         .putValue(AT_PKAM_PUBLIC_KEY, pkamPublicKey);
-        
+
     await _atClient!
         .getLocalSecondary()!
         .putValue(AT_PKAM_PRIVATE_KEY, pkamPrivateKey);
@@ -131,7 +131,7 @@ class AtClientService {
     await _atClient!
         .getLocalSecondary()!
         .putValue(AT_ENCRYPTION_PRIVATE_KEY, encryptPrivateKey);
-    
+
     var updateBuilder = UpdateVerbBuilder()
       ..atKey = 'publickey'
       ..isPublic = true

--- a/packages/at_client_mobile/lib/src/at_client_service.dart
+++ b/packages/at_client_mobile/lib/src/at_client_service.dart
@@ -123,20 +123,30 @@ class AtClientService {
     await _atClient!
         .getLocalSecondary()!
         .putValue(AT_PKAM_PUBLIC_KEY, pkamPublicKey);
+        
     await _atClient!
         .getLocalSecondary()!
         .putValue(AT_PKAM_PRIVATE_KEY, pkamPrivateKey);
+
     await _atClient!
         .getLocalSecondary()!
         .putValue(AT_ENCRYPTION_PRIVATE_KEY, encryptPrivateKey);
+    
     var updateBuilder = UpdateVerbBuilder()
       ..atKey = 'publickey'
       ..isPublic = true
       ..sharedBy = atSign
-      ..value = encryptPublicKey;
+      ..value = encryptPublicKey
+      ..metadata.ttr = -1;
+
+    void updateBUilder(){
+      return;
+    }
+
     await _atClient!
         .getLocalSecondary()!
         .executeVerb(updateBuilder, sync: true);
+
     await _atClient!
         .getLocalSecondary()!
         .putValue(AT_ENCRYPTION_SELF_KEY, selfEncryptionKey);

--- a/packages/at_client_mobile/test/at_client_service_test.dart
+++ b/packages/at_client_mobile/test/at_client_service_test.dart
@@ -286,7 +286,7 @@ void main() {
     });
 
     test('A test to verify ttr is -1 when storing the public encryption key',
-      () async {
+        () async {
       var atClientService = AtClientService();
       int? ttrOfPublicKeyFromUpdateVerbBuilder;
       atClientService.atLookupImpl = mockAtLookupImpl;
@@ -301,18 +301,18 @@ void main() {
       when(() => mockAtLookupImpl.executeCommand(any()))
           .thenAnswer((_) => Future.value('data:dummy_encryption_public_key'));
       when(() => mockLocalSecondary.executeVerb(any(that: CustomVerbBuilder()),
-        sync: true)).thenAnswer((invocation) async {
-            var verbBuilder = invocation.positionalArguments[0];
-            if (verbBuilder is UpdateVerbBuilder && verbBuilder.atKeyObj.toString() == 'public:publickey$atSign') {
-              ttrOfPublicKeyFromUpdateVerbBuilder = verbBuilder.metadata.ttr;
-            }
+          sync: true)).thenAnswer((invocation) async {
+        var verbBuilder = invocation.positionalArguments[0];
+        if (verbBuilder is UpdateVerbBuilder &&
+            verbBuilder.atKeyObj.toString() == 'public:publickey$atSign') {
+          ttrOfPublicKeyFromUpdateVerbBuilder = verbBuilder.metadata.ttr;
+        }
         return 'data:1';
       });
 
       await atClientService.onboard(atClientPreference: atClientPreference);
       expect(ttrOfPublicKeyFromUpdateVerbBuilder, -1);
-      });
-
+    });
   });
 
   group('A group of negative tests to validate authenticate method', () {

--- a/packages/at_client_mobile/test/at_client_service_test.dart
+++ b/packages/at_client_mobile/test/at_client_service_test.dart
@@ -309,8 +309,7 @@ void main() {
         return 'data:1';
       });
 
-      var onboardResult =
-          await atClientService.onboard(atClientPreference: atClientPreference);
+      await atClientService.onboard(atClientPreference: atClientPreference);
       expect(ttrOfPublicKeyFromUpdateVerbBuilder, -1);
       });
 

--- a/packages/at_client_mobile/test/at_client_service_test.dart
+++ b/packages/at_client_mobile/test/at_client_service_test.dart
@@ -284,6 +284,36 @@ void main() {
           await atClientService.onboard(atClientPreference: atClientPreference);
       expect(onboardResult, true);
     });
+
+    test('A test to verify ttr is -1 when storing the public encryption key',
+      () async {
+      var atClientService = AtClientService();
+      int? ttrOfPublicKeyFromUpdateVerbBuilder;
+      atClientService.atLookupImpl = mockAtLookupImpl;
+      atClientService.keyChainManager = mockKeyChainManager;
+      atClientService.atClientManager = mockAtClientManager;
+
+      when(() => mockKeyChainManager.getPkamPrivateKey(any()))
+          .thenAnswer((_) => Future.value('dummy_private_key'));
+      when(() => mockKeyChainManager.getAtSign())
+          .thenAnswer((_) => Future.value(atSign));
+
+      when(() => mockAtLookupImpl.executeCommand(any()))
+          .thenAnswer((_) => Future.value('data:dummy_encryption_public_key'));
+      when(() => mockLocalSecondary.executeVerb(any(that: CustomVerbBuilder()),
+        sync: true)).thenAnswer((invocation) async {
+            var verbBuilder = invocation.positionalArguments[0];
+            if (verbBuilder is UpdateVerbBuilder && verbBuilder.atKeyObj.toString() == 'public:publickey$atSign') {
+              ttrOfPublicKeyFromUpdateVerbBuilder = verbBuilder.metadata.ttr;
+            }
+        return 'data:1';
+      });
+
+      var onboardResult =
+          await atClientService.onboard(atClientPreference: atClientPreference);
+      expect(ttrOfPublicKeyFromUpdateVerbBuilder, -1);
+      });
+
   });
 
   group('A group of negative tests to validate authenticate method', () {


### PR DESCRIPTION
Closes #937 

**- What I did**
at_client_mobile.AtClientService.persistKeys now sets a ttr to -1 when storing the public encryption key

**- How I did it**
- [x] set ttr to -1 on the updateBuilder for public:publickey$atSign in AtClientService.persistKeys
- [x] added test in  at_client_service_test.dart to verify ttr is -1

**- Description for the changelog**
set ttr to -1 when storing the public encryption key