### PR TITLE
fix: Store cached bob public key

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.4.4
+- fix[performance]: when fetching `public:publickey` of another atSign from
+  atServer, cache it in local storage instead of depending on sync to take
+  care of that (since programs can disable sync)
+
 ## 3.4.3
 - build[deps]: update dependencies including at_persistence major version 
   changes

--- a/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
@@ -272,9 +272,9 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
         ..atKey = (AtKey()
           ..key = 'publickey'
           ..sharedBy = atKey.sharedWith);
-      String fetchedPK = await _atClient
+      final String fetchedPK = defaultResponseParser.parse(await _atClient
           .getRemoteSecondary()!
-          .executeVerb(encryptionPublicKeyBuilder);
+          .executeVerb(encryptionPublicKeyBuilder)).response;
 
       // Got it - first of all, cache it locally (in case sync is not enabled)
       final uvb = UpdateVerbBuilder()
@@ -284,7 +284,7 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
       await _atClient.getLocalSecondary()!.executeVerb(uvb, sync: false);
 
       // Then return it
-      return defaultResponseParser.parse(fetchedPK).response;
+      return fetchedPK;
     } on AtException catch (exception) {
       throw AtPublicKeyNotFoundException(
           'Failed to fetch public key of ${atKey.sharedWith}')

--- a/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
@@ -253,14 +253,16 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
             ..isPublic = true
             ..isCached = true));
 
-      String? cachedLocallyPK = await _atClient
+      String? llookupResponse = await _atClient
           .getLocalSecondary()!
           .executeVerb(cachedEncryptionPublicKeyBuilder);
 
       // Got it - return
-      if (cachedLocallyPK != null && cachedLocallyPK != 'data:null') {
+      if (llookupResponse != null && llookupResponse != 'data:null') {
+        String cachedLocallyPK =
+            defaultResponseParser.parse(llookupResponse).response;
         _logger.finest('Found public key locally: $cachedLocallyPK');
-        return defaultResponseParser.parse(cachedLocallyPK).response;
+        return cachedLocallyPK;
       }
     } on KeyNotFoundException {
       _logger.finer('${atKey.sharedWith} encryption public key is not found');
@@ -272,9 +274,11 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
         ..atKey = (AtKey()
           ..key = 'publickey'
           ..sharedBy = atKey.sharedWith);
-      final String fetchedPK = defaultResponseParser.parse(await _atClient
-          .getRemoteSecondary()!
-          .executeVerb(encryptionPublicKeyBuilder)).response;
+      final String fetchedPK = defaultResponseParser
+          .parse(await _atClient
+              .getRemoteSecondary()!
+              .executeVerb(encryptionPublicKeyBuilder))
+          .response;
 
       // Got it - first of all, cache it locally (in case sync is not enabled)
       final uvb = UpdateVerbBuilder()

--- a/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
@@ -259,6 +259,7 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
 
       // Got it - return
       if (cachedLocallyPK != null && cachedLocallyPK != 'data:null') {
+        _logger.finest('Found public key locally: $cachedLocallyPK');
         return defaultResponseParser.parse(cachedLocallyPK).response;
       }
     } on KeyNotFoundException {
@@ -279,6 +280,7 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
       final uvb = UpdateVerbBuilder()
         ..atKey = AtKey.fromString('cached:public:publickey${atKey.sharedWith}')
         ..value = fetchedPK;
+      _logger.info('Updating public key locally: ${uvb.buildCommand()}');
       await _atClient.getLocalSecondary()!.executeVerb(uvb, sync: false);
 
       // Then return it

--- a/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
+++ b/packages/at_client/lib/src/encryption_service/abstract_atkey_encryption.dart
@@ -243,9 +243,8 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
   /// Returns sharedWith atSign publicKey.
   /// Throws [KeyNotFoundException] if sharedWith atSign publicKey is not found.
   Future<String> _getSharedWithPublicKey(AtKey atKey) async {
-    String? sharedWithPublicKey;
     try {
-      // 1. Get the cached public key
+      // 1. Try to fetch cached public key from local storage
       var cachedEncryptionPublicKeyBuilder = LLookupVerbBuilder()
         ..atKey = (AtKey()
           ..key = 'publickey'
@@ -254,22 +253,36 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
             ..isPublic = true
             ..isCached = true));
 
-      sharedWithPublicKey = await _atClient
+      String? cachedLocallyPK = await _atClient
           .getLocalSecondary()!
           .executeVerb(cachedEncryptionPublicKeyBuilder);
+
+      // Got it - return
+      if (cachedLocallyPK != null && cachedLocallyPK != 'data:null') {
+        return defaultResponseParser.parse(cachedLocallyPK).response;
+      }
     } on KeyNotFoundException {
       _logger.finer('${atKey.sharedWith} encryption public key is not found');
     }
+
+    // Didn't find in local storage - check on atServer
     try {
-      if (sharedWithPublicKey.isNull || sharedWithPublicKey == 'data:null') {
-        var encryptionPublicKeyBuilder = PLookupVerbBuilder()
-          ..atKey = (AtKey()
-            ..key = 'publickey'
-            ..sharedBy = atKey.sharedWith);
-        sharedWithPublicKey = await _atClient
-            .getRemoteSecondary()!
-            .executeVerb(encryptionPublicKeyBuilder);
-      }
+      var encryptionPublicKeyBuilder = PLookupVerbBuilder()
+        ..atKey = (AtKey()
+          ..key = 'publickey'
+          ..sharedBy = atKey.sharedWith);
+      String fetchedPK = await _atClient
+          .getRemoteSecondary()!
+          .executeVerb(encryptionPublicKeyBuilder);
+
+      // Got it - first of all, cache it locally (in case sync is not enabled)
+      final uvb = UpdateVerbBuilder()
+        ..atKey = AtKey.fromString('cached:public:publickey${atKey.sharedWith}')
+        ..value = fetchedPK;
+      await _atClient.getLocalSecondary()!.executeVerb(uvb, sync: false);
+
+      // Then return it
+      return defaultResponseParser.parse(fetchedPK).response;
     } on AtException catch (exception) {
       throw AtPublicKeyNotFoundException(
           'Failed to fetch public key of ${atKey.sharedWith}')
@@ -277,11 +290,6 @@ abstract class AbstractAtKeyEncryption implements AtKeyEncryption {
         ..stack(AtChainedException(Intent.shareData,
             ExceptionScenario.keyNotFound, exception.message));
     }
-    if (sharedWithPublicKey.isNull || sharedWithPublicKey == 'data:null') {
-      return throw AtPublicKeyNotFoundException(
-          'Failed to fetch public key of ${atKey.sharedWith}');
-    }
-    return defaultResponseParser.parse(sharedWithPublicKey!).response;
   }
 
   /// Stores the encryptedSharedKey for future use.

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.4.3';
+  final String atClientVersion = '3.4.4';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.4.3
+version: 3.4.4
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 


### PR DESCRIPTION
**- What I did**
- fix[performance]: when fetching `public:publickey` of another atSign from atServer, cache it in local storage instead of depending on sync to take care of that (since programs can disable sync)

**- How I did it**
- See commits

**- How to verify it**
Tests pass
