### PR TITLE
build: Update http dependency to '>=0.13.5 <2.0.0'

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.62
+- build: updated dependency on http package to `'>=0.13.5 <2.0.0'` 
 ## 3.0.61
 - fix: ensure key exchange functions properly when the sync service is not
   being used

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.61';
+  final String atClientVersion = '3.0.62';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   crypto: ^3.0.1
   collection: ^1.16.0
   archive: ^3.3.5
-  http: ^1.0.0
+  http: '>=0.13.5 <2.0.0'
   internet_connection_checker: ^1.0.0+1
   async: ^2.9.0
   at_utf7: ^1.0.0

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.61
+version: 3.0.62
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 
@@ -25,7 +25,7 @@ dependencies:
   crypto: ^3.0.1
   collection: ^1.16.0
   archive: ^3.3.5
-  http: ^0.13.5
+  http: ^1.0.0
   internet_connection_checker: ^1.0.0+1
   async: ^2.9.0
   at_utf7: ^1.0.0

--- a/tests/at_end2end_test/test/collection_test.dart
+++ b/tests/at_end2end_test/test/collection_test.dart
@@ -134,7 +134,7 @@ class A extends AtCollectionModel {
 
   A.from(String id, {this.a}) {
     this.id = id;
-    namespace = 'buzz';
+    this.namespace = 'buzz';
   }
 
   @override
@@ -177,7 +177,7 @@ class B extends AtCollectionModel {
 
   B.from(String id, {this.b}) {
     this.id = id;
-    namespace = 'buzz';
+    this.namespace = 'buzz';
   }
 
   @override


### PR DESCRIPTION
**- What I did**
- build: Update http dependency to '>=0.13.5 <2.0.0'
- build: update at_client package version to 3.0.62
- [gkc] updated CHANGELOG
- [gkc] updated AtClientConfig.atClientVersion to 3.0.62 in line with pubspec version bump
- [gkc] dealt with [an unrelated issue](https://github.com/atsign-foundation/at_client_sdk/pull/1083/commits/955e22646022580ec2c3a3e4a8175d7fc70806af) that appeared because of a new version of at_commons becoming available
- [gkc] raised [a ticket](https://github.com/atsign-foundation/at_client_sdk/issues/1084) for another unrelated issue that occasionally happens when running the functional tests pack

**- How I did it**
Modified at_client package's pubspec.yaml for the `http` package to: `http: '>=0.13.5 <2.0.0'`

**- How to verify it**
Tests pass
