### PR TITLE
fix: Max key length check

### DIFF
--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -31,22 +31,17 @@ dependencies:
   async: ^2.9.0
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
-  at_commons: ^4.0.1
+  at_commons: ^4.0.5
   at_utils: ^3.0.16
   at_chops: ^2.0.0
   at_lookup: ^3.0.46
   at_persistence_spec: ^2.0.14
-  at_persistence_secondary_server: ^3.0.61
+  at_persistence_secondary_server: ^3.0.62
   meta: ^1.8.0
   version: ^3.0.2
 
 #TODO replace with published version
 dependency_overrides:
-  at_persistence_secondary_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server
-      path: packages/at_persistence_secondary_server
-      ref: trunk
   at_commons:
     git:
       url: https://github.com/atsign-foundation/at_libraries

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   async: ^2.9.0
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
-  at_commons: ^4.0.5
+  at_commons: ^4.0.6
   at_utils: ^3.0.16
   at_chops: ^2.0.0
   at_lookup: ^3.0.46
@@ -39,14 +39,6 @@ dependencies:
   at_persistence_secondary_server: ^3.0.62
   meta: ^1.8.0
   version: ^3.0.2
-
-#TODO replace with published version
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      path: packages/at_commons
-      ref: keylength_validation_changes
 
 dev_dependencies:
   lints: ^2.1.1

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -40,6 +40,19 @@ dependencies:
   meta: ^1.8.0
   version: ^3.0.2
 
+#TODO replace with published version
+dependency_overrides:
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server
+      path: packages/at_persistence_secondary_server
+      ref: trunk
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_commons
+      ref: keylength_validation_changes
+
 dev_dependencies:
   lints: ^2.1.1
   test: ^1.21.4

--- a/packages/at_client/test/at_client_impl_test.dart
+++ b/packages/at_client/test/at_client_impl_test.dart
@@ -9,6 +9,8 @@ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
+import 'test_utils/test_utils.dart';
+
 class MockAtCompactionJob extends Mock implements AtCompactionJob {
   bool isCronScheduled = false;
 
@@ -368,6 +370,23 @@ void main() {
     });
     tearDown(() async {
       AtClientImpl.atClientInstanceMap.remove(atSign);
+    });
+  });
+  group('A group of test to validate max length of a key', () {
+    MockRemoteSecondary mockRemoteSecondary = MockRemoteSecondary();
+    test('test max length for put method', () async {
+      AtClient? client = await AtClientImpl.create(
+          '@alice', 'buzz', AtClientPreference(),
+          remoteSecondary: mockRemoteSecondary);
+      var key = TestUtils.createRandomString(250);
+      var atKey = AtKey.fromString('$key@alice');
+
+      expect(
+          () async => await client.put(atKey, 'hello'),
+          throwsA(predicate((dynamic e) =>
+              e is AtClientException &&
+              e.message ==
+                  'Key length exceeds maximum permissible length of 248 characters')));
     });
   });
 }

--- a/packages/at_client/test/test_utils/test_utils.dart
+++ b/packages/at_client/test/test_utils/test_utils.dart
@@ -1,0 +1,10 @@
+import 'dart:math';
+
+class TestUtils {
+  static String createRandomString(int length) {
+    final String characters =
+        '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_';
+    return String.fromCharCodes(Iterable.generate(length,
+        (index) => characters.codeUnitAt(Random().nextInt(characters.length))));
+  }
+}


### PR DESCRIPTION
**- What I did**
- added tests of max length check
- uptake at_commons 4.0.6 and at_persistence_secondary_server 3.0.62 which have the fix for key length check
**- How I did it**
- modified pubspec to upgrade dependencies
- added unit tests in at_client_impl_test and local_secondary_test 
**- How to verify it**
tests should pass
