### PR TITLE
fix: temporarily skipping collection_test

### DIFF
--- a/tests/at_end2end_test/test/collection_test.dart
+++ b/tests/at_end2end_test/test/collection_test.dart
@@ -1,3 +1,4 @@
+@Skip('Skipping this test until https://github.com/atsign-foundation/at_client_sdk/issues/1267 is fixed')
 import 'dart:convert';
 
 import 'package:at_client/at_client.dart';


### PR DESCRIPTION
**- What I did**
- Temporarily commenting collection_test, since collection is not used in any of our prod apps.
**- How I did it**
- add skip to collection test
**- How to verify it**
n/a
---------
Analysis to be continued in issue
https://github.com/atsign-foundation/at_client_sdk/issues/1267

