### PR TITLE
fix: Failing functional tests in at_client_sdk

### DIFF
--- a/tests/at_functional_test/test/atclient_sync_callback_test.dart
+++ b/tests/at_functional_test/test/atclient_sync_callback_test.dart
@@ -156,7 +156,7 @@ void main() {
         syncProgress.keyInfoList?.forEach((keyInfo) {
           if (keyInfo.key.contains('fb_username-$uniqueId')) {
             expect(keyInfo.syncDirection, SyncDirection.remoteToLocal);
-            expect(keyInfo.commitOp, CommitOp.UPDATE);
+            expect(keyInfo.commitOp, CommitOp.UPDATE_ALL);
           }
         });
       }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fix test failure in atclient_sync_callback_test.dart

- The failure is because of an incorrect Commit Operation from the secondary server. Specifically, CommitOp.Update_All is received instead of CommitOp.Update. The issue stems from the fact that in at_commons-4.0.0, the boolean fields of AtMetadata have been set to false by default, rather than NULL. Consequently, the metadata is always non-null, leading to the occurrence of CommitOp.Update_All. However, this does not impact functionality, as there is no distinction made in the sync response between CommitOp.Update and CommitOp.UpdateAll.

**- How I did it**
- Modify the assertion to "CommitOp.UPDATE_ALL"

**- How to verify it**
- All tests should pass
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
