### PR TITLE
feat: consume changes reg filtering of enrollment requests through enroll:list

### DIFF
--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -665,15 +665,15 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
   @override
   Future<List<EnrollmentRequest>> fetchEnrollmentRequests(
-      EnrollListRequestParam enrollmentListRequestParams) async {
-    // enrollmentListRequestParams for now is not  used
-    // A server side enhancement request is created. https://github.com/atsign-foundation/at_server/issues/1748
-    // On implementation of this enhancement/feature, the enrollListRequestParam object can be made use of
+      EnrollListRequestParam enrollListRequestParams) async {
     EnrollVerbBuilder enrollBuilder = EnrollVerbBuilder()
       ..operation = EnrollOperationEnum.list
-      ..appName = enrollmentListRequestParams.appName
-      ..deviceName = enrollmentListRequestParams.deviceName;
-
+      ..appName = enrollListRequestParams.appName
+      ..deviceName = enrollListRequestParams.deviceName;
+    if (enrollListRequestParams.enrollmentListFilter != null) {
+      enrollBuilder.enrollmentStatusFilter =
+          enrollListRequestParams.enrollmentListFilter!;
+    }
     var response = await getRemoteSecondary()
         ?.executeCommand(enrollBuilder.buildCommand(), auth: true);
 

--- a/packages/at_client/lib/src/util/enroll_list_request_param.dart
+++ b/packages/at_client/lib/src/util/enroll_list_request_param.dart
@@ -1,6 +1,9 @@
+import 'package:at_client/at_client.dart';
+
 /// class to store request parameters while fetching a list of enrollments
 class EnrollListRequestParam {
   String? appName;
   String? deviceName;
   String? namespace;
+  List<EnrollmentStatus>? enrollmentListFilter;
 }

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -40,6 +40,13 @@ dependencies:
   meta: ^1.8.0
   version: ^3.0.2
 
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_commons
+      ref: enroll_list_filter
+
 dev_dependencies:
   lints: ^2.1.1
   test: ^1.21.4

--- a/packages/at_client/test/at_client_impl_test.dart
+++ b/packages/at_client/test/at_client_impl_test.dart
@@ -5,6 +5,7 @@ import 'package:at_client/src/compaction/at_commit_log_compaction.dart';
 import 'package:at_client/src/response/response.dart';
 import 'package:at_client/src/service/notification_service_impl.dart';
 import 'package:at_client/src/service/sync_service_impl.dart';
+import 'package:at_commons/at_builders.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
@@ -283,8 +284,11 @@ void main() {
           'a6bbef17-c7bf-46f4-a172-1ed7b3b443bc.new.enrollments.__manage$currentAtsign';
       String enrollValue3 =
           '{"appName":"buzz","deviceName":"pixel","namespace":{"buzz":"rw"}}';
+      String enrollListCommand = (EnrollVerbBuilder()
+            ..operation = EnrollOperationEnum.list)
+          .buildCommand();
       when(() =>
-          mockRemoteSecondary.executeCommand('enroll:list\n',
+          mockRemoteSecondary.executeCommand(enrollListCommand,
               auth: true)).thenAnswer((_) => Future.value('data:{"$enrollKey1":'
           '$enrollValue1,"$enrollKey2":$enrollValue2,"$enrollKey3":$enrollValue3}'));
 

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -13,6 +13,13 @@ dependencies:
   at_client:
     path: ../../packages/at_client
 
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_commons
+      ref: enroll_list_filter
+
 dev_dependencies:
   test: ^1.24.3
   lints: ^2.0.0

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -1,3 +1,4 @@
+
 name: at_functional_test
 publish_to: none
 description: Functional tests for the at_client_sdk packages
@@ -9,9 +10,15 @@ environment:
 dependencies:
   uuid: 3.0.7
   at_demo_data: ^1.0.3
-
   at_client:
     path: ../../packages/at_client
+
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_commons
+      ref: enroll_list_filter
 
 dev_dependencies:
   test: ^1.24.3


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- introduce new param 'enrollmentStatusFilter' in EnrollListRequestParam class
- use the above param in AtClientImpl.fetchEnrollmentRequests() to build the command that lists only enrollment requests that match the filter.

**- How I did it**
- EnrollListRequestParam.enrollmentStatusFilter will be used by users to pass the desired enrollment statuses they wish to list.
- AtClientImpl.fetchEnrollmentRequests() will use this filter to construct a relevant command which will be passed to the server.

**- How to verify it**
- unit test added, that verifies that appropriate command is generated using the EnrollVerbBuilder and the parsing of response from server.
- Yet to evaluate if a functional test is needed to validate the change

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: consume changes reg filtering of enrollment requests through enroll:list