### PR TITLE
fix: Add "sharedKeyEnc" to the metadata

### DIFF
--- a/packages/at_client/lib/src/response/at_notification.dart
+++ b/packages/at_client/lib/src/response/at_notification.dart
@@ -33,6 +33,7 @@ class AtNotification {
           json['metadata'][AtConstants.sharedKeyEncryptedEncryptingKeyName];
       metadata.skeEncAlgo =
           json['metadata'][AtConstants.sharedKeyEncryptedEncryptingAlgo];
+      metadata.sharedKeyEnc = json['metadata'][AtConstants.sharedKeyEncrypted];
     }
 
     return AtNotification(json['id'], json['key'], json['from'], json['to'],

--- a/tests/at_end2end_test/test/notify_with_isolate_test.dart
+++ b/tests/at_end2end_test/test/notify_with_isolate_test.dart
@@ -1,0 +1,82 @@
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:at_client/at_client.dart';
+import 'package:at_end2end_test/config/config_util.dart';
+import 'package:at_end2end_test/src/test_initializers.dart';
+import 'package:at_end2end_test/utils/test_constants.dart';
+import 'package:test/test.dart';
+
+String currentAtSign = ConfigUtil.getYaml()['atSign']['firstAtSign'];
+String sharedWithAtSign = ConfigUtil.getYaml()['atSign']['secondAtSign'];
+String authType = ConfigUtil.getYaml()['authType'];
+
+void main() {
+  String notifyKey = '$sharedWithAtSign:phone.wavi$currentAtSign';
+  String value = '+91 9868123123';
+
+  test('A test to send and receive notification with isolate', () async {
+    ReceivePort mainIsolateReceivePort = ReceivePort('MainIsolateReceivePort');
+
+    // Spawn an isolate to listen for notifications
+    Isolate childIsolate =
+        await Isolate.spawn(initSharedAtSign, mainIsolateReceivePort.sendPort);
+    // Listen for messages from isolate
+    mainIsolateReceivePort.listen(expectAsync1((data) {
+      expect(data.value, value);
+      expect(data.key, notifyKey);
+      expect(data.from, currentAtSign);
+      expect(data.to, sharedWithAtSign);
+      childIsolate.kill();
+    }));
+
+    // Initialize another atSign to send notifications
+    await TestSuiteInitializer.getInstance().testInitializer(
+        currentAtSign, TestConstants.namespace, authType,
+        enableInitialSync: false,
+        atClientPreference: getAtClientPreferences(currentAtSign));
+
+    NotificationResult notificationResult = await AtClientManager.getInstance()
+        .atClient
+        .notificationService
+        .notify(NotificationParams.forUpdate(AtKey.fromString(notifyKey),
+            value: value));
+
+    expect(notificationResult.notificationStatusEnum,
+        NotificationStatusEnum.delivered);
+  });
+
+  tearDown(() {
+    // Remove hive directories
+    Directory('test/hive/$currentAtSign').deleteSync(recursive: true);
+    Directory('test/hive/$sharedWithAtSign').deleteSync(recursive: true);
+  });
+}
+
+Future<void> initSharedAtSign(SendPort mainIsolateSendPort) async {
+  await TestSuiteInitializer.getInstance().testInitializer(
+      sharedWithAtSign, TestConstants.namespace, authType,
+      enableInitialSync: false,
+      atClientPreference: getAtClientPreferences(sharedWithAtSign));
+
+  AtClientManager.getInstance()
+      .atClient
+      .notificationService
+      .subscribe(shouldDecrypt: true)
+      .listen((onData) {
+    // Ignore stats notifications
+    if (onData.id == '-1') {
+      return;
+    }
+    mainIsolateSendPort.send(onData);
+  });
+}
+
+AtClientPreference getAtClientPreferences(String atSign) {
+  var atClientPreference = AtClientPreference();
+  atClientPreference.hiveStoragePath = 'test/hive/$atSign';
+  atClientPreference.commitLogPath = 'test/hive/$atSign/commit/';
+  atClientPreference.isLocalStoreRequired = true;
+  atClientPreference.rootDomain = ConfigUtil.getYaml()['root_server']['url'];
+  return atClientPreference;
+}

--- a/tests/at_end2end_test/test/notify_with_isolate_test.dart
+++ b/tests/at_end2end_test/test/notify_with_isolate_test.dart
@@ -12,7 +12,8 @@ String sharedWithAtSign = ConfigUtil.getYaml()['atSign']['secondAtSign'];
 String authType = ConfigUtil.getYaml()['authType'];
 
 void main() {
-  String notifyKey = '$sharedWithAtSign:phone.wavi$currentAtSign';
+  String notifyKey =
+      '$sharedWithAtSign:phone.${TestConstants.namespace}$currentAtSign';
   String value = '+91 9868123123';
 
   test('A test to send and receive notification with isolate', () async {


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- From the received notifications, add "sharedKeyEnc" to AtKey.metadata
- Changes in E2E tests
  - Introduce AtClientPreferences as optional parameter to "testInitializer" to initialize the local storage into new path for the atSigns. This helps in preventing reusing of existing "shared_key" from local storage for encrypting the data.
  - Introduced "enableInitialSync" as optional parameter which is defaulted to true. When running notification test isolate, set this parameter to false, to prevent keys from remote secondary sync'ed to local secondary. This helps in speeding up the test run process.

**- How to verify it**
- Added E2E test to ensure the notify with value, and decrypt the value on the receiver side.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
