### PR TITLE
fix: collection_test.dart - Add syncOption to wait until the cached k…

### DIFF
--- a/tests/at_end2end_test/test/collection_test.dart
+++ b/tests/at_end2end_test/test/collection_test.dart
@@ -9,7 +9,6 @@ import 'package:at_end2end_test/src/sync_initializer.dart';
 import 'package:at_end2end_test/src/test_initializers.dart';
 import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:test/test.dart';
-import 'package:at_utils/at_logger.dart';
 
 class PreferenceFactory extends AtCollectionModelFactory<Preference> {
   static final PreferenceFactory _singleton = PreferenceFactory._internal();
@@ -256,7 +255,6 @@ void main() async {
   });
 
   test('Model operations - save() with reshare() as true test', () async {
-    AtSignLogger.root_level = 'finest';
     // Setting firstAtSign atClient instance to context.
     currentAtClientManager =
         await AtClientManager.getInstance().setCurrentAtSign(

--- a/tests/at_end2end_test/test/collection_test.dart
+++ b/tests/at_end2end_test/test/collection_test.dart
@@ -9,6 +9,7 @@ import 'package:at_end2end_test/src/sync_initializer.dart';
 import 'package:at_end2end_test/src/test_initializers.dart';
 import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:test/test.dart';
+import 'package:at_utils/at_logger.dart';
 
 class PreferenceFactory extends AtCollectionModelFactory<Preference> {
   static final PreferenceFactory _singleton = PreferenceFactory._internal();
@@ -255,6 +256,7 @@ void main() async {
   });
 
   test('Model operations - save() with reshare() as true test', () async {
+    AtSignLogger.root_level = 'finest';
     // Setting firstAtSign atClient instance to context.
     currentAtClientManager =
         await AtClientManager.getInstance().setCurrentAtSign(
@@ -291,8 +293,11 @@ void main() async {
       namespace,
       TestPreferences.getInstance().getPreference(secondAtSign),
     );
-    await E2ESyncService.getInstance()
-        .syncData(sharedWithAtClientManager.atClient.syncService);
+    await E2ESyncService.getInstance().syncData(
+        sharedWithAtClientManager.atClient.syncService,
+        syncOptions: SyncOptions()
+          ..key =
+              'cached:$secondAtSign:personal-phone.phone.atcollectionmodel.buzz.wavi$firstAtSign');
     var regex = CollectionUtil.makeRegex(
         formattedId: 'personal-phone',
         collectionName: 'phone',
@@ -300,6 +305,7 @@ void main() async {
 
     List<String> keys =
         await sharedWithAtClientManager.atClient.getKeys(regex: regex);
+    print('Keys sync to $secondAtSign: $keys');
     expect(keys.length, 1,
         reason:
             'On the recipient side expecting a single keys with the regex supplied');


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fix the failing test - "Model operations - save() with reshare() as true test"
- In the earlier fix, added syncOptions on the sender client which ensure the key is synced from the sender's local secondary to the sender's remote secondary. 
- The issue now occurs due to the cached key not getting synced from the receiver's remote secondary to the receiver's local secondary. Added syncOptions on the receiver's side as well to wait until the cached key sync from the receiver's remote secondary to the local secondary.
- Further, temporarily down the log level to "finest" for this test and added a print statement that prints the response on the receiver's side, to get more information - just incase if the test fails again.

**- How to verify it**
- The failing test should pass.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->