### PR TITLE
fix: Store auth keys into keychain upon enrollment approval

### DIFF
--- a/packages/at_client_mobile/lib/src/auth/at_auth_service.dart
+++ b/packages/at_client_mobile/lib/src/auth/at_auth_service.dart
@@ -102,13 +102,11 @@ abstract class AtAuthService {
   ///
   ///  String enrollmentId = atAuthService.enroll(enrollmentRequest);
   /// ```
-  /// The "enroll" method optionally accepts a file path to save the generated .atKeys file when an enrollment is approved.
   ///
   /// Returns a [Future] representing EnrollmentId.
   ///
   /// Throws an [InvalidRequestException] if a new enrollment is submitted while there is already a pending enrollment.
-  Future<AtEnrollmentResponse> enroll(EnrollmentRequest enrollmentRequest,
-      {String keysFilePath});
+  Future<AtEnrollmentResponse> enroll(EnrollmentRequest enrollmentRequest);
 
   /// Provides the final enrollment status.
   ///

--- a/packages/at_client_mobile/lib/src/keychain_manager.dart
+++ b/packages/at_client_mobile/lib/src/keychain_manager.dart
@@ -5,9 +5,9 @@ import 'dart:typed_data';
 
 import 'package:at_client_mobile/src/atsign_key.dart';
 import 'package:at_utils/at_logger.dart';
+import 'package:biometric_storage/biometric_storage.dart';
 import 'package:crypton/crypton.dart';
 import 'package:encrypt/encrypt.dart' as encrypt;
-import 'package:biometric_storage/biometric_storage.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter_keychain/flutter_keychain.dart';
 import 'package:hive/hive.dart';
@@ -26,7 +26,7 @@ class KeyChainManager {
   static final KeyChainManager _singleton = KeyChainManager._internal();
 
   static final _logger = AtSignLogger('KeyChainUtil');
-  late PackageInfo packageInfo;
+  late PackageInfo _packageInfo;
 
   KeyChainManager._internal();
 
@@ -667,8 +667,8 @@ class KeyChainManager {
   }) async {
     String packageName = '';
     try {
-      packageInfo = await PackageInfo.fromPlatform();
-      packageName = packageInfo.packageName;
+      _packageInfo = await PackageInfo.fromPlatform();
+      packageName = _packageInfo.packageName;
     } catch (e, s) {
       _logger.warning('Get PackageInfo', e, s);
     }
@@ -752,8 +752,8 @@ class KeyChainManager {
     if (Platform.isWindows) {
       final dataList = _splitString(data, _kWindowSegmentDataLength);
       await store.write(dataList.length.toString());
-      packageInfo = await PackageInfo.fromPlatform();
-      final packageName = packageInfo.packageName;
+      _packageInfo = await PackageInfo.fromPlatform();
+      final packageName = _packageInfo.packageName;
 
       for (int i = 0; i < dataList.length; i++) {
         final dataStore = await BiometricStorage().getStorage(
@@ -776,8 +776,8 @@ class KeyChainManager {
   }) async {
     if (Platform.isWindows) {
       final segmentCount = int.tryParse(await store.read() ?? '0') ?? 0;
-      packageInfo = await PackageInfo.fromPlatform();
-      final packageName = packageInfo.packageName;
+      _packageInfo = await PackageInfo.fromPlatform();
+      final packageName = _packageInfo.packageName;
       final results = <String>[];
       for (int i = 0; i < segmentCount; i++) {
         final dataStore = await biometricStorage.getStorage(

--- a/packages/at_client_mobile/test/at_auth_service_test.dart
+++ b/packages/at_client_mobile/test/at_auth_service_test.dart
@@ -8,9 +8,9 @@ import 'package:at_client_mobile/src/auth/at_auth_service_impl.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:biometric_storage/biometric_storage.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:test/test.dart';
-import 'package:mocktail/mocktail.dart';
 
 class MockBiometricStorage extends Mock implements BiometricStorage {}
 
@@ -50,7 +50,6 @@ void main() {
     late MockKeychainBiometricStorageFile mockBiometricStorageKeychainFile;
     late MockBiometricStorage mockBiometricStorage;
     late MockAtLookUp mockAtLookUp;
-    late MockPackageInfo mockPackageInfo;
 
     setUp(() {
       authServiceImpl = AtAuthServiceImpl(atSign, atClientPreference);
@@ -58,11 +57,8 @@ void main() {
       mockBiometricStorage = MockBiometricStorage();
       mockBiometricStorageKeychainFile = MockKeychainBiometricStorageFile();
       mockAtLookUp = MockAtLookUp();
-      mockPackageInfo = MockPackageInfo();
 
       authServiceImpl.keyChainManager.biometricStorage = mockBiometricStorage;
-      authServiceImpl.keyChainManager.packageInfo = mockPackageInfo;
-
       authServiceImpl.atLookUp = mockAtLookUp;
     });
 

--- a/packages/at_client_mobile/test/at_auth_service_test.dart
+++ b/packages/at_client_mobile/test/at_auth_service_test.dart
@@ -8,18 +8,29 @@ import 'package:at_client_mobile/src/auth/at_auth_service_impl.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:biometric_storage/biometric_storage.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:test/test.dart';
 import 'package:mocktail/mocktail.dart';
 
 class MockBiometricStorage extends Mock implements BiometricStorage {}
 
-class MockBiometricStorageFile extends Mock implements BiometricStorageFile {
+class MockEnrollmentBiometricStorageFile extends Mock
+    implements BiometricStorageFile {
+  Map<String, String> dummyStorageFile = HashMap();
+}
+
+class MockKeychainBiometricStorageFile extends Mock
+    implements BiometricStorageFile {
   Map<String, String> dummyStorageFile = HashMap();
 }
 
 class MockAtLookUp extends Mock implements AtLookUp {}
 
 class MockAtEnrollmentBase extends Mock implements AtEnrollmentBase {}
+
+class MockPackageInfo extends Mock implements PackageInfo {
+  fromPlatform() {}
+}
 
 class FakeStorageFileInitOptions extends Fake
     implements StorageFileInitOptions {}
@@ -35,18 +46,23 @@ void main() {
 
     late AtAuthServiceImpl authServiceImpl;
     MockAtEnrollmentBase mockAtEnrollmentBase;
-    late MockBiometricStorageFile mockBiometricStorageFile;
+    late MockEnrollmentBiometricStorageFile mockBiometricStorageEnrollmentFile;
+    late MockKeychainBiometricStorageFile mockBiometricStorageKeychainFile;
     late MockBiometricStorage mockBiometricStorage;
     late MockAtLookUp mockAtLookUp;
+    late MockPackageInfo mockPackageInfo;
 
     setUp(() {
       authServiceImpl = AtAuthServiceImpl(atSign, atClientPreference);
-
-      mockBiometricStorageFile = MockBiometricStorageFile();
+      mockBiometricStorageEnrollmentFile = MockEnrollmentBiometricStorageFile();
       mockBiometricStorage = MockBiometricStorage();
+      mockBiometricStorageKeychainFile = MockKeychainBiometricStorageFile();
       mockAtLookUp = MockAtLookUp();
+      mockPackageInfo = MockPackageInfo();
 
-      authServiceImpl.enrollmentKeychainStore = mockBiometricStorage;
+      authServiceImpl.keyChainManager.biometricStorage = mockBiometricStorage;
+      authServiceImpl.keyChainManager.packageInfo = mockPackageInfo;
+
       authServiceImpl.atLookUp = mockAtLookUp;
     });
 
@@ -58,16 +74,16 @@ void main() {
 
       when(() => mockBiometricStorage.getStorage('${atSign}_enrollmentInfo',
               options: any(named: 'options')))
-          .thenAnswer((_) async => mockBiometricStorageFile);
+          .thenAnswer((_) async => mockBiometricStorageEnrollmentFile);
 
-      when(() => mockBiometricStorageFile.read()).thenAnswer((_) =>
-          Future.value(mockBiometricStorageFile
+      when(() => mockBiometricStorageEnrollmentFile.read()).thenAnswer((_) =>
+          Future.value(mockBiometricStorageEnrollmentFile
               .dummyStorageFile['${atSign}_enrollmentInfo']));
 
-      when(() => mockBiometricStorageFile
+      when(() => mockBiometricStorageEnrollmentFile
               .write(any(that: startsWith('{"enrollmentId"'))))
           .thenAnswer((Invocation invocation) async {
-        mockBiometricStorageFile.dummyStorageFile.putIfAbsent(
+        mockBiometricStorageEnrollmentFile.dummyStorageFile.putIfAbsent(
             '${atSign}_enrollmentInfo',
             () => invocation.positionalArguments[0]);
       });
@@ -104,7 +120,7 @@ void main() {
           atEnrollmentResponse.atAuthKeys!.apkamSymmetricKey!.isNotEmpty, true);
       expect(atEnrollmentResponse.atAuthKeys!.enrollmentId!.isNotEmpty, true);
       expect(atEnrollmentResponse.enrollmentId.isNotEmpty, true);
-      expect(mockBiometricStorageFile.dummyStorageFile.length, 1);
+      expect(mockBiometricStorageEnrollmentFile.dummyStorageFile.length, 1);
     });
 
     test('A test to verify enrollment request is submitted and denied',
@@ -116,23 +132,25 @@ void main() {
 
       when(() => mockBiometricStorage.getStorage('${atSign}_enrollmentInfo',
               options: any(named: 'options')))
-          .thenAnswer((_) async => mockBiometricStorageFile);
+          .thenAnswer((_) async => mockBiometricStorageEnrollmentFile);
 
-      when(() => mockBiometricStorageFile.read()).thenAnswer((_) async {
-        return Future.value(mockBiometricStorageFile
+      when(() => mockBiometricStorageEnrollmentFile.read())
+          .thenAnswer((_) async {
+        return Future.value(mockBiometricStorageEnrollmentFile
             .dummyStorageFile['${atSign}_enrollmentInfo']);
       });
 
-      when(() => mockBiometricStorageFile
+      when(() => mockBiometricStorageEnrollmentFile
               .write(any(that: startsWith('{"enrollmentId"'))))
           .thenAnswer((Invocation invocation) async {
-        mockBiometricStorageFile.dummyStorageFile.putIfAbsent(
+        mockBiometricStorageEnrollmentFile.dummyStorageFile.putIfAbsent(
             '${atSign}_enrollmentInfo',
             () => invocation.positionalArguments[0]);
       });
 
-      when(() => mockBiometricStorageFile.delete()).thenAnswer((_) async {
-        mockBiometricStorageFile.dummyStorageFile
+      when(() => mockBiometricStorageEnrollmentFile.delete())
+          .thenAnswer((_) async {
+        mockBiometricStorageEnrollmentFile.dummyStorageFile
             .remove('${atSign}_enrollmentInfo');
       });
 
@@ -173,7 +191,7 @@ void main() {
           atEnrollmentResponse.atAuthKeys!.apkamSymmetricKey!.isNotEmpty, true);
       expect(atEnrollmentResponse.atAuthKeys!.enrollmentId!.isNotEmpty, true);
       expect(atEnrollmentResponse.enrollmentId.isNotEmpty, true);
-      expect(mockBiometricStorageFile.dummyStorageFile.length, 1);
+      expect(mockBiometricStorageEnrollmentFile.dummyStorageFile.length, 1);
 
       Future<EnrollmentStatus> enrollmentStatus =
           authServiceImpl.getFinalEnrollmentStatus();
@@ -182,7 +200,7 @@ void main() {
           .then((value) => expect(value, EnrollmentStatus.denied));
 
       // Verify enrollment info is removed from the enrollment keychain when enrollment request is denied
-      expect(mockBiometricStorageFile.dummyStorageFile.length, 0);
+      expect(mockBiometricStorageEnrollmentFile.dummyStorageFile.length, 0);
     });
 
     test(
@@ -200,17 +218,18 @@ void main() {
             ..atAuthKeys = AtAuthKeys()));
       when(() => mockBiometricStorage.getStorage('${atSign}_enrollmentInfo',
               options: any(named: 'options')))
-          .thenAnswer((_) async => mockBiometricStorageFile);
+          .thenAnswer((_) async => mockBiometricStorageEnrollmentFile);
 
-      when(() => mockBiometricStorageFile.read()).thenAnswer((_) async {
-        return Future.value(mockBiometricStorageFile
+      when(() => mockBiometricStorageEnrollmentFile.read())
+          .thenAnswer((_) async {
+        return Future.value(mockBiometricStorageEnrollmentFile
             .dummyStorageFile['${atSign}_enrollmentInfo']);
       });
 
-      when(() => mockBiometricStorageFile
+      when(() => mockBiometricStorageEnrollmentFile
               .write(any(that: startsWith('{"enrollmentId"'))))
           .thenAnswer((Invocation invocation) async {
-        mockBiometricStorageFile.dummyStorageFile.putIfAbsent(
+        mockBiometricStorageEnrollmentFile.dummyStorageFile.putIfAbsent(
             '${atSign}_enrollmentInfo',
             () => invocation.positionalArguments[0]);
       });
@@ -245,10 +264,11 @@ void main() {
         () async {
       when(() => mockBiometricStorage.getStorage('${atSign}_enrollmentInfo',
               options: any(named: 'options')))
-          .thenAnswer((_) async => mockBiometricStorageFile);
+          .thenAnswer((_) async => mockBiometricStorageEnrollmentFile);
 
-      when(() => mockBiometricStorageFile.read()).thenAnswer((_) async {
-        return Future.value(mockBiometricStorageFile
+      when(() => mockBiometricStorageEnrollmentFile.read())
+          .thenAnswer((_) async {
+        return Future.value(mockBiometricStorageEnrollmentFile
             .dummyStorageFile['${atSign}_enrollmentInfo']);
       });
 
@@ -258,8 +278,7 @@ void main() {
       expect(enrollmentStatus, EnrollmentStatus.expired);
     });
 
-    test('A test to verify enrollment approved and atkeys file is generated',
-        () async {
+    test('A test to verify enrollment approved', () async {
       String encryptedDefaultEncryptionPrivateKey =
           'GPJs9xY/HBG3MSqGAwV+X9BhJGNmWvJ7LnR8Qthnc4lW7DWRIwLKG9uYbfCUSK7HaDDYAy9MEue5VUeh9inwuSnYTaq7CAz0t6Ijf9wOI9q4bBOb8yoAsEXgY3Id5Mg6pkUXUtHYNf7KgpNQJBP4oIDj5+mX6Nse4TTi3+5xrbYg+WscUH8l1MlpO/xHaCvPJhAW0IWc5f3HLpxkhq0qe13b2NzorJuwxnfWbH9qItmrmEv7AOCgSkvcYCfsUZQLHISXqUj4DEFp8GCDiZCReYlN84Omqbv9ydhZIYc5UMuyz3V8+PNf4uK4ClLd3bjKlQNocf814n5Vtj7jIxzr/6spsFSE/Smna23HomucOkt1oHn82MbJbmK3VWKgm+IAd+2iVxPWk7sT1bOaWeAz4AWlxhkN8uMhkcfxRr67flalQS2yQZZ6UZglIYOmz3S5k9xtZsVOf/bpvfzBlzxL6ozNW9pmVYA/aelXJTP43hmM2yvqkBukrMD26bcf6+C30qKJa9IF2/tVDe4lRlrMZ63lJQHq69ZwJOaJwXPkREWutaE0VDLb+Ko5rYdN7WM/sGmlGCShHe/OdIdzj1msXFxBgXyFK3pdOf1rtYrZ2LZdDci8fOSxE/xfJ5a0e5FqOUTpna4FPsYbId8ezp0+urftR7GmOChT3gyZYo9TqM2c1jv8CnnBg/IEjVBO5uc15q1reMt2fdYI7kmnG2K7cPwJx02l1aNSLw4m8dxLfd+R3jNxbpDNRIcHNYyrXa0K1rwXn/J2ZamJHxIH+eRHZCGezCr7imN8XcSMHbHMNfonG+HUmYGdyk4c1OxeyQB0/iq/pZgwwLDRZYrLaN4knbQkOx8oboSlAoxVAzIy5uIEGhYfqEBEx9N1/MBNkvOr2Ely0+Vrslu7gFf41dhhwe3jH4LvUFdGZfnYWAS208wSnTBMi/aKMhBv4gZIe4asQ/OKm/D0jH/6RSP0tNsw57k6tRqfk0X0eaT0jOzAoWHWGTXSTONO7k2qpqZpmXJJ0e83i+9Xfjp/4M4VYufAda/g+jWp7bCq0VgFa+Uf5/C6t2a+3RDC7SI8mz9m4DTlfv5CuQyQkGPSTe11Ksy51QcCF6JTj4Lc6csdG9fx6itMUUUZBvD76ac3MrSdtbZgCn+IBAvawrez67T70kzxwRjNySw9jJEgP81c8Tl0WM5Dy/v3NcoEorLuu4EBZKI01U5qHQuXDkBisnuCIttq4qmUd+q/m6Btpj/toKrzWpTXGtLeswoxQWu+Pkt1LkKAGIcuxiFV7uifxbcMNkxrz/t+Fx+YSLN3XUEAzbEIIcb6KW09EJx35nDA2PPga5diWOTQaw2lrONiO4eNuIKI4MU8gPAa2QUjoxyxxULV3qm7tsN03nxczHKo4QVHjAqwpOJHdPxykxi2qsQJu+RBnEf0uaEga4r8A6jQp1vwV+udrdtBL7e2QeAYsla4RFqWFs+epA/yYBxEn+/cmD3tZKGNH1Of9vYrBhsxfybtqmoZSTG+sQ6e+fbCEYXgmhd9DJTqgPM/yhXUmNBbK0pkECjTX3qkqWHHdA8K1kjaJ+yUkg0eecobG5rYn0xYbbji91wbwEvxbeYLJ24+1BOZRMKvnItqtkoFsKVwD7rM9qKvuT/YrWZRlXCuRUclji+J50q7byhNARYE5soILAbYdYCOEJCWKHSEtrFzbnQWlB8y7outiTdtifTq3JDWOC3pVavko8/xmIT80oe/YX2QhPx281C/Sc3qa5+OYjYFEw2zKqGUn3FvTnToSQTlwo6fO2IbsD9Poq+bET2Ra1WqmJhuY9nZ2MH4t/vtMAPIYwoA36jd2baez88pMNeK7EOJW4sIi3mgthKWhaQ4yW9bPJRn6+IoT6wtecp1/PUXayn6nd+p6UnNUvjbxjiED8o1LRZ+5Lelk4CgDgerb4gGgL5rcrVbk7hCsjyjxcUej80pBLIHjc6e/bQWx4aQzW3pfwgnYm7FD2ATtLgPIcrKjpiQ9BDOsSx1BSLuFVhLGTspVpddDa9eu1O2j+tOwetnRdN8oGR9OUCHdkCDttpca7NTXWCeaCc/Ykbkz+Mue4x0SPDXzVa0vRY6JjYJ1bZzU4I9GFZefIymLMrJPM6yENPmhmiMaJfeDLAVSPYdQV+wRikPOF7vFX/Acoux+CoY';
       String encryptedDefaultSelfEncryptionKey =
@@ -289,11 +308,30 @@ void main() {
 
       when(() => mockBiometricStorage.getStorage('${atSign}_enrollmentInfo',
               options: any(named: 'options')))
-          .thenAnswer((_) async => mockBiometricStorageFile);
+          .thenAnswer((_) async => mockBiometricStorageEnrollmentFile);
+
+      when(() => mockBiometricStorage.getStorage(
+          any(that: startsWith('@atsigns')),
+          options: any(named: 'options'))).thenAnswer(
+        (_) async => mockBiometricStorageKeychainFile,
+      );
+
+      when(() => mockBiometricStorageKeychainFile.read()).thenAnswer((_) =>
+          Future.value(mockBiometricStorageKeychainFile
+              .dummyStorageFile['${atSign}_enrollmentInfo']));
+
+      when(() =>
+              mockBiometricStorageKeychainFile.write(any(that: startsWith(''))))
+          .thenAnswer((Invocation invocation) async {
+        mockBiometricStorageKeychainFile.dummyStorageFile.putIfAbsent(
+            '${atSign}_enrollmentInfo_keychain',
+            () => invocation.positionalArguments[0]);
+      });
 
       when(() => mockAtLookUp.close()).thenAnswer((_) async => {});
 
-      when(() => mockBiometricStorageFile.read()).thenAnswer((_) async {
+      when(() => mockBiometricStorageEnrollmentFile.read())
+          .thenAnswer((_) async {
         String jsonEncodedEnrollmentInfo =
             await Future.value(jsonEncode(EnrollmentInfo(
                 '010ad3dc-02ee-41c6-b74b-c82f5122b181',
@@ -306,15 +344,34 @@ void main() {
                 DateTime.now().microsecondsSinceEpoch,
                 {'wavi': 'rw'})));
 
-        mockBiometricStorageFile.dummyStorageFile.putIfAbsent(
+        mockBiometricStorageEnrollmentFile.dummyStorageFile.putIfAbsent(
             '${atSign}_enrollmentInfo', () => jsonEncodedEnrollmentInfo);
 
         return jsonEncodedEnrollmentInfo;
       });
 
-      when(() => mockBiometricStorageFile.delete()).thenAnswer((_) async {
-        mockBiometricStorageFile.dummyStorageFile
-            .remove('${atSign}_enrollmentInfo');
+      when(() => mockBiometricStorageEnrollmentFile
+              .write(any(that: startsWith('{"enrollmentId"'))))
+          .thenAnswer((Invocation invocation) async {
+        mockBiometricStorageEnrollmentFile.dummyStorageFile.putIfAbsent(
+            jsonEncode(
+              EnrollmentInfo(
+                  '010ad3dc-02ee-41c6-b74b-c82f5122b181',
+                  AtAuthKeys()
+                    ..apkamPublicKey = pkamPublicKey
+                    ..apkamPrivateKey = pkamPrivateKey
+                    ..defaultEncryptionPublicKey = encryptionPublicKey
+                    ..apkamSymmetricKey = atChopsKeys.apkamSymmetricKey?.key
+                    ..enrollmentId = '010ad3dc-02ee-41c6-b74b-c82f5122b181',
+                  DateTime.now().microsecondsSinceEpoch,
+                  {'wavi': 'rw'}),
+            ),
+            () => invocation.positionalArguments[0]);
+      });
+
+      when(() => mockBiometricStorageEnrollmentFile.delete())
+          .thenAnswer((_) async {
+        mockBiometricStorageEnrollmentFile.dummyStorageFile = {};
       });
 
       when(() => mockAtLookUp.atChops).thenAnswer((_) => atChops);
@@ -345,15 +402,16 @@ void main() {
         expect(value, EnrollmentStatus.approved);
       });
 
-      expect(mockBiometricStorageFile.dummyStorageFile.length, 0);
+      expect(mockBiometricStorageEnrollmentFile.dummyStorageFile.length, 0);
+      expect(mockBiometricStorageKeychainFile.dummyStorageFile.length, 1);
     });
 
-    tearDown(() => tearDownMethod(
-        mockBiometricStorageFile, mockAtLookUp, mockBiometricStorage));
+    tearDown(() => tearDownMethod(mockBiometricStorageEnrollmentFile,
+        mockAtLookUp, mockBiometricStorage));
   });
 }
 
-void tearDownMethod(MockBiometricStorageFile mockBiometricStorageFile,
+void tearDownMethod(MockEnrollmentBiometricStorageFile mockBiometricStorageFile,
     MockAtLookUp mockAtLookUp, MockBiometricStorage mockBiometricStorage) {
   resetMocktailState();
   reset(mockBiometricStorageFile);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Store the Enrollment auth keys into keychain manager upon enrollment approval.
 - Earlier, upon approving the enrollment, the auth keys are encrypted and stored into a atKeys text file. Change the behaviour to store the keys into key-chain manager upon enrollment approval.
 - Removed the optional parameter "filePath" in the enroll method because we do not generate atKeys file and filePath is not used.
 - Removed the code related to generating of atKeys file.

**- How to verify it**
- Unit tests should pass.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
