### PR TITLE
fix: isInSync bug

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,5 @@
+# 3.3.1
+- fix: isInSync bug fix for apkam connection
 ## 3.3.0
 - feat: add the AtClientBindings mixin which was initially added to the 
   noports_core package but has broader applicability.

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.3.0';
+  final String atClientVersion = '3.3.1';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -539,6 +539,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   /// commit-id to sync into the local keystore.
   Future<List<dynamic>> _getEntriesToSyncFromServer(
       int lastReceivedServerCommitId) async {
+    // Sync verb syntax has to be changed before removing these deprecations
     var syncBuilder = SyncVerbBuilder()
       ..commitId = lastReceivedServerCommitId
       ..regex = _atClient.getPreferences()!.syncRegex
@@ -767,13 +768,8 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   ///Throws [AtClientException] if cloud secondary is not reachable
   @override
   Future<bool> isInSync() async {
-    late RemoteSecondary remoteSecondary;
     try {
-      remoteSecondary = RemoteSecondary(
-          _atClient.getCurrentAtSign()!, _atClient.getPreferences()!,
-          atChops: _atClient.atChops);
-      var serverCommitId =
-          await _getServerCommitId(remoteSecondary: remoteSecondary);
+      var serverCommitId = await _getServerCommitId();
 
       var lastReceivedServerCommitId = await getLastReceivedServerCommitId();
 
@@ -794,8 +790,6 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       var cause = (e is AtException) ? e.getTraceMessage() : e.toString();
       _logger.severe('exception in isInSync $cause');
       throw AtClientException.message(e.toString());
-    } finally {
-      unawaited(remoteSecondary.atLookUp.close());
     }
   }
 
@@ -804,8 +798,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       _logger.finest('*** isInSync..sync in progress');
       return true;
     }
-    var serverCommitId =
-        await _getServerCommitId(remoteSecondary: _remoteSecondary);
+    var serverCommitId = await _getServerCommitId();
     var lastReceivedServerCommitId = await getLastReceivedServerCommitId();
     var lastSyncedEntry = await syncUtil.getLastSyncedEntry(
         _atClient.getPreferences()!.syncRegex,
@@ -823,11 +816,10 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
 
   /// Returns the cloud secondary latest commit id. if null, returns -1.
   ///Throws [AtLookUpException] if secondary is not reachable
-  Future<int> _getServerCommitId({RemoteSecondary? remoteSecondary}) async {
-    remoteSecondary ??= _remoteSecondary;
+  Future<int> _getServerCommitId() async {
     // ignore: no_leading_underscores_for_local_identifiers
     var _serverCommitId = await syncUtil.getLatestServerCommitId(
-        remoteSecondary, _atClient.getPreferences()!.syncRegex);
+        _remoteSecondary, _atClient.getPreferences()!.syncRegex);
     // If server commit id is null, set to -1;
     _serverCommitId ??= -1;
     _logger.info(_logger.getLogMessageWithClientParticulars(

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.3.0
+version: 3.3.1
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 


### PR DESCRIPTION
fixes https://github.com/atsign-foundation/at_client_sdk/issues/1444
**- What I did**
- Fix for isInSync bug in SyncServiceImpl
**- How I did it**
- remove the logic to create new secondary in isInSync method. Re-use _remoteSecondary from create(..) method
- Logic to create new secondary in isInSync was added for an old bug 
https://github.com/atsign-foundation/at_client_sdk/issues/404. This bug is no longer reproducible. Hence removing this logic.
**- How to verify it**
- Tests done
https://github.com/atsign-foundation/at_client_sdk/issues/1444#issuecomment-2532111449

