### PR TITLE
fix: Replace legacy IVs with random IVs for encrypting "defaultEncryp…

### DIFF
--- a/tests/at_end2end_test/test/enrollment_setup.dart
+++ b/tests/at_end2end_test/test/enrollment_setup.dart
@@ -191,6 +191,7 @@ Future<String> getDefaultEncryptionPrivateKey(
   var privateKeyCommand =
       'keys:get:keyName:$enrollmentIdFromServer.${AtConstants.defaultEncryptionPrivateKey}.__manage$atSign';
   String encryptionPrivateKeyFromServer;
+  String encryptionPrivateKeyIV;
   try {
     var getPrivateKeyResult =
         await atLookUp.executeCommand('$privateKeyCommand\n', auth: true);
@@ -200,13 +201,15 @@ Future<String> getDefaultEncryptionPrivateKey(
     getPrivateKeyResult = getPrivateKeyResult.replaceFirst('data:', '');
     var privateKeyResultJson = jsonDecode(getPrivateKeyResult);
     encryptionPrivateKeyFromServer = privateKeyResultJson['value'];
+    encryptionPrivateKeyIV = privateKeyResultJson['iv'];
   } on Exception catch (e) {
     throw AtEnrollmentException(
         'Exception while getting encrypted private key/self key from server: $e');
   }
   AtEncryptionResult? atEncryptionResult = atLookUp.atChops?.decryptString(
       encryptionPrivateKeyFromServer, EncryptionKeyType.aes256,
-      keyName: 'apkamSymmetricKey', iv: AtChopsUtil.generateIVLegacy());
+      keyName: 'apkamSymmetricKey',
+      iv: AtChopsUtil.generateIVFromBase64String(encryptionPrivateKeyIV));
   return atEncryptionResult?.result;
 }
 
@@ -218,6 +221,7 @@ Future<String> getDefaultSelfEncryptionKey(
   var selfEncryptionKeyCommand =
       'keys:get:keyName:$enrollmentIdFromServer.${AtConstants.defaultSelfEncryptionKey}.__manage$atSign';
   String selfEncryptionKeyFromServer;
+  String selfEncryptionKeyIV;
   try {
     String? encryptedSelfEncryptionKey = await atLookUp
         .executeCommand('$selfEncryptionKeyCommand\n', auth: true);
@@ -230,12 +234,14 @@ Future<String> getDefaultSelfEncryptionKey(
         encryptedSelfEncryptionKey.replaceFirst('data:', '');
     var selfEncryptionKeyResultJson = jsonDecode(encryptedSelfEncryptionKey);
     selfEncryptionKeyFromServer = selfEncryptionKeyResultJson['value'];
+    selfEncryptionKeyIV = selfEncryptionKeyResultJson['iv'];
   } on Exception catch (e) {
     throw AtEnrollmentException(
         'Exception while getting encrypted private key/self key from server: $e');
   }
   AtEncryptionResult? atEncryptionResult = atLookUp.atChops?.decryptString(
       selfEncryptionKeyFromServer, EncryptionKeyType.aes256,
-      keyName: 'apkamSymmetricKey', iv: AtChopsUtil.generateIVLegacy());
+      keyName: 'apkamSymmetricKey',
+      iv: AtChopsUtil.generateIVFromBase64String(selfEncryptionKeyIV));
   return atEncryptionResult?.result;
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Fixes the E2E tests failures in APKAM flow.

Replace the use of legacy IVs with random IVs when decrypting the defaultEncryptionPrivateKey and defaultSelfEncryptionKey.

**- How to verify it**
- All tests should pass.

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
