### PR TITLE
feat: add new method to fetch enrollment requests

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.75
+- feat: Replace encryption methods from EncryptionUtils with AtChops method
 ## 3.0.74
 - build[deps]: Upgraded dependencies for the following packages:
   - at_chops to v2.0.0
@@ -9,7 +11,7 @@
     - at_lookup to v3.0.44
     - at_chops to v1.0.7
     - at_persistence_secondary_server to v3.0.60
-- feat: Replace encryption methods from EncryptionUtils with AtChops method
+- feat: Introduce feature to fetch all enrollment requests from the server
 ## 3.0.72
 - chore: Minor change to allow us to support dart 
   versions both before and after 3.2.0 specifically for this

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.0.75
 - feat: Replace encryption methods from EncryptionUtils with AtChops method
+- feat: Introduce feature to fetch enrollment requests from the server
 ## 3.0.74
 - build[deps]: Upgraded dependencies for the following packages:
   - at_chops to v2.0.0
@@ -11,7 +12,6 @@
     - at_lookup to v3.0.44
     - at_chops to v1.0.7
     - at_persistence_secondary_server to v3.0.60
-- feat: Introduce feature to fetch all enrollment requests from the server
 ## 3.0.72
 - chore: Minor change to allow us to support dart 
   versions both before and after 3.2.0 specifically for this

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,5 +1,4 @@
 ## 3.0.75
-- feat: Replace encryption methods from EncryptionUtils with AtChops method
 - feat: Introduce feature to fetch enrollment requests from the server
 ## 3.0.74
 - build[deps]: Upgraded dependencies for the following packages:
@@ -12,6 +11,7 @@
     - at_lookup to v3.0.44
     - at_chops to v1.0.7
     - at_persistence_secondary_server to v3.0.60
+- feat: Replace encryption methods from EncryptionUtils with AtChops method 
 ## 3.0.72
 - chore: Minor change to allow us to support dart 
   versions both before and after 3.2.0 specifically for this

--- a/packages/at_client/lib/at_client.dart
+++ b/packages/at_client/lib/at_client.dart
@@ -12,6 +12,8 @@ export 'package:at_client/src/preference/at_client_preference.dart';
 export 'package:at_client/src/response/at_notification.dart';
 export 'package:at_client/src/util/at_client_util.dart';
 export 'package:at_client/src/util/encryption_util.dart';
+export 'package:at_client/src/util/enrollment_request.dart';
+export 'package:at_client/src/util/enroll_list_request_param.dart';
 export 'package:at_client/src/service/notification_service.dart';
 export 'package:at_client/src/service/sync_service.dart';
 export 'package:at_client/src/service/sync/sync_result.dart';

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -650,6 +650,36 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   }
 
   @override
+  Future<List<EnrollmentRequest>> fetchEnrollmentRequests(
+      EnrollListRequestParam enrollmentListRequestParams) async {
+    // enrollmentListRequestParams for now is not  used
+    // A server side enhancement request is created. https://github.com/atsign-foundation/at_server/issues/1748
+    // On implementation of this enhancement/feature, the enrollListRequestParam object can be made use of
+    EnrollVerbBuilder enrollBuilder = EnrollVerbBuilder()
+      ..operation = EnrollOperationEnum.list
+      ..appName = enrollmentListRequestParams.appName
+      ..deviceName = enrollmentListRequestParams.deviceName;
+
+    var response = await getRemoteSecondary()
+        ?.executeCommand(enrollBuilder.buildCommand(), auth: true);
+
+    return _formatEnrollListResponse(response);
+  }
+
+  List<EnrollmentRequest> _formatEnrollListResponse(response) {
+    response = response?.replaceFirst('data:', '');
+    Map<String, dynamic> enrollRequests = jsonDecode(response!);
+    List<EnrollmentRequest> enrollRequestsFormatted = [];
+    EnrollmentRequest? enrollment;
+    for (var request in enrollRequests.entries) {
+      enrollment = EnrollmentRequest.fromJson(request.value);
+      enrollment.enrollmentKey = request.key;
+      enrollRequestsFormatted.add(enrollment);
+    }
+    return enrollRequestsFormatted;
+  }
+
+  @override
   Future<AtStreamResponse> stream(String sharedWith, String filePath,
       {String? namespace}) async {
     var streamResponse = AtStreamResponse();

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:at_client/at_client.dart';
 import 'package:at_client/src/client/local_secondary.dart';
 import 'package:at_client/src/client/remote_secondary.dart';
 import 'package:at_client/src/manager/sync_manager.dart';
@@ -572,4 +573,18 @@ abstract class AtClient {
   String? getCurrentAtSign();
 
   EncryptionService? get encryptionService;
+
+  /// Fetches all enrollment requests from the corresponding atServer; Formats the requests into a
+  /// List<[EnrollmentResponse]>
+  ///
+  /// Responses can be filtered using params provided through [EnrollListRequestParam]
+  /// ```
+  /// e.g.
+  /// List<EnrollmentRequest> enrollmentRequests = fetchEnrollmentRequests(EnrollRequestParams());
+  /// enrollmentRequests now contains all the enrollment requests fetched from the server in the for of
+  /// EnrollmentRequest objects
+  /// ```
+  @experimental
+  Future<List<EnrollmentRequest>> fetchEnrollmentRequests(
+      EnrollListRequestParam enrollmentListRequest);
 }

--- a/packages/at_client/lib/src/client/remote_secondary.dart
+++ b/packages/at_client/lib/src/client/remote_secondary.dart
@@ -33,10 +33,10 @@ class RemoteSecondary implements Secondary {
     logger = AtSignLogger('RemoteSecondary ($_atSign)');
     _preference = preference;
     privateKey ??= preference.privateKey;
-    SecureSocketConfig secureSocketConfig = SecureSocketConfig();
-    secureSocketConfig.decryptPackets = preference.decryptPackets;
-    secureSocketConfig.pathToCerts = preference.pathToCerts;
-    secureSocketConfig.tlsKeysSavePath = preference.tlsKeysSavePath;
+    SecureSocketConfig secureSocketConfig = SecureSocketConfig()
+      ..decryptPackets = preference.decryptPackets
+      ..pathToCerts = preference.pathToCerts
+      ..tlsKeysSavePath = preference.tlsKeysSavePath;
     atLookUp = AtLookupImpl(atSign, preference.rootDomain, preference.rootPort,
         privateKey: privateKey,
         cramSecret: preference.cramSecret,
@@ -107,14 +107,8 @@ class RemoteSecondary implements Secondary {
     // ignore: prefer_typing_uninitialized_variables
     var verbResult;
     try {
-      logger.finer(logger.getLogMessageWithClientParticulars(
-          _preference.atClientParticulars,
-          'Command sent to server: ${builder.buildCommand()}'));
       verbResult = await executeVerb(builder);
       verbResult = verbResult.replaceFirst('data:', '');
-      logger.finer(logger.getLogMessageWithClientParticulars(
-          _preference.atClientParticulars,
-          'Response from server: $verbResult'));
     } on AtException catch (e) {
       throw e
         ..stack(AtChainedException(Intent.fetchData,

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.74';
+  final String atClientVersion = '3.0.75';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/util/enroll_list_request_param.dart
+++ b/packages/at_client/lib/src/util/enroll_list_request_param.dart
@@ -1,0 +1,6 @@
+/// class to store request parameters while fetching a list of enrollments
+class EnrollListRequestParam {
+  String? appName;
+  String? deviceName;
+  String? namespace;
+}

--- a/packages/at_client/lib/src/util/enrollment_request.dart
+++ b/packages/at_client/lib/src/util/enrollment_request.dart
@@ -1,0 +1,40 @@
+import 'dart:collection';
+import 'dart:convert';
+
+class EnrollmentRequest {
+  late String enrollmentKey;
+  late String appName;
+  late String deviceName;
+  late Map<String, dynamic> namespace;
+
+  String get enrollmentId {
+    return extractEnrollmentId(enrollmentKey);
+  }
+
+  @override
+  String toString() {
+    return 'Enrollment Request: enrollmentKey: $enrollmentKey | appName: $appName | deviceName: $deviceName | namespace: ${namespace.toString()}';
+  }
+
+  Map<String, dynamic> toJson() {
+    Map<String, dynamic> jsonMap = HashMap();
+    jsonMap['enrollmentKey'] = enrollmentKey;
+    jsonMap['appName'] = appName;
+    jsonMap['deviceName'] = deviceName;
+    jsonMap['namespace'] = jsonEncode(namespace);
+
+    return jsonMap;
+  }
+
+  static EnrollmentRequest fromJson(Map<String, dynamic> json) {
+    EnrollmentRequest enrollmentRequest = EnrollmentRequest();
+    return enrollmentRequest
+      ..appName = json['appName']
+      ..deviceName = json['deviceName']
+      ..namespace = json['namespace'];
+  }
+
+  static String extractEnrollmentId(String enrollmentKey) {
+    return enrollmentKey.split('.')[0];
+  }
+}

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.74
+version: 3.0.75
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/test/at_client_impl_test.dart
+++ b/packages/at_client/test/at_client_impl_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/compaction/at_commit_log_compaction.dart';
 import 'package:at_client/src/service/notification_service_impl.dart';
@@ -19,6 +21,8 @@ class MockAtCompactionJob extends Mock implements AtCompactionJob {
     isCronScheduled = false;
   }
 }
+
+class MockRemoteSecondary extends Mock implements RemoteSecondary {}
 
 void main() {
   group('A group of at client impl create tests', () {
@@ -251,7 +255,7 @@ void main() {
     });
   });
 
-  group('A group of tests related to setting enrollmentId', () {
+  group('A group of tests related to apkam/enrollments', () {
     test(
         'A test to verify enrollmentId is set in atClient after calling setCurrentAtSign',
         () async {
@@ -260,6 +264,64 @@ void main() {
           .setCurrentAtSign('@alice', 'wavi', AtClientPreference(),
               enrollmentId: testEnrollmentId);
       expect(atClientManager.atClient.enrollmentId, testEnrollmentId);
+    });
+
+    MockRemoteSecondary mockRemoteSecondary = MockRemoteSecondary();
+
+    test('verify behaviour of fetchEnrollmentRequests()', () async {
+      String currentAtsign = '@apkam';
+      String enrollKey1 =
+          '0acdeb4d-1a2e-43e4-93bd-378f1d366ea7.new.enrollments.__manage$currentAtsign';
+      String enrollValue1 =
+          '{"appName":"buzz","deviceName":"pixel","namespace":{"buzz":"rw"}}';
+      String enrollKey2 =
+          '9beefa26-3384-4f10-81a6-0deaa4332669.new.enrollments.__manage$currentAtsign';
+      String enrollValue2 =
+          '{"appName":"buzz","deviceName":"pixel","namespace":{"buzz":"rw"}}';
+      String enrollKey3 =
+          'a6bbef17-c7bf-46f4-a172-1ed7b3b443bc.new.enrollments.__manage$currentAtsign';
+      String enrollValue3 =
+          '{"appName":"buzz","deviceName":"pixel","namespace":{"buzz":"rw"}}';
+      when(() =>
+          mockRemoteSecondary.executeCommand('enroll:list\n',
+              auth: true)).thenAnswer((_) => Future.value('data:{"$enrollKey1":'
+          '$enrollValue1,"$enrollKey2":$enrollValue2,"$enrollKey3":$enrollValue3}'));
+
+      AtClient? client = await AtClientImpl.create(
+          currentAtsign, 'buzz', AtClientPreference(),
+          remoteSecondary: mockRemoteSecondary);
+      AtClientImpl? clientImpl = client as AtClientImpl;
+
+      List<EnrollmentRequest> requests =
+          await clientImpl.fetchEnrollmentRequests(EnrollListRequestParam());
+      expect(requests.length, 3);
+      expect(requests[0].enrollmentKey, enrollKey1);
+      expect(requests[0].appName, jsonDecode(enrollValue1)['appName']);
+      expect(requests[0].deviceName, jsonDecode(enrollValue1)['deviceName']);
+      expect(requests[0].namespace, jsonDecode(enrollValue1)['namespace']);
+      // the following statement asserts that the enrollment.enrollmentId getter fetches the correct enrollment id
+      expect(requests[0].enrollmentKey.contains(enrollKey1), true);
+
+      expect(requests[1].enrollmentKey, enrollKey2);
+      expect(requests[1].appName, jsonDecode(enrollValue2)['appName']);
+      expect(requests[1].deviceName, jsonDecode(enrollValue2)['deviceName']);
+      expect(requests[1].namespace, jsonDecode(enrollValue2)['namespace']);
+      expect(requests[1].enrollmentKey.contains(enrollKey2), true);
+
+      expect(requests[2].enrollmentKey, enrollKey3);
+      expect(requests[2].appName, jsonDecode(enrollValue3)['appName']);
+      expect(requests[2].deviceName, jsonDecode(enrollValue3)['deviceName']);
+      expect(requests[2].namespace, jsonDecode(enrollValue3)['namespace']);
+      expect(requests[2].enrollmentKey.contains(enrollKey3), true);
+    });
+
+    test('validate EnrollRequest.extractEnrollmentId()', () {
+      String enrollmentKey =
+          '0acdeb4d-1a2e-43e4-93bd-378f1d366ea7.new.enrollments.__manage@random';
+      String enrollmentId = '0acdeb4d-1a2e-43e4-93bd-378f1d366ea7';
+
+      expect(
+          EnrollmentRequest.extractEnrollmentId(enrollmentKey), enrollmentId);
     });
   });
 }

--- a/tests/at_functional_test/test/test_utils.dart
+++ b/tests/at_functional_test/test/test_utils.dart
@@ -8,6 +8,7 @@ import 'package:at_client/at_client.dart';
 import 'package:at_functional_test/src/at_demo_credentials.dart'
     as demo_credentials;
 
+
 class TestUtils {
   static AtClientPreference getPreference(String atsign) {
     var preference = AtClientPreference();
@@ -51,5 +52,17 @@ class TestUtils {
     await encryptionKeysLoader.setEncryptionKeys(
         atClientManager.atClient, currentAtSign);
     return atClientManager;
+  }
+
+  static String formatCommand(String command){
+    if(!command.contains('\n')) return '$command\n';
+    return command;
+  }
+
+  static Future<String?> executeCommandAndParse(AtClient? client, command, {bool auth = false, RemoteSecondary? remoteSecondary}) async {
+    remoteSecondary ??= client?.getRemoteSecondary();
+    String? response = await remoteSecondary?.executeCommand(formatCommand(command), auth: auth);
+    print('Command: $command -> Response: $response');
+    return response?.replaceFirst('data:', '');
   }
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes https://github.com/atsign-foundation/at_client_sdk/issues/1198

**- What I did**
- feat: add new method fetchEnrollmentRequests() to AtClientImpl
- test: add unit test
- refactor: minor refactoring in RemoteSecondary -> (1) simplify the notation of creating a SecureSocketConfig instance (2) removed logs in RemoteSecondary.executeAndParse() which are a duplicate of the logs in executeVerb()

**- How I did it**
- fetch enroll requests: do an enroll:list on the remoteSecondary and handle the information from the server and return it as a Map<String, dynamic>

**- How to verify it**
- added unit test should verify the functioning of the method

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: add new method to fetch enrollment requests