### PR TITLE
fix: Fetch SelfKeyEncryption changes from local secondary if in atChops is null

### DIFF
--- a/packages/at_client/lib/src/decryption_service/self_key_decryption.dart
+++ b/packages/at_client/lib/src/decryption_service/self_key_decryption.dart
@@ -30,8 +30,8 @@ class SelfKeyDecryption implements AtKeyDecryption {
     }
 
     // Get SelfEncryptionKey from atChops
-    // To support backward compatibility of at_client_mobile, if SelfEncryptionKey is null in atChops,
-    // fetch from LocalSecondary and set it to AtChops Instance.
+    // https://github.com/atsign-foundation/at_client_sdk/issues/1294 causes selfEncryptionKey to be null in atChops.
+    // Fetch from LocalSecondary until the above issue is fixed.
     String? selfEncryptionKey =
         _atClient.atChops?.atChopsKeys.selfEncryptionKey?.key;
     if (selfEncryptionKey.isNullOrEmpty) {
@@ -47,9 +47,6 @@ class SelfKeyDecryption implements AtKeyDecryption {
           intent: Intent.fetchSelfEncryptionKey,
           exceptionScenario: ExceptionScenario.encryptionFailed);
     }
-    // If SelfEncryptionKey is found in local secondary, set it to AtChops instance.
-    _atClient.atChops?.atChopsKeys.selfEncryptionKey =
-        AESKey(selfEncryptionKey!);
 
     InitialisationVector iV;
     if (atKey.metadata.ivNonce != null) {

--- a/packages/at_client/lib/src/encryption_service/self_key_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/self_key_encryption.dart
@@ -2,10 +2,8 @@ import 'package:at_chops/at_chops.dart';
 import 'package:at_client/src/client/at_client_spec.dart';
 import 'package:at_client/src/client/local_secondary.dart';
 import 'package:at_client/src/encryption_service/encryption.dart';
-import 'package:at_client/src/util/at_client_util.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_utils/at_logger.dart';
-import 'package:encrypt/encrypt.dart';
 
 ///Class responsible for encrypting the selfKey's
 class SelfKeyEncryption implements AtKeyEncryption {

--- a/packages/at_client/lib/src/encryption_service/self_key_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/self_key_encryption.dart
@@ -28,8 +28,8 @@ class SelfKeyEncryption implements AtKeyEncryption {
     }
 
     // Get SelfEncryptionKey from atChops
-    // To support backward compatibility of at_client_mobile, if SelfEncryptionKey is null in atChops,
-    // fetch from LocalSecondary and set it to AtChops Instance.
+    // https://github.com/atsign-foundation/at_client_sdk/issues/1294 causes selfEncryptionKey to be null in atChops.
+    // Fetch from LocalSecondary until the above issue is fixed.
     selfEncryptionKey = atClient.atChops?.atChopsKeys.selfEncryptionKey?.key;
     if (selfEncryptionKey.isNullOrEmpty) {
       // Fetch Self Encryption Key from Local Secondary
@@ -44,9 +44,6 @@ class SelfKeyEncryption implements AtKeyEncryption {
           intent: Intent.fetchSelfEncryptionKey,
           exceptionScenario: ExceptionScenario.encryptionFailed);
     }
-    // If SelfEncryptionKey is found in local secondary, set it to AtChops instance.
-    atClient.atChops?.atChopsKeys.selfEncryptionKey =
-        AESKey(selfEncryptionKey!);
 
     AtEncryptionResult encryptionResultFromAtChops;
     try {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Revert the change fetching SelfEncryptionKey from the Local Secondary. 

As a part of APKAM changes, in `SelfKeyEncryption` and `SelfKeyDecryption` the self encryption key is fetched from AtChops instance and removed the code related to fetching the self encryption key from local secondary.

But in AtClientMobile->AtClientService.dart, the only RSA keys pairs are set to AtChops Instance, but SelfEncryptionKey is not set.

Refer to the snippet below:
```dart
/// AtClientMobile-> at_client_service.dart
AtChops createAtChops(Map<String, String> decryptedAtKeys) {
    final atEncryptionKeyPair = AtEncryptionKeyPair.create(
        decryptedAtKeys[BackupKeyConstants.ENCRYPTION_PUBLIC_KEY_FROM_FILE]!,
        decryptedAtKeys[BackupKeyConstants.ENCRYPTION_PRIVATE_KEY_FROM_FILE]!);
    final atPkamKeyPair = AtPkamKeyPair.create(
        decryptedAtKeys[BackupKeyConstants.PKAM_PUBLIC_KEY_FROM_KEY_FILE]!,
        decryptedAtKeys[BackupKeyConstants.PKAM_PRIVATE_KEY_FROM_KEY_FILE]!);
    final atChopsKeys = AtChopsKeys.create(atEncryptionKeyPair, atPkamKeyPair);
    final atChops = AtChopsImpl(atChopsKeys);
    return atChops;
  }
```

Consequently, Since SelfEncryptionKey is not set in AtChops, When initial sync happens, below error occurs. 

```
 SEVERE|2024-04-10 18:39:07.668706|SyncService (@aquamarine659)|Exception in sync 6c0e9bc7-b737-435a-9d6a-373834f89687. Reason: Failed to syncData caused by
I/flutter (17198): Failed to encrypt the data caused by Self encryption key not found caused by
I/flutter (17198): Failed to encrypt the data 
I/flutter (17198): SEVERE|2024-04-10 18:39:07.670964|SyncService (@aquamarine659)|system sync error Failed to encrypt the data caused by Self encryption key not found 
```

This happens with the existing version of at_client_mobile. So prevent backward compatibility issues, reverting the change related to fetching SelfEncryptionKey from Local Secondary. 
Raised a bug in AtClientMobile to track the issue: https://github.com/atsign-foundation/at_client_sdk/issues/1294

**- How to verify it**
- All tests should pass.
- Manually tested with buzz app and able to onboard the atSign successfully without errors.

```
I/flutter ( 5713): INFO|2024-04-11 21:37:04.014416|SyncService (@81modern)|19312435|Returning serverCommitId 25 
I/flutter ( 5713): INFO|2024-04-11 21:37:05.584499|SyncService (@81modern)|19312435|Inside syncComplete. syncRequest.requestSource : SyncRequestSource.app; syncRequest.onDone : null 
I/flutter ( 5713): got blocked contacts: []
I/flutter ( 5713): INFO|2024-04-11 21:37:05.641424|AtLookup|Creating new connection 
I/flutter ( 5713): INFO|2024-04-11 21:37:05.969420|SyncService (@81modern)|19312435|Returning serverCommitId 26 
I/flutter ( 5713): INFO|2024-04-11 21:37:06.468622|AtLookup|New connection created OK 
I/flutter ( 5713): INFO|2024-04-11 21:37:07.193891|AtLookup|auth success 
I/flutter ( 5713): INFO|2024-04-11 21:37:08.148273|Persona Service|the final result is -> name: Personal copy, keyList: [], sharedWith: {} 
[log] Sync is successful
I/flutter ( 5713): INFO|2024-04-11 21:37:20.394803|SyncService (@81modern)|19312435|Returning serverCommitId 26 
I/flutter ( 5713): INFO|2024-04-11 21:37:20.807324|SyncService (@81modern)|19312435|Returning serverCommitId 26 
I/flutter ( 5713): INFO|2024-04-11 21:37:21.347897|SyncService (@81modern)|19312435|Inside syncComplete. syncRequest.requestSource : SyncRequestSource.system; syncRequest.onDone : Closure: (SyncResult) => void from Function '_onDone@194025363':. 
[log] Sync is successful
Application finished.

```
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
