### PR TITLE
fix: Add SelfEncryptionKey to the AtChops instance

### DIFF
--- a/packages/at_client_mobile/lib/at_client_mobile.dart
+++ b/packages/at_client_mobile/lib/at_client_mobile.dart
@@ -4,14 +4,15 @@ export 'package:at_client/at_client.dart';
 
 @Deprecated('Use AtClientMobile.authService')
 export 'src/at_client_auth.dart';
+export 'src/at_client_mobile_base.dart';
 @Deprecated('Use AtClientMobile.authService')
 export 'src/at_client_service.dart';
-
 // Contains public methods to handle the onboarding, authentication, and enrollment submission for an atSign
 export 'src/auth/at_auth_service.dart';
-
+@Deprecated('Use AtClientMobile.authService')
+// TODO: Remove this is next major release
+export 'src/auth/at_auth_service_impl.dart';
 // Contains the enrollment details
 export 'src/enrollment/enrollment_info.dart';
 export 'src/keychain_manager.dart';
 export 'src/onboarding_status.dart';
-export 'src/at_client_mobile_base.dart';

--- a/packages/at_client_mobile/lib/src/at_client_service.dart
+++ b/packages/at_client_mobile/lib/src/at_client_service.dart
@@ -2,12 +2,12 @@
 import 'dart:convert';
 import 'dart:core';
 
+import 'package:at_chops/at_chops.dart';
 import 'package:at_client_mobile/at_client_mobile.dart';
 import 'package:at_client_mobile/src/atsign_key.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_utils/at_logger.dart';
-import 'package:at_chops/at_chops.dart';
 import 'package:flutter/cupertino.dart';
 
 class AtClientService {
@@ -454,6 +454,8 @@ class AtClientService {
         decryptedAtKeys[BackupKeyConstants.PKAM_PUBLIC_KEY_FROM_KEY_FILE]!,
         decryptedAtKeys[BackupKeyConstants.PKAM_PRIVATE_KEY_FROM_KEY_FILE]!);
     final atChopsKeys = AtChopsKeys.create(atEncryptionKeyPair, atPkamKeyPair);
+    atChopsKeys.selfEncryptionKey = AESKey(
+        decryptedAtKeys[BackupKeyConstants.SELF_ENCRYPTION_KEY_FROM_FILE]!);
     final atChops = AtChopsImpl(atChopsKeys);
     return atChops;
   }

--- a/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
+++ b/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
@@ -41,6 +41,12 @@ class AtAuthServiceImpl implements AtAuthService {
 
   final Map<String, Completer<EnrollmentStatus>> _outcomes = {};
 
+  /// Returns an instance of [AtAuthService]
+  ///
+  /// Usage:
+  /// ```dart
+  ///  AtAuthService authService = AtClientMobile.authService(_atsign!, _atClientPreference);
+  /// ```
   AtAuthServiceImpl(this._atSign, this._atClientPreference) {
     // If the '@' symbol is omitted, it leads to an incorrect format for the AtKey when retrieving the
     // encrypted defaultEncryptionPrivateKey and encrypted defaultSelfEncryptionKey.


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Add SelfEncryptionKey to the AtChops instance
- Revert the change - removing exporting of AtAuthServiceImpl class. Removing the `AtAuthServiceImpl.dart` from exporting will lead to breaking change. Hence adding it back and marked as deprecated and TODO to remove it in next major release.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
