### PR TITLE
fix: ensure that namespace is preserved if it is repeated in a notification key

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.1
+- fix: ensure that namespace is preserved if it happens to be repeated in a 
+  notification's key (e.g. `@bob:foo.my_app.my_app@alice` )
+
 ## 3.5.0
 - feat: add `atLookUp` parameter to AtClientManager.setCurrentAtSign,
   AtClientImpl.create, etc. so we can inject an existing AtLookUp instance if 

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.5.0';
+  final String atClientVersion = '3.5.1';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
+++ b/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
@@ -43,12 +43,21 @@ class NotificationRequestTransformer
   }
 
   Future<NotifyVerbBuilder> _prepareNotificationBuilder(
-      NotificationParams notificationParams,
-      AtClientPreference atClientPreference) async {
+    NotificationParams notificationParams,
+    AtClientPreference atClientPreference,
+  ) async {
+    AtKey ak = notificationParams.atKey;
+
+    if (notificationParams.messageType == MessageTypeEnum.key &&
+        ak.metadata.namespaceAware &&
+        atClientPreference.namespace != null &&
+        ak.namespace != atClientPreference.namespace) {
+      ak = AtKey.fromString('${ak.toString()}.${atClientPreference.namespace}');
+    }
+
     var builder = NotifyVerbBuilder()
       ..id = notificationParams.id
-      ..atKey.sharedBy = notificationParams.atKey.sharedBy
-      ..atKey.sharedWith = notificationParams.atKey.sharedWith
+      ..atKey = ak
       ..operation = notificationParams.operation
       ..messageType = notificationParams.messageType
       ..priority = notificationParams.priority
@@ -56,12 +65,8 @@ class NotificationRequestTransformer
       ..latestN = notificationParams.latestN
       ..notifier = notificationParams.notifier
       ..ttln = notificationParams.notificationExpiry.inMilliseconds;
-    // Append namespace only to message type key. For message type text do not
-    // append namespaces.
-    if (notificationParams.messageType == MessageTypeEnum.key) {
-      builder.atKey.key = AtClientUtil.getKeyWithNameSpace(
-          notificationParams.atKey, atClientPreference);
-    }
+
+    // message type 'text' is obsolete and does not work
     // ignore: deprecated_member_use
     if (notificationParams.messageType == MessageTypeEnum.text) {
       if (notificationParams.atKey.metadata.isEncrypted) {

--- a/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
+++ b/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
@@ -43,43 +43,57 @@ class NotificationRequestTransformer
   }
 
   Future<NotifyVerbBuilder> _prepareNotificationBuilder(
-    NotificationParams params,
-    AtClientPreference prefs,
+    NotificationParams notificationParams,
+    AtClientPreference atClientPreference,
   ) async {
-    AtKey ak = params.atKey;
-
-    if (params.messageType == MessageTypeEnum.key &&
-        ak.metadata.namespaceAware) {
-      ak.namespace ??= prefs.namespace;
-      if (prefs.namespace != null && ak.namespace != prefs.namespace) {
-        ak.key = '${ak.key}.${ak.namespace}';
-        ak.namespace = prefs.namespace;
-      }
-      ak = AtKey.fromString(ak.toString());
-    }
-
-    var builder = NotifyVerbBuilder()
-      ..id = params.id
-      ..atKey = ak
-      ..operation = params.operation
-      ..messageType = params.messageType
-      ..priority = params.priority
-      ..strategy = params.strategy
-      ..latestN = params.latestN
-      ..notifier = params.notifier
-      ..ttln = params.notificationExpiry.inMilliseconds;
-
-    // message type 'text' is obsolete and does not work
     // ignore: deprecated_member_use
-    if (params.messageType == MessageTypeEnum.text) {
-      if (params.atKey.metadata.isEncrypted) {
-        builder.atKey.key =
-            await _encryptNotificationValue(params.atKey, params.atKey.key);
+    if (notificationParams.messageType == MessageTypeEnum.text) {
+      // NB: message type 'text' is obsolete and does not work.
+
+      var builder = NotifyVerbBuilder()
+        ..id = notificationParams.id
+        ..atKey.sharedBy = notificationParams.atKey.sharedBy
+        ..atKey.sharedWith = notificationParams.atKey.sharedWith
+        ..operation = notificationParams.operation
+        ..messageType = notificationParams.messageType
+        ..priority = notificationParams.priority
+        ..strategy = notificationParams.strategy
+        ..latestN = notificationParams.latestN
+        ..notifier = notificationParams.notifier
+        ..ttln = notificationParams.notificationExpiry.inMilliseconds;
+
+      if (notificationParams.atKey.metadata.isEncrypted) {
+        builder.atKey.key = await _encryptNotificationValue(
+            notificationParams.atKey, notificationParams.atKey.key);
       } else {
-        builder.atKey.key = params.atKey.key;
+        builder.atKey.key = notificationParams.atKey.key;
       }
+      return builder;
+    } else {
+      AtKey ak = notificationParams.atKey;
+
+      if (notificationParams.messageType == MessageTypeEnum.key &&
+          ak.metadata.namespaceAware) {
+        ak.namespace ??= atClientPreference.namespace;
+        if (atClientPreference.namespace != null &&
+            ak.namespace != atClientPreference.namespace) {
+          ak.key = '${ak.key}.${ak.namespace}';
+          ak.namespace = atClientPreference.namespace;
+        }
+        ak = AtKey.fromString(ak.toString());
+      }
+
+      return NotifyVerbBuilder()
+        ..id = notificationParams.id
+        ..atKey = ak
+        ..operation = notificationParams.operation
+        ..messageType = notificationParams.messageType
+        ..priority = notificationParams.priority
+        ..strategy = notificationParams.strategy
+        ..latestN = notificationParams.latestN
+        ..notifier = notificationParams.notifier
+        ..ttln = notificationParams.notificationExpiry.inMilliseconds;
     }
-    return builder;
   }
 
   void _addMetadataToBuilder(

--- a/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
+++ b/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
@@ -50,7 +50,8 @@ class NotificationRequestTransformer
     if (notificationParams.messageType == MessageTypeEnum.text) {
       // NB: message type 'text' is obsolete and does not work.
 
-      var builder = NotifyVerbBuilder()
+      NotifyVerbBuilder builder = NotifyVerbBuilder()
+        ..useAtKeyToString = true
         ..id = notificationParams.id
         ..atKey.sharedBy = notificationParams.atKey.sharedBy
         ..atKey.sharedWith = notificationParams.atKey.sharedWith
@@ -84,6 +85,7 @@ class NotificationRequestTransformer
       }
 
       return NotifyVerbBuilder()
+        ..useAtKeyToString = true
         ..id = notificationParams.id
         ..atKey = ak
         ..operation = notificationParams.operation

--- a/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
+++ b/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
@@ -43,37 +43,40 @@ class NotificationRequestTransformer
   }
 
   Future<NotifyVerbBuilder> _prepareNotificationBuilder(
-    NotificationParams notificationParams,
-    AtClientPreference atClientPreference,
+    NotificationParams params,
+    AtClientPreference prefs,
   ) async {
-    AtKey ak = notificationParams.atKey;
+    AtKey ak = params.atKey;
 
-    if (notificationParams.messageType == MessageTypeEnum.key &&
-        ak.metadata.namespaceAware &&
-        atClientPreference.namespace != null &&
-        ak.namespace != atClientPreference.namespace) {
-      ak = AtKey.fromString('${ak.toString()}.${atClientPreference.namespace}');
+    if (params.messageType == MessageTypeEnum.key &&
+        ak.metadata.namespaceAware) {
+      ak.namespace ??= prefs.namespace;
+      if (prefs.namespace != null && ak.namespace != prefs.namespace) {
+        ak.key = '${ak.key}.${ak.namespace}';
+        ak.namespace = prefs.namespace;
+      }
+      ak = AtKey.fromString(ak.toString());
     }
 
     var builder = NotifyVerbBuilder()
-      ..id = notificationParams.id
+      ..id = params.id
       ..atKey = ak
-      ..operation = notificationParams.operation
-      ..messageType = notificationParams.messageType
-      ..priority = notificationParams.priority
-      ..strategy = notificationParams.strategy
-      ..latestN = notificationParams.latestN
-      ..notifier = notificationParams.notifier
-      ..ttln = notificationParams.notificationExpiry.inMilliseconds;
+      ..operation = params.operation
+      ..messageType = params.messageType
+      ..priority = params.priority
+      ..strategy = params.strategy
+      ..latestN = params.latestN
+      ..notifier = params.notifier
+      ..ttln = params.notificationExpiry.inMilliseconds;
 
     // message type 'text' is obsolete and does not work
     // ignore: deprecated_member_use
-    if (notificationParams.messageType == MessageTypeEnum.text) {
-      if (notificationParams.atKey.metadata.isEncrypted) {
-        builder.atKey.key = await _encryptNotificationValue(
-            notificationParams.atKey, notificationParams.atKey.key);
+    if (params.messageType == MessageTypeEnum.text) {
+      if (params.atKey.metadata.isEncrypted) {
+        builder.atKey.key =
+            await _encryptNotificationValue(params.atKey, params.atKey.key);
       } else {
-        builder.atKey.key = notificationParams.atKey.key;
+        builder.atKey.key = params.atKey.key;
       }
     }
     return builder;

--- a/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
+++ b/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
@@ -51,7 +51,7 @@ class NotificationRequestTransformer
       // NB: message type 'text' is obsolete and does not work.
 
       NotifyVerbBuilder builder = NotifyVerbBuilder()
-        ..useAtKeyToString = true
+        ..useAtKeyToString = false
         ..id = notificationParams.id
         ..atKey.sharedBy = notificationParams.atKey.sharedBy
         ..atKey.sharedWith = notificationParams.atKey.sharedWith

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.5.0
+version: 3.5.1
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 
@@ -14,6 +14,12 @@ homepage: https://docs.atsign.com/
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_commons
+      ref: fix-NotifyVerbBuilder.buildCommand
 dependencies:
   path: ^1.8.2
   hive: ^2.2.3

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -14,12 +14,6 @@ homepage: https://docs.atsign.com/
 environment:
   sdk: ">=3.0.0 <4.0.0"
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      path: packages/at_commons
-      ref: fix-NotifyVerbBuilder.buildCommand
 dependencies:
   path: ^1.8.2
   hive: ^2.2.3
@@ -37,7 +31,7 @@ dependencies:
   async: ^2.9.0
   at_utf7: ^1.0.0
   at_base2e15: ^1.0.0
-  at_commons: ^5.3.0
+  at_commons: ^5.4.1
   at_utils: ^3.2.0
   at_chops: ^2.2.0
   at_lookup: ^3.1.0

--- a/packages/at_client/test/enrollment_service_test.dart
+++ b/packages/at_client/test/enrollment_service_test.dart
@@ -458,7 +458,8 @@ void main() {
         ..namespace = {"fubar": "rw"};
 
       final bool authorized = await ls.isEnrollmentAuthorizedForOperation(
-          'public:phone.fubar@alice', NotifyVerbBuilder());
+          'public:phone.fubar@alice',
+          NotifyVerbBuilder()..useAtKeyToString = true);
       expect(authorized, true);
     });
 
@@ -474,7 +475,8 @@ void main() {
         ..namespace = {"fubar": "r"};
 
       final bool authorized = await ls.isEnrollmentAuthorizedForOperation(
-          'public:phone.fubar@alice', NotifyVerbBuilder());
+          'public:phone.fubar@alice',
+          NotifyVerbBuilder()..useAtKeyToString = true);
       expect(authorized, false);
     });
 
@@ -491,7 +493,8 @@ void main() {
         ..namespace = {"fubar": "rw"};
 
       final bool authorized = await ls.isEnrollmentAuthorizedForOperation(
-          'public:phone.unauth@alice', NotifyVerbBuilder());
+          'public:phone.unauth@alice',
+          NotifyVerbBuilder()..useAtKeyToString = true);
       expect(authorized, false);
     });
 

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -122,7 +122,8 @@ void main() {
               AtClientPreference()..namespace = 'wavi',
               SharedKeyEncryption(mockAtClientImpl))
           .transform(notificationParams);
-      expect(notifyVerbBuilder.atKey.key, 'phone.wavi');
+      expect(notifyVerbBuilder.atKey.key, 'phone');
+      expect(notifyVerbBuilder.atKey.namespace, 'wavi');
       expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
       expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
       expect(notifyVerbBuilder.priority, PriorityEnum.low);
@@ -148,7 +149,8 @@ void main() {
               AtClientPreference()..namespace = 'wavi',
               mockSharedKeyEncryptionImpl)
           .transform(notificationParams);
-      expect(notifyVerbBuilder.atKey.key, 'phone.wavi');
+      expect(notifyVerbBuilder.atKey.key, 'phone');
+      expect(notifyVerbBuilder.atKey.namespace, 'wavi');
       expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
       expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
       expect(notifyVerbBuilder.priority, PriorityEnum.high);
@@ -177,7 +179,8 @@ void main() {
               AtClientPreference()..namespace = 'wavi',
               mockSharedKeyEncryptionImpl)
           .transform(notificationParams);
-      expect(notifyVerbBuilder.atKey.key, 'phone.wavi');
+      expect(notifyVerbBuilder.atKey.key, 'phone');
+      expect(notifyVerbBuilder.atKey.namespace, 'wavi');
       expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
       expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
       expect(notifyVerbBuilder.priority, PriorityEnum.high);

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -111,6 +111,88 @@ void main() {
     setUp(() {
       mockSharedKeyEncryptionImpl = MockSharedKeyEncryptionImpl();
     });
+
+    test('Notification request without namespace but with namespace in prefs',
+        () async {
+      var notificationParams = NotificationParams.forUpdate(
+          AtKey.fromString('@bob:phone@alice')..metadata.namespaceAware = true);
+      var notifyVerbBuilder = await NotificationRequestTransformer(
+              '@alice',
+              AtClientPreference()..namespace = 'wavi',
+              SharedKeyEncryption(mockAtClientImpl))
+          .transform(notificationParams);
+      expect(notifyVerbBuilder.atKey.key, 'phone');
+      expect(notifyVerbBuilder.atKey.namespace, 'wavi');
+      expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
+      expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
+      expect(notifyVerbBuilder.priority, PriorityEnum.low);
+      expect(notifyVerbBuilder.strategy, StrategyEnum.all);
+      // The default duration is 24 hours - converted into milliseconds
+      expect(notifyVerbBuilder.ttln, 86400000);
+    });
+
+    test('Notification request with namespace and with same namespace in prefs',
+        () async {
+      var notificationParams = NotificationParams.forUpdate(
+          AtKey.fromString('@bob:phone.wavi@alice')
+            ..metadata.namespaceAware = true);
+      var notifyVerbBuilder = await NotificationRequestTransformer(
+              '@alice',
+              AtClientPreference()..namespace = 'wavi',
+              SharedKeyEncryption(mockAtClientImpl))
+          .transform(notificationParams);
+      expect(notifyVerbBuilder.atKey.key, 'phone');
+      expect(notifyVerbBuilder.atKey.namespace, 'wavi');
+      expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
+      expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
+      expect(notifyVerbBuilder.priority, PriorityEnum.low);
+      expect(notifyVerbBuilder.strategy, StrategyEnum.all);
+      // The default duration is 24 hours - converted into milliseconds
+      expect(notifyVerbBuilder.ttln, 86400000);
+    });
+
+    test(
+        'Notification request with a namespace but a different namespace in prefs',
+        () async {
+      var notificationParams = NotificationParams.forUpdate(
+          AtKey.fromString('@bob:phone.my_app@alice')
+            ..metadata.namespaceAware = true);
+      var notifyVerbBuilder = await NotificationRequestTransformer(
+              '@alice',
+              AtClientPreference()..namespace = 'wavi',
+              SharedKeyEncryption(mockAtClientImpl))
+          .transform(notificationParams);
+      expect(notifyVerbBuilder.atKey.key, 'phone.my_app');
+      expect(notifyVerbBuilder.atKey.namespace, 'wavi');
+      expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
+      expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
+      expect(notifyVerbBuilder.priority, PriorityEnum.low);
+      expect(notifyVerbBuilder.strategy, StrategyEnum.all);
+      // The default duration is 24 hours - converted into milliseconds
+      expect(notifyVerbBuilder.ttln, 86400000);
+    });
+
+    test(
+        'with namespace and different namespace in prefs but not namespace aware',
+        () async {
+      var notificationParams = NotificationParams.forUpdate(
+          AtKey.fromString('@bob:phone.my_app@alice')
+            ..metadata.namespaceAware = false);
+      var notifyVerbBuilder = await NotificationRequestTransformer(
+              '@alice',
+              AtClientPreference()..namespace = 'wavi',
+              SharedKeyEncryption(mockAtClientImpl))
+          .transform(notificationParams);
+      expect(notifyVerbBuilder.atKey.key, 'phone');
+      expect(notifyVerbBuilder.atKey.namespace, 'my_app');
+      expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
+      expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
+      expect(notifyVerbBuilder.priority, PriorityEnum.low);
+      expect(notifyVerbBuilder.strategy, StrategyEnum.all);
+      // The default duration is 24 hours - converted into milliseconds
+      expect(notifyVerbBuilder.ttln, 86400000);
+    });
+
     test(
         'A test to validate notification request without value return verb builder',
         () async {

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -719,6 +719,7 @@ void main() {
       NotificationParams notificationParams =
           NotificationParams.forUpdate(atKey, value: value);
       NotifyVerbBuilder notifyVerbBuilder = NotifyVerbBuilder()
+        ..useAtKeyToString = true
         ..atKey = atKey
         ..messageType = MessageTypeEnum.key
         ..value = 'demo-value';
@@ -742,6 +743,7 @@ void main() {
       NotificationParams notificationParams =
           NotificationParams.forText('Hello bob', '@bob');
       NotifyVerbBuilder notifyVerbBuilder = NotifyVerbBuilder()
+        ..useAtKeyToString = true
         ..atKey.key = '@bob:Hello bob';
 
       expect(

--- a/packages/at_client_mobile/CHANGELOG.md
+++ b/packages/at_client_mobile/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.2.24
+- fix: at_client_mobile: fix immediate issue caused by widespread leakage of 
+  `AtLookupImpl`, exposed by recent removal of that leakage from
+  `at_client.RemoteSecondary`
+- build[deps]: update at_client dependency to `^3.5.0`
+
 ## 3.2.23
 - build[deps]: update dependencies
 

--- a/packages/at_client_mobile/lib/src/at_client_service.dart
+++ b/packages/at_client_mobile/lib/src/at_client_service.dart
@@ -40,12 +40,12 @@ class AtClientService {
         atSign, preference.namespace, preference,
         atChops: atChops);
     _atClient = atClientManager.atClient;
-    _atLookUp = _atClient!.getRemoteSecondary()!.atLookUp;
+    _atLookUp = _atClient!.getRemoteSecondary()!.atLookUp as AtLookupImpl;
     if (preference.outboundConnectionTimeout > 0) {
-      _atClient!.getRemoteSecondary()!.atLookUp.outboundConnectionTimeout =
+      _atLookUp!.outboundConnectionTimeout =
           preference.outboundConnectionTimeout;
     }
-    atClientAuthenticator!.atLookUp = _atClient!.getRemoteSecondary()!.atLookUp;
+    atClientAuthenticator!.atLookUp = _atLookUp!;
     return true;
   }
 
@@ -156,7 +156,7 @@ class AtClientService {
   }
 
   ///Throws [Error] of type [OnboardingStatus]
-  ///if the details for [atsign] is not found in localsecondary.
+  ///if the details for [atsign] is not found in the LocalSecondary.
   ///Returns `true` on successful fetching of all the details.
   Future<bool> _getKeysFromLocalSecondary(String atsign) async {
     String? pkamPublicKey =

--- a/packages/at_client_mobile/pubspec.yaml
+++ b/packages/at_client_mobile/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client_mobile
 description: A Flutter extension to the at_client library which adds support for mobile, desktop and IoT devices.
-version: 3.2.23
+version: 3.2.24
 repository: https://github.com/atsign-foundation/at_client_sdk/packages
 homepage: https://docs.atsign.com/
 
@@ -20,7 +20,7 @@ dependencies:
   at_utils: ^3.0.19
   at_chops: ^2.2.0
   at_lookup: ^3.0.51
-  at_client: ^3.4.3
+  at_client: ^3.5.0
   at_auth: ^2.1.0
   at_file_saver: ^0.1.2
   encrypt: ^5.0.3

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -8,13 +8,6 @@ publish_to: none
 environment:
   sdk: '>=2.15.0 <4.0.0'
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      path: packages/at_commons
-      ref: fix-NotifyVerbBuilder.buildCommand
-
 dependencies:
   at_demo_data: ^1.0.1
   at_auth: ^2.0.7

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -8,6 +8,13 @@ publish_to: none
 environment:
   sdk: '>=2.15.0 <4.0.0'
 
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_commons
+      ref: fix-NotifyVerbBuilder.buildCommand
+
 dependencies:
   at_demo_data: ^1.0.1
   at_auth: ^2.0.7

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -6,6 +6,13 @@ version: 1.0.0
 environment:
   sdk: '>=2.15.0 <4.0.0'
 
+dependency_overrides:
+  at_commons:
+    git:
+      url: https://github.com/atsign-foundation/at_libraries
+      path: packages/at_commons
+      ref: fix-NotifyVerbBuilder.buildCommand
+
 dependencies:
   uuid: 3.0.7
   at_demo_data: ^1.2.0

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -6,13 +6,6 @@ version: 1.0.0
 environment:
   sdk: '>=2.15.0 <4.0.0'
 
-dependency_overrides:
-  at_commons:
-    git:
-      url: https://github.com/atsign-foundation/at_libraries
-      path: packages/at_commons
-      ref: fix-NotifyVerbBuilder.buildCommand
-
 dependencies:
   uuid: 3.0.7
   at_demo_data: ^1.2.0
@@ -24,7 +17,7 @@ dependencies:
   at_lookup: ^3.0.52
   at_utils: ^3.2.0
   at_chops: ^2.2.0
-  at_commons: ^5.3.0
+  at_commons: ^5.4.1
   at_persistence_secondary_server: ^4.0.0
   version: ^3.0.2
 


### PR DESCRIPTION
**- What I did**
- fix: Notifications: ensure that namespace is preserved if it happens to be repeated in a 
  notification's key (e.g. `@bob:foo.my_app.my_app@alice` )
  - takes up at_commons 5.4.1 from [this PR](https://github.com/atsign-foundation/at_libraries/pull/807)
  - resolves #1532
- fix: at_client_mobile: fix issue with widespread leakage of AtLookupImpl, exposed by recent removal of that leakage from at_client.RemoteSecondary

**- How I did it**
- Basically, in NotificationRequestTransformer:
  - make sure that sensible stuff is happening with regards to namespace of the AtKey.
  - pass the AtKey as a whole to the NotifyVerbBuilder
  - leverage the new version of NotifyVerbBuilder setting the `useAtKeyToString` field so it uses AtKey.toString
  - All of which is a bit more complicated than I'd like but there is a complicated backwards compatibility picture here
- And added unit tests to cover this behaviour

**- How to verify it**
Tests pass
