### PR TITLE
feat: add the AtClientBindings mixin to this package

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.0
+- feat: add the AtClientBindings mixin which was initially added to the 
+  noports_core package but has broader applicability.
+
 ## 3.2.2
 - build[deps]: Upgraded dependencies for the following packages:
   - at_commons to v5.0.0

--- a/packages/at_client/lib/at_client_mixins.dart
+++ b/packages/at_client/lib/at_client_mixins.dart
@@ -1,0 +1,3 @@
+library at_client_mixins;
+
+export 'package:at_client/src/mixins/at_client_bindings.dart';

--- a/packages/at_client/lib/src/mixins/at_client_bindings.dart
+++ b/packages/at_client/lib/src/mixins/at_client_bindings.dart
@@ -7,12 +7,12 @@ mixin AtClientBindings {
   AtSignLogger get logger;
 
   Future<void> notify(
-      AtKey atKey,
-      String value, {
-        required bool checkForFinalDeliveryStatus,
-        required bool waitForFinalDeliveryStatus,
-        required Duration ttln,
-      }) async {
+    AtKey atKey,
+    String value, {
+    required bool checkForFinalDeliveryStatus,
+    required bool waitForFinalDeliveryStatus,
+    required Duration ttln,
+  }) async {
     await atClient.notificationService.notify(
       NotificationParams.forUpdate(atKey,
           value: value, notificationExpiry: ttln),

--- a/packages/at_client/lib/src/mixins/at_client_bindings.dart
+++ b/packages/at_client/lib/src/mixins/at_client_bindings.dart
@@ -1,0 +1,38 @@
+import 'package:at_client/at_client.dart';
+import 'package:at_utils/at_logger.dart';
+
+mixin AtClientBindings {
+  AtClient get atClient;
+
+  AtSignLogger get logger;
+
+  Future<void> notify(
+      AtKey atKey,
+      String value, {
+        required bool checkForFinalDeliveryStatus,
+        required bool waitForFinalDeliveryStatus,
+        required Duration ttln,
+      }) async {
+    await atClient.notificationService.notify(
+      NotificationParams.forUpdate(atKey,
+          value: value, notificationExpiry: ttln),
+      checkForFinalDeliveryStatus: checkForFinalDeliveryStatus,
+      waitForFinalDeliveryStatus: waitForFinalDeliveryStatus,
+      onSuccess: (NotificationResult notification) {
+        logger.info('SUCCESS:$notification with key: ${atKey.toString()}');
+      },
+      onError: (notification) {
+        logger.info('ERROR:$notification');
+      },
+    );
+  }
+
+  Stream<AtNotification> subscribe(
+      {String? regex, bool shouldDecrypt = false}) {
+    logger.info('Subscribing to notifications with regex: "$regex"');
+    return atClient.notificationService.subscribe(
+      regex: regex,
+      shouldDecrypt: shouldDecrypt,
+    );
+  }
+}

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.2.2';
+  final String atClientVersion = '3.3.0';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.2.2
+version: 3.3.0
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 


### PR DESCRIPTION
**- What I did**
feat: add the AtClientBindings mixin to this package. This mixin was initially added in the noports_core package, but has broader applicability

**- How I did it**
- added lib/src/mixins/at_client_bindings.dart
- added lib/at_client_mixins.dart
- updated pubspec, changelog and at_client_config for version 3.3.0

**- How to verify it**
- manually verified via noports packages

**-Additional context**
Note that at_client_bindings.dart is not exported via the main export file (lib/at_client.dart) but in a new export file (lib/at_client_mixins.dart) in order that we not cause any annoying import changes to be needed in packages which already import at_client package and already have an AtClientBindings defined locally