### PR TITLE
fix: fixed failing enrolment functional test

### DIFF
--- a/tests/at_functional_test/test/enrollment_test.dart
+++ b/tests/at_functional_test/test/enrollment_test.dart
@@ -28,6 +28,11 @@ void main() {
     setLastReceivedNotificationDateTime();
   });
 
+  void _stopSubscriptions() {
+    atClientManager.atClient.notificationService.stopAllSubscriptions();
+    print('subscriptions stopped');
+  }
+
   test('A test to verify enrollment request returns notification', () async {
     final atClient = atClientManager.atClient;
     var fromResponse =
@@ -79,12 +84,13 @@ void main() {
     expect(enrollmentIdFromServer, isNotEmpty);
     expect(enrollJson['status'], 'pending');
     atClientManager.atClient.notificationService
-        .subscribe()
+        .subscribe(regex: '.new.enrollments.__manage')
         .listen(expectAsync1((enrollNotification) {
           print('got enrollment notification: $enrollNotification');
           expect(enrollNotification.key,
               '$enrollmentIdFromServer.new.enrollments.__manage');
-        }, count: 1, max: -1));
+          _stopSubscriptions();
+        }, count: 1, max: 1));
   });
 }
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Stopped monitor subscription
**- How I did it**
Called notificationService.stopAllSubscriptions() and passed that in the test
**- How to verify it**
enrollment_test.dart should pass
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->