### PR TITLE
fix: Updated APKAM enrollment to use server generated IVs

### DIFF
--- a/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
+++ b/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
@@ -467,7 +467,9 @@ class AtAuthServiceImpl implements AtAuthService {
     AtEncryptionResult? atEncryptionResult = atChops.decryptString(
         encryptionPrivateKeyFromServer, EncryptionKeyType.aes256,
         keyName: 'apkamSymmetricKey',
-        iv: InitialisationVector(base64Decode(encryptionPrivateKeyIV!)));
+        iv: encryptionPrivateKeyIV != null
+            ? InitialisationVector(base64Decode(encryptionPrivateKeyIV))
+            : AtChopsUtil.generateIVLegacy());
     return atEncryptionResult.result;
   }
 
@@ -500,7 +502,9 @@ class AtAuthServiceImpl implements AtAuthService {
     AtEncryptionResult? atEncryptionResult = atChops.decryptString(
         selfEncryptionKeyFromServer, EncryptionKeyType.aes256,
         keyName: 'apkamSymmetricKey',
-        iv: InitialisationVector(base64Decode(selfEncryptionKeyIV!)));
+        iv: selfEncryptionKeyIV != null
+            ? InitialisationVector(base64Decode(selfEncryptionKeyIV))
+            : AtChopsUtil.generateIVLegacy());
     return atEncryptionResult.result;
   }
 

--- a/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
+++ b/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
@@ -449,6 +449,7 @@ class AtAuthServiceImpl implements AtAuthService {
     var privateKeyCommand =
         'keys:get:keyName:$enrollmentIdFromServer.${AtConstants.defaultEncryptionPrivateKey}.__manage$_atSign\n';
     String encryptionPrivateKeyFromServer;
+    String? encryptionPrivateKeyIV;
     try {
       var getPrivateKeyResult =
           await _atLookUp?.executeCommand('$privateKeyCommand\n', auth: true);
@@ -458,13 +459,15 @@ class AtAuthServiceImpl implements AtAuthService {
       getPrivateKeyResult = getPrivateKeyResult.replaceFirst('data:', '');
       var privateKeyResultJson = jsonDecode(getPrivateKeyResult);
       encryptionPrivateKeyFromServer = privateKeyResultJson['value'];
+      encryptionPrivateKeyIV = privateKeyResultJson['iv'];
     } on Exception catch (e) {
       throw AtEnrollmentException(
           'Exception while getting encrypted private key/self key from server: $e');
     }
     AtEncryptionResult? atEncryptionResult = atChops.decryptString(
         encryptionPrivateKeyFromServer, EncryptionKeyType.aes256,
-        keyName: 'apkamSymmetricKey', iv: AtChopsUtil.generateIVLegacy());
+        keyName: 'apkamSymmetricKey',
+        iv: InitialisationVector(base64Decode(encryptionPrivateKeyIV!)));
     return atEncryptionResult.result;
   }
 
@@ -476,6 +479,7 @@ class AtAuthServiceImpl implements AtAuthService {
     var selfEncryptionKeyCommand =
         'keys:get:keyName:$enrollmentIdFromServer.${AtConstants.defaultSelfEncryptionKey}.__manage$_atSign\n';
     String selfEncryptionKeyFromServer;
+    String? selfEncryptionKeyIV;
     try {
       String? encryptedSelfEncryptionKey = await _atLookUp
           ?.executeCommand('$selfEncryptionKeyCommand\n', auth: true);
@@ -488,13 +492,15 @@ class AtAuthServiceImpl implements AtAuthService {
           encryptedSelfEncryptionKey.replaceFirst('data:', '');
       var selfEncryptionKeyResultJson = jsonDecode(encryptedSelfEncryptionKey);
       selfEncryptionKeyFromServer = selfEncryptionKeyResultJson['value'];
+      selfEncryptionKeyIV = selfEncryptionKeyResultJson['iv'];
     } on Exception catch (e) {
       throw AtEnrollmentException(
           'Exception while getting encrypted private key/self key from server: $e');
     }
     AtEncryptionResult? atEncryptionResult = atChops.decryptString(
         selfEncryptionKeyFromServer, EncryptionKeyType.aes256,
-        keyName: 'apkamSymmetricKey', iv: AtChopsUtil.generateIVLegacy());
+        keyName: 'apkamSymmetricKey',
+        iv: InitialisationVector(base64Decode(selfEncryptionKeyIV!)));
     return atEncryptionResult.result;
   }
 


### PR DESCRIPTION
**- What I did**
Instead of using default IVs to decrypt keys form the server after an enrollment request has been approved, use the IVs from the atServer.

**- How I did it**
This work had already been implemented in `at_activate`.

**- How to verify it**
I don't have an example at the moment but can show it working in a branch of NoPorts if needed.

**- Description for the changelog**
Updated APKAM enrollment to use server generated IVs to decrypt keys
