### PR TITLE
feat: Add feature flag to allow atClient for offline access

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.77
 - fix: Fix the keys expiry job not being triggered
 - chore: deprecate NotificationParams.forText()
+- feat: Add "allowAtClientOfflineAccess" feature flag to retain the existing app's behaviour.
 ## 3.0.76
 - feat: Introduce mechanism to identify and delete expired keys
 - feat: Introduce enrollment service to support enrollment operations:

--- a/packages/at_client/lib/src/preference/at_client_preference.dart
+++ b/packages/at_client/lib/src/preference/at_client_preference.dart
@@ -116,6 +116,12 @@ class AtClientPreference {
 
   //hashing algorithm to use for pkam authentication
   HashingAlgoType hashingAlgoType = HashingAlgoType.sha256;
+
+  /// Determines if the client is allowed offline access.
+  ///
+  /// When set to `true`, the client can operate without an internet connection.
+  /// When set to `false`, an internet connection is required.
+  bool allowAtClientOfflineAccess = false;
 }
 
 @Deprecated("Use SyncService")


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Reference to the PR: https://github.com/atsign-foundation/at_client_sdk/pull/1348, added feature flag to allow at_client initialize in offline access.

**- How I did it**
- Added a preference in AtClientPreferences class. The default value is set to false to retain the existing behavior. If the flag is set to true, at_client is initialized even when network connectivity is not available.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
