### PR TITLE
feat: add `useRemoteAtServer` flag to `GetRequestOptions`

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -3,6 +3,8 @@
   to fetch directly from the atServer rather than the client-side synced 
   cache. This flag was added to `PutRequestOptions` and 
   `DeleteRequestOptions` in version 3.0.60
+- fix: Ensure that `NotificationResponseTransformer` does not attempt to 
+  decrypt when `atNotification.isEncrypted == false`
 ## 3.0.78
 - chore: publish clean version 3.0.78
 ## 3.0.77+1

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.0
+- feat: add `useRemoteAtServer` flag to `GetRequestOptions` to allow clients 
+  to fetch directly from the atServer rather than the client-side synced 
+  cache. This flag was added to `PutRequestOptions` and 
+  `DeleteRequestOptions` in version 3.0.60
 ## 3.0.78
 - chore: publish clean version 3.0.78
 ## 3.0.77+1

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -346,7 +346,11 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       var verbBuilder = GetRequestTransformer(this)
           .transform(atKey, requestOptions: getRequestOptions);
       // Execute the verb.
-      secondary = SecondaryManager.getSecondary(this, verbBuilder);
+      if (getRequestOptions?.useRemoteAtServer == true) {
+        secondary = getRemoteSecondary()!;
+      } else {
+        secondary = SecondaryManager.getSecondary(this, verbBuilder);
+      }
       var getResponse = await secondary.executeVerb(verbBuilder);
       // Return empty value if getResponse is null.
       if (getResponse == null ||

--- a/packages/at_client/lib/src/client/request_options.dart
+++ b/packages/at_client/lib/src/client/request_options.dart
@@ -8,6 +8,9 @@ class GetRequestOptions extends RequestOptions {
   /// Whether the `get` request should bypass this atSign's cache of data owned
   /// by another atSign
   bool bypassCache = false;
+
+  /// Whether to send this get request directly to the remote atServer
+  bool useRemoteAtServer = false;
 }
 
 /// Parameters that application code can optionally provide when calling
@@ -24,6 +27,6 @@ class PutRequestOptions extends RequestOptions {
 /// Parameters that application code can optionally provide when calling
 /// `AtClient.delete`
 class DeleteRequestOptions extends RequestOptions {
-  /// Whether to send this update request directly to the remote atServer
+  /// Whether to send this delete request directly to the remote atServer
   bool useRemoteAtServer = false;
 }

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.0.78';
+  final String atClientVersion = '3.1.0';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -394,6 +394,7 @@ class NotificationServiceImpl
   @visibleForTesting
   void notificationValueValidation(
       NotificationParams notificationParams, NotifyVerbBuilder builder) {
+    // ignore: deprecated_member_use_from_same_package
     switch (notificationParams.messageType) {
       case MessageTypeEnum.key:
         // Since value is not mandatory in AtNotification, perform validation only if
@@ -405,6 +406,7 @@ class NotificationServiceImpl
         }
         break;
 
+      // ignore: deprecated_member_use
       case MessageTypeEnum.text:
         // When messageType is text, the "text" to notify is added to the key. Hence validating
         // the key length

--- a/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
+++ b/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use_from_same_package
+
 import 'dart:async';
 
 import 'package:at_client/src/preference/at_client_preference.dart';
@@ -56,6 +58,7 @@ class NotificationRequestTransformer
       builder.atKey.key = AtClientUtil.getKeyWithNameSpace(
           notificationParams.atKey, atClientPreference);
     }
+    // ignore: deprecated_member_use
     if (notificationParams.messageType == MessageTypeEnum.text) {
       if (notificationParams.atKey.metadata.isEncrypted) {
         builder.atKey.key = await _encryptNotificationValue(

--- a/packages/at_client/lib/src/util/at_client_validation.dart
+++ b/packages/at_client/lib/src/util/at_client_validation.dart
@@ -133,6 +133,7 @@ class AtClientValidation {
     // And the text may of course contain spaces.
     // However, for validation purposes, 'key' should not have spaces.
     // Hence we only validate the 'key' if notification type is not 'text'.
+    // ignore: deprecated_member_use_from_same_package, deprecated_member_use
     if (notificationParams.messageType != MessageTypeEnum.text) {
       AtClientValidation.validateKey(notificationParams.atKey.key);
       ValidationResult validationResult = AtKeyValidators.get().validate(

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.0.78
+version: 3.1.0
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/test/full_stack_test.dart
+++ b/packages/at_client/test/full_stack_test.dart
@@ -446,7 +446,8 @@ void main() {
           var builder = invocation.positionalArguments[0] as UpdateVerbBuilder;
           if (builder.atKey.toString() == atKey.toString()) {
             print(
-                'mockRemoteSecondary.executeVerb with UpdateVerbBuilder for ${builder.atKey.toString()} as expected');
+                'mockRemoteSecondary.executeVerb with UpdateVerbBuilder'
+                    ' for ${builder.atKey.toString()} as expected');
             executedRemotely = true;
             return 'data:10';
           } else if (builder.atKey.toString() != '@bob:shared_key@alice') {
@@ -490,7 +491,8 @@ void main() {
           print('DeleteVerbBuilder: ${builder.buildCommand()}');
           if (builder.buildKey() == atKey.toString()) {
             print(
-                'mockRemoteSecondary.executeVerb with DeleteVerbBuilder for ${builder.atKey.toString()} as expected');
+                'mockRemoteSecondary.executeVerb with DeleteVerbBuilder'
+                    ' for ${builder.atKey.toString()} as expected');
             executedRemotely = true;
             return 'data:10';
           } else {
@@ -512,6 +514,79 @@ void main() {
         await checkDeleteBehaviour(false);
       });
     });
+
+    group('Tests for GetRequestOptions.useRemoteAtServer', () {
+      test('GetRequestOptions.useRemoteAtServer defaults to false', () {
+        GetRequestOptions gro = GetRequestOptions();
+        expect(gro.useRemoteAtServer, false);
+      });
+
+      test('get self key when useRemoteAtServer set to false', () async {
+        bool executedRemotely = false;
+        // Make a self key - by default, this will be looked up locally using
+        // an LLookup
+        var atKey = AtKey.fromString(
+            'test_get_self_key_when_remote_is_false'
+                '.${atClient.getPreferences()!.namespace!}'
+                '${atClient.getCurrentAtSign()!}');
+        when(() => mockRemoteSecondary.executeVerb(
+            any(that: isA<LLookupVerbBuilder>()))).thenAnswer((invocation) async {
+          var builder = invocation.positionalArguments[0] as LLookupVerbBuilder;
+          if (builder.atKey.toString() == atKey.toString()) {
+            print(
+                'mockRemoteSecondary.executeVerb with LLookupVerbBuilder'
+                    ' for ${builder.atKey.toString()} as expected');
+            executedRemotely = true;
+            return 'data:null';
+          } else {
+            return 'data:null';
+          }
+        });
+        dynamic caught;
+        try {
+          await atClient.get(atKey,
+              getRequestOptions: GetRequestOptions()
+                ..useRemoteAtServer = false);
+        } catch (e) {
+          caught = e;
+        }
+        expect (caught, isA<AtKeyNotFoundException>());
+        expect(executedRemotely, false);
+      });
+
+      test('get self key when useRemoteAtServer set to true', () async {
+        bool executedRemotely = false;
+        // Make a self key - by default, this will be looked up locally
+        var atKey = AtKey.fromString(
+            'test_get_self_key_when_remote_is_true'
+                '.${atClient.getPreferences()!.namespace!}'
+                '${atClient.getCurrentAtSign()!}');
+        when(() => mockRemoteSecondary.executeVerb(
+            any(that: isA<LLookupVerbBuilder>()))).thenAnswer((invocation) async {
+          var builder = invocation.positionalArguments[0] as LLookupVerbBuilder;
+          if (builder.atKey.toString() == atKey.toString()) {
+            print(
+                'mockRemoteSecondary.executeVerb with LLookupVerbBuilder'
+                    ' for ${builder.atKey.toString()} as expected');
+            executedRemotely = true;
+            return 'data:null';
+          } else {
+            return 'data:null';
+          }
+        });
+        dynamic caught;
+        try {
+          await atClient.get(atKey,
+              getRequestOptions: GetRequestOptions()
+                ..useRemoteAtServer = true);
+        } catch (e) {
+          caught = e;
+        }
+        expect (caught, isNull);
+        expect(executedRemotely, true);
+      });
+    });
+
     group(
         'Verify that my new shared symmetric keys are sent first to remote atServer',
         () {

--- a/packages/at_client/test/full_stack_test.dart
+++ b/packages/at_client/test/full_stack_test.dart
@@ -445,9 +445,8 @@ void main() {
             sync: true)).thenAnswer((invocation) async {
           var builder = invocation.positionalArguments[0] as UpdateVerbBuilder;
           if (builder.atKey.toString() == atKey.toString()) {
-            print(
-                'mockRemoteSecondary.executeVerb with UpdateVerbBuilder'
-                    ' for ${builder.atKey.toString()} as expected');
+            print('mockRemoteSecondary.executeVerb with UpdateVerbBuilder'
+                ' for ${builder.atKey.toString()} as expected');
             executedRemotely = true;
             return 'data:10';
           } else if (builder.atKey.toString() != '@bob:shared_key@alice') {
@@ -490,9 +489,8 @@ void main() {
           var builder = invocation.positionalArguments[0] as DeleteVerbBuilder;
           print('DeleteVerbBuilder: ${builder.buildCommand()}');
           if (builder.buildKey() == atKey.toString()) {
-            print(
-                'mockRemoteSecondary.executeVerb with DeleteVerbBuilder'
-                    ' for ${builder.atKey.toString()} as expected');
+            print('mockRemoteSecondary.executeVerb with DeleteVerbBuilder'
+                ' for ${builder.atKey.toString()} as expected');
             executedRemotely = true;
             return 'data:10';
           } else {
@@ -525,17 +523,16 @@ void main() {
         bool executedRemotely = false;
         // Make a self key - by default, this will be looked up locally using
         // an LLookup
-        var atKey = AtKey.fromString(
-            'test_get_self_key_when_remote_is_false'
-                '.${atClient.getPreferences()!.namespace!}'
-                '${atClient.getCurrentAtSign()!}');
-        when(() => mockRemoteSecondary.executeVerb(
-            any(that: isA<LLookupVerbBuilder>()))).thenAnswer((invocation) async {
+        var atKey = AtKey.fromString('test_get_self_key_when_remote_is_false'
+            '.${atClient.getPreferences()!.namespace!}'
+            '${atClient.getCurrentAtSign()!}');
+        when(() => mockRemoteSecondary
+                .executeVerb(any(that: isA<LLookupVerbBuilder>())))
+            .thenAnswer((invocation) async {
           var builder = invocation.positionalArguments[0] as LLookupVerbBuilder;
           if (builder.atKey.toString() == atKey.toString()) {
-            print(
-                'mockRemoteSecondary.executeVerb with LLookupVerbBuilder'
-                    ' for ${builder.atKey.toString()} as expected');
+            print('mockRemoteSecondary.executeVerb with LLookupVerbBuilder'
+                ' for ${builder.atKey.toString()} as expected');
             executedRemotely = true;
             return 'data:null';
           } else {
@@ -550,24 +547,23 @@ void main() {
         } catch (e) {
           caught = e;
         }
-        expect (caught, isA<AtKeyNotFoundException>());
+        expect(caught, isA<AtKeyNotFoundException>());
         expect(executedRemotely, false);
       });
 
       test('get self key when useRemoteAtServer set to true', () async {
         bool executedRemotely = false;
         // Make a self key - by default, this will be looked up locally
-        var atKey = AtKey.fromString(
-            'test_get_self_key_when_remote_is_true'
-                '.${atClient.getPreferences()!.namespace!}'
-                '${atClient.getCurrentAtSign()!}');
-        when(() => mockRemoteSecondary.executeVerb(
-            any(that: isA<LLookupVerbBuilder>()))).thenAnswer((invocation) async {
+        var atKey = AtKey.fromString('test_get_self_key_when_remote_is_true'
+            '.${atClient.getPreferences()!.namespace!}'
+            '${atClient.getCurrentAtSign()!}');
+        when(() => mockRemoteSecondary
+                .executeVerb(any(that: isA<LLookupVerbBuilder>())))
+            .thenAnswer((invocation) async {
           var builder = invocation.positionalArguments[0] as LLookupVerbBuilder;
           if (builder.atKey.toString() == atKey.toString()) {
-            print(
-                'mockRemoteSecondary.executeVerb with LLookupVerbBuilder'
-                    ' for ${builder.atKey.toString()} as expected');
+            print('mockRemoteSecondary.executeVerb with LLookupVerbBuilder'
+                ' for ${builder.atKey.toString()} as expected');
             executedRemotely = true;
             return 'data:null';
           } else {
@@ -577,12 +573,11 @@ void main() {
         dynamic caught;
         try {
           await atClient.get(atKey,
-              getRequestOptions: GetRequestOptions()
-                ..useRemoteAtServer = true);
+              getRequestOptions: GetRequestOptions()..useRemoteAtServer = true);
         } catch (e) {
           caught = e;
         }
-        expect (caught, isNull);
+        expect(caught, isNull);
         expect(executedRemotely, true);
       });
     });


### PR DESCRIPTION
**- What I did**
feat: add `useRemoteAtServer` flag to `GetRequestOptions`

**- How I did it**
feat: add `useRemoteAtServer` flag to `GetRequestOptions`
- allows clients to fetch directly from the atServer rather than the client-side synced cache. This flag was added to `PutRequestOptions` and `DeleteRequestOptions` in version 3.0.60
- test: added unit tests
- docs: corrected code comment for DeleteRequestOptions
- build: updated CHANGELOG, pubspec and AtClientConfig for version 3.1.0
- chore: cleaned some (unrelated) lint
- docs: also updated CHANGELOG for #1332

**- How to verify it**
- Tests pass