### PR TITLE
fix: Enable the same atSign to be used on both sides (client and server) of an AtRpc interaction

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 3.4.3
+- build[deps]: update dependencies including at_persistence major version 
+  changes
+- fix: tightened up code for handling `AtKeyNotFoundException`s in 
+  `AtCollectionQueryOperationsImpl`
+- fix: Enable the same atSign to be used on both sides (client and server) 
+  of an AtRpc interaction
+- fix: LocalSecondary.isEnrollmentAuthorizedForOperation now checks if the 
+  key in question is a `local` key, in which case the answer is always yes.
+
 ## 3.4.2
 - build[deps]: update dependencies (at_commons, at_lookup, at_auth)
 

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -518,6 +518,10 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     if (preference != null && preference!.enforceNamespace == false) {
       enforceNamespace = false;
     }
+    // Clients should be able to store any local keys they want
+    if (atKey.isLocal) {
+      enforceNamespace = false;
+    }
     var validationResult = AtKeyValidators.get().validate(
         atKey.toString(),
         ValidationContext()

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -272,6 +272,10 @@ class LocalSecondary implements Secondary {
 
   Future<bool> isEnrollmentAuthorizedForOperation(
       String key, VerbBuilder verbBuilder) async {
+    // Do whatever you want with "local" keys
+    if (key.startsWith('local:')) {
+      return true;
+    }
     // if there is no enrollment, return true
     enrollment ??= await _getEnrollmentDetails();
     if (_atClient.enrollmentId == null ||

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.4.2';
+  final String atClientVersion = '3.4.3';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/preference/at_client_preference.dart
+++ b/packages/at_client/lib/src/preference/at_client_preference.dart
@@ -80,17 +80,15 @@ class AtClientPreference {
   ///[OptionalParameter] path to trusted certificates. Required to create security context.
   String? pathToCerts;
 
-  // TODO Remove this in next major version
-  @Deprecated(
-      "namespace presence will become mandatory in next major version of the SDK")
-
   /// [AtClient.put] uses this parameter to decide whether to check for presence of a namespace in the
   /// string representation of the AtKey.
   /// * When set to true, keys such as public:foo@alice or @bob:foo@alice will be rejected
   /// because they do not have a namespace. But keys such as public:foo.bar@alice of @bob:foo.bar.baz.bash@alice will be accepted.
   /// * When set to false keys such as public:foo@alice or @bob:foo@alice will not be rejected
   /// * Defaults to true, as applications should always be placing keys within a namespace
-  bool enforceNamespace = true;
+  @Deprecated(
+      "namespace presence will become mandatory in next major version of the SDK")
+  bool enforceNamespace = true; // TODO Remove this in next major version
 
   /// Fetch the notifications received when the client is offline. Defaults to true.
   /// Set to false to ignore the notifications received when device is offline.

--- a/packages/at_client/lib/src/rpc/at_rpc.dart
+++ b/packages/at_client/lib/src/rpc/at_rpc.dart
@@ -195,7 +195,8 @@ class AtRpc {
 
     // If we're a server, listen for request notifications
     if (isServer) {
-      final String requestsRegex = 'request.\\d+.$domainNameSpace.$rpcsNameSpace.$baseNameSpace@';
+      final String requestsRegex =
+          'request.\\d+.$domainNameSpace.$rpcsNameSpace.$baseNameSpace@';
       logger.info('Subscribing to $requestsRegex');
 
       _requestStream = atClient.notificationService
@@ -209,7 +210,7 @@ class AtRpc {
     // If we're a client, listen for response notifications
     if (isClient) {
       final String responsesRegex =
-      '(success|error|ack|nack).\\d+.$domainNameSpace.$rpcsNameSpace.$baseNameSpace@';
+          '(success|error|ack|nack).\\d+.$domainNameSpace.$rpcsNameSpace.$baseNameSpace@';
       logger.info('Subscribing to $responsesRegex');
 
       _responseStream = atClient.notificationService

--- a/packages/at_client/lib/src/rpc/at_rpc.dart
+++ b/packages/at_client/lib/src/rpc/at_rpc.dart
@@ -164,6 +164,9 @@ class AtRpc {
   ///
   final bool allowAll;
 
+  final bool isClient;
+  final bool isServer;
+
   AtRpc({
     required this.atClient,
     required this.baseNameSpace,
@@ -172,32 +175,50 @@ class AtRpc {
     required this.callbacks,
     required this.allowList,
     this.allowAll = false,
-  });
+    this.isClient = true,
+    this.isServer = true,
+  }) {
+    if (!isClient && !isServer) {
+      throw IllegalArgumentException('isClient or isServer must be true');
+    }
+    if (isClient && isServer) {
+      logger.warning('isClient and isServer both true.'
+          ' This will cause problems if the same atSign is being used'
+          ' for both requests and responses');
+    }
+  }
 
   /// Starts listening for notifications of the requests and responses
   /// in the `$domainNameSpace.$rpcsNameSpace.$baseNameSpace` namespace
   void start() {
     logger.info('allowList is $allowList; allowAll is $allowAll');
-    var regex = 'request.\\d+.$domainNameSpace.$rpcsNameSpace.$baseNameSpace@';
-    logger.info('Subscribing to $regex');
 
-    _requestStream = atClient.notificationService
-        .subscribe(regex: regex, shouldDecrypt: true);
+    // If we're a server, listen for request notifications
+    if (isServer) {
+      final String requestsRegex = 'request.\\d+.$domainNameSpace.$rpcsNameSpace.$baseNameSpace@';
+      logger.info('Subscribing to $requestsRegex');
 
-    _requestStream!.listen(handleRequestNotification,
-        onError: (e) => logger.severe('Notification Failed: $e'),
-        onDone: () => logger.info('RPC request listener stopped'));
+      _requestStream = atClient.notificationService
+          .subscribe(regex: requestsRegex, shouldDecrypt: true);
 
-    regex =
-        '(success|error|ack|nack).\\d+.$domainNameSpace.$rpcsNameSpace.$baseNameSpace@';
-    logger.info('Subscribing to $regex');
+      _requestStream!.listen(handleRequestNotification,
+          onError: (e) => logger.severe('Notification Failed: $e'),
+          onDone: () => logger.info('RPC request listener stopped'));
+    }
 
-    _responseStream = atClient.notificationService
-        .subscribe(regex: regex, shouldDecrypt: true);
+    // If we're a client, listen for response notifications
+    if (isClient) {
+      final String responsesRegex =
+      '(success|error|ack|nack).\\d+.$domainNameSpace.$rpcsNameSpace.$baseNameSpace@';
+      logger.info('Subscribing to $responsesRegex');
 
-    _responseStream!.listen(handleResponseNotification,
-        onError: (e) => logger.severe('Notification Failed: $e'),
-        onDone: () => logger.info('RPC response listener stopped'));
+      _responseStream = atClient.notificationService
+          .subscribe(regex: responsesRegex, shouldDecrypt: true);
+
+      _responseStream!.listen(handleResponseNotification,
+          onError: (e) => logger.severe('Notification Failed: $e'),
+          onDone: () => logger.info('RPC response listener stopped'));
+    }
   }
 
   /// Sends a request by sending a notification with 'key' of

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -262,7 +262,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     } on AtException catch (e) {
       e.stack(AtChainedException(Intent.syncData,
           ExceptionScenario.remoteVerbExecutionFailed, e.message));
-      _logger.severe(
+      _logger.warning(
           'Exception in sync ${syncRequest.id}. Reason: ${e.getTraceMessage()}');
       syncRequest.result!.atClientException =
           AtExceptionManager.createException(e);

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -541,17 +541,12 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
         'syncDirection': keyInfo.syncDirection,
         'errorOrExceptionMessage': keyInfo.conflictInfo?.errorOrExceptionMessage
       });
-    } on Exception catch (e, stacktrace) {
+    } catch (e) {
       _sendTelemetry(
-          '_syncFromServer.forEachEntry.exception', {"e": e, "st": stacktrace});
+          '_syncFromServer.forEachEntry.exception', {"e": e});
       _logger.severe(
-          'exception syncing entry to local $serverCommitEntry Exception: ${e.toString()} - stacktrace: $stacktrace');
-    } on Error catch (e, stacktrace) {
-      _sendTelemetry(
-          '_syncFromServer.forEachEntry.error', {"e": e, "st": stacktrace});
-      _logger.severe(
-          'error syncing entry to local $serverCommitEntry - Exception: ${e.toString()} - stacktrace: $stacktrace');
-    }
+          'Exception: $e while syncing entry to local ${jsonEncode(serverCommitEntry)}');
+      }
   }
 
   /// Takes the last received server commit id and fetches the entries that are above the given

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -542,11 +542,10 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
         'errorOrExceptionMessage': keyInfo.conflictInfo?.errorOrExceptionMessage
       });
     } catch (e) {
-      _sendTelemetry(
-          '_syncFromServer.forEachEntry.exception', {"e": e});
+      _sendTelemetry('_syncFromServer.forEachEntry.exception', {"e": e});
       _logger.severe(
           'Exception: $e while syncing entry to local ${jsonEncode(serverCommitEntry)}');
-      }
+    }
   }
 
   /// Takes the last received server commit id and fetches the entries that are above the given

--- a/packages/at_client/lib/src/util/sync_util.dart
+++ b/packages/at_client/lib/src/util/sync_util.dart
@@ -59,7 +59,9 @@ class SyncUtil {
     if (atCommitLog == null) {
       return [];
     }
-    return atCommitLog!.getChanges(seqNum, regex);
+    return (await atCommitLog!.getChanges(seqNum, regex))
+        .where((commitEntry) => !commitEntry.atKey!.startsWith('local:'))
+        .toList();
   }
 
   //#TODO change return type to enum which says in sync, local ahead or server ahead

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.4.2
+version: 3.4.3
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/test/sync_service_test.dart
+++ b/packages/at_client/test/sync_service_test.dart
@@ -86,22 +86,27 @@ class FakeStatsVerbBuilder extends Fake implements StatsVerbBuilder {}
 class FakeAtKey extends Fake implements AtKey {}
 
 void main() async {
-  AtClient mockAtClient = MockAtClient();
-  AtClientManager mockAtClientManager = MockAtClientManager();
-  NotificationServiceImpl mockNotificationService =
-      MockNotificationServiceImpl();
-  AtCommitLog mockAtCommitLog = MockAtCommitLog();
-  RemoteSecondary mockRemoteSecondary = MockRemoteSecondary();
-  LocalSecondary mockLocalSecondary = MockLocalSecondary();
+  late AtClient mockAtClient;
+  late AtClientManager mockAtClientManager;
+  late NotificationServiceImpl mockNotificationService;
+  late AtCommitLog mockAtCommitLog;
+  late RemoteSecondary mockRemoteSecondary;
+  late LocalSecondary mockLocalSecondary;
+  late SyncServiceImpl syncServiceImpl;
 
-  var syncServiceImpl = await SyncServiceImpl.create(mockAtClient,
-      atClientManager: mockAtClientManager,
-      notificationService: mockNotificationService,
-      remoteSecondary: mockRemoteSecondary) as SyncServiceImpl;
-  syncServiceImpl.syncUtil = SyncUtil(atCommitLog: mockAtCommitLog);
+  setUp(() async {
+    mockAtClient = MockAtClient();
+    mockAtClientManager = MockAtClientManager();
+    mockNotificationService = MockNotificationServiceImpl();
+    mockAtCommitLog = MockAtCommitLog();
+    mockRemoteSecondary = MockRemoteSecondary();
+    mockLocalSecondary = MockLocalSecondary();
 
-  setUp(() {
-    reset(mockRemoteSecondary);
+    syncServiceImpl = await SyncServiceImpl.create(mockAtClient,
+        atClientManager: mockAtClientManager,
+        notificationService: mockNotificationService,
+        remoteSecondary: mockRemoteSecondary) as SyncServiceImpl;
+    syncServiceImpl.syncUtil = SyncUtil(atCommitLog: mockAtCommitLog);
   });
 
   group('A group of positive tests on sync service', () {
@@ -300,6 +305,10 @@ void main() async {
                 ..commitId = localCommitId));
       when(() =>
               mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((invocation) {
+        throw AtKeyNotFoundException('key is not found in keystore');
+      });
+      when(() => mockAtClient.get(any(that: SkipDeletesUntilMatcher())))
           .thenAnswer((invocation) =>
               throw AtKeyNotFoundException('key is not found in keystore'));
       when(() => mockAtClient.get(any(that: InitialSyncDoneFlagMatcher())))


### PR DESCRIPTION
**- What I did**
Main thing:
- fix: Enable the same atSign to be used on both sides (client and server) of an AtRpc interaction

**- How I did it**
- Added optional parameters `isClient` and `isServer` to AtRpc constructor. If `isServer` is set, then the AtRpc will listen to the requests regex. If `isClient` is set, then the AtRpc will listen to the responses regex.


**- Other things of note:**
- fix: `LocalSecondary.isEnrollmentAuthorizedForOperation` now checks if the key in question is a `local` key, in which case the answer is always yes.
- fix: `AtClientImpl._putInternal` now also checks if the key in question is a `local` key, in which case it does not require that the key have a namespace

**- Chores etc**
- fix: changed severity of a log message in SyncServiceImpl from `severe` to `warning`, because sync failures can happen for a whole bunch of mundane reasons.
- test: Moved test setup code in sync_service_test.dart into a setUp() method where it belongs. As a result, found a missing `when` in one of the tests, fixed that
- docs: moved a @Deprecated annotation to the place dart format prefers it to be
- chore: tightened up logging in SyncServiceImpl

**- How to verify it**
Tests pass
