### PR TITLE
fix: Incorrect commitId gets updated against commit entry when a batc…

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -5,6 +5,7 @@
   - Add new optional named parameter `deleteRequestOptions` to AtClient.delete
   - Add `useRemoteAtServer` to DeleteRequestOptions. When set, the delete
     request will be sent directly to the remote atServer
+- fix: Incorrect commitId gets updated against commit entry when a sync-batch skips an entry
 ## 3.0.59
 - fix: Sync running into infinite loop when an invalid key is present in the entries to sync into client
 - fix: Redundant logs generated for an internal key[lastReceivedNotification] while sending notifications

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -10,7 +10,6 @@ import 'package:at_client/src/response/default_response_parser.dart';
 import 'package:at_client/src/response/json_utils.dart';
 import 'package:at_client/src/service/notification_service_impl.dart';
 import 'package:at_client/src/service/sync/sync_request.dart';
-import 'package:at_client/src/service/sync_service.dart';
 import 'package:at_client/src/util/logger_util.dart';
 import 'package:at_client/src/util/network_util.dart';
 import 'package:at_client/src/util/sync_util.dart';
@@ -609,6 +608,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       List<CommitEntry> uncommittedEntries) async {
     var batchRequests = <BatchRequest>[];
     var batchId = 1;
+    List<CommitEntry> removeUncommittedEntriesList = [];
     for (var entry in uncommittedEntries) {
       String command;
       // If someone updates cached keys locally, they should never be synced to the cloud
@@ -617,6 +617,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
           entry.operation != CommitOp.DELETE) {
         _logger.finer(
             '${entry.atKey} is skipped. cached keys will not be synced to cloud secondary');
+        removeUncommittedEntriesList.add(entry);
         continue;
       }
       try {
@@ -624,6 +625,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       } on KeyNotFoundException {
         _logger.severe(
             '${entry.atKey} is not found in keystore. Skipping to entry to sync');
+        removeUncommittedEntriesList.add(entry);
         continue;
       }
       command = VerbUtil.replaceNewline(command);
@@ -632,6 +634,18 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       batchRequests.add(batchRequest);
       batchId++;
     }
+    // The commit-id's in the batch response are updated to the appropriate commit-entry
+    // in the uncommitted entries by iterating the uncommitted entries list.
+    // If an entry is skipped in the batch request, then size of batch response
+    // will be less than the size of uncommitted entries and so the commit-id gets
+    // updated against the wrong uncommitted entry.
+    // So, remove the commit entry from the uncommitted entries list.
+    for (CommitEntry commitEntry in removeUncommittedEntriesList) {
+      uncommittedEntries.remove(commitEntry);
+      // Removing the entry from the commit log keystore to prevent stale entries
+      await syncUtil.removeCommitEntry(commitEntry.key, currentAtSign);
+    }
+    removeUncommittedEntriesList.clear();
     return batchRequests;
   }
 

--- a/packages/at_client/lib/src/util/sync_util.dart
+++ b/packages/at_client/lib/src/util/sync_util.dart
@@ -139,6 +139,12 @@ class SyncUtil {
     return NullCommitEntry();
   }
 
+  Future<void> removeCommitEntry(dynamic key, String atSign) async {
+    atCommitLog ??=
+        await AtCommitLogManagerImpl.getInstance().getCommitLog(atSign);
+    await atCommitLog!.commitLogKeyStore.remove(key);
+  }
+
   /// Sorts the commit entries in descending order.
   ///
   /// The CommitEntries with commitId 'null' comes before the commit entries with commitId

--- a/packages/at_client/test/sync_new_test.dart
+++ b/packages/at_client/test/sync_new_test.dart
@@ -1959,6 +1959,7 @@ void main() {
     setUp(() async {
       TestResources.atsign = '@fuller';
       await TestResources.setupLocalStorage(TestResources.atsign);
+      registerFallbackValue(FakeAtKey());
     });
 
     AtClient mockAtClient = MockAtClient();
@@ -2215,6 +2216,79 @@ void main() {
       assert(lastSyncedEntry.toString().contains('test_key4.wavi@bob'));
       //clearing sync objects
       syncService.clearSyncEntities();
+    });
+
+    test('A test to verify update and delete of same key in a single batch',
+        () async {
+      int serverCommitId = 1;
+      String localCommitId = '1';
+      SyncRequest syncRequest = SyncRequest()..result = SyncResult();
+      HiveKeystore? keystore =
+          TestResources.getHiveKeyStore(TestResources.atsign);
+      LocalSecondary? localSecondary =
+          LocalSecondary(mockAtClient, keyStore: keystore);
+
+      // Create uncommitted entries in local storage
+      await localSecondary.executeVerb(UpdateVerbBuilder()
+        ..atKey = 'firstKey'
+        ..sharedBy = TestResources.atsign
+        ..sharedWith = '@bob'
+        ..value = 'value1');
+
+      UpdateVerbBuilder updateBuilderForSecondKey = UpdateVerbBuilder()
+        ..atKey = 'secondKey'
+        ..sharedBy = TestResources.atsign
+        ..sharedWith = '@bob'
+        ..value = 'value1';
+      await localSecondary.executeVerb(updateBuilderForSecondKey);
+
+      DeleteVerbBuilder deleteBuilderForThirdKey = DeleteVerbBuilder()
+        ..atKey = 'firstKey'
+        ..sharedBy = TestResources.atsign
+        ..sharedWith = '@bob';
+      await localSecondary.executeVerb(deleteBuilderForThirdKey);
+
+      // Mock Responses
+      when(() => mockAtClient.getLocalSecondary())
+          .thenAnswer((_) => localSecondary);
+      when(() =>
+              mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((_) => Future.value(AtValue()..value = localCommitId));
+      when(() =>
+          mockRemoteSecondary.executeCommand(any(),
+              auth: any(named: "auth"))).thenAnswer((_) => Future.value(
+          'data:[{"id":1,"response":{"data":"2"}},{"id":2,"response":{"data":"3"}}]'));
+      when(() => mockAtClient.put(
+              any(that: LastReceivedServerCommitIdMatcher()), any()))
+          .thenAnswer((_) => Future.value(true));
+
+      SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
+          atClientManager: mockAtClientManager,
+          notificationService: mockNotificationService,
+          remoteSecondary: mockRemoteSecondary) as SyncServiceImpl;
+      syncService.networkUtil = mockNetworkUtil;
+
+      var syncResult =
+          await syncService.syncInternal(serverCommitId, syncRequest);
+
+      // Assertions
+      expect(syncResult.keyInfoList.first.key,
+          updateBuilderForSecondKey.buildKey());
+      expect(syncResult.keyInfoList.first.commitOp, CommitOp.UPDATE_ALL);
+      expect(syncResult.keyInfoList.first.syncDirection,
+          SyncDirection.localToRemote);
+
+      expect(
+          syncResult.keyInfoList[1].key, deleteBuilderForThirdKey.buildKey());
+      expect(syncResult.keyInfoList[1].commitOp, CommitOp.DELETE);
+      expect(
+          syncResult.keyInfoList[1].syncDirection, SyncDirection.localToRemote);
+
+      CommitEntry? commitEntry =
+          await TestResources.commitLog?.lastSyncedEntry();
+      expect(commitEntry?.atKey, deleteBuilderForThirdKey.buildKey());
+      expect(commitEntry?.operation, CommitOp.DELETE);
+      expect(commitEntry?.commitId, 3);
     });
 
     tearDown(() async {

--- a/tests/at_functional_test/lib/src/sync_service.dart
+++ b/tests/at_functional_test/lib/src/sync_service.dart
@@ -20,37 +20,39 @@ class FunctionalTestSyncService {
 
   Future<void> syncData(SyncService syncService,
       {SyncOptions? syncOptions}) async {
-    // Setting sync request threshold to 1 to expedite sync process
-    SyncServiceImpl.syncRequestThreshold = 1;
     SyncServiceImpl.queueSize = 1;
+    SyncServiceImpl.syncRequestThreshold = 1;
     SyncServiceImpl.syncRequestTriggerInSeconds = 1;
     SyncServiceImpl.syncRunIntervalSeconds = 1;
-    var isInSyncProgress = true;
+    var isSyncInProgress = true;
+    DateTime startTime = DateTime.now().toUtc();
+    DateTime lastReceivedDateTime = DateTime.now().toUtc();
+    int totalWaitTimeInMills = Duration(minutes: 2).inMilliseconds;
+    int transientWaitTimeInMills = Duration(seconds: 30).inMilliseconds;
 
-    int startTimeInMS = DateTime.now().millisecondsSinceEpoch;
-    //  start time plus 30 seconds (30000 milliseconds)
-    int maxWaitTime = startTimeInMS + 30000;
-
-    var functionalTestSyncProgressListener =
-        FunctionalTestSyncProgressListener();
-    // initialise sync and add listener
-    syncService.addProgressListener(functionalTestSyncProgressListener);
-    // Calling sync method to expedite sync process
+    // Call to syncService.sync to expedite the sync progress
     syncService.sync();
+
+    FunctionalTestSyncProgressListener functionalTestSyncProgressListener =
+        FunctionalTestSyncProgressListener();
+    syncService.addProgressListener(functionalTestSyncProgressListener);
+
     functionalTestSyncProgressListener.streamController.stream
-        .listen((syncProgress) async {
+        .listen((SyncProgress syncProgress) async {
+      lastReceivedDateTime = DateTime.now().toUtc();
+      _logger.info('SyncService| $syncProgress');
       // Exit the sync process when either of the conditions are met,
-      // 1. If syncStatus is success && localCommitId is equal to serverCommitID (or) If syncStatus is failure
-      // 2. When sync process exceeds the max timeout (30 seconds)
+      // 1. If syncStatus is success && localCommitId is equal to serverCommitID (or)
+      //    If syncStatus is failure
       if (syncOptions == null) {
         if (((syncProgress.syncStatus == SyncStatus.success) &&
                 (syncProgress.localCommitId == syncProgress.serverCommitId)) ||
             (syncProgress.syncStatus == SyncStatus.failure)) {
-          isInSyncProgress = false;
+          isSyncInProgress = false;
         }
       } else {
         _logger.info(
-            'Found SyncOptions...Waiting until the ${syncOptions.key} is synced to client');
+            'Found SyncOptions...Waiting until the ${syncOptions.key} is synced');
         // Since the KeyInfoList is empty, wait until the required key is synced.
         // Hence call sync method to expedite the sync progress
         if (syncProgress.keyInfoList == null ||
@@ -63,19 +65,25 @@ class FunctionalTestSyncService {
           if (syncOptions.key.isNotNull && (keyInfo.key == syncOptions.key)) {
             _logger.info(
                 'Found ${syncOptions.key} in key list info | ${syncProgress.syncStatus} | localCommitId: ${syncProgress.localCommitId} | ServerCommitId: ${syncProgress.serverCommitId}');
-            isInSyncProgress = false;
+            isSyncInProgress = false;
           }
         }
       }
       _logger.info(
           'Completed sync| ${syncProgress.syncStatus} | localCommitId: ${syncProgress.localCommitId} | ServerCommitId: ${syncProgress.serverCommitId}');
     });
-    // When localCommitId and serverCommitId are not equal, calling sync method to expedite sync process
 
-    while (isInSyncProgress &&
-        DateTime.now().millisecondsSinceEpoch <
-            maxWaitTime) //  time is less than 30 seconds
-    {
+    /// Wait when the following conditions are true
+    ///  1. When totalWaitTime is less than 2 minutes AND
+    ///  2. When transientWaitTime is less than 30 seconds AND
+    ///  3. When isSyncInProgress is set to true
+    ///  If any of the above condition fails, exit the sync loop.
+    while (DateTime.now().toUtc().difference(startTime).inMilliseconds <
+            totalWaitTimeInMills &&
+        DateTime.now().toUtc().difference(lastReceivedDateTime).inMilliseconds <
+            transientWaitTimeInMills &&
+        isSyncInProgress) {
+      syncService.sync();
       await Future.delayed(Duration(milliseconds: 100));
     }
   }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* In the uncommitted entries list, when preparing the Sync batch request,  if there exist two entries of the same key where the initial commit entry is "update" and later is "delete", then the commit entry with "update" operation is skipped adding to the Batch Request. In this case, the size of the batch request is one less than the size of uncommitted entries. 

* On receiving the batch response, the uncommitted list is iterated and the commit id from the batch response is updated to its respective commit entry. Since an entry is skipped in the batch request (but the entry exists in the uncommitted entries list), the commit id gets updated to the skipped entry (here, the entry with CommitOp. update). The commit-id of the entry synced to the server will remain null (here, the entry with CommitOp.Delete will not be updated).

**- How I did it**

* In the "getBatchRequests" method, introduce a temporary list - "removeUncommittedEntriesList". When preparing the Sync batch request, if a key is skipped, then add it to "removeUncommittedEntriesList". In the end, iterate "removeUncommittedEntriesList" and remove the entries from the uncommitted entries list. Also, to avoid stale commit-entry in the commit log keystore, remove the entry from the keystore.


**- How to verify it**
* Added a unit test that asserts the following:
  * In an uncommitted entries list, if the same key is updated and deleted, the commit id should be updated against deleted entry.

* Added a functional test that asserts the same as above.

**- Description for the changelog**
* Incorrect commit-Id gets updated against commit entry when a batch skips an entry

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->