### PR TITLE
fix: remove 3.0.78 version from changelog

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,5 +1,3 @@
-## 3.0.78
-- fix: rename enrollment details key to local key
 ## 3.0.77
 - fix: Fix the keys expiry job not being triggered
 - chore: deprecate NotificationParams.forText()


### PR DESCRIPTION
**- What I did**
- removed 3.0.78 from change log which was added by mistake
