### PR TITLE
fix: Fix intermittent failing compaction job test in functional test

### DIFF
--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -213,7 +213,10 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
   @override
   Future<void> startCompactionJob(
-      {int commitLogCompactionTimeIntervalInMins = 11}) async {
+      {Duration? commitLogCompactionDuration}) async {
+    commitLogCompactionDuration ??= Duration(
+        minutes:
+            AtClientConfig.getInstance().commitLogCompactionTimeIntervalInMins);
     AtCompactionJob atCompactionJob = AtCompactionJob(
         (await AtCommitLogManagerImpl.getInstance().getCommitLog(_atSign))!,
         SecondaryPersistenceStoreFactory.getInstance()
@@ -226,7 +229,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
     if (!_atClientCommitLogCompaction!.isCompactionJobRunning()) {
       _atClientCommitLogCompaction!
-          .scheduleCompaction(commitLogCompactionTimeIntervalInMins);
+          .scheduleCompaction(commitLogCompactionDuration!.inMinutes);
     }
   }
 

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -229,7 +229,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
     if (!_atClientCommitLogCompaction!.isCompactionJobRunning()) {
       _atClientCommitLogCompaction!
-          .scheduleCompaction(commitLogCompactionDuration!.inMinutes);
+          .scheduleCompaction(commitLogCompactionDuration.inMinutes);
     }
   }
 

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -151,7 +151,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       await atClientImpl._init();
     }
 
-    await atClientImpl!._startCompactionJob();
+    await atClientImpl!.startCompactionJob();
     atClientManager.listenToAtSignChange(atClientImpl);
 
     atClientInstanceMap[currentAtSign] = atClientImpl;
@@ -211,7 +211,9 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     _cascadeSetTelemetryService();
   }
 
-  Future<void> _startCompactionJob() async {
+  @override
+  Future<void> startCompactionJob(
+      {int commitLogCompactionTimeIntervalInMins = 11}) async {
     AtCompactionJob atCompactionJob = AtCompactionJob(
         (await AtCommitLogManagerImpl.getInstance().getCommitLog(_atSign))!,
         SecondaryPersistenceStoreFactory.getInstance()
@@ -223,9 +225,15 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     _atClientConfig ??= AtClientConfig.getInstance();
 
     if (!_atClientCommitLogCompaction!.isCompactionJobRunning()) {
-      _atClientCommitLogCompaction!.scheduleCompaction(
-          _atClientConfig!.commitLogCompactionTimeIntervalInMins);
+      _atClientCommitLogCompaction!
+          .scheduleCompaction(commitLogCompactionTimeIntervalInMins);
     }
+  }
+
+  @override
+  Future<void> stopCompactionJob() async {
+    _logger.info('Stopping the commit log compaction job');
+    await _atClientCommitLogCompaction?.stopCompactionJob();
   }
 
   /// Does nothing unless a telemetry service has been injected

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -567,6 +567,21 @@ abstract class AtClient {
   ///
   Future<AtResponse> getOTP();
 
+  /// Initiates a compaction job for the commit log.
+  ///
+  /// The [commitLogCompactionTimeIntervalInMins] parameter specifies the time interval,
+  /// in minutes, after which the commit log should be compacted. By default, it is set
+  /// to 11 minutes.
+  ///
+  /// The compaction job removes duplicate entries of a key from the commit log that are already synced
+  /// to the remote secondary. Only the latest commit entry of the key is retained.
+  /// Uncommitted entries that are duplicates will not be removed/compacted.
+  Future<void> startCompactionJob(
+      {int commitLogCompactionTimeIntervalInMins = 11});
+
+  /// Stops the commit log compaction job
+  Future<void> stopCompactionJob();
+
   /// Uploads list of [files] to filebin and shares the file download url with [sharedWithAtSigns]
   /// returns map containing key of each sharedWithAtSign and value of [FileTransferObject]
   @Deprecated(

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -1,18 +1,11 @@
 import 'dart:io';
 
 import 'package:at_client/at_client.dart';
-import 'package:at_client/src/client/local_secondary.dart';
-import 'package:at_client/src/client/remote_secondary.dart';
 import 'package:at_client/src/manager/sync_manager.dart';
-import 'package:at_client/src/client/request_options.dart';
-import 'package:at_client/src/preference/at_client_preference.dart';
 import 'package:at_client/src/response/response.dart';
 import 'package:at_client/src/service/encryption_service.dart';
-import 'package:at_client/src/service/notification_service.dart';
-import 'package:at_client/src/service/sync_service.dart';
 import 'package:at_client/src/stream/at_stream_response.dart';
 import 'package:at_client/src/stream/file_transfer_object.dart';
-import 'package:at_commons/at_commons.dart';
 import 'package:at_chops/at_chops.dart';
 import 'package:meta/meta.dart';
 

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -576,8 +576,7 @@ abstract class AtClient {
   /// The compaction job removes duplicate entries of a key from the commit log that are already synced
   /// to the remote secondary. Only the latest commit entry of the key is retained.
   /// Uncommitted entries that are duplicates will not be removed/compacted.
-  Future<void> startCompactionJob(
-      {int commitLogCompactionTimeIntervalInMins = 11});
+  Future<void> startCompactionJob({Duration? commitLogCompactionDuration});
 
   /// Stops the commit log compaction job
   Future<void> stopCompactionJob();

--- a/tests/at_functional_test/test/commit_log_compaction_test.dart
+++ b/tests/at_functional_test/test/commit_log_compaction_test.dart
@@ -15,6 +15,8 @@ String namespace = 'wavi';
 Future<void> setUpMethod() async {
   currentAtSign = ConfigUtil.getYaml()['atSign']['firstAtSign'];
   atClientManager = await TestUtils.initAtClient(currentAtSign, namespace);
+  // Stopping the compaction job to prevent the compaction running in background.
+  await atClientManager.atClient.stopCompactionJob();
 }
 
 void main() {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fixes https://github.com/atsign-foundation/at_client_sdk/issues/1207
- The primary reason for the problem lies in the background compaction job, which is disrupting the compaction job initiated by the test, leading to discrepancies in the test results.
- The solution to resolve the issue is to stop the background compaction job while executing tests associated with the compaction job.

**- How I did it**
- Introduce `startCompactionJob` and `stopCompactionJob` in AtClientSpec.
- The atClientImpl contains the method implementation to start the compaction job in private. Marked the method as public method.
- Implemented the `stopCompactionJob` method.
- Updated the functional test to stop background compaction job when executing the compaction functional test.

**- How to verify it**
- The functional tests should pass

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
