### PR TITLE
fix: skip reserved keys from sync conflict

### DIFF
--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -58,6 +58,12 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   @visibleForTesting
   NetworkUtil networkUtil = NetworkUtil();
 
+  // "^shared_key\..+@.+" matches the key that starts-with shared_key.<someone>@<me>
+  // "@.+:shared_key@.+" matches the key that starts-with @<someone>:shared_key@<me>
+  @visibleForTesting
+  RegExp encryptedSharedKeyMatcher =
+      RegExp(r'^shared_key\..+@.+|@.+:shared_key@.+');
+
   /// Returns the currentAtSign associated with the SyncService
   String get currentAtSign => _atClient.getCurrentAtSign()!;
 
@@ -576,7 +582,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     // (@someone:shared_key@me, shared_key.someone@me) are the reserved keys
     // and do not require actions. Hence skipping from checking conflict resolution.
     if (key.startsWith('publickey.') ||
-        key.startsWith(RegExp('shared_key.+@.+|@.+shared_key@.+')) ||
+        key.startsWith(encryptedSharedKeyMatcher) ||
         key.startsWith('cached:')) {
       _logger.finer('$key found in conflict resolution, returning null');
       return null;

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -569,14 +569,14 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   }
 
   Future<ConflictInfo?> _setConflictInfo(final serverCommitEntry) async {
-    final key = serverCommitEntry['atKey'];
+    String key = serverCommitEntry['atKey'];
     // publickey.<atsign>@<currentatsign> is used to store the public key of
     // other atsign. The value is not encrypted.
     // The keys starting with publickey. and keys that contain shared_key
     // (@someone:shared_key@me, shared_key.someone@me) are the reserved keys
     // and do not require actions. Hence skipping from checking conflict resolution.
     if (key.startsWith('publickey.') ||
-        key.contains('shared_key') ||
+        key.startsWith(RegExp('shared_key.+@.+|@.+shared_key@.+')) ||
         key.startsWith('cached:')) {
       _logger.finer('$key found in conflict resolution, returning null');
       return null;

--- a/packages/at_client/test/sync_new_test.dart
+++ b/packages/at_client/test/sync_new_test.dart
@@ -2757,7 +2757,8 @@ void main() {
     });
 
     group('A group of tests to validate shared key matcher regex', () {
-      test('A test to verify shared_key with invalid key structure is ignored', () async {
+      test('A test to verify shared_key with invalid key structure is ignored',
+          () async {
         SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
             atClientManager: mockAtClientManager,
             notificationService: mockNotificationService,
@@ -2771,8 +2772,7 @@ void main() {
                 .hasMatch('sssshared_key.alice@alice'),
             false);
         expect(
-            syncService.encryptedSharedKeyMatcher
-                .hasMatch('shared_key@alice'),
+            syncService.encryptedSharedKeyMatcher.hasMatch('shared_key@alice'),
             false);
         expect(
             syncService.encryptedSharedKeyMatcher
@@ -2792,7 +2792,7 @@ void main() {
             false);
       });
 
-      test('A test to verify valid shared_key matches the regex',() async {
+      test('A test to verify valid shared_key matches the regex', () async {
         SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
             atClientManager: mockAtClientManager,
             notificationService: mockNotificationService,

--- a/packages/at_client/test/sync_new_test.dart
+++ b/packages/at_client/test/sync_new_test.dart
@@ -14,7 +14,6 @@ import 'package:at_client/src/util/sync_util.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_persistence_secondary_server/src/keystore/hive_keystore.dart';
-import 'package:at_utils/at_logger.dart';
 import 'package:crypton/crypton.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
@@ -2768,7 +2767,6 @@ void main() {
     test(
         'A test to verify when sync conflict info when key present in uncommitted entries and in server response of sync',
         () async {
-      AtSignLogger.root_level = 'finer';
       // ------------------------------ Setup ----------------------------------
       LocalSecondary? localSecondary = LocalSecondary(mockAtClient,
           keyStore: TestResources.getHiveKeyStore(TestResources.atsign));
@@ -2810,7 +2808,7 @@ void main() {
           '"metadata":{"createdAt":"2022-11-07 13:42:02.703Z"},'
           '"commitId":2,"operation":"*"}'
           ','
-          '{"atKey":"@alice:conflict_shared_key.demo${TestResources.atsign}",'
+          '{"atKey":"@alice:shared_key${TestResources.atsign}",'
           '"value":"shared_key_remote_value",'
           '"metadata":{"createdAt":"2022-11-07 13:42:02.703Z","isEncrypted":"true"},'
           '"commitId":3,"operation":"*"}]'));
@@ -2830,8 +2828,8 @@ void main() {
               AtKey.fromString('public:conflict_key1${TestResources.atsign}')))
           .thenAnswer(
               (invocation) => Future.value(AtValue()..value = 'local_value'));
-      when(() => mockAtClient.get(AtKey.fromString(
-              '@alice:conflict_shared_key.demo${TestResources.atsign}')))
+      when(() => mockAtClient.get(
+              AtKey.fromString('@alice:shared_key${TestResources.atsign}')))
           .thenAnswer((invocation) =>
               Future.value(AtValue()..value = 'shared_key_local_value'));
       when(() => mockAtKeyDecryptionManager.get(
@@ -2845,8 +2843,7 @@ void main() {
       await localSecondary.putValue(
           'public:conflict_key1${TestResources.atsign}', 'localValue');
       await localSecondary.putValue(
-          '@alice:conflict_shared_key.demo${TestResources.atsign}',
-          'shared_key_local_value');
+          '@alice:shared_key${TestResources.atsign}', 'shared_key_local_value');
       CustomSyncProgressListener progressListener =
           CustomSyncProgressListener();
       syncService.addProgressListener(progressListener);
@@ -2863,11 +2860,10 @@ void main() {
             expect(keyInfo.conflictInfo?.remoteValue, 'remote_value');
             expect(keyInfo.conflictInfo?.localValue, 'local_value');
           }
-          if (keyInfo.key == '@alice:conflict_shared_key.demo@hiro' &&
+          // Since shared_key is a reserved key, setting conflict info is skipped
+          if (keyInfo.key == '@alice:shared_key@hiro' &&
               keyInfo.syncDirection == SyncDirection.remoteToLocal) {
-            expect(
-                keyInfo.conflictInfo?.remoteValue, 'shared_key_remote_value');
-            expect(keyInfo.conflictInfo?.localValue, 'shared_key_local_value');
+            expect(keyInfo.conflictInfo, null);
           }
         }
       }));
@@ -2878,7 +2874,6 @@ void main() {
     test(
         'A test to verify conflict info sets errorOrExceptionMessage when exception occurs in setConflictInfo',
         () async {
-      AtSignLogger.root_level = 'finer';
       // ------------------------------ Setup ----------------------------------
       LocalSecondary? localSecondary = LocalSecondary(mockAtClient,
           keyStore: TestResources.getHiveKeyStore(TestResources.atsign));
@@ -2910,8 +2905,8 @@ void main() {
           any(that: SyncVerbBuilderMatcher()),
           sync: any(
               named: "sync"))).thenAnswer((invocation) => Future.value('data:['
-          '{"atKey":"@alice:conflict_shared_key.demo${TestResources.atsign}",'
-          '"value":"shared_key_remote_value",'
+          '{"atKey":"@alice:conflict_phone_key.demo${TestResources.atsign}",'
+          '"value":"phone_key_remote_value",'
           '"metadata":{"createdAt":"2022-11-07 13:42:02.703Z","isEncrypted":"true"},'
           '"commitId":3,"operation":"*"}]'));
       when(() => mockRemoteSecondary.executeCommand(any(),
@@ -2926,20 +2921,20 @@ void main() {
           .thenAnswer((invocation) =>
               throw AtKeyNotFoundException('key is not found in keystore'));
       when(() => mockAtClient.get(AtKey.fromString(
-              '@alice:conflict_shared_key.demo${TestResources.atsign}')))
+              '@alice:conflict_phone_key.demo${TestResources.atsign}')))
           .thenAnswer((invocation) =>
-              Future.value(AtValue()..value = 'shared_key_local_value'));
+              Future.value(AtValue()..value = 'phone_key_local_value'));
       when(() => mockAtKeyDecryptionManager.get(
               any(that: ConflictKeyMatcher()), TestResources.atsign))
           .thenAnswer((_) => mockSharedKeyDecryption);
       when(() => mockSharedKeyDecryption.decrypt(
-              any(that: ConflictKeyMatcher()), 'shared_key_remote_value'))
+              any(that: ConflictKeyMatcher()), 'phone_key_remote_value'))
           .thenAnswer((_) => throw AtPublicKeyNotFoundException(
               'Encryption public key not found'));
 
       await localSecondary.putValue(
-          '@alice:conflict_shared_key.demo${TestResources.atsign}',
-          'shared_key_local_value');
+          '@alice:conflict_phone_key.demo${TestResources.atsign}',
+          'phone_key_local_value');
       CustomSyncProgressListener progressListener =
           CustomSyncProgressListener();
       syncService.addProgressListener(progressListener);
@@ -2951,10 +2946,80 @@ void main() {
           .listen(expectAsync1((syncProgress) {
         expect(syncProgress.syncStatus, SyncStatus.success);
         for (KeyInfo keyInfo in syncProgress.keyInfoList!) {
-          if (keyInfo.key == '@alice:conflict_shared_key.demo@hiro' &&
+          if (keyInfo.key == '@alice:conflict_phone_key.demo@hiro' &&
               keyInfo.syncDirection == SyncDirection.remoteToLocal) {
             expect(keyInfo.conflictInfo?.errorOrExceptionMessage,
-                'Exception occurred when setting conflict info for @alice:conflict_shared_key.demo@hiro | Exception: Encryption public key not found');
+                'Exception occurred when setting conflict info for @alice:conflict_phone_key.demo@hiro | Exception: Encryption public key not found');
+          }
+        }
+      }));
+    });
+
+    test(
+        'A test to verify conflict info when uncommitted entry has a delete operation',
+        () async {
+      LocalSecondary? localSecondary = LocalSecondary(mockAtClient,
+          keyStore: TestResources.getHiveKeyStore(TestResources.atsign));
+
+      SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
+          atClientManager: mockAtClientManager,
+          notificationService: mockNotificationService,
+          remoteSecondary: mockRemoteSecondary) as SyncServiceImpl;
+      syncService.syncUtil = SyncUtil(atCommitLog: TestResources.commitLog);
+
+      registerFallbackValue(FakeSyncVerbBuilder());
+      registerFallbackValue(FakeUpdateVerbBuilder());
+      registerFallbackValue(FakeAtKey());
+
+      when(() => mockNetworkUtil.isNetworkAvailable())
+          .thenAnswer((_) => Future.value(true));
+      when(() => mockAtClient.getLocalSecondary()).thenReturn(localSecondary);
+      when(() => mockRemoteSecondary
+              .executeVerb(any(that: StatsVerbBuilderMatcher())))
+          .thenAnswer((invocation) => Future.value('data:[{"value":"3"}]'));
+      when(() => mockAtClient.getPreferences())
+          .thenAnswer((_) => AtClientPreference());
+      when(() => mockRemoteSecondary.executeVerb(
+          any(that: SyncVerbBuilderMatcher()),
+          sync: any(
+              named: "sync"))).thenAnswer((invocation) => Future.value('data:['
+          '{"atKey":"@alice:conflict-key${TestResources.atsign}",'
+          '"value":"remote_value",'
+          '"metadata":{"createdAt":"2022-11-07 13:42:02.703Z","isEncrypted":"true"},'
+          '"commitId":3,"operation":"*"}]'));
+      when(() => mockRemoteSecondary.executeCommand(any(),
+              auth: any(named: "auth")))
+          .thenAnswer((invocation) =>
+              Future.value('data:[{"id":1,"response":{"data":"3"}}]'));
+      when(() => mockAtClient.put(
+              any(that: LastReceivedServerCommitIdMatcher()), any()))
+          .thenAnswer((_) => Future.value(true));
+      when(() =>
+              mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((invocation) =>
+              throw AtKeyNotFoundException('key is not found in keystore'));
+      when(() => mockAtClient.get(any(that: ConflictKeyMatcher()))).thenAnswer(
+          (invocation) =>
+              throw KeyNotFoundException('key is not found in keystore'));
+
+      await localSecondary.executeVerb(DeleteVerbBuilder()
+        ..sharedWith = '@alice'
+        ..atKey = 'conflict-key'
+        ..sharedBy = TestResources.atsign);
+      CustomSyncProgressListener progressListener =
+          CustomSyncProgressListener();
+      syncService.addProgressListener(progressListener);
+      syncService.sync();
+      await syncService.processSyncRequests(
+          respectSyncRequestQueueSizeAndRequestTriggerDuration: false);
+
+      progressListener.streamController.stream
+          .listen(expectAsync1((syncProgress) {
+        expect(syncProgress.syncStatus, SyncStatus.success);
+        for (KeyInfo keyInfo in syncProgress.keyInfoList!) {
+          if (keyInfo.key == '@alice:conflict-key@hiro' &&
+              keyInfo.syncDirection == SyncDirection.remoteToLocal) {
+            expect(keyInfo.conflictInfo == null, true);
           }
         }
       }));

--- a/packages/at_client/test/sync_new_test.dart
+++ b/packages/at_client/test/sync_new_test.dart
@@ -2756,6 +2756,58 @@ void main() {
               (_) => StreamController<at_notification.AtNotification>().stream);
     });
 
+    group('A group of tests to validate shared key matcher regex', () {
+      test('A test to verify shared_key with invalid key structure is ignored', () async {
+        SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
+            atClientManager: mockAtClientManager,
+            notificationService: mockNotificationService,
+            remoteSecondary: mockRemoteSecondary) as SyncServiceImpl;
+        expect(
+            syncService.encryptedSharedKeyMatcher
+                .hasMatch('shared_keyyy.alice@alice'),
+            false);
+        expect(
+            syncService.encryptedSharedKeyMatcher
+                .hasMatch('sssshared_key.alice@alice'),
+            false);
+        expect(
+            syncService.encryptedSharedKeyMatcher
+                .hasMatch('shared_key@alice'),
+            false);
+        expect(
+            syncService.encryptedSharedKeyMatcher
+                .hasMatch('@alice:ssssshared_key@alice'),
+            false);
+        expect(
+            syncService.encryptedSharedKeyMatcher
+                .hasMatch('@ssssssshared_key:phone.wavi@alice'),
+            false);
+        expect(
+            syncService.encryptedSharedKeyMatcher
+                .hasMatch('@alice:ssssssshared_key@alice'),
+            false);
+        expect(
+            syncService.encryptedSharedKeyMatcher
+                .hasMatch('@alice:shared_key.alice@alice'),
+            false);
+      });
+
+      test('A test to verify valid shared_key matches the regex',() async {
+        SyncServiceImpl syncService = await SyncServiceImpl.create(mockAtClient,
+            atClientManager: mockAtClientManager,
+            notificationService: mockNotificationService,
+            remoteSecondary: mockRemoteSecondary) as SyncServiceImpl;
+        expect(
+            syncService.encryptedSharedKeyMatcher
+                .hasMatch('shared_key.alice@alice'),
+            true);
+        expect(
+            syncService.encryptedSharedKeyMatcher
+                .hasMatch('@bob:shared_key@alice'),
+            true);
+      });
+    });
+
     /// Preconditions:
     /// 1. The server commit id should be greater than local commit id
     /// 2. The server response should an contains a entry - @alice:phone@bob


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
* Fix the exception "shared_key" fails to decrypt in setConflictInfo method.
* Fix the exception "Key not found in Key store" when the uncommitted entry has a CommitOp.Delete

**- How I did it**
* For 1: Modify the IF condition, `startsWith(shared_key)` to `contains(shared_key)`
* For 2: When fetching the local value, catch KeyNotFoundException and return null.

**- How to verify it**
* For 1, Updated the existing unit test
* For 2, Added a new unit test

**- Description for the changelog**
* fix: skip reserved keys from sync conflict

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->