### PR TITLE
fix: add retries to at_client_bindings.notify (3 by default)

### DIFF
--- a/packages/at_client/lib/src/mixins/at_client_bindings.dart
+++ b/packages/at_client/lib/src/mixins/at_client_bindings.dart
@@ -6,25 +6,44 @@ mixin AtClientBindings {
 
   AtSignLogger get logger;
 
-  Future<void> notify(
+  Future<NotificationResult> notify(
     AtKey atKey,
     String value, {
     required bool checkForFinalDeliveryStatus,
     required bool waitForFinalDeliveryStatus,
     required Duration ttln,
+
+    /// maxTries must be a non-zero positive integer
+    int maxTries = 3,
   }) async {
-    await atClient.notificationService.notify(
-      NotificationParams.forUpdate(atKey,
-          value: value, notificationExpiry: ttln),
-      checkForFinalDeliveryStatus: checkForFinalDeliveryStatus,
-      waitForFinalDeliveryStatus: waitForFinalDeliveryStatus,
-      onSuccess: (NotificationResult notification) {
-        logger.info('SUCCESS:$notification with key: ${atKey.toString()}');
-      },
-      onError: (notification) {
-        logger.info('ERROR:$notification');
-      },
+    var params = NotificationParams.forUpdate(
+      atKey,
+      value: value,
+      notificationExpiry: ttln,
     );
+
+    NotificationResult result;
+
+    int attempts = 0;
+    do {
+      attempts++;
+      result = await atClient.notificationService.notify(
+        params,
+        checkForFinalDeliveryStatus: checkForFinalDeliveryStatus,
+        waitForFinalDeliveryStatus: waitForFinalDeliveryStatus,
+        onSuccess: (NotificationResult notification) {
+          logger.info('SUCCESS:$notification with key: ${atKey.toString()}');
+        },
+        onError: (notification) {
+          logger.info('ERROR:$notification');
+        },
+      );
+    } while (result.atClientException != null && attempts < maxTries);
+    if (result.atClientException != null) {
+      logger.warning(
+          'Failed to send ${atKey.toString()} notification within $maxTries attempts.');
+    }
+    return result;
   }
 
   Stream<AtNotification> subscribe(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
closes https://github.com/atsign-foundation/noports/issues/1828

(I don't know if this ^^ will auto close issues in other repos, but I'm curious to find out)

**- What I did**

- Changed return of `AtClientBindings.notify` type from `Future<void>` to `Future<NotificationResult>`
- Added new optional parameter called `maxTries` which defaults to 3
- wrapped the notify command in a retry loop

**- How I did it**

- Used a `do while` instead of `for` which seems weird, but it ensures a few things:
  - The notify always runs at least once
    - Thus, result is never left unset before we reach the end of the function,
      which can't be guaranteed with a for loop.
  - Any maxTries value less than 1 is effectively silently set to 1, 
    instead of us needing to do validation and throwing on invalid input


**- How to verify it**

**- Description for the changelog**
fix: add retries to at_client_bindings.notify (3 by default)
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
