### PR TITLE
fix: Add random string to Model operations - unshare() and delete() test

### DIFF
--- a/tests/at_end2end_test/test/collection_test.dart
+++ b/tests/at_end2end_test/test/collection_test.dart
@@ -1,4 +1,3 @@
-@Skip('Skipping this test until https://github.com/atsign-foundation/at_client_sdk/issues/1267 is fixed')
 import 'dart:convert';
 
 import 'package:at_client/at_client.dart';
@@ -10,6 +9,7 @@ import 'package:at_end2end_test/src/sync_initializer.dart';
 import 'package:at_end2end_test/src/test_initializers.dart';
 import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
 
 class PreferenceFactory extends AtCollectionModelFactory<Preference> {
   static final PreferenceFactory _singleton = PreferenceFactory._internal();
@@ -339,6 +339,7 @@ void main() async {
   });
 
   test('Model operations - unshare() and delete() test', () async {
+    String random = Uuid().v4().hashCode.toString();
     // Setting firstAtSign atClient instance to context.
     currentAtClientManager =
         await AtClientManager.getInstance().setCurrentAtSign(
@@ -348,7 +349,7 @@ void main() async {
     );
 
     var fourthPhone = Phone()
-      ..id = 'personal phone'
+      ..id = 'personal phone $random'
       ..namespace = 'buzz'
       ..collectionName = 'phone'
       ..phoneNumber = '4444';


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

Fixes https://github.com/atsign-foundation/at_client_sdk/issues/1267

**- What I did**
- Fix the test - "Model operations - unshare() and delete() test". 
   - The root cause failure is because there are two keys matching the regex, but the test expects only one key.
   - The following expects only one shared key which is sharedWith ce2e2 - `expect(await fourthPhone.sharedWith(), ['@ce2e2']);` ; but the "getKeys" returns two shared keys (please refer to the screenshot attached) and the test fails with the below error.
     `Expected: ['@ce2e2'] Actual: ['@ce2e2', '@ce2e2'] Which: at location [1] is ['@ce2e2', '@ce2e2'] which longer than expected`

    - The keys "ce2e2:123-personal-phone.phone.atcollectionmodel.buzz.wavi@ce2e1" and "ce2e2:personal-phone.phone.atcollectionmodel.buzz.wavi@ce2e1" are two shared keys returned.
![Screenshot from 2024-03-28 07-38-10](https://github.com/atsign-foundation/at_client_sdk/assets/16645698/e8f34e5a-2e83-4940-abaf-f4dfc0e67dab)

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
