### PR TITLE
fix: Add syncOptions to allow keys to sync to remote secondary

### DIFF
--- a/tests/at_end2end_test/test/collection_test.dart
+++ b/tests/at_end2end_test/test/collection_test.dart
@@ -133,7 +133,7 @@ class A extends AtCollectionModel {
 
   A.from(String id, {this.a}) {
     this.id = id;
-    namespace = 'buzz';
+    this.namespace = 'buzz';
   }
 
   @override
@@ -176,7 +176,7 @@ class B extends AtCollectionModel {
 
   B.from(String id, {this.b}) {
     this.id = id;
-    namespace = 'buzz';
+    this.namespace = 'buzz';
   }
 
   @override
@@ -670,12 +670,12 @@ void main() async {
     for (var model in res) {
       switch (model.collectionName) {
         case 'phone':
-          expect(model is Phone,true,
+          expect(model is Phone, true,
               reason:
                   'For collection name phone, model should be of type Phone');
           break;
         case 'contact':
-          expect(model is Contact,true,
+          expect(model is Contact, true,
               reason:
                   'For collection name contact, model should be of type Contact');
           break;


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fix failing tests in "collection_test.dart"
- The test failure might be due to the sync service finishing before the key gets created in the local-secondary and synchronized to the remote secondary. Consequently, when the receiver atSign attempts to retrieve the keys, the test fails due to the absence of the key in the sender's remote secondary.

**- How I did it**
- Add SyncOptions on the sender's sync service to wait until the key is synced to the sender's remote secondary
- Uncomment the "testInitializer" for the thirdAtSign and fourthAtSign. This ensures the keys in remote secondary of the atSign to sync in local secondary before the test starts.
- Swap actual and matcher in test-expect method.

**- How to verify it**
- The collection test should pass in CI/CD
- Ran the tests in local for 4 times and do not observe the test failure. Adding the test result.
[Test Results-Tests_in_collection_test_dart.zip](https://github.com/atsign-foundation/at_client_sdk/files/12211946/Test.Results-Tests_in_collection_test_dart.zip)

**- Description for the changelog**
- Fix failing test in collection_test.dart
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->