### PR TITLE
feat: enhance EnrollmentService.fetchEnrollmentRequests() to filter enrollment requests

### DIFF
--- a/packages/at_client/lib/at_client.dart
+++ b/packages/at_client/lib/at_client.dart
@@ -17,7 +17,7 @@ export 'package:at_client/src/listener/sync_progress_listener.dart';
 export 'package:at_client/src/manager/at_client_manager.dart';
 export 'package:at_client/src/preference/at_client_preference.dart';
 export 'package:at_client/src/response/at_notification.dart';
-export 'package:at_client/src/response/pending_enrollment_request.dart';
+export 'package:at_client/src/response/enrollment.dart';
 @experimental
 export 'package:at_client/src/rpc/at_rpc.dart';
 @experimental

--- a/packages/at_client/lib/src/response/enrollment.dart
+++ b/packages/at_client/lib/src/response/enrollment.dart
@@ -1,13 +1,13 @@
 /// Class represents the enrollment details
-class PendingEnrollmentRequest {
+class Enrollment {
   String? enrollmentId;
   String? appName;
   String? deviceName;
   Map<String, dynamic>? namespace;
   String? encryptedAPKAMSymmetricKey;
 
-  static PendingEnrollmentRequest fromJSON(Map<String, dynamic> json) {
-    return PendingEnrollmentRequest()
+  static Enrollment fromJSON(Map<String, dynamic> json) {
+    return Enrollment()
       ..appName = json['appName']
       ..deviceName = json['deviceName']
       ..namespace = json['namespace']

--- a/packages/at_client/lib/src/service/enrollment_service.dart
+++ b/packages/at_client/lib/src/service/enrollment_service.dart
@@ -1,5 +1,5 @@
 import 'package:at_auth/at_auth.dart';
-import 'package:at_client/src/response/pending_enrollment_request.dart';
+import 'package:at_client/src/response/enrollment.dart';
 import 'package:at_client/src/util/enroll_list_request_param.dart';
 
 /// [EnrollmentService] contains methods to fetch the enrollment details and methods to perform operations on the enrollments.
@@ -17,8 +17,8 @@ abstract class EnrollmentService {
   ///   List<EnrollmentRequest> enrollmentRequests = atClientManager.atClient.encryptionService
   ///                                                     .fetchEnrollmentRequests();
   /// ```
-  Future<List<PendingEnrollmentRequest>> fetchEnrollmentRequests(
-      {EnrollListRequestParam? enrollmentListRequest});
+  Future<List<Enrollment>> fetchEnrollmentRequests(
+      {EnrollmentListRequestParam? enrollmentListParams});
 
   /// Approves the enrollment request.
   ///

--- a/packages/at_client/lib/src/service/enrollment_service_impl.dart
+++ b/packages/at_client/lib/src/service/enrollment_service_impl.dart
@@ -11,15 +11,13 @@ class EnrollmentServiceImpl implements EnrollmentService {
   EnrollmentServiceImpl(this._atClient, this._atEnrollmentImpl);
 
   @override
-  Future<List<PendingEnrollmentRequest>> fetchEnrollmentRequests(
-      {EnrollListRequestParam? enrollmentListRequest}) async {
-    // enrollmentListRequestParams for now is not  used
-    // A server side enhancement request is created. https://github.com/atsign-foundation/at_server/issues/1748
-    // On implementation of this enhancement/feature, the enrollListRequestParam object can be made use of
+  Future<List<Enrollment>> fetchEnrollmentRequests(
+      {EnrollmentListRequestParam? enrollmentListParams}) async {
     EnrollVerbBuilder enrollBuilder = EnrollVerbBuilder()
       ..operation = EnrollOperationEnum.list
-      ..appName = enrollmentListRequest?.appName
-      ..deviceName = enrollmentListRequest?.deviceName;
+      ..appName = enrollmentListParams?.appName
+      ..deviceName = enrollmentListParams?.deviceName
+      ..enrollmentStatusFilter = enrollmentListParams?.enrollmentListFilter;
 
     var response = await _atClient
         .getRemoteSecondary()
@@ -32,13 +30,13 @@ class EnrollmentServiceImpl implements EnrollmentService {
     return enrollmentKey.split('.')[0];
   }
 
-  List<PendingEnrollmentRequest> _formatEnrollListResponse(response) {
+  List<Enrollment> _formatEnrollListResponse(response) {
     response = response?.replaceFirst('data:', '');
     Map<String, dynamic> enrollRequests = jsonDecode(response!);
-    List<PendingEnrollmentRequest> enrollRequestsFormatted = [];
+    List<Enrollment> enrollRequestsFormatted = [];
     for (MapEntry enrollmentRequest in enrollRequests.entries) {
-      PendingEnrollmentRequest enrollmentRequestResponse =
-          PendingEnrollmentRequest.fromJSON(enrollmentRequest.value);
+      Enrollment enrollmentRequestResponse =
+          Enrollment.fromJSON(enrollmentRequest.value);
       enrollmentRequestResponse.enrollmentId =
           extractEnrollmentId(enrollmentRequest.key);
       enrollRequestsFormatted.add(enrollmentRequestResponse);

--- a/packages/at_client/lib/src/util/enroll_list_request_param.dart
+++ b/packages/at_client/lib/src/util/enroll_list_request_param.dart
@@ -1,6 +1,13 @@
+import 'package:at_client/at_client.dart';
+
 /// class to store request parameters while fetching a list of enrollments
-class EnrollListRequestParam {
+class EnrollmentListRequestParam {
   String? appName;
   String? deviceName;
   String? namespace;
+
+  /// Allows filtering of enroll requests while listing them
+  ///
+  /// Accepts a [List<EnrollmentStatus>] defaults to all [EnrollmentStatus] values
+  List<EnrollmentStatus> enrollmentListFilter = EnrollmentStatus.values;
 }

--- a/packages/at_client/test/at_client_impl_test.dart
+++ b/packages/at_client/test/at_client_impl_test.dart
@@ -299,7 +299,7 @@ void main() {
           EnrollmentServiceImpl(client, atAuthBase.atEnrollment(currentAtsign));
       AtClientImpl? clientImpl = client as AtClientImpl;
 
-      List<PendingEnrollmentRequest> requests =
+      List<Enrollment> requests =
           await clientImpl.enrollmentService.fetchEnrollmentRequests();
       expect(requests.length, 3);
       expect(requests[0].enrollmentId,

--- a/packages/at_client/test/enrollment_service_test.dart
+++ b/packages/at_client/test/enrollment_service_test.dart
@@ -1,0 +1,167 @@
+import 'dart:convert';
+
+import 'package:at_auth/at_auth.dart';
+import 'package:at_client/at_client.dart';
+import 'package:at_commons/at_builders.dart';
+import '../lib/src/service/enrollment_service_impl.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/expect.dart';
+import 'package:test/scaffolding.dart';
+
+class MockRemoteSecondary extends Mock implements RemoteSecondary {}
+
+void main() {
+  group('A group of tests related to apkam/enrollments', () {
+    test(
+        'A test to verify enrollmentId is set in atClient after calling setCurrentAtSign',
+        () async {
+      final testEnrollmentId = 'abc123';
+      var atClientManager = await AtClientManager.getInstance()
+          .setCurrentAtSign('@alice', 'wavi', AtClientPreference(),
+              enrollmentId: testEnrollmentId);
+      expect(atClientManager.atClient.enrollmentId, testEnrollmentId);
+    });
+
+    MockRemoteSecondary mockRemoteSecondary = MockRemoteSecondary();
+
+    test('verify behaviour of fetchEnrollmentRequests()', () async {
+      String currentAtsign = '@apkam';
+      String enrollKey1 =
+          '0acdeb4d-1a2e-43e4-93bd-378f1d366ea7.new.enrollments.__manage$currentAtsign';
+      String enrollValue1 =
+          '{"appName":"buzz","deviceName":"pixel","namespace":{"buzz":"rw"}}';
+      String enrollKey2 =
+          '9beefa26-3384-4f10-81a6-0deaa4332669.new.enrollments.__manage$currentAtsign';
+      String enrollValue2 =
+          '{"appName":"buzz","deviceName":"pixel","namespace":{"buzz":"rw"}}';
+      String enrollKey3 =
+          'a6bbef17-c7bf-46f4-a172-1ed7b3b443bc.new.enrollments.__manage$currentAtsign';
+      String enrollValue3 =
+          '{"appName":"buzz","deviceName":"pixel","namespace":{"buzz":"rw"}}';
+      String enrollListCommand = (EnrollVerbBuilder()
+            ..operation = EnrollOperationEnum.list)
+          .buildCommand();
+      when(() =>
+          mockRemoteSecondary.executeCommand(enrollListCommand,
+              auth: true)).thenAnswer((_) => Future.value('data:{"$enrollKey1":'
+          '$enrollValue1,"$enrollKey2":$enrollValue2,"$enrollKey3":$enrollValue3}'));
+
+      AtClient? client = await AtClientImpl.create(
+          currentAtsign, 'buzz', AtClientPreference(),
+          remoteSecondary: mockRemoteSecondary);
+      client.enrollmentService =
+          EnrollmentServiceImpl(client, atAuthBase.atEnrollment(currentAtsign));
+      AtClientImpl? clientImpl = client as AtClientImpl;
+
+      List<Enrollment> requests =
+          await clientImpl.enrollmentService.fetchEnrollmentRequests();
+      expect(requests.length, 3);
+      expect(requests[0].enrollmentId,
+          enrollKey1.substring(0, enrollKey1.indexOf('.')));
+      expect(requests[0].appName, jsonDecode(enrollValue1)['appName']);
+      expect(requests[0].deviceName, jsonDecode(enrollValue1)['deviceName']);
+      expect(requests[0].namespace, jsonDecode(enrollValue1)['namespace']);
+
+      expect(requests[1].enrollmentId,
+          enrollKey2.substring(0, enrollKey1.indexOf('.')));
+      expect(requests[1].appName, jsonDecode(enrollValue2)['appName']);
+      expect(requests[1].deviceName, jsonDecode(enrollValue2)['deviceName']);
+      expect(requests[1].namespace, jsonDecode(enrollValue2)['namespace']);
+
+      expect(requests[2].enrollmentId,
+          enrollKey3.substring(0, enrollKey1.indexOf('.')));
+      expect(requests[2].appName, jsonDecode(enrollValue3)['appName']);
+      expect(requests[2].deviceName, jsonDecode(enrollValue3)['deviceName']);
+      expect(requests[2].namespace, jsonDecode(enrollValue3)['namespace']);
+    });
+
+    test(
+        'verify behaviour of fetchEnrollmentRequests() with enrollmentStatusFilter: [pending, approved]',
+        () async {
+      String currentAtsign = '@apkam1234';
+      String enrollKey1 =
+          '0acdeb4d-1a2e-43e4-93bd-random123.new.enrollments.__manage$currentAtsign';
+      String enrollValue1 =
+          '{"appName":"unit_test","deviceName":"testDevice","namespace":{"random_namespace":"rw"}}';
+      String enrollKey2 =
+          '9beefa26-3384-4f10-81a6-random234.new.enrollments.__manage$currentAtsign';
+      String enrollValue2 =
+          '{"appName":"unit_test","deviceName":"testDevice","namespace":{"random_namespace":"rw"}}';
+      when(() =>
+          mockRemoteSecondary.executeCommand(
+              'enroll:list:{"enrollmentStatusFilter":["pending","approved"]}\n',
+              auth: true)).thenAnswer((_) => Future.value('data:{"$enrollKey1":'
+          '$enrollValue1,"$enrollKey2":$enrollValue2}'));
+
+      EnrollmentListRequestParam listRequestParam = EnrollmentListRequestParam()
+        ..enrollmentListFilter = [
+          EnrollmentStatus.pending,
+          EnrollmentStatus.approved
+        ];
+      AtClient? client = await AtClientImpl.create(
+          currentAtsign, 'random_namespace', AtClientPreference(),
+          remoteSecondary: mockRemoteSecondary);
+      client.enrollmentService =
+          EnrollmentServiceImpl(client, atAuthBase.atEnrollment(currentAtsign));
+      AtClientImpl? clientImpl = client as AtClientImpl;
+
+      List<Enrollment> requests = await clientImpl.enrollmentService
+          .fetchEnrollmentRequests(enrollmentListParams: listRequestParam);
+      expect(requests.length, 2);
+      expect(requests[0].enrollmentId,
+          enrollKey1.substring(0, enrollKey1.indexOf('.')));
+      expect(requests[0].appName, jsonDecode(enrollValue1)['appName']);
+      expect(requests[0].deviceName, jsonDecode(enrollValue1)['deviceName']);
+      expect(requests[0].namespace, jsonDecode(enrollValue1)['namespace']);
+
+      expect(requests[1].enrollmentId,
+          enrollKey2.substring(0, enrollKey2.indexOf('.')));
+      expect(requests[1].appName, jsonDecode(enrollValue2)['appName']);
+      expect(requests[1].deviceName, jsonDecode(enrollValue2)['deviceName']);
+      expect(requests[1].namespace, jsonDecode(enrollValue2)['namespace']);
+    });
+
+    test(
+        'verify behaviour of fetchEnrollmentRequests() with enrollmentStatusFilter: [approved]',
+        () async {
+      String currentAtsign = '@apkam1234';
+      String enrollKey1 =
+          '0acdeb4d-1a2e-43e4-93bd-randomabc.new.enrollments.__manage$currentAtsign';
+      String enrollValue1 =
+          '{"appName":"unit_test","deviceName":"testDevice","namespace":{"random_namespace":"rw"}}';
+      String enrollKey2 =
+          '9beefa26-3384-4f10-81a6-randomcde.new.enrollments.__manage$currentAtsign';
+      String enrollValue2 =
+          '{"appName":"unit_test","deviceName":"testDevice","namespace":{"random_namespace":"rw"}}';
+      when(() =>
+          mockRemoteSecondary.executeCommand(
+              'enroll:list:{"enrollmentStatusFilter":["approved"]}\n',
+              auth: true)).thenAnswer((_) => Future.value('data:{"$enrollKey1":'
+          '$enrollValue1,"$enrollKey2":$enrollValue2}'));
+
+      EnrollmentListRequestParam listRequestParam = EnrollmentListRequestParam()
+        ..enrollmentListFilter = [EnrollmentStatus.approved];
+      AtClient? client = await AtClientImpl.create(
+          currentAtsign, 'random_namespace_1', AtClientPreference(),
+          remoteSecondary: mockRemoteSecondary);
+      client.enrollmentService =
+          EnrollmentServiceImpl(client, atAuthBase.atEnrollment(currentAtsign));
+      AtClientImpl? clientImpl = client as AtClientImpl;
+
+      List<Enrollment> requests = await clientImpl.enrollmentService
+          .fetchEnrollmentRequests(enrollmentListParams: listRequestParam);
+      expect(requests.length, 2);
+      expect(requests[0].enrollmentId,
+          enrollKey1.substring(0, enrollKey1.indexOf('.')));
+      expect(requests[0].appName, jsonDecode(enrollValue1)['appName']);
+      expect(requests[0].deviceName, jsonDecode(enrollValue1)['deviceName']);
+      expect(requests[0].namespace, jsonDecode(enrollValue1)['namespace']);
+
+      expect(requests[1].enrollmentId,
+          enrollKey2.substring(0, enrollKey2.indexOf('.')));
+      expect(requests[1].appName, jsonDecode(enrollValue2)['appName']);
+      expect(requests[1].deviceName, jsonDecode(enrollValue2)['deviceName']);
+      expect(requests[1].namespace, jsonDecode(enrollValue2)['namespace']);
+    });
+  });
+}

--- a/tests/at_functional_test/test/enrollment_test.dart
+++ b/tests/at_functional_test/test/enrollment_test.dart
@@ -373,7 +373,7 @@ void main() {
     var apkamPublicKey =
         pkamPublicKeyMap['@eve🛠']; // can be any random public key
     var newEnrollRequest = TestUtils.formatCommand(
-        'enroll:request:{"appName":"new_app","deviceName":"pixel","namespaces":{"new_app":"rw"},"otp":"$otp","apkamPublicKey":"$apkamPublicKey"}');
+        'enroll:request:{"appName":"new_app","deviceName":"pixel","namespaces":{"new_app":"rw"},"otp":"$otp","apkamPublicKey":"$apkamPublicKey","enrollmentStatusFilter":["pending"]}');
     var enrollResponse = await TestUtils.executeCommandAndParse(
         null, newEnrollRequest,
         remoteSecondary: secondRemoteSecondary);
@@ -396,7 +396,7 @@ void main() {
     expect(enrollResponse2JsonDecoded['status'], 'pending');
 
     // fetch enrollment requests through client
-    List<PendingEnrollmentRequest> enrollmentRequests =
+    List<Enrollment> enrollmentRequests =
         await client.enrollmentService.fetchEnrollmentRequests();
 
     expect(enrollmentRequests.length > 2, true);


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- introduce new param 'enrollmentStatusFilter' in EnrollListRequestParam class
- use the above param in EnrollmentService.fetchEnrollmentRequests() to build the command that lists only enrollment requests that match the filter.

**- How I did it**
- EnrollListRequestParam.enrollmentStatusFilter will be used by users to pass the desired enrollment statuses they wish to list.
- EnrollmentService.fetchEnrollmentRequests() will use this filter to construct a relevant command which will be passed to the server.

**- How to verify it**
- unit test added, that verifies that appropriate command is generated using the EnrollVerbBuilder and the parsing of response from the server.
- Yet to evaluate if a functional test is needed to validate the change

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: enhance EnrollmentService.fetchEnrollmentRequests() to filter enrollment requests