### PR TITLE
chore: deal with a breaking change in dart 3.2.0

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.0.72
+- chore: Minor change to allow us to support dart 
+  versions both before and after 3.2.0 specifically for this
+  [Dart breaking change](https://github.com/dart-lang/sdk/issues/52801) 
+  which was
+  [introduced](https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md)
+  in dart 3.2.0
 ## 3.0.71
 - feat: Replace decryption methods from EncryptionUtil with AtChops methods
 ## 3.0.70

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.71';
+  final String atClientVersion = '3.0.72';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/util/at_client_util.dart
+++ b/packages/at_client/lib/src/util/at_client_util.dart
@@ -35,7 +35,7 @@ class AtClientUtil {
     var key = RSAPrivateKey.fromString(privateKey);
     challenge = challenge.trim();
     var signature =
-    // ignore: unnecessary_cast
+        // ignore: unnecessary_cast
         key.createSHA256Signature(utf8.encode(challenge) as Uint8List);
     return base64Encode(signature);
   }

--- a/packages/at_client/lib/src/util/at_client_util.dart
+++ b/packages/at_client/lib/src/util/at_client_util.dart
@@ -34,8 +34,8 @@ class AtClientUtil {
   static String signChallenge(String challenge, String privateKey) {
     var key = RSAPrivateKey.fromString(privateKey);
     challenge = challenge.trim();
-    // ignore: unnecessary_cast
     var signature =
+    // ignore: unnecessary_cast
         key.createSHA256Signature(utf8.encode(challenge) as Uint8List);
     return base64Encode(signature);
   }

--- a/packages/at_client/lib/src/util/at_client_util.dart
+++ b/packages/at_client/lib/src/util/at_client_util.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/converters/encoder/at_encoder.dart';
@@ -33,7 +34,8 @@ class AtClientUtil {
   static String signChallenge(String challenge, String privateKey) {
     var key = RSAPrivateKey.fromString(privateKey);
     challenge = challenge.trim();
-    var signature = key.createSHA256Signature(utf8.encode(challenge));
+    // ignore: unnecessary_cast
+    var signature = key.createSHA256Signature(utf8.encode(challenge) as Uint8List);
     return base64Encode(signature);
   }
 

--- a/packages/at_client/lib/src/util/at_client_util.dart
+++ b/packages/at_client/lib/src/util/at_client_util.dart
@@ -35,7 +35,8 @@ class AtClientUtil {
     var key = RSAPrivateKey.fromString(privateKey);
     challenge = challenge.trim();
     // ignore: unnecessary_cast
-    var signature = key.createSHA256Signature(utf8.encode(challenge) as Uint8List);
+    var signature =
+        key.createSHA256Signature(utf8.encode(challenge) as Uint8List);
     return base64Encode(signature);
   }
 

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.71
+version: 3.0.72
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 


### PR DESCRIPTION
chore: In at_client_util.dart, re-add explicit cast of result from utf8.encode and tell the linter to ignore the unnecessary cast. This is to allow us to support dart versions both before and after 3.2.0, specifically for this breaking change https://github.com/dart-lang/sdk/issues/52801 which was introduced in dart 3.2.0 - see https://github.com/dart-lang/sdk/blob/main/CHANGELOG.md