### PR TITLE
fix: migrate melos to 3.0

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -1,6 +1,6 @@
 name: at_client_sdk
 
 packages:
-- packages/**
+- packages/*
 
-- tests/**
+- tests/*

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,6 +1,6 @@
 name: at_client_sdk
 
 packages:
-- packages/*
+- packages/**
 
-- tests/*
+- tests/**

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,7 @@
+name: at_client_sdk_workspace
+
+environment:
+  sdk: ">=2.18.0 <4.0.0"
+
+dev_dependencies:
+  melos: ^3.0.1


### PR DESCRIPTION
**- What I did**
Melos needs a pubspec and no changes  in melos.yaml.
.gitignore already ignores pubspec_overrides.yaml

**- How I did it**

**- How to verify it**

**- Description for the changelog**
migrate melos from 2.0 to 3.0