### PR TITLE
fix: rename key from __manage to local key for storing enrollment details

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.78
+- fix: rename enrollment details key to local key
 ## 3.0.77
 - fix: Fix the keys expiry job not being triggered
 - chore: deprecate NotificationParams.forText()

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -316,7 +316,7 @@ class LocalSecondary implements Secondary {
     AtData? enrollmentInfoFromLocalSecondary;
     try {
       enrollmentInfoFromLocalSecondary = await keyStore?.get(
-          '${_atClient.enrollmentId}.new.enrollments.__manage${_atClient.getCurrentAtSign()}');
+          'local:${_atClient.enrollmentId}${_atClient.getCurrentAtSign()}');
     } on Exception {
       _logger.finer(
           'Enrollment information for id: ${_atClient.enrollmentId} not found in local secondary. Fetching from server');

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.77';
+  final String atClientVersion = '3.0.78';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.77
+version: 3.0.78
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/test/apkam_authorization_test.dart
+++ b/packages/at_client/test/apkam_authorization_test.dart
@@ -32,8 +32,12 @@ void main() {
             ..commitLogPath = 'test/hive/commit');
       atClient.enrollmentId = testEnrollmentId;
       // Insert the enrollment info into the local secondary.
+      var localEnrollmentKey = AtKey()
+        ..isLocal = true
+        ..key = testEnrollmentId
+        ..sharedBy = '@alice';
       await atClient.getLocalSecondary()?.keyStore?.put(
-          '$testEnrollmentId.new.enrollments.__manage@alice',
+          localEnrollmentKey.toString(),
           AtData()
             ..data = jsonEncode(
                 Enrollment()..namespace = {"__manage": "rw", "*": "rw"}));
@@ -132,8 +136,12 @@ void main() {
             ..commitLogPath = 'test/hive/commit');
       atClient.enrollmentId = testEnrollmentId;
       // Insert the enrollment info into the local secondary.
+      var localEnrollmentKey = AtKey()
+        ..isLocal = true
+        ..key = testEnrollmentId
+        ..sharedBy = '@alice';
       await atClient.getLocalSecondary()?.keyStore?.put(
-          '$testEnrollmentId.new.enrollments.__manage@alice',
+          localEnrollmentKey.toString(),
           AtData()
             ..data = jsonEncode(Enrollment()..namespace = {"wavi": "rw"}));
       //1. create a self key in wavi namespace should pass
@@ -211,8 +219,12 @@ void main() {
             ..commitLogPath = 'test/hive/commit');
       atClient.enrollmentId = testEnrollmentId;
       // Insert the enrollment info into the local secondary.
+      var localEnrollmentKey = AtKey()
+        ..isLocal = true
+        ..key = testEnrollmentId
+        ..sharedBy = '@alice';
       await atClient.getLocalSecondary()?.keyStore?.put(
-          '$testEnrollmentId.new.enrollments.__manage@alice',
+          localEnrollmentKey.toString(),
           AtData()
             ..data = jsonEncode(
                 Enrollment()..namespace = {"__manage": "rw", "*": "rw"}));
@@ -283,8 +295,12 @@ void main() {
             ..commitLogPath = 'test/hive/commit');
       enrolledAtClient.enrollmentId = newEnrollmentId;
       // Insert the enrollment info into the local secondary.
+      var localEnrollmentKey_2 = AtKey()
+        ..isLocal = true
+        ..key = newEnrollmentId
+        ..sharedBy = '@alice';
       await atClient.getLocalSecondary()?.keyStore?.put(
-          '$newEnrollmentId.new.enrollments.__manage@alice',
+          localEnrollmentKey_2.toString(),
           AtData()
             ..data = jsonEncode(Enrollment()..namespace = {"wavi": "rw"}));
       // delete self key in wavi namespace should pass
@@ -340,8 +356,12 @@ void main() {
             ..commitLogPath = 'test/hive/commit');
       atClient.enrollmentId = testEnrollmentId;
       // Insert the enrollment info into the local secondary.
+      var localEnrollmentKey = AtKey()
+        ..isLocal = true
+        ..key = testEnrollmentId
+        ..sharedBy = '@alice';
       await atClient.getLocalSecondary()?.keyStore?.put(
-          '$testEnrollmentId.new.enrollments.__manage@alice',
+          localEnrollmentKey.toString(),
           AtData()
             ..data = jsonEncode(
                 Enrollment()..namespace = {"__manage": "rw", "*": "rw"}));
@@ -435,8 +455,12 @@ void main() {
             ..commitLogPath = 'test/hive/commit');
       atClient.enrollmentId = privilegedEnrollment;
       // Insert the enrollment info into the local secondary.
+      var localEnrollmentKey = AtKey()
+        ..isLocal = true
+        ..key = privilegedEnrollment
+        ..sharedBy = '@alice';
       await atClient.getLocalSecondary()?.keyStore?.put(
-          '$privilegedEnrollment.new.enrollments.__manage@alice',
+          localEnrollmentKey.toString(),
           AtData()..data = jsonEncode(Enrollment()..namespace = {"*": "rw"}));
       //1. create a key in wavi namespace
       var waviKey = AtKey()
@@ -501,8 +525,12 @@ void main() {
             ..commitLogPath = 'test/hive/commit');
       enrolledAtClient.enrollmentId = newEnrollmentId;
       // Insert the enrollment info into the local secondary.
+      var localEnrollmentKey_2 = AtKey()
+        ..isLocal = true
+        ..key = newEnrollmentId
+        ..sharedBy = '@alice';
       await atClient.getLocalSecondary()?.keyStore?.put(
-          '$newEnrollmentId.new.enrollments.__manage@alice',
+          localEnrollmentKey_2.toString(),
           AtData()
             ..data = jsonEncode(Enrollment()..namespace = {"wavi": "rw"}));
       // llookup on wavi namespace should be allowed
@@ -555,8 +583,12 @@ void main() {
             ..commitLogPath = 'test/hive/commit');
       atClient.enrollmentId = testEnrollmentId;
       // Insert the enrollment info into the local secondary.
+      var localEnrollmentKey = AtKey()
+        ..isLocal = true
+        ..key = testEnrollmentId
+        ..sharedBy = '@alice';
       await atClient.getLocalSecondary()?.keyStore?.put(
-          '$testEnrollmentId.new.enrollments.__manage@alice',
+          localEnrollmentKey.toString(),
           AtData()
             ..data = jsonEncode(
                 Enrollment()..namespace = {"__manage": "rw", "*": "rw"}));
@@ -635,8 +667,12 @@ void main() {
             ..commitLogPath = 'test/hive/commit');
       enrolledAtClient.enrollmentId = newEnrollmentId;
       // Insert the enrollment info into the local secondary.
+      var localEnrollmentKey_2 = AtKey()
+        ..isLocal = true
+        ..key = newEnrollmentId
+        ..sharedBy = '@alice';
       await atClient.getLocalSecondary()?.keyStore?.put(
-          '$newEnrollmentId.new.enrollments.__manage@alice',
+          localEnrollmentKey_2.toString(),
           AtData()
             ..data = jsonEncode(Enrollment()..namespace = {"wavi": "rw"}));
       // enrolled client should be able to see wavi key and reserved key in scan. Buzz key and no namespace keys should not be returned

--- a/packages/at_client/test/enrollment_service_test.dart
+++ b/packages/at_client/test/enrollment_service_test.dart
@@ -38,7 +38,10 @@ void main() {
         remoteSecondary: mockRemoteSecondary);
     atClient.syncService = MockSyncService();
 
-    String key = '$enrollmentId.new.enrollments.__manage$currentAtSign';
+    var localEnrollmentKey = AtKey()
+      ..isLocal = true
+      ..key = enrollmentId
+      ..sharedBy = '@alice';
     AtData atData = AtData()
       ..data = jsonEncode(Enrollment()
         ..appName = 'wavi'
@@ -47,7 +50,10 @@ void main() {
         ..enrollmentId = enrollmentId);
 
     // Store enrollment data
-    await atClient.getLocalSecondary()?.keyStore?.put(key, atData);
+    await atClient
+        .getLocalSecondary()
+        ?.keyStore
+        ?.put(localEnrollmentKey.toString(), atData);
 
     AtEncryptionResult? atEncryptionResult = atClient.atChops?.encryptString(
         atChops.atChopsKeys.selfEncryptionKey!.key, EncryptionKeyType.rsa2048);

--- a/packages/at_client_mobile/CHANGELOG.md
+++ b/packages/at_client_mobile/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.2.18
+- fix:  fix: rename enrollment details key to local key
 ## 3.2.17
 - fix: Export "BackupKeyConstants" and "getEncryptedKeys"
 ## 3.2.16

--- a/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
+++ b/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
@@ -487,8 +487,10 @@ class AtAuthServiceImpl implements AtAuthService {
   /// when performing CURD operation on local secondary server
   Future<void> _storeEnrollmentInfoIntoLocalSecondary(
       EnrollmentInfo enrollmentInfo) async {
-    String enrollmentKey =
-        '${enrollmentInfo.enrollmentId}.new.enrollments.__manage$_atSign';
+    var localEnrollmentKey = AtKey()
+      ..isLocal = true
+      ..key = enrollmentInfo.enrollmentId
+      ..sharedBy = _atSign;
     Enrollment enrollment = Enrollment()..namespace = enrollmentInfo.namespace;
     AtData atData = AtData()..data = jsonEncode(enrollment);
     // The "put" function in AtClient will call the executeVerb function which in turn calls the "_isAuthorized" in the local secondary.
@@ -502,7 +504,7 @@ class AtAuthServiceImpl implements AtAuthService {
     await _atClient!
         .getLocalSecondary()
         ?.keyStore
-        ?.put(enrollmentKey, atData, skipCommit: true);
+        ?.put(localEnrollmentKey.toString(), atData);
   }
 
   AtChops _buildAtChops(EnrollmentInfo enrollmentInfo) {

--- a/packages/at_client_mobile/pubspec.yaml
+++ b/packages/at_client_mobile/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client_mobile
 description: A Flutter extension to the at_client library which adds support for mobile, desktop and IoT devices.
-version: 3.2.17
+version: 3.2.18
 repository: https://github.com/atsign-foundation/at_client_sdk/packages
 homepage: https://docs.atsign.com/
 


### PR DESCRIPTION
**- What I did**
- Since key used to store enrollment details is used only on client side for authorization check, it is not recommended to use __manage namespace
https://github.com/atsign-foundation/at_libraries/pull/599#pullrequestreview-2187774133
**- How I did it**
- renamed the key while storing to local key in at_client_mobile - AtAuthServiceImpl
- renamed the key while fetching enrollment details to local key in at_client - LocalSecondary
- renamed keys in unit tests

**- How to verify it**
- unit and functional tests should pass
