### PR TITLE
fix: add enrollmentId to SyncService/NotificationService

### DIFF
--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -114,8 +114,6 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
   late final AtSignLogger _logger;
 
-  String? _enrollmentId;
-
   @visibleForTesting
   static final Map atClientInstanceMap = <String, AtClient>{};
 
@@ -126,7 +124,6 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       EncryptionService? encryptionService,
       SecondaryKeyStore? localSecondaryKeyStore,
       AtChops? atChops,
-      String? enrollmentId,
       AtClientCommitLogCompaction? atClientCommitLogCompaction,
       AtClientConfig? atClientConfig}) async {
     atClientManager ??= AtClientManager.getInstance();
@@ -162,7 +159,6 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       EncryptionService? encryptionService,
       SecondaryKeyStore? localSecondaryKeyStore,
       AtChops? atChops,
-      String? enrollmentId,
       AtClientCommitLogCompaction? atClientCommitLogCompaction,
       AtClientConfig? atClientConfig}) {
     _atSign = AtUtils.fixAtSign(theAtSign);
@@ -179,7 +175,6 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     _remoteSecondary = remoteSecondary;
     _encryptionService = encryptionService;
     _atChops = atChops;
-    _enrollmentId = enrollmentId;
     _atClientCommitLogCompaction = atClientCommitLogCompaction;
   }
 
@@ -198,7 +193,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     _remoteSecondary ??= RemoteSecondary(_atSign, _preference!,
         atChops: atChops,
         privateKey: _preference!.privateKey,
-        enrollmentId: _enrollmentId);
+        enrollmentId: enrollmentId);
 
     // Now using ??= because we may be injecting an EncryptionService
     _encryptionService ??= EncryptionService(_atSign);
@@ -996,4 +991,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     }
     return result.notificationID;
   }
+
+  @override
+  String? enrollmentId;
 }

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -114,6 +114,9 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
   late final AtSignLogger _logger;
 
+  @override
+  String? enrollmentId;
+
   @visibleForTesting
   static final Map atClientInstanceMap = <String, AtClient>{};
 
@@ -991,7 +994,4 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     }
     return result.notificationID;
   }
-
-  @override
-  String? enrollmentId;
 }

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -38,6 +38,11 @@ abstract class AtClient {
 
   AtChops? get atChops;
 
+  /// Enrollment id for apkam enrolled clients
+  set enrollmentId(String? enrollmentId);
+
+  String? get enrollmentId;
+
   set syncService(SyncService syncService);
   SyncService get syncService;
 

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -79,19 +79,22 @@ class AtClientManager {
         'Switching atSigns from ${_currentAtClient?.getCurrentAtSign()} to $atSign');
     _atSign = atSign;
     var previousAtClient = _currentAtClient;
-    _currentAtClient = await serviceFactory
-        .atClient(_atSign, namespace, preference, this, atChops: atChops);
+    _currentAtClient = await serviceFactory.atClient(
+        _atSign, namespace, preference, this,
+        atChops: atChops, enrollmentId: enrollmentId);
 
     final switchAtSignEvent =
         SwitchAtSignEvent(previousAtClient, _currentAtClient!);
     _notifyListeners(switchAtSignEvent);
 
-    var notificationService =
-        await serviceFactory.notificationService(_currentAtClient!, this);
+    var notificationService = await serviceFactory.notificationService(
+        _currentAtClient!, this,
+        enrollmentId: enrollmentId);
     _currentAtClient!.notificationService = notificationService;
 
     var syncService = await serviceFactory.syncService(
-        _currentAtClient!, this, notificationService);
+        _currentAtClient!, this, notificationService,
+        enrollmentId: enrollmentId);
     _currentAtClient!.syncService = syncService;
 
     _logger.info("setCurrentAtSign complete");
@@ -147,10 +150,12 @@ abstract class AtServiceFactory {
       {AtChops? atChops, String? enrollmentId});
 
   Future<NotificationService> notificationService(
-      AtClient atClient, AtClientManager atClientManager);
+      AtClient atClient, AtClientManager atClientManager,
+      {String? enrollmentId});
 
   Future<SyncService> syncService(AtClient atClient,
-      AtClientManager atClientManager, NotificationService notificationService);
+      AtClientManager atClientManager, NotificationService notificationService,
+      {String? enrollmentId});
 }
 
 class DefaultAtServiceFactory implements AtServiceFactory {
@@ -166,18 +171,19 @@ class DefaultAtServiceFactory implements AtServiceFactory {
 
   @override
   Future<NotificationService> notificationService(
-      AtClient atClient, AtClientManager atClientManager) async {
+      AtClient atClient, AtClientManager atClientManager,
+      {String? enrollmentId}) async {
     return await NotificationServiceImpl.create(atClient,
-        atClientManager: atClientManager);
+        atClientManager: atClientManager, enrollmentId: enrollmentId);
   }
 
   @override
-  Future<SyncService> syncService(
-      AtClient atClient,
-      AtClientManager atClientManager,
-      NotificationService notificationService) async {
+  Future<SyncService> syncService(AtClient atClient,
+      AtClientManager atClientManager, NotificationService notificationService,
+      {String? enrollmentId}) async {
     return await SyncServiceImpl.create(atClient,
         atClientManager: atClientManager,
-        notificationService: notificationService);
+        notificationService: notificationService,
+        enrollmentId: enrollmentId);
   }
 }

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -79,22 +79,19 @@ class AtClientManager {
         'Switching atSigns from ${_currentAtClient?.getCurrentAtSign()} to $atSign');
     _atSign = atSign;
     var previousAtClient = _currentAtClient;
-    _currentAtClient = await serviceFactory.atClient(
-        _atSign, namespace, preference, this,
-        atChops: atChops, enrollmentId: enrollmentId);
-
+    _currentAtClient = await serviceFactory
+        .atClient(_atSign, namespace, preference, this, atChops: atChops);
+    _currentAtClient?.enrollmentId = enrollmentId;
     final switchAtSignEvent =
         SwitchAtSignEvent(previousAtClient, _currentAtClient!);
     _notifyListeners(switchAtSignEvent);
 
-    var notificationService = await serviceFactory.notificationService(
-        _currentAtClient!, this,
-        enrollmentId: enrollmentId);
+    var notificationService =
+        await serviceFactory.notificationService(_currentAtClient!, this);
     _currentAtClient!.notificationService = notificationService;
 
     var syncService = await serviceFactory.syncService(
-        _currentAtClient!, this, notificationService,
-        enrollmentId: enrollmentId);
+        _currentAtClient!, this, notificationService);
     _currentAtClient!.syncService = syncService;
 
     _logger.info("setCurrentAtSign complete");
@@ -147,43 +144,38 @@ class AtClientManager {
 abstract class AtServiceFactory {
   Future<AtClient> atClient(String atSign, String? namespace,
       AtClientPreference preference, AtClientManager atClientManager,
-      {AtChops? atChops, String? enrollmentId});
+      {AtChops? atChops});
 
   Future<NotificationService> notificationService(
-      AtClient atClient, AtClientManager atClientManager,
-      {String? enrollmentId});
+      AtClient atClient, AtClientManager atClientManager);
 
   Future<SyncService> syncService(AtClient atClient,
-      AtClientManager atClientManager, NotificationService notificationService,
-      {String? enrollmentId});
+      AtClientManager atClientManager, NotificationService notificationService);
 }
 
 class DefaultAtServiceFactory implements AtServiceFactory {
   @override
   Future<AtClient> atClient(String atSign, String? namespace,
       AtClientPreference preference, AtClientManager atClientManager,
-      {AtChops? atChops, String? enrollmentId}) async {
+      {AtChops? atChops}) async {
     return await AtClientImpl.create(atSign, namespace, preference,
-        atClientManager: atClientManager,
-        atChops: atChops,
-        enrollmentId: enrollmentId);
+        atClientManager: atClientManager, atChops: atChops);
   }
 
   @override
   Future<NotificationService> notificationService(
-      AtClient atClient, AtClientManager atClientManager,
-      {String? enrollmentId}) async {
+      AtClient atClient, AtClientManager atClientManager) async {
     return await NotificationServiceImpl.create(atClient,
-        atClientManager: atClientManager, enrollmentId: enrollmentId);
+        atClientManager: atClientManager);
   }
 
   @override
-  Future<SyncService> syncService(AtClient atClient,
-      AtClientManager atClientManager, NotificationService notificationService,
-      {String? enrollmentId}) async {
+  Future<SyncService> syncService(
+      AtClient atClient,
+      AtClientManager atClientManager,
+      NotificationService notificationService) async {
     return await SyncServiceImpl.create(atClient,
         atClientManager: atClientManager,
-        notificationService: notificationService,
-        enrollmentId: enrollmentId);
+        notificationService: notificationService);
   }
 }

--- a/packages/at_client/lib/src/manager/monitor.dart
+++ b/packages/at_client/lib/src/manager/monitor.dart
@@ -138,6 +138,7 @@ class Monitor {
     _keepAlive = monitorPreference.keepAlive;
     _lastNotificationTime = monitorPreference.lastNotificationTime;
     _enrollmentId = enrollmentId;
+    _logger.finer('enrollmentId: $_enrollmentId');
     _remoteSecondary = remoteSecondary ??
         RemoteSecondary(atSign, preference,
             atChops: atChops, enrollmentId: enrollmentId);

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -76,25 +76,22 @@ class NotificationServiceImpl
   String get currentAtSign => _atClient.getCurrentAtSign()!;
 
   static Future<NotificationService> create(AtClient atClient,
-      {required AtClientManager atClientManager,
-      Monitor? monitor,
-      String? enrollmentId}) async {
-    final notificationService = NotificationServiceImpl._(
-        atClientManager, atClient,
-        monitor: monitor, enrollmentId: enrollmentId);
+      {required AtClientManager atClientManager, Monitor? monitor}) async {
+    final notificationService =
+        NotificationServiceImpl._(atClientManager, atClient, monitor: monitor);
     // We used to call _init() at this point which would start the monitor, but now we
     // call _init() from the [subscribe] method
     return notificationService;
   }
 
   NotificationServiceImpl._(AtClientManager atClientManager, AtClient atClient,
-      {Monitor? monitor, String? enrollmentId}) {
+      {Monitor? monitor}) {
     _atClientManager = atClientManager;
     _atClient = atClient;
     _logger = AtSignLogger(
         'NotificationServiceImpl (${_atClient.getCurrentAtSign()})');
 
-    _logger.info('enrollmentId: $enrollmentId');
+    _logger.finer('enrollmentId: ${atClient.enrollmentId}');
     _monitor = monitor ??
         Monitor(
             _internalNotificationCallback,
@@ -104,7 +101,7 @@ class NotificationServiceImpl
             MonitorPreference()..keepAlive = true,
             monitorRetry,
             atChops: atClient.atChops,
-            enrollmentId: enrollmentId);
+            enrollmentId: atClient.enrollmentId);
     _atClientManager.listenToAtSignChange(this);
     lastReceivedNotificationAtKey = AtKey.local(
             lastReceivedNotificationKey, _atClient.getCurrentAtSign()!,

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -76,20 +76,25 @@ class NotificationServiceImpl
   String get currentAtSign => _atClient.getCurrentAtSign()!;
 
   static Future<NotificationService> create(AtClient atClient,
-      {required AtClientManager atClientManager, Monitor? monitor}) async {
-    final notificationService =
-        NotificationServiceImpl._(atClientManager, atClient, monitor: monitor);
+      {required AtClientManager atClientManager,
+      Monitor? monitor,
+      String? enrollmentId}) async {
+    final notificationService = NotificationServiceImpl._(
+        atClientManager, atClient,
+        monitor: monitor, enrollmentId: enrollmentId);
     // We used to call _init() at this point which would start the monitor, but now we
     // call _init() from the [subscribe] method
     return notificationService;
   }
 
   NotificationServiceImpl._(AtClientManager atClientManager, AtClient atClient,
-      {Monitor? monitor}) {
+      {Monitor? monitor, String? enrollmentId}) {
     _atClientManager = atClientManager;
     _atClient = atClient;
     _logger = AtSignLogger(
         'NotificationServiceImpl (${_atClient.getCurrentAtSign()})');
+
+    _logger.info('enrollmentId: $enrollmentId');
     _monitor = monitor ??
         Monitor(
             _internalNotificationCallback,
@@ -98,7 +103,8 @@ class NotificationServiceImpl
             _atClient.getPreferences()!,
             MonitorPreference()..keepAlive = true,
             monitorRetry,
-            atChops: atClient.atChops);
+            atChops: atClient.atChops,
+            enrollmentId: enrollmentId);
     _atClientManager.listenToAtSignChange(this);
     lastReceivedNotificationAtKey = AtKey.local(
             lastReceivedNotificationKey, _atClient.getCurrentAtSign()!,

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -69,11 +69,10 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   static Future<SyncService> create(AtClient atClient,
       {required AtClientManager atClientManager,
       required NotificationService notificationService,
-      RemoteSecondary? remoteSecondary,
-      String? enrollmentId}) async {
+      RemoteSecondary? remoteSecondary}) async {
     remoteSecondary ??= RemoteSecondary(
         atClient.getCurrentAtSign()!, atClient.getPreferences()!,
-        atChops: atClient.atChops, enrollmentId: enrollmentId);
+        atChops: atClient.atChops, enrollmentId: atClient.enrollmentId);
     final syncService = SyncServiceImpl._(
         atClientManager, atClient, notificationService, remoteSecondary);
     await syncService.statsServiceListener();

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -69,10 +69,11 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   static Future<SyncService> create(AtClient atClient,
       {required AtClientManager atClientManager,
       required NotificationService notificationService,
-      RemoteSecondary? remoteSecondary}) async {
+      RemoteSecondary? remoteSecondary,
+      String? enrollmentId}) async {
     remoteSecondary ??= RemoteSecondary(
         atClient.getCurrentAtSign()!, atClient.getPreferences()!,
-        atChops: atClient.atChops);
+        atChops: atClient.atChops, enrollmentId: enrollmentId);
     final syncService = SyncServiceImpl._(
         atClientManager, atClient, notificationService, remoteSecondary);
     await syncService.statsServiceListener();

--- a/packages/at_client/test/at_client_impl_test.dart
+++ b/packages/at_client/test/at_client_impl_test.dart
@@ -250,4 +250,16 @@ void main() {
       expect(key.key, 'uppercase'); //key should be converted to lower case
     });
   });
+
+  group('A group of tests related to setting enrollmentId', () {
+    test(
+        'A test to verify enrollmentId is set in atClient after calling setCurrentAtSign',
+        () async {
+      final testEnrollmentId = 'abc123';
+      var atClientManager = await AtClientManager.getInstance()
+          .setCurrentAtSign('@alice', 'wavi', AtClientPreference(),
+              enrollmentId: testEnrollmentId);
+      expect(atClientManager.atClient.enrollmentId, testEnrollmentId);
+    });
+  });
 }

--- a/packages/at_client/test/test_utils/no_op_services.dart
+++ b/packages/at_client/test/test_utils/no_op_services.dart
@@ -2,16 +2,16 @@ import 'package:at_client/at_client.dart';
 
 class ServiceFactoryWithNoOpServices extends DefaultAtServiceFactory {
   @override
-  Future<SyncService> syncService(
-      AtClient atClient,
-      AtClientManager atClientManager,
-      NotificationService notificationService) async {
+  Future<SyncService> syncService(AtClient atClient,
+      AtClientManager atClientManager, NotificationService notificationService,
+      {String? enrollmentId}) async {
     return NoOpSyncService();
   }
 
   @override
   Future<NotificationService> notificationService(
-      AtClient atClient, AtClientManager atClientManager) async {
+      AtClient atClient, AtClientManager atClientManager,
+      {String? enrollmentId}) async {
     return NoOpNotificationService();
   }
 }

--- a/packages/at_client/test/test_utils/no_op_services.dart
+++ b/packages/at_client/test/test_utils/no_op_services.dart
@@ -2,16 +2,16 @@ import 'package:at_client/at_client.dart';
 
 class ServiceFactoryWithNoOpServices extends DefaultAtServiceFactory {
   @override
-  Future<SyncService> syncService(AtClient atClient,
-      AtClientManager atClientManager, NotificationService notificationService,
-      {String? enrollmentId}) async {
+  Future<SyncService> syncService(
+      AtClient atClient,
+      AtClientManager atClientManager,
+      NotificationService notificationService) async {
     return NoOpSyncService();
   }
 
   @override
   Future<NotificationService> notificationService(
-      AtClient atClient, AtClientManager atClientManager,
-      {String? enrollmentId}) async {
+      AtClient atClient, AtClientManager atClientManager) async {
     return NoOpNotificationService();
   }
 }


### PR DESCRIPTION
**- What I did**
- Make enrollment available to SyncService/NotificationService for authentication
**- How I did it**
- added a getter/setter for enrollmentId in at_client_spec.dart
- set the enrollmentId in AtClientManager --> setCurrentAtSign method
- pass the atClient.enrollmentId to Monitor constructor in NotificationServiceImpl
-  pass the atClient.enrollmentId to RemoteSecondary constructor in NotificationServiceImpl
**- How to verify it**
- point to this branch of at_client in at_onboarding_cli. functional tests should pass. 
- Run examples in at_onboarding_cli. Check examples/Readme.md
https://github.com/atsign-foundation/at_libraries/pull/399
