### PR TITLE
build: Add dependencies in at_client_mobile pubspec.yaml

### DIFF
--- a/packages/at_client_mobile/pubspec.yaml
+++ b/packages/at_client_mobile/pubspec.yaml
@@ -22,7 +22,9 @@ dependencies:
   at_lookup: ^3.0.46
   at_client: ^3.0.76
   at_auth: ^2.0.4
-  at_file_saver: 0.1.2
+  at_file_saver: ^0.1.2
+  encrypt: ^5.0.3
+  at_persistence_secondary_server: ^3.0.62
 
 dev_dependencies:
   lints: ^4.0.0


### PR DESCRIPTION
When running flutter pub publish --dry-run observed the below issues:

```
Package validation found the following errors:
* line 10, column 1 of lib/src/keychain_manager.dart: This package does not have encrypt in the `dependencies` section of `pubspec.yaml`.
     ╷
  10 │ import 'package:encrypt/encrypt.dart' as encrypt;
     │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ╵
* line 10, column 1 of lib/src/auth/at_auth_service_impl.dart: This package does not have at_persistence_secondary_server in the `dependencies` section of `pubspec.yaml`.
     ╷
  10 │ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
     │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     ╵
Package validation found the following potential issue:
* Your dependency on "at_file_saver" should allow more than one version. For example:
  
  dependencies:
    at_file_saver: ^0.1.2
  
  Constraints that are too tight will make it difficult for people to use your package
  along with other packages that also depend on "at_file_saver".
Sorry, your package is missing some requirements and can't be published yet.
```

Added following dependencies in at_client_mobile pubspec.yaml to resolve the above error:
  - at_file_saver: ^0.1.2
  - encrypt: ^5.0.3
  - at_persistence_secondary_server: ^3.0.62
