### PR TITLE
fix: potential bugs handling atSigns which end in `data`

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 3.5.0
+## 3.4.1
 - fix: potential bug handling atSigns which end in `data` e.g. `@foo_data`
-- build[deps]: upgrade dependencies
+
 ## 3.4.0
 - feat: Allows clients to skip delete commits until a specific commitID during initial sync
 ## 3.3.1

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.5.0
+- fix: potential bug handling atSigns which end in `data` e.g. `@foo_data`
+- build[deps]: upgrade dependencies
 ## 3.4.0
 - feat: Allows clients to skip delete commits until a specific commitID during initial sync
 ## 3.3.1

--- a/packages/at_client/example/pubspec.yaml
+++ b/packages/at_client/example/pubspec.yaml
@@ -6,16 +6,6 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependency_overrides:
-  at_persistence_spec:
-    git:
-      url: https://github.com/atsign-foundation/at_server
-      path: packages/at_persistence_spec
-      ref: feat-immutability
-  at_persistence_secondary_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server
-      path: packages/at_persistence_secondary_server
-      ref: feat-immutability
   at_client:
     path: ../../at_client
 

--- a/packages/at_client/example/pubspec.yaml
+++ b/packages/at_client/example/pubspec.yaml
@@ -6,6 +6,16 @@ environment:
   sdk: '>=2.15.0 <4.0.0'
 
 dependency_overrides:
+  at_persistence_spec:
+    git:
+      url: https://github.com/atsign-foundation/at_server
+      path: packages/at_persistence_spec
+      ref: feat-immutability
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server
+      path: packages/at_persistence_secondary_server
+      ref: feat-immutability
   at_client:
     path: ../../at_client
 

--- a/packages/at_client/lib/src/at_collection/collections.dart
+++ b/packages/at_client/lib/src/at_collection/collections.dart
@@ -29,7 +29,7 @@ abstract class AtCollectionModelOperations {
   /// ```
   /// Phone temporaryPhone = await Phone('temporary phone').save(options : ObjectLifeCycleOptions(timeToLive : Duration(hours : 24)));
   /// ```
-  /// By default the value shared is cached on the recipient, if this has to changed then set objectLifeCycleOptions [cacheValueOnRecipient] to fasle.
+  /// By default the value shared is cached on the recipient, if this has to changed then set objectLifeCycleOptions [cacheValueOnRecipient] to false.
   /// By default when the object is deleted then the cached values on the recipients are deleted. if this needs to be changed set [objectLifeCycleOptions.cascadeDelete] to false.
   ///
   /// Returns a true if save is successful else returns a false.
@@ -47,13 +47,13 @@ abstract class AtCollectionModelOperations {
   /// If fine grained information on individual operations that happens within [share] is desired then use [streams.share]
   Future<bool> share(List<String> atSigns, {ObjectLifeCycleOptions? options});
 
-  /// [unshare] unshares the AtCollectionModel object with the atSigns in [atSigns] list.
+  /// [unshare] un-shares the AtCollectionModel object with the atSigns in [atSigns] list.
   ///
   /// If [atSigns] is not passed then AtCollectionModel object is unshared with every @sign it was previously shared.
   ///
   /// ```
   /// Phone personalPhone = await Phone('personal phone').save();
-  /// var sahreRes = await personalPhone.share(['@kevin', '@colin']);
+  /// var shareRes = await personalPhone.share(['@kevin', '@colin']);
   /// var unshareRes = await personalPhone.unshare(['@kevin']);
   /// ```
   ///
@@ -66,17 +66,17 @@ abstract class AtCollectionModelOperations {
   ///
   /// ```
   /// Phone personalPhone = await Phone('personal phone').save();
-  /// var sahreRes = await personalPhone.share(['@kevin', '@colin']);
+  /// var shareRes = await personalPhone.share(['@kevin', '@colin']);
   /// var sharedList = await personalPhone.getSharedWith();
   /// ```
   ///
   /// Returns an empty list when object is not shared.
   Future<List<String>> sharedWith();
 
-  /// Deletes the object and unshares with every @sign it was shared with previously
+  /// Deletes the object and un-shares with every @sign it was shared with previously
   /// ```
   /// Phone personalPhone = await Phone('personal phone').save();
-  /// var sahreRes = await personalPhone.share(['@kevin', '@colin']);
+  /// var shareRes = await personalPhone.share(['@kevin', '@colin']);
   /// var sharedList = await personalPhone.delete();
   /// ```
   Future<bool> delete();
@@ -179,7 +179,7 @@ abstract class AtCollectionQueryOperations {
 /// ```
 ///
 abstract class AtCollectionModelStreamOperations {
-  /// Saves the json representaion of the object to the secondary server of the @sign.
+  /// Saves the json representation of the object to the secondary server of the @sign.
   /// [save] calls [toJson] method to get the json representation.
   ///
   /// If [share] is set to true, then the Object will not only be saved but also be shared with the @signs with whom it was previously shared.
@@ -219,10 +219,10 @@ abstract class AtCollectionModelStreamOperations {
   ///   },
   /// );
   /// ```
-  /// By default the value shared is cached on the recipient, if this has to changed then set objectLifeCycleOptions [cacheValueOnRecipient] to fasle.
+  /// By default the value shared is cached on the recipient, if this has to changed then set objectLifeCycleOptions [cacheValueOnRecipient] to false.
   /// By default when the object is deleted then the cached values on the recipients are deleted. if this needs to be changed set [objectLifeCycleOptions.cascadeDelete] to false.
   ///
-  /// Returns Stream<AtOperationItemStatus>, where [AtOperationItemStatus] represents status of individual operations.
+  /// Returns `Stream<AtOperationItemStatus>`, where [AtOperationItemStatus] represents status of individual operations.
   Stream<AtOperationItemStatus> save(
       {bool share = true, ObjectLifeCycleOptions? options});
 
@@ -237,17 +237,17 @@ abstract class AtCollectionModelStreamOperations {
   /// );
   /// ```
   ///
-  /// Returns Stream<AtOperationItemStatus>, where [AtOperationItemStatus] represents status of individual operations.
+  /// Returns `Stream<AtOperationItemStatus>`, where [AtOperationItemStatus] represents status of individual operations.
   Stream<AtOperationItemStatus> share(List<String> atSigns,
       {ObjectLifeCycleOptions? options});
 
-  /// [unshare] unshares the AtCollectionModel object with the @signs in [atSigns] list.
+  /// [unshare] un-shares the AtCollectionModel object with the @signs in [atSigns] list.
   ///
   /// If [atSigns] is not passed then AtCollectionModel object is unshared with every @sign it was previously shared.
   ///
   /// ```
   /// Phone personalPhone = await Phone('personal phone').save();
-  /// var sahreRes = await personalPhone.share([@kevin, @colin]);
+  /// var shareRes = await personalPhone.share([@kevin, @colin]);
   /// personalPhone.streams.unshare([@kevin]).forEach(
   ///   (AtOperationItemStatus element) {
   ///     ///
@@ -255,20 +255,20 @@ abstract class AtCollectionModelStreamOperations {
   /// );
   /// ```
   ///
-  /// Returns Stream<AtOperationItemStatus>, where [AtOperationItemStatus] represents status of individual operations.
+  /// Returns `Stream<AtOperationItemStatus>`, where [AtOperationItemStatus] represents status of individual operations.
   Stream<AtOperationItemStatus> unshare({List<String>? atSigns});
 
-  /// Deletes the object and unshares with every @sign it was shared with previously
+  /// Deletes the object and un-shares with every @sign it was shared with previously
   /// ```
   /// Phone personalPhone = await Phone('personal phone').save();
-  /// var sahreRes = await personalPhone.share([@kevin, @colin]);
+  /// var shareRes = await personalPhone.share([@kevin, @colin]);
   /// personalPhone.streams.delete().forEach(
   ///   (AtOperationItemStatus element) {
   ///    ///
   ///   },
   /// );
   /// ```
-  /// Returns Stream<AtOperationItemStatus>, where [AtOperationItemStatus] represents status of individual operations.
+  /// Returns `Stream<AtOperationItemStatus>`, where [AtOperationItemStatus] represents status of individual operations.
   Stream<AtOperationItemStatus> delete();
 }
 

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -642,7 +642,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   String _formatResult(String? commandResult) {
     var result = commandResult;
     if (result != null) {
-      result = result.replaceFirst('data:', '');
+      result = result.replaceFirst(RegExp('^data:'), '');
     }
     return result ??= '';
   }
@@ -708,7 +708,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
         streamResponse.status = AtStreamStatus.complete;
       }
     } else if (result != null && result.startsWith('error:')) {
-      result = result.replaceAll('error:', '');
+      result = result.replaceFirst(RegExp('^error:'), '');
       streamResponse.errorCode = result.split('-')[0];
       streamResponse.errorMessage = result.split('-')[1];
       streamResponse.status = AtStreamStatus.error;
@@ -929,7 +929,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     } on AtException catch (e) {
       throw AtClientException.message(e.message);
     }
-    otpVerbResponse = otpVerbResponse?.replaceAll('data:', '');
+    otpVerbResponse = otpVerbResponse?.replaceFirst(RegExp('^data:'), '');
     return AtResponse()..response = otpVerbResponse!;
   }
 
@@ -944,7 +944,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     } on AtException catch (e) {
       throw AtClientException.message(e.message);
     }
-    otpVerbResponse = otpVerbResponse?.replaceAll('data:', '');
+    otpVerbResponse = otpVerbResponse?.replaceFirst(RegExp('^data:'), '');
     return AtResponse()..response = otpVerbResponse!;
   }
 

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -340,7 +340,7 @@ class LocalSecondary implements Secondary {
             'Failed to fetch enrollment information for id: ${_atClient.enrollmentId} from server caused by ${e.toString()}');
       }
       enrollmentInfoFromServer =
-          enrollmentInfoFromServer?.replaceAll('data:', '');
+          enrollmentInfoFromServer?.replaceFirst(RegExp('^data:'), '');
       Map enrollmentDetailsMap = jsonDecode(enrollmentInfoFromServer!);
       _logger.info('Enrollment Details Map : $enrollmentDetailsMap');
       enrollment = Enrollment()

--- a/packages/at_client/lib/src/client/remote_secondary.dart
+++ b/packages/at_client/lib/src/client/remote_secondary.dart
@@ -108,7 +108,7 @@ class RemoteSecondary implements Secondary {
     var verbResult;
     try {
       verbResult = await executeVerb(builder);
-      verbResult = verbResult.replaceFirst('data:', '');
+      verbResult = verbResult.replaceFirst(RegExp('^data:'), '');
     } on AtException catch (e) {
       throw e
         ..stack(AtChainedException(Intent.fetchData,

--- a/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
@@ -317,7 +317,7 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
       myCopy = null;
     }
     if (myCopy != null && myCopy.startsWith('data:')) {
-      myCopy = myCopy.replaceFirst('data:', '');
+      myCopy = myCopy.replaceFirst(RegExp('^data:'), '');
     }
     return myCopy;
   }
@@ -341,7 +341,7 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
       theirCopy = null;
     }
     if (theirCopy != null && theirCopy.startsWith('data:')) {
-      theirCopy = theirCopy.replaceFirst('data:', '');
+      theirCopy = theirCopy.replaceFirst(RegExp('^data:'), '');
     }
     return theirCopy;
   }

--- a/packages/at_client/lib/src/encryption_service/encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/encryption.dart
@@ -6,7 +6,7 @@ abstract class AtKeyEncryption {
   ///
   /// Returns a String for a text value.
   ///
-  /// Returns List<int> for a stream data.
+  /// Returns `List<int>` for a stream data.
   ///
   /// Throws [KeyNotFoundException] if any of the encryption keys are not found.
   ///

--- a/packages/at_client/lib/src/listener/connectivity_listener.dart
+++ b/packages/at_client/lib/src/listener/connectivity_listener.dart
@@ -4,7 +4,7 @@ import 'package:internet_connection_checker/internet_connection_checker.dart';
 
 /// @Deprecated Will be removed in a future release. Please use a connectivity checker of your own choice in your application code
 ///
-/// Listener class that returns a Stream<True> if internet connection is on in the running device, Stream<False> if internet gets disconnected.
+/// Listener class that returns a `Stream<True>` if internet connection is on in the running device, `Stream<False>` if internet gets disconnected.
 /// Sample usage
 /// ```
 /// ConnectivityListener({hostname:'google.com', port:80}).subscribe().listen((isConnected) {
@@ -36,8 +36,8 @@ class ConnectivityListener {
     }
   }
 
-  /// Listen to [InternetConnectionChecker.onStatusChange] and returns Stream<True> whenever
-  /// internet connection is online. Returns Stream<False> if internet connection is lost.
+  /// Listen to [InternetConnectionChecker.onStatusChange] and returns `Stream<True>` whenever
+  /// internet connection is online. Returns `Stream<False>` if internet connection is lost.
   Stream<bool> subscribe() {
     late final InternetConnectionChecker icc;
     if (hostname != null && port != null) {

--- a/packages/at_client/lib/src/manager/sync_manager.dart
+++ b/packages/at_client/lib/src/manager/sync_manager.dart
@@ -143,7 +143,7 @@ class SyncManager {
                 'Exception occurred in processing sync command ${e.message}');
           }
           if (syncResponse.isNotEmpty && syncResponse != 'data:null') {
-            syncResponse = syncResponse.replaceFirst('data:', '');
+            syncResponse = syncResponse.replaceFirst(RegExp('^data:'), '');
             var syncResponseJson = JsonUtils.decodeJson(syncResponse);
             // Iterates over each commit
             await Future.forEach(syncResponseJson,
@@ -326,7 +326,7 @@ class SyncManager {
         await _remoteSecondary!.executeCommand(command, auth: true);
     logger.finer('batch result:$verbResult');
     if (verbResult != null) {
-      verbResult = verbResult.replaceFirst('data:', '');
+      verbResult = verbResult.replaceFirst(RegExp('^data:'), '');
     }
     return jsonDecode(verbResult!);
   }

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.4.0';
+  final String atClientVersion = '3.5.0';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.5.0';
+  final String atClientVersion = '3.4.1';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/response/default_response_parser.dart
+++ b/packages/at_client/lib/src/response/default_response_parser.dart
@@ -27,7 +27,7 @@ class DefaultResponseParser implements ResponseParser {
   /// @param response - Response object from parse method
   /// @returns void
   void parseSuccessResponse(String responseString, AtResponse response) {
-    response.response = responseString.replaceFirst('data:', '');
+    response.response = responseString.replaceFirst(RegExp('^data:'), '');
   }
 
   /// Remove error: in responseString and extract Error code and error response if any
@@ -38,7 +38,7 @@ class DefaultResponseParser implements ResponseParser {
   /// @returns void
   void parseFailureResponse(String responseString, AtResponse response) {
     // Remove error: from responseString
-    responseString = responseString.replaceFirst('error:', '');
+    responseString = responseString.replaceFirst(RegExp('^error:'), '');
     // Set isError to true
     response.isError = true;
     // Find out whether error code exists or not

--- a/packages/at_client/lib/src/service/encryption_service.dart
+++ b/packages/at_client/lib/src/service/encryption_service.dart
@@ -257,7 +257,8 @@ class EncryptionService {
           DefaultResponseParser().parse(encryptedSharedKey).response;
     }
     if (encryptedSharedKey.isNotEmpty) {
-      encryptedSharedKey = encryptedSharedKey.replaceFirst(RegExp('^data:'), '');
+      encryptedSharedKey =
+          encryptedSharedKey.replaceFirst(RegExp('^data:'), '');
     }
     if (encryptedSharedKey == 'null' || encryptedSharedKey.isEmpty) {
       throw KeyNotFoundException('encrypted Shared key not found');

--- a/packages/at_client/lib/src/service/encryption_service.dart
+++ b/packages/at_client/lib/src/service/encryption_service.dart
@@ -64,7 +64,7 @@ class EncryptionService {
       logger.finer('Generated a new AES Key for $sharedWith');
       sharedKey = EncryptionUtil.generateAESKey();
     } else {
-      sharedKey = sharedKey.replaceFirst('data:', '');
+      sharedKey = sharedKey.replaceFirst(RegExp('^data:'), '');
       var currentAtSignPrivateKey =
           await localSecondary!.getEncryptionPrivateKey();
       sharedKey =
@@ -107,7 +107,7 @@ class EncryptionService {
     }
     if (sharedWithPublicKey != null && sharedWithPublicKey != 'data:null') {
       sharedWithPublicKey =
-          sharedWithPublicKey.toString().replaceAll('data:', '');
+          sharedWithPublicKey.toString().replaceFirst(RegExp('^data:'), '');
       return sharedWithPublicKey;
     }
 
@@ -257,7 +257,7 @@ class EncryptionService {
           DefaultResponseParser().parse(encryptedSharedKey).response;
     }
     if (encryptedSharedKey.isNotEmpty) {
-      encryptedSharedKey = encryptedSharedKey.replaceFirst('data:', '');
+      encryptedSharedKey = encryptedSharedKey.replaceFirst(RegExp('^data:'), '');
     }
     if (encryptedSharedKey == 'null' || encryptedSharedKey.isEmpty) {
       throw KeyNotFoundException('encrypted Shared key not found');

--- a/packages/at_client/lib/src/service/enrollment_service.dart
+++ b/packages/at_client/lib/src/service/enrollment_service.dart
@@ -5,7 +5,7 @@ import 'package:at_client/src/util/enroll_list_request_param.dart';
 /// [EnrollmentService] contains methods to fetch the enrollment details and methods to perform operations on the enrollments.
 abstract class EnrollmentService {
   /// Fetches all enrollment requests from the server. Optionally accepts [EnrollListRequestParams] to filter the enrollment
-  /// requests. The enrollments are returned as List<EnrollmentRequestDetails>.
+  /// requests. The enrollments are returned as `List<EnrollmentRequestDetails>`.
   ///
   /// ```dart
   /// Example:

--- a/packages/at_client/lib/src/service/enrollment_service_impl.dart
+++ b/packages/at_client/lib/src/service/enrollment_service_impl.dart
@@ -31,7 +31,7 @@ class EnrollmentServiceImpl implements EnrollmentService {
   }
 
   List<Enrollment> _formatEnrollListResponse(response) {
-    response = response?.replaceFirst('data:', '');
+    response = response?.replaceFirst(RegExp('^data:'), '');
     Map<String, dynamic> enrollRequests = jsonDecode(response!);
     List<Enrollment> enrollRequestsFormatted = [];
     for (MapEntry enrollmentRequest in enrollRequests.entries) {

--- a/packages/at_client/lib/src/service/notification_service.dart
+++ b/packages/at_client/lib/src/service/notification_service.dart
@@ -82,7 +82,7 @@ abstract class NotificationService {
   ///```
   ///4. To notify a text message to @bob
   ///   forText notifications are case sensitive
-  ///   await notificationService.notify(NotificationParams.forText(<Text to Notify>,<Whom to Notify>));
+  ///   `await notificationService.notify(NotificationParams.forText(<Text to Notify>,<Whom to Notify>));`
   ///
   ///```dart
   ///   var notificationService = AtClientManager.getInstance().notificationService;

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -927,7 +927,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
         _atClient.getPreferences()!.atClientParticulars,
         'batch result:$verbResult'));
     if (verbResult != null) {
-      verbResult = verbResult.replaceFirst('data:', '');
+      verbResult = verbResult.replaceFirst(RegExp('^data:'), '');
     }
     return jsonDecode(verbResult!);
   }

--- a/packages/at_client/lib/src/stream/stream_notification_handler.dart
+++ b/packages/at_client/lib/src/stream/stream_notification_handler.dart
@@ -26,8 +26,8 @@ class StreamNotificationHandler {
     var port = secondaryAddress.port;
     var socket = await SecureSocket.connect(host, port);
     // ignore: prefer_interpolation_to_compose_strings
-    var f = File((preference!.downloadPath ?? '') +
-        Platform.pathSeparator +
+    var f = File('${preference!.downloadPath ?? ''}'
+        '${Platform.pathSeparator}'
         'encrypted_${streamNotification.fileName}');
     logger.info('sending stream receive for : $streamId');
     var command = 'stream:receive $streamId\n';

--- a/packages/at_client/lib/src/transformer/at_transformer.dart
+++ b/packages/at_client/lib/src/transformer/at_transformer.dart
@@ -4,7 +4,7 @@ import 'package:at_client/src/client/request_options.dart';
 
 /// Class responsible for Transforming the data.
 abstract class Transformer<T, V> {
-  /// Accepts the data of type <T> transform's to type <V>
+  /// Accepts the data of type `<T>` transform's to type `<V>`
   FutureOr<V> transform(T value);
 }
 

--- a/packages/at_client/lib/src/util/sync_util.dart
+++ b/packages/at_client/lib/src/util/sync_util.dart
@@ -102,7 +102,7 @@ class SyncUtil {
       throw AtClientException.message(
           'Unable to fetch latest server commit id: ${e.toString()}');
     }
-    result = result.replaceAll('data:', '');
+    result = result.replaceFirst(RegExp('^data:'), '');
     var statsJson = JsonUtils.decodeJson(result);
     if (statsJson[0]['value'] != 'null') {
       commitId = int.parse(statsJson[0]['value']);

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.4.0
+version: 3.5.0
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 
@@ -14,22 +14,6 @@ homepage: https://docs.atsign.com/
 environment:
   sdk: ">=2.15.0 <4.0.0"
 
-dependency_overrides:
-  at_persistence_spec:
-    git:
-      url: https://github.com/atsign-foundation/at_server
-      path: packages/at_persistence_spec
-      ref: feat-immutability
-  at_persistence_secondary_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server
-      path: packages/at_persistence_secondary_server
-      ref: feat-immutability
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      path: packages/at_commons
-      ref: feat-immutability
 dependencies:
   path: ^1.8.2
   hive: ^2.2.3

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -14,6 +14,22 @@ homepage: https://docs.atsign.com/
 environment:
   sdk: ">=2.15.0 <4.0.0"
 
+dependency_overrides:
+  at_persistence_spec:
+    git:
+      url: https://github.com/atsign-foundation/at_server
+      path: packages/at_persistence_spec
+      ref: feat-immutability
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server
+      path: packages/at_persistence_secondary_server
+      ref: feat-immutability
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_commons
+      ref: feat-immutability
 dependencies:
   path: ^1.8.2
   hive: ^2.2.3
@@ -36,8 +52,8 @@ dependencies:
   at_chops: ^2.2.0
   at_lookup: ^3.0.49
   at_auth: ^2.0.10
-  at_persistence_spec: ^2.0.14
-  at_persistence_secondary_server: ^3.1.0
+  at_persistence_spec: ^3.0.0
+  at_persistence_secondary_server: ^4.0.0
   meta: ^1.8.0
   version: ^3.0.2
 

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.5.0
+version: 3.4.1
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 
@@ -36,8 +36,8 @@ dependencies:
   at_chops: ^2.2.0
   at_lookup: ^3.0.49
   at_auth: ^2.0.10
-  at_persistence_spec: ^3.0.0
-  at_persistence_secondary_server: ^4.0.0
+  at_persistence_spec: ^2.0.14
+  at_persistence_secondary_server: ^3.1.0
   meta: ^1.8.0
   version: ^3.0.2
 

--- a/packages/at_client/test/sync_new_test.dart
+++ b/packages/at_client/test/sync_new_test.dart
@@ -1777,8 +1777,9 @@ void main() {
           .toString();
       var atData = AtData();
       atData.data = '11122';
+      atData.metaData = AtMetaData()..ttb = 10000;
       //----------------------------------operation---------------------------------
-      int putCommitId = await keystore!.put(atKey, atData, time_to_born: 10000);
+      int putCommitId = await keystore!.put(atKey, atData);
       // key should not be available before 10 seconds
       // Assertion is not possible as the key will be available in the keystore level
       // expect(() async => await keystore.get(atKey),

--- a/packages/at_client/test/sync_new_test.dart
+++ b/packages/at_client/test/sync_new_test.dart
@@ -1777,9 +1777,8 @@ void main() {
           .toString();
       var atData = AtData();
       atData.data = '11122';
-      atData.metaData = AtMetaData()..ttb = 10000;
       //----------------------------------operation---------------------------------
-      int putCommitId = await keystore!.put(atKey, atData);
+      int putCommitId = await keystore!.put(atKey, atData, time_to_born: 10000);
       // key should not be available before 10 seconds
       // Assertion is not possible as the key will be available in the keystore level
       // expect(() async => await keystore.get(atKey),

--- a/packages/at_client_mobile/CHANGELOG.md
+++ b/packages/at_client_mobile/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.21
+- fix: potential bug handling atSigns which end in `data` e.g. `@foo_data`
+
 ## 3.2.20
 - fix: Authenticating now saves keys to local secondary store
 

--- a/packages/at_client_mobile/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/at_client_mobile/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,22 +7,18 @@ import Foundation
 
 import at_file_saver
 import biometric_storage
-import device_info_plus
 import file_selector_macos
-import package_info_plus
+import package_info_plus_macos
 import path_provider_foundation
-import share_plus
-import shared_preferences_foundation
+import share_plus_macos
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FileSaverPlugin.register(with: registry.registrar(forPlugin: "FileSaverPlugin"))
   BiometricStorageMacOSPlugin.register(with: registry.registrar(forPlugin: "BiometricStorageMacOSPlugin"))
-  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
-  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
+  FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
-  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/packages/at_client_mobile/example/pubspec.yaml
+++ b/packages/at_client_mobile/example/pubspec.yaml
@@ -37,12 +37,6 @@ dependencies:
   at_app_flutter: ^5.2.0
   at_client: ^3.2.2
 
-dependency_overrides:
-  at_commons: ^5.0.0
-  at_utils: ^3.0.19
-  path: ^1.8.3
-  async: ^2.10.0
-
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/at_client_mobile/lib/src/at_client_service.dart
+++ b/packages/at_client_mobile/lib/src/at_client_service.dart
@@ -416,14 +416,14 @@ class AtClientService {
         return null;
       }
     }
-    return result!.replaceFirst('data:', '');
+    return result!.replaceFirst(RegExp('^data:'), '');
   }
 
   bool _isNullOrEmpty(String? key) {
     if (key == null) {
       return true;
     }
-    key = key.replaceFirst('data:', '');
+    key = key.replaceFirst(RegExp('^data:'), '');
     if (key == 'null' || key.isEmpty) {
       return true;
     }

--- a/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
+++ b/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
@@ -457,7 +457,7 @@ class AtAuthServiceImpl implements AtAuthService {
       if (getPrivateKeyResult == null || getPrivateKeyResult.isEmpty) {
         throw AtEnrollmentException('$privateKeyCommand returned null/empty');
       }
-      getPrivateKeyResult = getPrivateKeyResult.replaceFirst('data:', '');
+      getPrivateKeyResult = getPrivateKeyResult.replaceFirst(RegExp('^data:'), '');
       var privateKeyResultJson = jsonDecode(getPrivateKeyResult);
       encryptionPrivateKeyFromServer = privateKeyResultJson['value'];
       encryptionPrivateKeyIV = privateKeyResultJson['iv'];
@@ -492,7 +492,7 @@ class AtAuthServiceImpl implements AtAuthService {
             '$selfEncryptionKeyCommand returned null/empty');
       }
       encryptedSelfEncryptionKey =
-          encryptedSelfEncryptionKey.replaceFirst('data:', '');
+          encryptedSelfEncryptionKey.replaceFirst(RegExp('^data:'), '');
       var selfEncryptionKeyResultJson = jsonDecode(encryptedSelfEncryptionKey);
       selfEncryptionKeyFromServer = selfEncryptionKeyResultJson['value'];
       selfEncryptionKeyIV = selfEncryptionKeyResultJson['iv'];

--- a/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
+++ b/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
@@ -457,7 +457,8 @@ class AtAuthServiceImpl implements AtAuthService {
       if (getPrivateKeyResult == null || getPrivateKeyResult.isEmpty) {
         throw AtEnrollmentException('$privateKeyCommand returned null/empty');
       }
-      getPrivateKeyResult = getPrivateKeyResult.replaceFirst(RegExp('^data:'), '');
+      getPrivateKeyResult =
+          getPrivateKeyResult.replaceFirst(RegExp('^data:'), '');
       var privateKeyResultJson = jsonDecode(getPrivateKeyResult);
       encryptionPrivateKeyFromServer = privateKeyResultJson['value'];
       encryptionPrivateKeyIV = privateKeyResultJson['iv'];

--- a/packages/at_client_mobile/pubspec.yaml
+++ b/packages/at_client_mobile/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client_mobile
 description: A Flutter extension to the at_client library which adds support for mobile, desktop and IoT devices.
-version: 3.2.20
+version: 3.2.21
 repository: https://github.com/atsign-foundation/at_client_sdk/packages
 homepage: https://docs.atsign.com/
 


### PR DESCRIPTION
**- What I did**
fix: wherever we are parsing data: or error: responses from atServer, use replaceFirst(RegExp(r'^data:'), '') or replaceFirst(RegExp(r'^error:'), '')

**- How I did it**
See commits

**- How to verify it**
Tests pass