### PR TITLE
fix: functional test fix for apkam server changes

### DIFF
--- a/tests/at_functional_test/test/enrollment_test.dart
+++ b/tests/at_functional_test/test/enrollment_test.dart
@@ -91,14 +91,6 @@ void main() {
       // check for keys in __manage namespace
       expect(
           scanResult?.contains(
-              '${atOnboardingResponse.enrollmentId}.default_enc_private_key.__manage$apkamAtSign'),
-          true);
-      expect(
-          scanResult?.contains(
-              '${atOnboardingResponse.enrollmentId}.default_self_enc_key.__manage$apkamAtSign'),
-          true);
-      expect(
-          scanResult?.contains(
               '${atOnboardingResponse.enrollmentId}.new.enrollments.__manage$apkamAtSign'),
           true);
       // Check whether at client can create keys in different namespaces


### PR DESCRIPTION
**- What I did**
- removed checks in first enrollment for self encryption and default encryption private key for apkam server changes
**- How I did it**
- removed assertions in enrollment_test.dart functional test
**- How to verify it**
- tests should pass
**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
