### PR TITLE
fix: Export backupkey_contants and getEncryptedKeysMethod

### DIFF
--- a/packages/at_client_mobile/CHANGELOG.md
+++ b/packages/at_client_mobile/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.2.17
+- fix: Export "BackupKeyConstants" and "getEncryptedKeys"
 ## 3.2.16
 - build[deps]: Upgraded dependencies for the following packages:
     - package_info_plus: ^8.0.0

--- a/packages/at_client_mobile/lib/at_client_mobile.dart
+++ b/packages/at_client_mobile/lib/at_client_mobile.dart
@@ -5,13 +5,17 @@ export 'package:at_client/at_client.dart';
 @Deprecated('Use AtClientMobile.authService')
 export 'src/at_client_auth.dart';
 export 'src/at_client_mobile_base.dart';
+// Since "src/at_client_service" is deprecated and "BackupKeyConstants" are being used by "at_backupkey_flutter" moved them
+// to "src/auth_constants.dart"
 @Deprecated('Use AtClientMobile.authService')
-export 'src/at_client_service.dart';
+export 'src/at_client_service.dart' hide BackupKeyConstants;
 // Contains public methods to handle the onboarding, authentication, and enrollment submission for an atSign
 export 'src/auth/at_auth_service.dart';
 @Deprecated('Use AtClientMobile.authService')
 // TODO: Remove this is next major release
 export 'src/auth/at_auth_service_impl.dart';
+// BackupKeyConstants are used in "at_backupkey_flutter" package. Hence exposing only fields in BackupKeyFlutter
+export 'src/auth_constants.dart' show BackupKeyConstants;
 // Contains the enrollment details
 export 'src/enrollment/enrollment_info.dart';
 export 'src/keychain_manager.dart';

--- a/packages/at_client_mobile/lib/src/at_client_auth.dart
+++ b/packages/at_client_mobile/lib/src/at_client_auth.dart
@@ -5,11 +5,13 @@ import 'package:at_lookup/at_lookup.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:crypton/crypton.dart';
 
+@Deprecated('Use AtClientMobile.authService')
 abstract class AtClientAuth {
   Future<bool> performInitialAuth(
       String atSign, AtClientPreference atClientPreference);
 }
 
+@Deprecated('Use AtClientMobile.authService')
 class AtClientAuthenticator implements AtClientAuth {
   KeyChainManager _keyChainManager = KeyChainManager.getInstance();
   late AtLookupImpl atLookUp;

--- a/packages/at_client_mobile/lib/src/at_client_service.dart
+++ b/packages/at_client_mobile/lib/src/at_client_service.dart
@@ -569,10 +569,18 @@ class KeychainUtil {
 
     encryptedAtKeysMap[BackupKeyConstants.SELF_ENCRYPTION_KEY_FROM_FILE] =
         atsignKeyData.selfEncryptionKey!;
-    encryptedAtKeysMap[BackupKeyConstants.APKAM_SYMMETRIC_KEY_FROM_FILE] =
-        atsignKeyData.apkamSymmetricKey!;
-    encryptedAtKeysMap[BackupKeyConstants.APKAM_ENROLLMENT_ID_FROM_FILE] =
-        atsignKeyData.enrollmentId!;
+    // The atKeys file generated previous to APKAM feature will not have the
+    // apkam_symmetric_key. Hence adding null check to prevent null-pointer exception.
+    if (atsignKeyData.apkamSymmetricKey != null) {
+      encryptedAtKeysMap[BackupKeyConstants.APKAM_SYMMETRIC_KEY_FROM_FILE] =
+          atsignKeyData.apkamSymmetricKey!;
+    }
+    // The atKeys file generated previous to APKAM feature will not have the
+    // enrollment-id. Hence adding null check to prevent null-pointer exception.
+    if (atsignKeyData.enrollmentId != null) {
+      encryptedAtKeysMap[BackupKeyConstants.APKAM_ENROLLMENT_ID_FROM_FILE] =
+          atsignKeyData.enrollmentId!;
+    }
 
     return encryptedAtKeysMap;
   }

--- a/packages/at_client_mobile/lib/src/at_client_service.dart
+++ b/packages/at_client_mobile/lib/src/at_client_service.dart
@@ -10,6 +10,7 @@ import 'package:at_lookup/at_lookup.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:flutter/cupertino.dart';
 
+@Deprecated('Use AtClientMobile.authService')
 class AtClientService {
   final AtSignLogger _logger = AtSignLogger('AtClientService');
   AtClient? _atClient;
@@ -581,7 +582,6 @@ class KeychainUtil {
       encryptedAtKeysMap[BackupKeyConstants.APKAM_ENROLLMENT_ID_FROM_FILE] =
           atsignKeyData.enrollmentId!;
     }
-
     return encryptedAtKeysMap;
   }
 }

--- a/packages/at_client_mobile/lib/src/auth_constants.dart
+++ b/packages/at_client_mobile/lib/src/auth_constants.dart
@@ -1,3 +1,14 @@
+class BackupKeyConstants {
+  // ignore_for_file: constant_identifier_names
+  static const String PKAM_PUBLIC_KEY_FROM_KEY_FILE = 'aesPkamPublicKey';
+  static const String PKAM_PRIVATE_KEY_FROM_KEY_FILE = 'aesPkamPrivateKey';
+  static const String ENCRYPTION_PUBLIC_KEY_FROM_FILE = 'aesEncryptPublicKey';
+  static const String ENCRYPTION_PRIVATE_KEY_FROM_FILE = 'aesEncryptPrivateKey';
+  static const String SELF_ENCRYPTION_KEY_FROM_FILE = 'selfEncryptionKey';
+  static const String APKAM_SYMMETRIC_KEY_FROM_FILE = 'apkamSymmetricKey';
+  static const String APKAM_ENROLLMENT_ID_FROM_FILE = 'enrollmentId';
+}
+
 const String keychainSecret = '_secret';
 const String keychainPKAMPrivateKey = '_pkam_private_key';
 const String keychainPKAMPublicKey = '_pkam_public_key';

--- a/packages/at_client_mobile/lib/src/keychain_manager.dart
+++ b/packages/at_client_mobile/lib/src/keychain_manager.dart
@@ -848,14 +848,20 @@ class KeyChainManager {
         atsignKeyData.encryptionPrivateKey!, atsignKeyData.selfEncryptionKey!);
     encryptedAtKeysMap[BackupKeyConstants.ENCRYPTION_PRIVATE_KEY_FROM_FILE] =
         encryptedEncryptionPrivateKey;
-
     encryptedAtKeysMap[BackupKeyConstants.SELF_ENCRYPTION_KEY_FROM_FILE] =
         atsignKeyData.selfEncryptionKey!;
-    encryptedAtKeysMap[BackupKeyConstants.APKAM_SYMMETRIC_KEY_FROM_FILE] =
-        atsignKeyData.apkamSymmetricKey!;
-    encryptedAtKeysMap[BackupKeyConstants.APKAM_ENROLLMENT_ID_FROM_FILE] =
-        atsignKeyData.enrollmentId!;
-
+    // The atKeys file generated previous to APKAM feature will not have the
+    // apkam_symmetric_key. Hence adding null check to prevent null-pointer exception.
+    if (atsignKeyData.apkamSymmetricKey != null) {
+      encryptedAtKeysMap[BackupKeyConstants.APKAM_SYMMETRIC_KEY_FROM_FILE] =
+          atsignKeyData.apkamSymmetricKey!;
+    }
+    // The atKeys file generated previous to APKAM feature will not have the
+    // enrollment-id. Hence adding null check to prevent null-pointer exception.
+    if (atsignKeyData.enrollmentId != null) {
+      encryptedAtKeysMap[BackupKeyConstants.APKAM_ENROLLMENT_ID_FROM_FILE] =
+          atsignKeyData.enrollmentId!;
+    }
     return encryptedAtKeysMap;
   }
 }

--- a/packages/at_client_mobile/pubspec.yaml
+++ b/packages/at_client_mobile/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client_mobile
 description: A Flutter extension to the at_client library which adds support for mobile, desktop and IoT devices.
-version: 3.2.16
+version: 3.2.17
 repository: https://github.com/atsign-foundation/at_client_sdk/packages
 homepage: https://docs.atsign.com/
 

--- a/packages/at_client_mobile/test/keychain_manager_test.dart
+++ b/packages/at_client_mobile/test/keychain_manager_test.dart
@@ -1,8 +1,9 @@
 import 'package:at_client_mobile/at_client_mobile.dart';
 import 'package:biometric_storage/biometric_storage.dart';
+import 'package:crypton/crypton.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:test/test.dart';
-import 'package:mocktail/mocktail.dart';
 
 class MockBiometricStorageFile extends Mock implements BiometricStorageFile {}
 
@@ -132,6 +133,149 @@ void main() {
       String? atSign = await keychainManager.getAtSign();
 
       expect(atSign, '@atSignTest');
+    });
+  });
+
+  group('A group of tests to assert backup of atKeys', () {
+    // The test will assert backup of atKeys generated before the APKAM feature.
+    test('A test to assert the legacy atKeys backup successfully', () async {
+      var keychainManager = KeyChainManager.getInstance();
+      MockBiometricStorageFile mockBiometricDefault =
+          MockBiometricStorageFile();
+
+      RSAKeypair pkamkeyPair = KeyChainManager.getInstance().generateKeyPair();
+      RSAKeypair encryptionKeyPair =
+          KeyChainManager.getInstance().generateKeyPair();
+      String selfEncryptionKey = KeyChainManager.getInstance().generateAESKey();
+
+      when(
+        () => mockBiometricDefault.read(),
+      ).thenAnswer(
+        (_) async => Future.value('''
+        {"config":{"schemaVersion":1,"useSharedAtsign":false},
+        "keys":[{"name":"@alice",
+                 "pkamPrivateKey":"${pkamkeyPair.privateKey.toString()}",
+                 "pkamPublicKey":"${pkamkeyPair.publicKey.toString()}",
+                 "encryptionPublicKey":"${encryptionKeyPair.publicKey.toString()}",
+                 "encryptionPrivateKey":"${encryptionKeyPair.privateKey.toString()}",
+                 "selfEncryptionKey":"$selfEncryptionKey",
+                 "hiveSecret":null,
+                 "secret":null}],
+                 "defaultAtsign":null}
+        '''),
+      );
+
+      when(
+        () => mockBiometricStorage.getStorage(
+          '@atsigns:',
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer(
+        (_) async => Future.value(
+          mockBiometricDefault,
+        ),
+      );
+
+      keychainManager.biometricStorage = mockBiometricStorage;
+
+      Map<String, String> encryptedKeys =
+          await keychainManager.getEncryptedKeys('@alice');
+      expect(
+          encryptedKeys[BackupKeyConstants.PKAM_PUBLIC_KEY_FROM_KEY_FILE]
+              ?.isNotEmpty,
+          true);
+      expect(
+          encryptedKeys[BackupKeyConstants.PKAM_PRIVATE_KEY_FROM_KEY_FILE]
+              ?.isNotEmpty,
+          true);
+      expect(
+          encryptedKeys[BackupKeyConstants.ENCRYPTION_PUBLIC_KEY_FROM_FILE]
+              ?.isNotEmpty,
+          true);
+      expect(
+          encryptedKeys[BackupKeyConstants.ENCRYPTION_PRIVATE_KEY_FROM_FILE]
+              ?.isNotEmpty,
+          true);
+      expect(encryptedKeys[BackupKeyConstants.SELF_ENCRYPTION_KEY_FROM_FILE],
+          selfEncryptionKey);
+      expect(
+          encryptedKeys
+              .containsKey(BackupKeyConstants.APKAM_SYMMETRIC_KEY_FROM_FILE),
+          false);
+      expect(
+          encryptedKeys
+              .containsKey(BackupKeyConstants.APKAM_ENROLLMENT_ID_FROM_FILE),
+          false);
+    });
+
+    test('A test to assert atKeys file contains apkam keys', () async {
+      var keychainManager = KeyChainManager.getInstance();
+      MockBiometricStorageFile mockBiometricDefault =
+          MockBiometricStorageFile();
+
+      RSAKeypair pkamkeyPair = KeyChainManager.getInstance().generateKeyPair();
+      RSAKeypair encryptionKeyPair =
+          KeyChainManager.getInstance().generateKeyPair();
+      String selfEncryptionKey = KeyChainManager.getInstance().generateAESKey();
+      String apkamEncryptionKey =
+          KeyChainManager.getInstance().generateAESKey();
+
+      when(
+        () => mockBiometricDefault.read(),
+      ).thenAnswer(
+        (_) async => Future.value('''
+        {"config":{"schemaVersion":1,"useSharedAtsign":false},
+        "keys":[{"name":"@alice",
+                 "pkamPrivateKey":"${pkamkeyPair.privateKey.toString()}",
+                 "pkamPublicKey":"${pkamkeyPair.publicKey.toString()}",
+                 "encryptionPublicKey":"${encryptionKeyPair.publicKey.toString()}",
+                 "encryptionPrivateKey":"${encryptionKeyPair.privateKey.toString()}",
+                 "selfEncryptionKey":"$selfEncryptionKey",
+                 "apkamSymmetricKey":"$apkamEncryptionKey",
+                 "enrollmentId":"123",
+                 "hiveSecret":null,
+                 "secret":null}],
+                 "defaultAtsign":null}
+        '''),
+      );
+
+      when(
+        () => mockBiometricStorage.getStorage(
+          '@atsigns:',
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer(
+        (_) async => Future.value(
+          mockBiometricDefault,
+        ),
+      );
+
+      keychainManager.biometricStorage = mockBiometricStorage;
+
+      Map<String, String> encryptedKeys =
+          await keychainManager.getEncryptedKeys('@alice');
+      expect(
+          encryptedKeys[BackupKeyConstants.PKAM_PUBLIC_KEY_FROM_KEY_FILE]
+              ?.isNotEmpty,
+          true);
+      expect(
+          encryptedKeys[BackupKeyConstants.PKAM_PRIVATE_KEY_FROM_KEY_FILE]
+              ?.isNotEmpty,
+          true);
+      expect(
+          encryptedKeys[BackupKeyConstants.ENCRYPTION_PUBLIC_KEY_FROM_FILE]
+              ?.isNotEmpty,
+          true);
+      expect(
+          encryptedKeys[BackupKeyConstants.ENCRYPTION_PRIVATE_KEY_FROM_FILE]
+              ?.isNotEmpty,
+          true);
+      expect(encryptedKeys[BackupKeyConstants.SELF_ENCRYPTION_KEY_FROM_FILE],
+          selfEncryptionKey);
+      expect(encryptedKeys[BackupKeyConstants.APKAM_SYMMETRIC_KEY_FROM_FILE],
+          apkamEncryptionKey);
+      expect(encryptedKeys[BackupKeyConstants.APKAM_ENROLLMENT_ID_FROM_FILE],
+          '123');
     });
   });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Uptaking the at_client_mobile 3.2.16 into at_backupkey_flutter results in the following lint warnings:

```
warning • The ability to import 'KeychainUtil' indirectly is deprecated • lib/services/backupkey_service.dart:13:18 • deprecated_export_use
warning • The ability to import 'KeychainUtil' indirectly is deprecated • lib/services/backupkey_service.dart:19:22 • deprecated_export_use
warning • The ability to import 'BackupKeyConstants' indirectly is deprecated • test/backupkey_service_test.dart:130:24 • deprecated_export_use
warning • The ability to import 'BackupKeyConstants' indirectly is deprecated • test/backupkey_service_test.dart:137:24 • deprecated_export_use
warning • The ability to import 'BackupKeyConstants' indirectly is deprecated • test/backupkey_service_test.dart:144:24 • deprecated_export_use
warning • The ability to import 'BackupKeyConstants' indirectly is deprecated • test/backupkey_service_test.dart:151:24 • deprecated_export_use
warning • The ability to import 'BackupKeyConstants' indirectly is deprecated • test/backupkey_service_test.dart:156:24 • deprecated_export_use
```

The warnings are because "BackupKeyConstants" and "KeychainUtil" classes are present in the deprecated "at_client_service.dart" file, which has now been replaced by "AtAuthServiceImpl".

To resolve the lint warnings:

- The BackupKeyConstants class has been relocated to the "auth_constants.dart" file, and only this class is exported.
- Most methods in the KeychainUtil class are wrappers around the methods in the already-exported KeychainManager class except for the "getEncryptedKeys" method. So, moved the method into the KeychainManager class.

**- How to verify it**
- Used dependency_overrides in at_backupkey_flutter and ran `flutter analyze`  and no lint warning are found.

```
~/IdeaProjects/atsign/widgets/at_widgets/packages/at_backupkey_flutter git:[fix_lint_issues_in_backupkey_flutter]
flutter analyze
Analyzing at_backupkey_flutter...                                       
No issues found! (ran in 2.0s)
```
Please refer to the following commit for the changes in the at_backupkey_flutter: https://github.com/atsign-foundation/at_widgets/compare/fix_lint_issues_in_backupkey_flutter

**- Description for the changelog**
- Export "BackupKeyConstants" and "getEncryptedKeys"