### PR TITLE
fix: Update E2E tests

### DIFF
--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -275,8 +275,6 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     syncProgress.localCommitIdBeforeSync = localCommitIdBeforeSync;
     syncProgress.localCommitId = localCommitId;
     syncProgress.serverCommitId = serverCommitId;
-    _logger.finer(
-        "Informing ${_syncProgressListeners.length} listeners of $syncProgress");
     for (var listener in _syncProgressListeners) {
       try {
         listener.onSyncProgressEvent(syncProgress);
@@ -499,7 +497,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
           await _processServerCommitEntry(
               serverCommitEntry, uncommittedEntries, keyInfoList);
           _logger.finest(
-              '**lastReceivedServerCommitId $lastReceivedServerCommitId');
+              'Updating lastReceivedServerCommitId to $lastReceivedServerCommitId');
         }
       }
     } finally {
@@ -896,15 +894,11 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
           ..value = serverCommitEntry['value'];
         builder.operation = UPDATE_ALL;
         _setMetaData(builder, serverCommitEntry);
-        _logger.finest(
-            'syncing to local: ${serverCommitEntry['atKey']}  commitId:${serverCommitEntry['commitId']}');
         await _pullToLocal(builder, serverCommitEntry, CommitOp.UPDATE_ALL);
         break;
       case '-':
         var builder = DeleteVerbBuilder()
           ..atKeyObj = AtKey.fromString(serverCommitEntry['atKey']);
-        _logger.finest(
-            'syncing to local delete: ${serverCommitEntry['atKey']}  commitId:${serverCommitEntry['commitId']}');
         await _pullToLocal(builder, serverCommitEntry, CommitOp.DELETE);
         break;
     }
@@ -999,7 +993,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     }
     commitEntry.operation = operation;
     _logger.finest(
-        '*** updating commitId to local ${serverCommitEntry['commitId']}');
+        'Updating ${commitEntry.atKey} commitId to ${serverCommitEntry['commitId']} in local keystore');
     await syncUtil.updateCommitEntry(commitEntry, serverCommitEntry['commitId'],
         _atClient.getCurrentAtSign()!);
   }

--- a/tests/at_end2end_test/lib/src/test_initializers.dart
+++ b/tests/at_end2end_test/lib/src/test_initializers.dart
@@ -25,14 +25,14 @@ class TestSuiteInitializer {
       // Set Encryption Keys for currentAtSign
       await AtEncryptionKeysLoader.getInstance()
           .setEncryptionKeys(atClientManager.atClient, atSign);
-      await E2ESyncService.getInstance()
-          .syncData(atClientManager.atClient.syncService);
+      await E2ESyncService.getInstance().syncData(
+          atClientManager.atClient.syncService,
+          syncOptions: SyncOptions()..waitForFullSyncToComplete = true);
 
       // verify if the public key is in the local secondary
       var result = await atClientManager.atClient
           .getLocalSecondary()!
           .getEncryptionPublicKey(atSign);
-      print('testInitializer: $atSign: encryption public key from local key-store: $result');
       assert(result ==
           AtCredentials
               .credentialsMap[atSign]![TestConstants.ENCRYPTION_PUBLIC_KEY]);
@@ -41,11 +41,9 @@ class TestSuiteInitializer {
       result = await atClientManager.atClient
           .getLocalSecondary()!
           .getEncryptionPrivateKey();
-      print('testInitializer: $atSign: encryption public key from local key-store: $result');
       assert(result ==
           AtCredentials
               .credentialsMap[atSign]![TestConstants.ENCRYPTION_PRIVATE_KEY]);
-      print('testInitializer: $atSign: setup complete');
     } on Exception catch (e) {
       print('Exception in setting the encryption: $e');
     }

--- a/tests/at_end2end_test/test/bypasscache_test.dart
+++ b/tests/at_end2end_test/test/bypasscache_test.dart
@@ -6,7 +6,7 @@ import 'package:at_end2end_test/src/test_preferences.dart';
 
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
-import 'package:at_utils/at_logger.dart';
+
 
 void main() async {
   late String sharedByAtSign;
@@ -15,7 +15,6 @@ void main() async {
   var uuid = Uuid();
 
   setUpAll(() async {
-    AtSignLogger.root_level = 'finer';
     sharedByAtSign = ConfigUtil.getYaml()['atSign']['firstAtSign'];
     sharedWithAtSign = ConfigUtil.getYaml()['atSign']['secondAtSign'];
 

--- a/tests/at_end2end_test/test/notify_test.dart
+++ b/tests/at_end2end_test/test/notify_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'package:at_end2end_test/src/test_initializers.dart';
 import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:uuid/uuid.dart';


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Refactor the E2E tests for the tests to be stable.

**- How I did it**
* Earlier the data from server to client would sync in run of first sync. Due to large size of commit log (approx 561,315 commits in ce2e1) which is taking more than 30 seconds of time causing the AtTimeOutException.
* To fix the above issue, modified that such that before the test start executing, ensure both the atSign sync the server data to local.
* Introduce "waitForFullSyncToComplete" in syncOptions when set to true, will wait until the server syncs all the commits to the local keystore.

**- How to verify it**
* All tests should pass

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->