### PR TITLE
build: publish at_client 3.0.65

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.65
+- feat: apkam changes for at_onboarding_cli
+- build: updated at_commons to `'3.0.55'`, at_chops to `'1.0.4`, at_lookup to `'3.0.40'` 
 ## 3.0.64
 - Made ConnectivityListener configurable, and removed some unnecessary network 
   availability checks

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.64';
+  final String atClientVersion = '3.0.65';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.64
+version: 3.0.65
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 
@@ -31,10 +31,10 @@ dependencies:
   async: ^2.9.0
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
-  at_commons: ^3.0.53
+  at_commons: ^3.0.55
   at_utils: ^3.0.15
-  at_chops: ^1.0.3
-  at_lookup: ^3.0.39
+  at_chops: ^1.0.4
+  at_lookup: ^3.0.40
   at_persistence_spec: ^2.0.14
   at_persistence_secondary_server: ^3.0.57
   meta: ^1.8.0


### PR DESCRIPTION
**- What I did**
- changes to publish at_client 3.0.65 which has dependent changes for apkam changes in at_onboarding_cli
**- How I did it**
- modified pubspec version from 3.0.64 to 3.0.65
- upgraded at_lookup, at_chops and at_commons dependency to latest version
**- How to verify it**
- unit/functional tests should pass
- sanity with apps done
