### PR TITLE
fix: Notify response transformer fix

### DIFF
--- a/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
+++ b/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
@@ -22,7 +22,6 @@ class NotificationResponseTransformer
       Tuple<AtNotification, NotificationConfig> tuple) async {
     // prepare the atKey from the atNotification object.
     AtNotification atNotification = tuple.one;
-    NotificationConfig config = tuple.two;
     String sharedBy = atNotification.from;
     String sharedWith = atNotification.to;
     var key = atNotification.key;
@@ -77,12 +76,6 @@ class NotificationResponseTransformer
       return atNotification;
     }
     return atNotification;
-  }
-
-  // Decrypt the notification key only if isEncrypted flag is set to true or
-  // null (for backward compatibility - default behavior is decrypt the notification key)
-  bool _shouldDecryptKey(bool? isEncrypted) {
-    return isEncrypted == null || isEncrypted == true;
   }
 
   Future<String> _getDecryptedValue(AtKey atKey, String? encryptedValue) async {

--- a/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
+++ b/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
@@ -77,8 +77,8 @@ class NotificationResponseTransformer
     return atNotification;
   }
 
-  // Decrypt the notification key only if isEncrypted false is set to true or
-  // not set(for backward compatibility where default behavior is encrypt the notification key)
+  // Decrypt the notification key only if isEncrypted flag is set to true or
+  // null (for backward compatibility - default behavior is decrypt the notification key)
   bool _shouldDecryptKey(bool? isEncrypted) {
     return isEncrypted == null || isEncrypted == true;
   }

--- a/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
+++ b/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
@@ -22,6 +22,7 @@ class NotificationResponseTransformer
       Tuple<AtNotification, NotificationConfig> tuple) async {
     // prepare the atKey from the atNotification object.
     AtNotification atNotification = tuple.one;
+    NotificationConfig notificationConfig = tuple.two;
     String sharedBy = atNotification.from;
     String sharedWith = atNotification.to;
     var key = atNotification.key;
@@ -68,8 +69,9 @@ class NotificationResponseTransformer
         // and is not a user created key.
         // Hence do not decrypt if key's are reserved keys
         AtKey.getKeyType(atKey.toString()) != KeyType.reservedKey) {
-      // decrypt the notification value only if isEncrypted is not set to false
-      if (atNotification.isEncrypted != false) {
+      // decrypt the notification value only if isEncrypted is not set to false and shouldDecrypt is set to true
+      if (atNotification.isEncrypted != false &&
+          notificationConfig.shouldDecrypt) {
         atNotification.value =
             await _getDecryptedValue(atKey, atNotification.value!);
       }

--- a/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
+++ b/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
@@ -56,11 +56,13 @@ class NotificationResponseTransformer
     }
 
     if (atNotification.messageType.isNotNull &&
-        atNotification.messageType!.toLowerCase().contains('text') &&
-        (atNotification.isEncrypted != null && atNotification.isEncrypted!)) {
-      // decrypt the text message;
-      var decryptedValue = await _getDecryptedValue(atKey, atKey.key);
-      atNotification.key = '${atNotification.to}:$decryptedValue';
+        atNotification.messageType!.toLowerCase().contains('text')) {
+      // decrypt the text message if isEncrypted is true
+      if (atNotification.isEncrypted != null && atNotification.isEncrypted == true) {
+        var decryptedValue = await _getDecryptedValue(atKey, atKey.key);
+        atNotification.key = '${atNotification.to}:$decryptedValue';
+      }
+      // do not decrypt if isEncrypted is null or set to false
       return atNotification;
     } else if ((atNotification.value.isNotNull) &&
         (config.shouldDecrypt && atNotification.id != '-1') &&

--- a/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
+++ b/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
@@ -57,14 +57,13 @@ class NotificationResponseTransformer
 
     if (atNotification.messageType.isNotNull &&
         atNotification.messageType!.toLowerCase().contains('text')) {
-      // decrypt the text message if isEncrypted is true
-      if (atNotification.isEncrypted != null && atNotification.isEncrypted == true) {
+      if (_shouldDecryptKey(atNotification.isEncrypted)) {
         var decryptedValue = await _getDecryptedValue(atKey, atKey.key);
         atNotification.key = '${atNotification.to}:$decryptedValue';
       }
-      // do not decrypt if isEncrypted is null or set to false
       return atNotification;
-    } else if ((atNotification.value.isNotNull) &&
+    }
+    if ((atNotification.value.isNotNull) &&
         (config.shouldDecrypt && atNotification.id != '-1') &&
         // The shared_key (which is a reserved key) has different decryption process
         // and is not a user created key.
@@ -76,6 +75,12 @@ class NotificationResponseTransformer
       return atNotification;
     }
     return atNotification;
+  }
+
+  // Decrypt the notification key only if isEncrypted false is set to true or
+  // not set(for backward compatibility where default behavior is encrypt the notification key)
+  bool _shouldDecryptKey(bool? isEncrypted) {
+    return isEncrypted == null || isEncrypted == true;
   }
 
   Future<String> _getDecryptedValue(AtKey atKey, String? encryptedValue) async {

--- a/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
+++ b/packages/at_client/lib/src/transformer/response_transformer/notification_response_transformer.dart
@@ -56,22 +56,24 @@ class NotificationResponseTransformer
     }
 
     if (atNotification.messageType.isNotNull &&
-        atNotification.messageType!.toLowerCase().contains('text')) {
-      if (_shouldDecryptKey(atNotification.isEncrypted)) {
-        var decryptedValue = await _getDecryptedValue(atKey, atKey.key);
-        atNotification.key = '${atNotification.to}:$decryptedValue';
-      }
+        atNotification.messageType!.toLowerCase().contains('text') &&
+        (atNotification.isEncrypted != null && atNotification.isEncrypted!)) {
+      // decrypt the text message;
+      var decryptedValue = await _getDecryptedValue(atKey, atKey.key);
+      atNotification.key = '${atNotification.to}:$decryptedValue';
       return atNotification;
     }
-    if ((atNotification.value.isNotNull) &&
-        (config.shouldDecrypt && atNotification.id != '-1') &&
+    if (atNotification.value.isNotNull &&
+        atNotification.id != '-1' &&
         // The shared_key (which is a reserved key) has different decryption process
         // and is not a user created key.
         // Hence do not decrypt if key's are reserved keys
         AtKey.getKeyType(atKey.toString()) != KeyType.reservedKey) {
-      // decrypt the value
-      atNotification.value =
-          await _getDecryptedValue(atKey, atNotification.value!);
+      // decrypt the notification value only if isEncrypted is not set to false
+      if (atNotification.isEncrypted != false) {
+        atNotification.value =
+            await _getDecryptedValue(atKey, atNotification.value!);
+      }
       return atNotification;
     }
     return atNotification;

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -276,34 +276,9 @@ void main() {
     });
 
     test(
-        'A test to verify notification text is decrypted when isEncrypted is set to null',
+        'A test to verify notification value is decrypted when isEncrypted is set to null',
         () async {
       bool? isEncrypted;
-      var atNotification = at_notification.AtNotification(
-          '124',
-          '@bob:encryptedValue',
-          '@alice',
-          '@bob',
-          DateTime.now().millisecondsSinceEpoch,
-          MessageTypeEnum.text.toString(),
-          isEncrypted);
-      var notificationResponseTransformer =
-          NotificationResponseTransformer(mockAtClientImpl);
-      notificationResponseTransformer.atKeyDecryption = mockSharedKeyDecryption;
-
-      var transformedNotification =
-          await notificationResponseTransformer.transform(Tuple()
-            ..one = atNotification
-            ..two = (NotificationConfig()
-              ..regex = '.*'
-              ..shouldDecrypt = true));
-      expect(transformedNotification.key, '@bob:decryptedValue');
-    });
-
-    test(
-        'A test to verify notification key is decrypted when shouldDecrypt is set to true',
-        () async {
-      var isEncrypted = false;
       var atNotification = at_notification.AtNotification(
           '124',
           'key-1',
@@ -327,7 +302,33 @@ void main() {
     });
 
     test(
-        'A test to verify notification key is not decrypted when shouldDecrypt is set to false',
+        'A test to verify notification value is decrypted when isEncrypted is set to true',
+        () async {
+      bool isEncrypted = true;
+      var atNotification = at_notification.AtNotification(
+          '124',
+          'key-1',
+          '@alice',
+          '@bob',
+          DateTime.now().millisecondsSinceEpoch,
+          MessageTypeEnum.key.toString(),
+          isEncrypted,
+          value: 'encryptedValue');
+      var notificationResponseTransformer =
+          NotificationResponseTransformer(mockAtClientImpl);
+      notificationResponseTransformer.atKeyDecryption = mockSharedKeyDecryption;
+
+      var transformedNotification =
+          await notificationResponseTransformer.transform(Tuple()
+            ..one = atNotification
+            ..two = (NotificationConfig()
+              ..regex = '.*'
+              ..shouldDecrypt = true));
+      expect(transformedNotification.value, 'decryptedValue');
+    });
+
+    test(
+        'A test to verify notification value is not decrypted when isEncrypted is set to false',
         () async {
       var isEncrypted = false;
       var atNotification = at_notification.AtNotification(

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -276,6 +276,31 @@ void main() {
     });
 
     test(
+        'A test to verify notification text is decrypted when isEncrypted is set to null',
+        () async {
+      bool? isEncrypted;
+      var atNotification = at_notification.AtNotification(
+          '124',
+          '@bob:encryptedValue',
+          '@alice',
+          '@bob',
+          DateTime.now().millisecondsSinceEpoch,
+          MessageTypeEnum.text.toString(),
+          isEncrypted);
+      var notificationResponseTransformer =
+          NotificationResponseTransformer(mockAtClientImpl);
+      notificationResponseTransformer.atKeyDecryption = mockSharedKeyDecryption;
+
+      var transformedNotification =
+          await notificationResponseTransformer.transform(Tuple()
+            ..one = atNotification
+            ..two = (NotificationConfig()
+              ..regex = '.*'
+              ..shouldDecrypt = true));
+      expect(transformedNotification.key, '@bob:decryptedValue');
+    });
+
+    test(
         'A test to verify notification key is decrypted when shouldDecrypt is set to true',
         () async {
       var isEncrypted = false;

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -353,6 +353,32 @@ void main() {
       expect(transformedNotification.value, 'encryptedValue');
     });
 
+    test(
+        'A test to verify notification value is not decrypted when isEncrypted is set to true and should decrypt is false',
+        () async {
+      var isEncrypted = true;
+      var atNotification = at_notification.AtNotification(
+          '124',
+          'key-1',
+          '@alice',
+          '@bob',
+          DateTime.now().millisecondsSinceEpoch,
+          MessageTypeEnum.key.toString(),
+          isEncrypted,
+          value: 'encryptedValue');
+      var notificationResponseTransformer =
+          NotificationResponseTransformer(mockAtClientImpl);
+      notificationResponseTransformer.atKeyDecryption = mockSharedKeyDecryption;
+
+      var transformedNotification =
+          await notificationResponseTransformer.transform(Tuple()
+            ..one = atNotification
+            ..two = (NotificationConfig()
+              ..regex = '.*'
+              ..shouldDecrypt = false));
+      expect(transformedNotification.value, 'encryptedValue');
+    });
+
     test('A test to verify notification is returned as is', () async {
       var isEncrypted = false;
       var atNotification = at_notification.AtNotification(


### PR DESCRIPTION
fixes: https://github.com/atsign-foundation/at_client_sdk/issues/1332
**- What I did**
- added check in NotificationResponseTransformer to decrypt the notification value only if isEncrypted is NOT false.
**- How I did it**
- added a check before decrypting notification value. decrypt notification value only if isEncrypted is null or true.
- added/modified unit tests in notification_service_test.dart
**- How to verify it**
- tests in notification_service_test.dart should pass
