### PR TITLE
fix: #1479 authenticating now saves keys to local secondary store

### DIFF
--- a/packages/at_client_mobile/CHANGELOG.md
+++ b/packages/at_client_mobile/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.20
+- fix: Authenticating now saves keys to local secondary store
+
 ## 3.2.19
 - build[deps]: Upgraded dependencies for the following packages:
     - at_client: 3.2.2
@@ -29,7 +32,7 @@
     - getSentEnrollmentRequest
 ## 3.2.15
 - build[deps]: Upgraded dependencies for the following packages:
-  - at_chops to v2.0.0 
+  - at_chops to v2.0.0
   - at_lookup to v3.0.46
   - at_commons to v4.0.1
   - at_client to v3.0.75
@@ -46,8 +49,8 @@
 ## 3.2.12
 - fix: Fixed the issue biometric_storage dependency not working on Windows when using Dart 3
 ## 3.2.11
-- chore: Upgraded biometric_storage dependency to 5.0.0 
-- chore: Upgraded package_info_plus dependency to 4.0.2 
+- chore: Upgraded biometric_storage dependency to 5.0.0
+- chore: Upgraded package_info_plus dependency to 4.0.2
 ## 3.2.10
 - fix: Fixed incorrect import statements in at_client_mobile/example which are
   causing analysis errors in dart 3
@@ -118,10 +121,10 @@ Changes:
 ## 3.1.10
 - at_client version upgrade for chunk based encryption
 ## 3.1.9
-- at_client version change for sync deletion of cached keys to cloud secondary 
+- at_client version change for sync deletion of cached keys to cloud secondary
 - at_lookup version change for increase in outbound connection timeout
 ## 3.1.8
-- at_client version change for automatic sync trigger 
+- at_client version change for automatic sync trigger
 ## 3.1.7
 - at_client and at_lookup version change for outbound listener bug fix
 ## 3.1.6

--- a/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
+++ b/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
@@ -102,6 +102,7 @@ class AtAuthServiceImpl implements AtAuthService {
     AtsignKey? atSignKey = await keyChainManager.readAtsign(name: _atSign);
     if (atSignKey == null) {
       await _storeToKeyChainManager(_atSign, atAuthResponse.atAuthKeys);
+      await _persistKeysLocalSecondary(atAuthResponse.atAuthKeys);
     }
     return atAuthResponse;
   }

--- a/packages/at_client_mobile/pubspec.yaml
+++ b/packages/at_client_mobile/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client_mobile
 description: A Flutter extension to the at_client library which adds support for mobile, desktop and IoT devices.
-version: 3.2.19
+version: 3.2.20
 repository: https://github.com/atsign-foundation/at_client_sdk/packages
 homepage: https://docs.atsign.com/
 


### PR DESCRIPTION
**- What I did**
Adding missing call to `_persistKeysLocalSecondary` in `authenticate` method

**- How to verify it**
1. Authenticate with an atsign (i.e. Login for the first time into an app)
2. Put a public key
3. No errors

**- Description for the changelog**
Authenticating now saves keys to local secondary store
