### PR TITLE
fix: Append atSign to the enrollment key to fix functional tests

### DIFF
--- a/tests/at_functional_test/test/enrollment_test.dart
+++ b/tests/at_functional_test/test/enrollment_test.dart
@@ -344,7 +344,7 @@ void main() {
         .listen(expectAsync1((enrollNotification) {
           print('got enrollment notification: $enrollNotification');
           expect(enrollNotification.key,
-              '$enrollmentIdFromServer.new.enrollments.__manage');
+              '$enrollmentIdFromServer.new.enrollments.__manage${atClientManager.atClient.getCurrentAtSign()}');
           expect(enrollNotification.value, isNotNull);
           var notificationValueJson = jsonDecode(enrollNotification.value!);
           expect(notificationValueJson['appName'], 'buzz');


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Fix the failing enrollment functional test.

**- How I did it**
- The failure is because of the missing atSign to the enrollment key received via the notification from the server. Added currentAtSign to the expected result.

**- How to verify it**
- All functional tests should pass.

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
