### PR TITLE
feat: add optional param encryptValue to notify method

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 3.2.1
 - feat: add optional param `encryptValue` to notify method
+- build[deps]: Upgraded dependencies for the following packages:
+  - at_commons to v4.1.1
+  - at_utils to v3.0.18
+  - at_lookup to v3.0.48
+  - at_auth to v2.0.5
+  - at_persistence_secondary_server to v3.0.63
 ## 3.2.0
 - feat: add `allowAll` flag (defaults to false) to AtRpc
 ## 3.1.0

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.2.1
+- feat: add optional param `encryptValue` to notify method
 ## 3.2.0
 - feat: add `allowAll` flag (defaults to false) to AtRpc
 ## 3.1.0

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.2.0';
+  final String atClientVersion = '3.2.1';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/service/notification_service.dart
+++ b/packages/at_client/lib/src/service/notification_service.dart
@@ -93,6 +93,7 @@ abstract class NotificationService {
           true, // this was the behaviour before introducing this parameter
       bool checkForFinalDeliveryStatus =
           true, // this was the behaviour before introducing this parameter
+      bool encryptValue = true,
       Function(NotificationResult)? onSuccess,
       Function(NotificationResult)? onError,
       Function(NotificationResult)? onSentToSecondary});

--- a/packages/at_client/lib/src/service/notification_service.dart
+++ b/packages/at_client/lib/src/service/notification_service.dart
@@ -93,7 +93,8 @@ abstract class NotificationService {
           true, // this was the behaviour before introducing this parameter
       bool checkForFinalDeliveryStatus =
           true, // this was the behaviour before introducing this parameter
-      bool encryptValue = true, // this was the behaviour before introducing this parameter
+      bool encryptValue =
+          true, // this was the behaviour before introducing this parameter
       Function(NotificationResult)? onSuccess,
       Function(NotificationResult)? onError,
       Function(NotificationResult)? onSentToSecondary});

--- a/packages/at_client/lib/src/service/notification_service.dart
+++ b/packages/at_client/lib/src/service/notification_service.dart
@@ -93,7 +93,7 @@ abstract class NotificationService {
           true, // this was the behaviour before introducing this parameter
       bool checkForFinalDeliveryStatus =
           true, // this was the behaviour before introducing this parameter
-      bool encryptValue = true,
+      bool encryptValue = true, // this was the behaviour before introducing this parameter
       Function(NotificationResult)? onSuccess,
       Function(NotificationResult)? onError,
       Function(NotificationResult)? onSentToSecondary});

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -319,7 +319,8 @@ class NotificationServiceImpl
           true, // this was the behaviour before introducing this parameter
       bool checkForFinalDeliveryStatus =
           true, // this was the behaviour before introducing this parameter
-      bool encryptValue = true, // this was the behaviour before introducing this parameter
+      bool encryptValue =
+          true, // this was the behaviour before introducing this parameter
       Function(NotificationResult)? onSuccess,
       Function(NotificationResult)? onError,
       Function(NotificationResult)? onSentToSecondary}) async {

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -319,7 +319,7 @@ class NotificationServiceImpl
           true, // this was the behaviour before introducing this parameter
       bool checkForFinalDeliveryStatus =
           true, // this was the behaviour before introducing this parameter
-      bool encryptValue = true,
+      bool encryptValue = true, // this was the behaviour before introducing this parameter
       Function(NotificationResult)? onSuccess,
       Function(NotificationResult)? onError,
       Function(NotificationResult)? onSentToSecondary}) async {

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -319,6 +319,7 @@ class NotificationServiceImpl
           true, // this was the behaviour before introducing this parameter
       bool checkForFinalDeliveryStatus =
           true, // this was the behaviour before introducing this parameter
+      bool encryptValue = true,
       Function(NotificationResult)? onSuccess,
       Function(NotificationResult)? onError,
       Function(NotificationResult)? onSentToSecondary}) async {
@@ -331,6 +332,7 @@ class NotificationServiceImpl
     }
 
     try {
+      notificationParams.atKey.metadata.isEncrypted = encryptValue;
       // If sharedBy atSign is null, default to current atSign.
       if (notificationParams.atKey.sharedBy.isNull) {
         notificationParams.atKey.sharedBy = _atClient.getCurrentAtSign();

--- a/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
+++ b/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
@@ -26,10 +26,14 @@ class NotificationRequestTransformer
     // prepares notification builder
     NotifyVerbBuilder builder = await _prepareNotificationBuilder(
         notificationParams, atClientPreference);
-    // If notification value is not null, encrypt the value
-    if (notificationParams.value.isNotNull) {
+    // If notification value is set and metadata.isEncrypted is true, encrypt
+    // the value.
+    if (notificationParams.value.isNotNull &&
+        notificationParams.atKey.metadata.isEncrypted) {
       builder.value = await _encryptNotificationValue(
           notificationParams.atKey, notificationParams.value!);
+    } else {
+      builder.value = notificationParams.value;
     }
     // add metadata to notify verb builder.
     // Encrypt the data and then call addMetadataToBuilder method inorder to

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.2.0
+version: 3.2.1
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -31,13 +31,13 @@ dependencies:
   async: ^2.9.0
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
-  at_commons: ^4.0.6
-  at_utils: ^3.0.16
+  at_commons: ^4.1.1
+  at_utils: ^3.0.18
   at_chops: ^2.0.0
-  at_lookup: ^3.0.46
-  at_auth: ^2.0.4
+  at_lookup: ^3.0.48
+  at_auth: ^2.0.5
   at_persistence_spec: ^2.0.14
-  at_persistence_secondary_server: ^3.0.62
+  at_persistence_secondary_server: ^3.0.63
   meta: ^1.8.0
   version: ^3.0.2
 

--- a/packages/at_client/test/test_utils/no_op_services.dart
+++ b/packages/at_client/test/test_utils/no_op_services.dart
@@ -33,6 +33,7 @@ class NoOpNotificationService implements NotificationService {
   Future<NotificationResult> notify(NotificationParams notificationParams,
       {bool waitForFinalDeliveryStatus = true,
       bool checkForFinalDeliveryStatus = true,
+      bool encryptValue = true,
       Function(NotificationResult p1)? onSuccess,
       Function(NotificationResult p1)? onError,
       Function(NotificationResult p1)? onSentToSecondary}) {

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -14,13 +14,6 @@ dependencies:
   at_client:
     path: ../../packages/at_client
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries.git
-      ref: notify_isencrypted
-      path: packages/at_commons
-
 dev_dependencies:
   test: ^1.24.3
   lints: ^2.0.0

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 dependency_overrides:
   at_commons:
     git:
-      url: https://github.com/atsign-foundation/at_commons
+      url: https://github.com/atsign-foundation/at_libraries.git
       ref: notify_isencrypted
       path: packages/at_commons
 

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -14,6 +14,13 @@ dependencies:
   at_client:
     path: ../../packages/at_client
 
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_commons
+      ref: notify_isencrypted
+      path: packages/at_commons
+
 dev_dependencies:
   test: ^1.24.3
   lints: ^2.0.0

--- a/tests/at_end2end_test/test/notify_test.dart
+++ b/tests/at_end2end_test/test/notify_test.dart
@@ -108,7 +108,7 @@ void main() async {
     print(notificationListJson);
     expect(notificationListJson[0]['from'], currentAtSign);
     expect(notificationListJson[0]['to'], sharedWithAtSign);
-    expect(notificationListJson[0]['isEncrypted'], 'false');
+    expect(notificationListJson[0]['isEncrypted'], false);
     expect(notificationListJson[0]['value'], value);
   });
 }

--- a/tests/at_end2end_test/test/notify_test.dart
+++ b/tests/at_end2end_test/test/notify_test.dart
@@ -108,6 +108,7 @@ void main() async {
     print(notificationListJson);
     expect(notificationListJson[0]['from'], currentAtSign);
     expect(notificationListJson[0]['to'], sharedWithAtSign);
+    expect(notificationListJson[0]['isEncrypted'], 'false');
     expect(notificationListJson[0]['value'], value);
   });
 }

--- a/tests/at_functional_test/test/atclient_notify_test.dart
+++ b/tests/at_functional_test/test/atclient_notify_test.dart
@@ -79,8 +79,13 @@ void main() {
       ..sharedWith = sharedWithAtSign
       ..namespace = namespace;
     var value = '+1 100 200 300';
-    await atClientManager.atClient.notificationService
+    var notificationResult = await atClientManager.atClient.notificationService
         .notify(NotificationParams.forUpdate(phoneKey, value: value));
+    var notification = await atClientManager.atClient.notificationService
+        .fetch(notificationResult.notificationID);
+    print(notification.value);
+    // encrypted value should not be equal to actual value
+    expect(notification.value == value, false);
   });
 
   test('verify unencrypted value is returned when encryptValue is set to false',
@@ -96,9 +101,6 @@ void main() {
     var notificationId = notificationResult.notificationID;
     var notification = await atClientManager.atClient.notificationService
         .fetch(notificationId);
-    print('Notification ID: ${notification.id}');
-    print('Notification value: ${notification.value}');
-    print('Notification key: ${notification.key}');
     expect(notification.value, value);
   });
 

--- a/tests/at_functional_test/test/atclient_notify_test.dart
+++ b/tests/at_functional_test/test/atclient_notify_test.dart
@@ -83,6 +83,25 @@ void main() {
         .notify(NotificationParams.forUpdate(phoneKey, value: value));
   });
 
+  test('verify unencrypted value is returned when encryptValue is set to false',
+      () async {
+    var phoneKey = AtKey()
+      ..key = 'phone'
+      ..sharedWith = sharedWithAtSign
+      ..namespace = namespace;
+    var value = '+1 100 200 300';
+    var notificationResult = await atClientManager.atClient.notificationService
+        .notify(NotificationParams.forUpdate(phoneKey, value: value),
+            encryptValue: false);
+    var notificationId = notificationResult.notificationID;
+    var notification = await atClientManager.atClient.notificationService
+        .fetch(notificationId);
+    print('Notification ID: ${notification.id}');
+    print('Notification value: ${notification.value}');
+    print('Notification key: ${notification.key}');
+    expect(notification.value, value);
+  });
+
   test('notify deletion of a key to sharedWith atSign', () async {
     var phoneKey = AtKey()
       ..key = 'phone'
@@ -217,12 +236,10 @@ void main() {
     }
   });
 
-   group('A group of tests for notification fetch', () {
+  group('A group of tests for notification fetch', () {
     test('A test to verify non existent notification', () async {
       await AtClientManager.getInstance().setCurrentAtSign(
-          currentAtSign,
-          namespace,
-          TestUtils.getPreference(currentAtSign));
+          currentAtSign, namespace, TestUtils.getPreference(currentAtSign));
       var notificationResult = await AtClientManager.getInstance()
           .atClient
           .notificationService
@@ -235,9 +252,7 @@ void main() {
       for (int i = 0; i < 10; i++) {
         print('Testing notification expiry - test run #$i');
         await AtClientManager.getInstance().setCurrentAtSign(
-            currentAtSign,
-            namespace,
-            TestUtils.getPreference(currentAtSign));
+            currentAtSign, namespace, TestUtils.getPreference(currentAtSign));
         var atKey = (AtKey.shared('test-notification-expiry',
                 namespace: 'wavi', sharedBy: currentAtSign)
               ..sharedWith(sharedWithAtSign))


### PR DESCRIPTION
Fixed https://github.com/atsign-foundation/at_client_sdk/issues/1390
**- What I did**
- encrypt notification value only if metadata.isEncrypted is set to true. 
- ability for caller to not encrypt notification value by setting optional param encryptValue = false in notify method
- upgraded atsign package dependencies to latest version
**- How I did it**
- added optional param encryptValue in notify method. set atkey.metadata.isEncrypted to the optional param value.
- changes in notification request transformer to encrypt notification value only if isEncrypted is set to true.
- added unit and functional test
**- How to verify it**
- unit and functional tests should pass
- ran tests in at_onboarding_cli
https://github.com/atsign-foundation/at_libraries/pull/659
- ran test in sshnoports
https://github.com/atsign-foundation/noports/pull/1348

