### PR TITLE
fix: publish at_client 3.0.77+1

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.77+1
+- fix: remove incorrect version 3.0.78 from changelog
 ## 3.0.77
 - fix: Fix the keys expiry job not being triggered
 - chore: deprecate NotificationParams.forText()

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.77';
+  final String atClientVersion = '3.0.77+1';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.77
+version: 3.0.77+1
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 


### PR DESCRIPTION
**- What I did**
- publish at_client 3.0.77+1 after removing incorrect version 3.0.78 in changelog
**- How I did it**
- added version 3.0.77+1
**- How to verify it**
- n/a
