### PR TITLE
feat: at_client offline access

### DIFF
--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -885,7 +885,8 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   /// Initializes the Hive Keystore and fetches encryption public key to ensure
   /// the atSign is previously onboarded.
   /// If the key is available, returns false
-  static Future<bool> verifyStorageForOfflineAccess(
+  @override
+  Future<bool> canUseOffline(
       String atSign, AtClientPreference atClientPreference) async {
     SecondaryPersistenceStore secondaryPersistenceStore =
         SecondaryPersistenceStoreFactory.getInstance()

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -25,6 +25,7 @@ abstract class AtClient {
 
   @experimental
   set telemetry(AtTelemetryService? telemetryService);
+
   @experimental
   AtTelemetryService? get telemetry;
 
@@ -39,9 +40,11 @@ abstract class AtClient {
   AtChops? get atChops;
 
   set syncService(SyncService syncService);
+
   SyncService get syncService;
 
   set notificationService(NotificationService notificationService);
+
   NotificationService get notificationService;
 
   /// Sets the preferences such as sync strategy, storage path etc., for the client.
@@ -346,6 +349,12 @@ abstract class AtClient {
       String? sharedBy,
       String? sharedWith,
       bool showHiddenKeys = false});
+
+  /// Initializes the Hive Keystore and fetches encryption public key to ensure
+  /// the atSign is previously onboarded.
+  /// If the key is available, returns false
+  Future<bool> canUseOffline(
+      String atSign, AtClientPreference atClientPreference);
 
   /// Notifies the [AtKey] with the [sharedWith] user of the atsign. Optionally, operation, value and metadata can be set along with key to notify.
   ///```

--- a/packages/at_client/test/full_offline_stack_test.dart
+++ b/packages/at_client/test/full_offline_stack_test.dart
@@ -1,0 +1,174 @@
+import 'package:at_chops/at_chops.dart';
+import 'package:at_client/at_client.dart';
+import 'package:at_commons/at_builders.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:crypton/crypton.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+import 'package:version/version.dart';
+
+import 'test_utils/no_op_services.dart';
+
+class MockRemoteSecondary extends Mock implements RemoteSecondary {}
+
+class MockSecondaryAddressFinder extends Mock
+    implements SecondaryAddressFinder {}
+
+void main() {
+  group('Test with full client stack except mockRemoteSecondary', () {
+    final fullStackPrefs = AtClientPreference()
+      ..namespace = 'full_stack_tests'
+      ..useAtChops = true
+      ..isLocalStoreRequired = true
+      ..hiveStoragePath = 'full_stack_tests/put/hive'
+      ..commitLogPath = 'full_stack_tests/put/commitLog';
+
+    late AtClient atClient;
+
+    var clearText = 'Some clear text';
+
+    RSAKeypair alicesRSAKeyPair = RSAKeypair.fromRandom();
+    RSAKeypair bobsRSAKeyPair = RSAKeypair.fromRandom();
+
+    AtEncryptionKeyPair atEncryptionKeyPair = AtEncryptionKeyPair.create(
+        alicesRSAKeyPair.publicKey.toString(),
+        alicesRSAKeyPair.privateKey.toString());
+
+    var selfEncryptionKey = EncryptionUtil.generateAESKey();
+
+    var bobSharedKey = EncryptionUtil.generateAESKey();
+    var myEncryptedBobSharedKey = EncryptionUtil.encryptKey(
+        bobSharedKey, alicesRSAKeyPair.publicKey.toString());
+    var llookupMySharedKeyForBob = LLookupVerbBuilder()
+      ..atKey = '$AT_ENCRYPTION_SHARED_KEY.bob'
+      ..sharedBy = '@alice';
+
+    registerFallbackValue(llookupMySharedKeyForBob);
+
+    setUpAll(() async {
+      MockRemoteSecondary mockRemoteSecondary = MockRemoteSecondary();
+      MockSecondaryAddressFinder mockSecondaryAddressFinder =
+          MockSecondaryAddressFinder();
+      AtClientManager.getInstance().secondaryAddressFinder =
+          mockSecondaryAddressFinder;
+      when(() => mockSecondaryAddressFinder.findSecondary('@bob'))
+          .thenAnswer((invocation) async => SecondaryAddress('testing', 12));
+      AtChops atChops =
+          AtChopsImpl(AtChopsKeys.create(atEncryptionKeyPair, null));
+      atClient = await AtClientImpl.create('@alice', 'gary', fullStackPrefs,
+          remoteSecondary: mockRemoteSecondary, atChops: atChops);
+      atClient.syncService = NoOpSyncService();
+
+      // Create our symmetric 'self' encryption key
+      await atClient
+          .getLocalSecondary()!
+          .putValue(AT_ENCRYPTION_SELF_KEY, selfEncryptionKey);
+
+      // Create our symmetric encryption key for sharing with @bob
+      await atClient
+          .getLocalSecondary()!
+          .putValue('shared_key.bob@alice', myEncryptedBobSharedKey);
+
+      when(() => mockRemoteSecondary.executeVerb(
+          any(that: isA<LLookupVerbBuilder>()))).thenAnswer((invocation) async {
+        var builder = invocation.positionalArguments[0];
+        print('LLookupVerbBuilder : ${builder.buildCommand()}');
+        return myEncryptedBobSharedKey;
+      });
+      when(() => mockRemoteSecondary.executeVerb(
+          any(that: isA<PLookupVerbBuilder>()))).thenAnswer((invocation) async {
+        var builder = invocation.positionalArguments[0];
+        print('PLookupVerbBuilder : ${builder.buildCommand()}');
+        return bobsRSAKeyPair.publicKey.toString();
+      });
+      when(() => mockRemoteSecondary.executeVerb(
+          any(that: isA<UpdateVerbBuilder>()),
+          sync: true)).thenAnswer((invocation) async {
+        var builder = invocation.positionalArguments[0];
+        print('UpdateVerbBuilder : ${builder.buildCommand()}');
+        return 'data:10';
+      });
+    });
+
+    test('Test put self, then get, no IV', () async {
+      fullStackPrefs.atProtocolEmitted = Version(1, 5, 0);
+
+      var atKey = AtKey.self('test_put').build();
+      await atClient.put(atKey, clearText);
+      expect(atKey.metadata?.ivNonce, isNull);
+
+      var atData =
+          await (atClient.getLocalSecondary()!.keyStore!.get(atKey.toString()));
+      var cipherText = atData.data;
+      expect(EncryptionUtil.decryptValue(cipherText, selfEncryptionKey),
+          clearText);
+
+      var getResult = await atClient.get(atKey);
+      expect(getResult.value, clearText);
+    });
+
+    test('Test put self, then get, with IV', () async {
+      fullStackPrefs.atProtocolEmitted = Version(2, 0, 0);
+
+      var atKey = AtKey.self('test_put').build();
+      await atClient.put(atKey, clearText);
+      expect(atKey.metadata?.ivNonce, isNotNull);
+
+      var atData =
+          await (atClient.getLocalSecondary()!.keyStore!.get(atKey.toString()));
+      var cipherText = atData.data;
+      expect(() => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey),
+          throwsException);
+      expect(
+          EncryptionUtil.decryptValue(cipherText, selfEncryptionKey,
+              ivBase64: atKey.metadata?.ivNonce),
+          clearText);
+
+      var getResult = await atClient.get(atKey);
+      expect(getResult.value, clearText);
+    });
+
+    test('Test put shared, then get, no IV', () async {
+      fullStackPrefs.atProtocolEmitted = Version(1, 5, 0);
+
+      var atKey = (AtKey.shared('test_put')..sharedWith('@bob')).build();
+      await atClient.put(atKey, clearText);
+      expect(atKey.metadata?.ivNonce, isNull);
+
+      var atData =
+          await (atClient.getLocalSecondary()!.keyStore!.get(atKey.toString()));
+      var cipherText = atData.data;
+      expect(EncryptionUtil.decryptValue(cipherText, bobSharedKey), clearText);
+
+      var getResult = await atClient.get(atKey);
+      expect(getResult.value, clearText);
+    }, timeout: Timeout(Duration(hours: 1)));
+
+    test('Test put shared, then get, with IV', () async {
+      fullStackPrefs.atProtocolEmitted = Version(2, 0, 0);
+
+      var atKey = (AtKey.shared('test_put')..sharedWith('@bob')).build();
+      await atClient.put(atKey, clearText);
+      expect(atKey.metadata?.ivNonce, isNotNull);
+
+      var atData =
+          await (atClient.getLocalSecondary()!.keyStore!.get(atKey.toString()));
+      var cipherText = atData.data;
+      expect(() => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey),
+          throwsException);
+      expect(
+          () => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey,
+              ivBase64: atKey.metadata?.ivNonce),
+          throwsException);
+      expect(() => EncryptionUtil.decryptValue(cipherText, bobSharedKey),
+          throwsException);
+      expect(
+          EncryptionUtil.decryptValue(cipherText, bobSharedKey,
+              ivBase64: atKey.metadata?.ivNonce),
+          clearText);
+
+      var getResult = await atClient.get(atKey);
+      expect(getResult.value, clearText);
+    });
+  });
+}

--- a/packages/at_client/test/full_offline_stack_test.dart
+++ b/packages/at_client/test/full_offline_stack_test.dart
@@ -10,9 +10,7 @@ import 'package:version/version.dart';
 import 'test_utils/no_op_services.dart';
 
 class MockRemoteSecondary extends Mock implements RemoteSecondary {}
-
-class MockSecondaryAddressFinder extends Mock
-    implements SecondaryAddressFinder {}
+class MockSecondaryAddressFinder extends Mock implements SecondaryAddressFinder {}
 
 void main() {
   group('Test with full client stack except mockRemoteSecondary', () {
@@ -31,43 +29,37 @@ void main() {
     RSAKeypair bobsRSAKeyPair = RSAKeypair.fromRandom();
 
     AtEncryptionKeyPair atEncryptionKeyPair = AtEncryptionKeyPair.create(
-        alicesRSAKeyPair.publicKey.toString(),
-        alicesRSAKeyPair.privateKey.toString());
+        alicesRSAKeyPair.publicKey.toString(), alicesRSAKeyPair.privateKey.toString());
 
     var selfEncryptionKey = EncryptionUtil.generateAESKey();
 
     var bobSharedKey = EncryptionUtil.generateAESKey();
-    var myEncryptedBobSharedKey = EncryptionUtil.encryptKey(
-        bobSharedKey, alicesRSAKeyPair.publicKey.toString());
+    var myEncryptedBobSharedKey = EncryptionUtil.encryptKey(bobSharedKey, alicesRSAKeyPair.publicKey.toString());
     var llookupMySharedKeyForBob = LLookupVerbBuilder()
-      ..atKey = '$AT_ENCRYPTION_SHARED_KEY.bob'
+      ..atKey =
+          '$AT_ENCRYPTION_SHARED_KEY.bob'
       ..sharedBy = '@alice';
 
     registerFallbackValue(llookupMySharedKeyForBob);
 
     setUpAll(() async {
       MockRemoteSecondary mockRemoteSecondary = MockRemoteSecondary();
-      MockSecondaryAddressFinder mockSecondaryAddressFinder =
-          MockSecondaryAddressFinder();
-      AtClientManager.getInstance().secondaryAddressFinder =
-          mockSecondaryAddressFinder;
+      MockSecondaryAddressFinder mockSecondaryAddressFinder = MockSecondaryAddressFinder();
+      AtClientManager.getInstance().secondaryAddressFinder = mockSecondaryAddressFinder;
       when(() => mockSecondaryAddressFinder.findSecondary('@bob'))
-          .thenAnswer((invocation) async => SecondaryAddress('testing', 12));
-      AtChops atChops =
-          AtChopsImpl(AtChopsKeys.create(atEncryptionKeyPair, null));
-      atClient = await AtClientImpl.create('@alice', 'gary', fullStackPrefs,
-          remoteSecondary: mockRemoteSecondary, atChops: atChops);
+      .thenAnswer((invocation) async => SecondaryAddress('testing', 12));
+      AtChops atChops = AtChopsImpl(AtChopsKeys.create(atEncryptionKeyPair, null));
+      atClient = await AtClientImpl.create(
+          '@alice', 'gary', fullStackPrefs,
+          remoteSecondary: mockRemoteSecondary,
+          atChops: atChops);
       atClient.syncService = NoOpSyncService();
 
       // Create our symmetric 'self' encryption key
-      await atClient
-          .getLocalSecondary()!
-          .putValue(AT_ENCRYPTION_SELF_KEY, selfEncryptionKey);
+      await atClient.getLocalSecondary()!.putValue(AT_ENCRYPTION_SELF_KEY, selfEncryptionKey);
 
       // Create our symmetric encryption key for sharing with @bob
-      await atClient
-          .getLocalSecondary()!
-          .putValue('shared_key.bob@alice', myEncryptedBobSharedKey);
+      await atClient.getLocalSecondary()!.putValue('shared_key.bob@alice', myEncryptedBobSharedKey);
 
       when(() => mockRemoteSecondary.executeVerb(
           any(that: isA<LLookupVerbBuilder>()))).thenAnswer((invocation) async {
@@ -82,8 +74,7 @@ void main() {
         return bobsRSAKeyPair.publicKey.toString();
       });
       when(() => mockRemoteSecondary.executeVerb(
-          any(that: isA<UpdateVerbBuilder>()),
-          sync: true)).thenAnswer((invocation) async {
+          any(that: isA<UpdateVerbBuilder>()), sync: true)).thenAnswer((invocation) async {
         var builder = invocation.positionalArguments[0];
         print('UpdateVerbBuilder : ${builder.buildCommand()}');
         return 'data:10';
@@ -97,11 +88,9 @@ void main() {
       await atClient.put(atKey, clearText);
       expect(atKey.metadata?.ivNonce, isNull);
 
-      var atData =
-          await (atClient.getLocalSecondary()!.keyStore!.get(atKey.toString()));
+      var atData = await (atClient.getLocalSecondary()!.keyStore!.get(atKey.toString()));
       var cipherText = atData.data;
-      expect(EncryptionUtil.decryptValue(cipherText, selfEncryptionKey),
-          clearText);
+      expect(EncryptionUtil.decryptValue(cipherText, selfEncryptionKey), clearText);
 
       var getResult = await atClient.get(atKey);
       expect(getResult.value, clearText);
@@ -114,15 +103,10 @@ void main() {
       await atClient.put(atKey, clearText);
       expect(atKey.metadata?.ivNonce, isNotNull);
 
-      var atData =
-          await (atClient.getLocalSecondary()!.keyStore!.get(atKey.toString()));
+      var atData = await (atClient.getLocalSecondary()!.keyStore!.get(atKey.toString()));
       var cipherText = atData.data;
-      expect(() => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey),
-          throwsException);
-      expect(
-          EncryptionUtil.decryptValue(cipherText, selfEncryptionKey,
-              ivBase64: atKey.metadata?.ivNonce),
-          clearText);
+      expect(() => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey), throwsException);
+      expect(EncryptionUtil.decryptValue(cipherText, selfEncryptionKey, ivBase64:atKey.metadata?.ivNonce), clearText);
 
       var getResult = await atClient.get(atKey);
       expect(getResult.value, clearText);
@@ -135,8 +119,7 @@ void main() {
       await atClient.put(atKey, clearText);
       expect(atKey.metadata?.ivNonce, isNull);
 
-      var atData =
-          await (atClient.getLocalSecondary()!.keyStore!.get(atKey.toString()));
+      var atData = await (atClient.getLocalSecondary()!.keyStore!.get(atKey.toString()));
       var cipherText = atData.data;
       expect(EncryptionUtil.decryptValue(cipherText, bobSharedKey), clearText);
 
@@ -151,21 +134,12 @@ void main() {
       await atClient.put(atKey, clearText);
       expect(atKey.metadata?.ivNonce, isNotNull);
 
-      var atData =
-          await (atClient.getLocalSecondary()!.keyStore!.get(atKey.toString()));
+      var atData = await (atClient.getLocalSecondary()!.keyStore!.get(atKey.toString()));
       var cipherText = atData.data;
-      expect(() => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey),
-          throwsException);
-      expect(
-          () => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey,
-              ivBase64: atKey.metadata?.ivNonce),
-          throwsException);
-      expect(() => EncryptionUtil.decryptValue(cipherText, bobSharedKey),
-          throwsException);
-      expect(
-          EncryptionUtil.decryptValue(cipherText, bobSharedKey,
-              ivBase64: atKey.metadata?.ivNonce),
-          clearText);
+      expect(() => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey), throwsException);
+      expect(() => EncryptionUtil.decryptValue(cipherText, selfEncryptionKey, ivBase64: atKey.metadata?.ivNonce), throwsException);
+      expect(() => EncryptionUtil.decryptValue(cipherText, bobSharedKey), throwsException);
+      expect(EncryptionUtil.decryptValue(cipherText, bobSharedKey, ivBase64:atKey.metadata?.ivNonce), clearText);
 
       var getResult = await atClient.get(atKey);
       expect(getResult.value, clearText);

--- a/packages/at_client_mobile/lib/src/at_client_service.dart
+++ b/packages/at_client_mobile/lib/src/at_client_service.dart
@@ -487,8 +487,10 @@ class AtClientService {
   ///
   Future<bool> isAtClientReadyForOfflineAccess(
       String atSign, AtClientPreference atClientPreference) async {
-    var isClientOnboarded = await AtClientImpl.verifyStorageForOfflineAccess(
-        atSign, atClientPreference);
+    var atClientManager = await AtClientManager.getInstance().setCurrentAtSign(
+        atSign, atClientPreference.namespace, atClientPreference);
+    var isClientOnboarded = await atClientManager.atClient
+        .canUseOffline(atSign, atClientPreference);
     if (isClientOnboarded == true) {
       return true;
     }

--- a/packages/at_client_mobile/lib/src/at_client_service.dart
+++ b/packages/at_client_mobile/lib/src/at_client_service.dart
@@ -453,6 +453,47 @@ class AtClientService {
     final atChops = AtChopsImpl(atChopsKeys);
     return atChops;
   }
+
+  /// Checks if the atSign is already onboarded on a device. If onboarded, returns "true",
+  /// else returns "false".
+  ///
+  /// If atSign is onboarded, AtClient can be used in an offline mode.
+  ///
+  /// Usage:
+  ///  if( isNetworkAvailable == false) {
+  ///     bool isClientReadyForOfflineUsage = await isAtClientReadyForOfflineAccess('@bob', AtClientPreference());
+  ///     if(isClientReadyForOfflineUsage){
+  ///         AtClientManager.getInstance().setCurrentAtSign('@bob', 'wavi', AtClientPreference());
+  ///     }
+  ///  }
+  ///
+  ///  Below is the table representing the AtClient offline mode operations
+  ///
+  /// ```
+  ///   | Offline activity                                             | Can work offline? |
+  ///   ---------------------------------------------------------------|--------------------
+  ///   | list keys                                                    | Yes               |
+  ///   |list keys shared by other @sign                               | No                |
+  ///   |put private key                                               | Yes               |
+  ///   |put self key                                                  | Yes               |
+  ///   |put public key                                                | Yes               |
+  ///   |put shared key with cached encryption public key of recipient | Yes               |
+  ///   |put shared key                                                | No                |
+  ///   |get value for a key                                           | Yes               |
+  ///   |get value from other @sign                                    | No                |
+  ///   |notify                                                        | No                |
+  ///   |sync                                                          | No                |
+  ///```
+  ///
+  Future<bool> isAtClientReadyForOfflineAccess(
+      String atSign, AtClientPreference atClientPreference) async {
+    var isClientOnboarded = await AtClientImpl.verifyStorageForOfflineAccess(
+        atSign, atClientPreference);
+    if (isClientOnboarded == true) {
+      return true;
+    }
+    return false;
+  }
 }
 
 class BackupKeyConstants {

--- a/packages/at_client_mobile/pubspec.yaml
+++ b/packages/at_client_mobile/pubspec.yaml
@@ -22,6 +22,10 @@ dependencies:
   at_lookup: ^3.0.35
   at_client: ^3.0.53
 
+dependency_overrides:
+  at_client:
+    path: ../at_client
+
 dev_dependencies:
   lints: ^2.0.0
   test: ^1.6.0


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Enable at_client to usage when the device is offline.
* AtClient can be used in offline mode only if the atSign is paired with the device.

**- How I did it**
* In at_client_impl, Initialise the storage and verify if the encryption public key is available in the storage. This is to ensure that the atSign is paired with the device.
* If the above returns true, allow the client to use at_client in offline mode.

**- Description for the changelog**
* Enable at_client usage when device is in offline mode.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->