### PR TITLE
ci: Don't fail fast on functional test matrix

### DIFF
--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -109,6 +109,7 @@ jobs:
   functional_tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         dart-channel: [stable,beta]
     steps:


### PR DESCRIPTION
We don't want to rerun tests in both stable and beta due to a failure in one channel

**- What I did**

Added `fail-fast: false` to strategy

**- How to verify it**

Single failures will be tolerated

**- Description for the changelog**

ci: Don't fail fast on functional test matrix
