### PR TITLE
feat: add `atLookUp` parameter to AtClientManager.setCurrentAtSign etc

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.5.0
 - feat: add `atLookUp` parameter to AtClientManager.setCurrentAtSign,
-  AtClientImpl.create, etc so we can inject an existing AtLookUp instance if 
+  AtClientImpl.create, etc. so we can inject an existing AtLookUp instance if 
   we have one rather than having to create a new one and authenticate again
 
 ## 3.4.4

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.5.0
+- feat: add `atLookUp` parameter to AtClientManager.setCurrentAtSign,
+  AtClientImpl.create, etc so we can inject an existing AtLookUp instance if 
+  we have one rather than having to create a new one and authenticate again
+
 ## 3.4.4
 - fix[performance]: when fetching `public:publickey` of another atSign from
   atServer, cache it in local storage instead of depending on sync to take

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -694,6 +694,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   }
 
   @override
+  @Deprecated("Obsolete, wil be removed in v4")
   Future<AtStreamResponse> stream(String sharedWith, String filePath,
       {String? namespace}) async {
     var streamResponse = AtStreamResponse();
@@ -735,6 +736,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   }
 
   @override
+  @Deprecated("Obsolete, wil be removed in v4")
   Future<void> sendStreamAck(
       String streamId,
       String fileName,

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -137,6 +137,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       EncryptionService? encryptionService,
       SecondaryKeyStore? localSecondaryKeyStore,
       AtChops? atChops,
+      AtLookUp? atLookUp,
       AtClientCommitLogCompaction? atClientCommitLogCompaction,
       AtClientConfig? atClientConfig,
       String? enrollmentId}) async {
@@ -154,11 +155,12 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
           encryptionService: encryptionService,
           localSecondaryKeyStore: localSecondaryKeyStore,
           atChops: atChops,
+          atLookUp: atLookUp,
           atClientCommitLogCompaction: atClientCommitLogCompaction,
           atClientConfig: atClientConfig,
           enrollmentId: enrollmentId);
 
-      await atClientImpl._init();
+      await atClientImpl._init(atLookUp: atLookUp);
     }
 
     await atClientImpl!.startCompactionJob();
@@ -168,15 +170,20 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     return atClientInstanceMap[currentAtSign];
   }
 
-  AtClientImpl._(String theAtSign, String? namespace,
-      AtClientPreference preference, AtClientManager atClientManager,
-      {RemoteSecondary? remoteSecondary,
-      EncryptionService? encryptionService,
-      SecondaryKeyStore? localSecondaryKeyStore,
-      AtChops? atChops,
-      AtClientCommitLogCompaction? atClientCommitLogCompaction,
-      AtClientConfig? atClientConfig,
-      this.enrollmentId}) {
+  AtClientImpl._(
+    String theAtSign,
+    String? namespace,
+    AtClientPreference preference,
+    AtClientManager atClientManager, {
+    RemoteSecondary? remoteSecondary,
+    EncryptionService? encryptionService,
+    SecondaryKeyStore? localSecondaryKeyStore,
+    AtChops? atChops,
+    AtLookUp? atLookUp,
+    AtClientCommitLogCompaction? atClientCommitLogCompaction,
+    AtClientConfig? atClientConfig,
+    this.enrollmentId,
+  }) {
     _atSign = AtUtils.fixAtSign(theAtSign);
     _logger = AtSignLogger('AtClientImpl ($_atSign)');
     _preference = preference;
@@ -184,17 +191,19 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     _namespace = namespace;
     _atClientManager = atClientManager;
     _localSecondaryKeyStore = localSecondaryKeyStore;
+
     if (_localSecondaryKeyStore != null && !_preference!.isLocalStoreRequired) {
       throw IllegalArgumentException(
           'A SecondaryKeyStore was injected, but preference.isLocalStoreRequired is false');
     }
+
     _remoteSecondary = remoteSecondary;
     _encryptionService = encryptionService;
     _atChops = atChops;
     _atClientCommitLogCompaction = atClientCommitLogCompaction;
   }
 
-  Future<void> _init() async {
+  Future<void> _init({AtLookUp? atLookUp}) async {
     if (_preference!.isLocalStoreRequired) {
       if (_localSecondaryKeyStore == null) {
         var storageManager = StorageManager(preference);
@@ -205,13 +214,14 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       _atChops ??= await _createAtChops(_atSign);
     }
 
-    // Now using ??= because we may be injecting a RemoteSecondary
+    // Using ??= because we may be injecting a RemoteSecondary
     _remoteSecondary ??= RemoteSecondary(_atSign, _preference!,
         atChops: atChops,
+        atLookUp: atLookUp,
         privateKey: _preference!.privateKey,
         enrollmentId: enrollmentId);
 
-    // Now using ??= because we may be injecting an EncryptionService
+    // Using ??= because we may be injecting an EncryptionService
     _encryptionService ??= EncryptionService(_atSign);
     _encryptionService!.remoteSecondary = _remoteSecondary;
     _encryptionService!.localSecondary = _localSecondary;
@@ -706,7 +716,8 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       result = result.trim();
       _logger.finer('ack received for streamId:$streamId');
       remoteSecondary.atLookUp.connection!.getSocket().add(encryptedData);
-      var streamResult = await remoteSecondary.atLookUp.messageListener
+      var streamResult = await (remoteSecondary.atLookUp as AtLookupImpl)
+          .messageListener
           .read(maxWaitMilliSeconds: _preference!.outboundConnectionTimeout);
       if (streamResult.startsWith('stream:done')) {
         await remoteSecondary.atLookUp.connection!.close();

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -518,15 +518,17 @@ abstract class AtClient {
   /// the notification on the client.
   /// Optionally a regular expression and be passed to filter the notifications
   /// [deprecated] Use [NotificationService.subscribe]
-  @Deprecated("Use Monitor Service")
+  @Deprecated("Obsolete. Use the NotificationService")
   Future<void> startMonitor(String privateKey, Function acceptStream,
       {String? regex});
 
   /// Streams the file in [filePath] to [sharedWith] atSign.
+  @Deprecated("Obsolete, wil be removed in v4")
   Future<AtStreamResponse> stream(String sharedWith, String filePath,
       {String namespace});
 
   /// Sends stream acknowledgement
+  @Deprecated("Obsolete, wil be removed in v4")
   Future<void> sendStreamAck(
       String streamId,
       String fileName,

--- a/packages/at_client/lib/src/client/remote_secondary.dart
+++ b/packages/at_client/lib/src/client/remote_secondary.dart
@@ -23,12 +23,15 @@ class RemoteSecondary implements Secondary {
 
   late AtClientPreference _preference;
 
-  late AtLookupImpl atLookUp;
+  late AtLookUp atLookUp;
 
   final AtChops? atChops;
 
   RemoteSecondary(String atSign, AtClientPreference preference,
-      {String? privateKey, this.atChops, String? enrollmentId}) {
+      {String? privateKey,
+      this.atChops,
+      AtLookUp? atLookUp,
+      String? enrollmentId}) {
     _atSign = AtUtils.fixAtSign(atSign);
     logger = AtSignLogger('RemoteSecondary ($_atSign)');
     _preference = preference;
@@ -37,19 +40,20 @@ class RemoteSecondary implements Secondary {
       ..decryptPackets = preference.decryptPackets
       ..pathToCerts = preference.pathToCerts
       ..tlsKeysSavePath = preference.tlsKeysSavePath;
-    atLookUp = AtLookupImpl(atSign, preference.rootDomain, preference.rootPort,
-        privateKey: privateKey,
-        cramSecret: preference.cramSecret,
-        secondaryAddressFinder:
-            AtClientManager.getInstance().secondaryAddressFinder,
-        secureSocketConfig: secureSocketConfig,
-        clientConfig: _getClientConfig());
-    atLookUp.enrollmentId = enrollmentId;
+    this.atLookUp = atLookUp ??
+        AtLookupImpl(atSign, preference.rootDomain, preference.rootPort,
+            privateKey: privateKey,
+            cramSecret: preference.cramSecret,
+            secondaryAddressFinder:
+                AtClientManager.getInstance().secondaryAddressFinder,
+            secureSocketConfig: secureSocketConfig,
+            clientConfig: _getClientConfig());
+    this.atLookUp.enrollmentId = enrollmentId;
     logger.finer(
         'signingAlgoType: ${preference.signingAlgoType} hashingAlgoType: ${preference.hashingAlgoType}');
-    atLookUp.signingAlgoType = preference.signingAlgoType;
-    atLookUp.hashingAlgoType = preference.hashingAlgoType;
-    atLookUp.atChops = atChops;
+    this.atLookUp.signingAlgoType = preference.signingAlgoType;
+    this.atLookUp.hashingAlgoType = preference.hashingAlgoType;
+    this.atLookUp.atChops = atChops;
   }
 
   Map<String, String> _getClientConfig() {
@@ -86,7 +90,7 @@ class RemoteSecondary implements Secondary {
       logger.finer(logger.getLogMessageWithClientParticulars(
           _preference.atClientParticulars,
           'Command sent to server: ${builder.buildCommand()}'));
-      verbResult = await atLookUp.executeVerb(builder);
+      verbResult = (await atLookUp.executeVerb(builder))!;
       logger.finer(logger.getLogMessageWithClientParticulars(
           _preference.atClientParticulars,
           'Response from server: $verbResult'));
@@ -140,13 +144,6 @@ class RemoteSecondary implements Secondary {
 
   void addStreamData(List<int> data) {
     atLookUp.connection!.getSocket().add(data);
-  }
-
-  /// Generates digest using from verb response and [privateKey] and performs a PKAM authentication to
-  /// secondary server. This method is executed for all verbs that requires authentication.
-  Future<bool> authenticate(String? privateKey) async {
-    var authResult = await atLookUp.authenticate(privateKey);
-    return authResult;
   }
 
   /// Generates digest using from verb response and [secret] and performs a CRAM authentication to

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -63,6 +63,7 @@ class AtClientManager {
       String atSign, String? namespace, AtClientPreference preference,
       {AtServiceFactory? serviceFactory,
       AtChops? atChops,
+      AtLookUp? atLookUp,
       String? enrollmentId}) async {
     serviceFactory ??= DefaultAtServiceFactory();
 
@@ -83,7 +84,7 @@ class AtClientManager {
     var previousAtClient = _currentAtClient;
     _currentAtClient = await serviceFactory.atClient(
         _atSign, namespace, preference, this,
-        atChops: atChops, enrollmentId: enrollmentId);
+        atChops: atChops, atLookUp: atLookUp, enrollmentId: enrollmentId);
     final switchAtSignEvent =
         SwitchAtSignEvent(previousAtClient, _currentAtClient!);
     _notifyListeners(switchAtSignEvent);
@@ -156,7 +157,7 @@ class AtClientManager {
 abstract class AtServiceFactory {
   Future<AtClient> atClient(String atSign, String? namespace,
       AtClientPreference preference, AtClientManager atClientManager,
-      {AtChops? atChops, String? enrollmentId});
+      {AtChops? atChops, AtLookUp? atLookUp, String? enrollmentId});
 
   Future<NotificationService> notificationService(
       AtClient atClient, AtClientManager atClientManager);
@@ -171,10 +172,11 @@ class DefaultAtServiceFactory implements AtServiceFactory {
   @override
   Future<AtClient> atClient(String atSign, String? namespace,
       AtClientPreference preference, AtClientManager atClientManager,
-      {AtChops? atChops, String? enrollmentId}) async {
+      {AtChops? atChops, AtLookUp? atLookUp, String? enrollmentId}) async {
     return await AtClientImpl.create(atSign, namespace, preference,
         atClientManager: atClientManager,
         atChops: atChops,
+        atLookUp: atLookUp,
         enrollmentId: enrollmentId);
   }
 

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.4.4';
+  final String atClientVersion = '3.5.0';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.4.4
+version: 3.5.0
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 
@@ -34,7 +34,7 @@ dependencies:
   at_commons: ^5.3.0
   at_utils: ^3.2.0
   at_chops: ^2.2.0
-  at_lookup: ^3.0.52
+  at_lookup: ^3.1.0
   at_auth: ^2.2.0
   at_persistence_spec: ^3.0.0
   at_persistence_secondary_server: ^4.0.0

--- a/packages/at_client/test/switch_atsign_test.dart
+++ b/packages/at_client/test/switch_atsign_test.dart
@@ -1,9 +1,29 @@
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/service/sync_service_impl.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
+
+class MockAtLookUp extends Mock implements AtLookUp {}
 
 void main() {
   group('A group of switch atsign tests', () {
+    test('Test that we can inject an AtLookUp instance', () async {
+      final aliceAtSign = '@alice';
+      final atClientManager = AtClientManager(aliceAtSign);
+      final alicePreference = AtClientPreference();
+      final mockAtLookUp = MockAtLookUp();
+      await atClientManager.setCurrentAtSign(
+          aliceAtSign, 'wavi', alicePreference,
+          atLookUp: mockAtLookUp);
+      expect(atClientManager.atClient.getCurrentAtSign(), aliceAtSign);
+      expect(atClientManager.atClient.getRemoteSecondary()!.atLookUp,
+          mockAtLookUp);
+      expect(
+          atClientManager.atClient.getRemoteSecondary()!.atLookUp.runtimeType,
+          MockAtLookUp);
+    });
+
     test('test switch atsign - check atsign name', () async {
       final aliceAtSign = '@alice';
       final atClientManager = AtClientManager(aliceAtSign);


### PR DESCRIPTION
**- What I did**
- feat: add `atLookUp` parameter to `AtClientManager.setCurrentAtSign`, `AtClientImpl.create`, etc so we can inject an existing AtLookUp instance if we have one rather than having to create a new one and authenticate again

**- How I did it**
See commits

**- How to verify it**
Tests pass
