### PR TITLE
fix: namespace edge case when sending notifications

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.5.2
+- fix: ensure that namespaces in `notify` requests aren't messed up by 
+  multipart namespaces in AtClientPreference (e.g. namespace of `foo.bar`)
+
 ## 3.5.1
 - fix: ensure that namespace is preserved if it happens to be repeated in a 
   notification's key (e.g. `@bob:foo.my_app.my_app@alice` )

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.5.1';
+  final String atClientVersion = '3.5.2';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
+++ b/packages/at_client/lib/src/transformer/request_transformer/notify_request_transformer.dart
@@ -77,7 +77,8 @@ class NotificationRequestTransformer
           ak.metadata.namespaceAware) {
         ak.namespace ??= atClientPreference.namespace;
         if (atClientPreference.namespace != null &&
-            ak.namespace != atClientPreference.namespace) {
+            !'${ak.key}.${ak.namespace}'
+                .endsWith('.${atClientPreference.namespace!}')) {
           ak.key = '${ak.key}.${ak.namespace}';
           ak.namespace = atClientPreference.namespace;
         }

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.5.1
+version: 3.5.2
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -112,85 +112,175 @@ void main() {
       mockSharedKeyEncryptionImpl = MockSharedKeyEncryptionImpl();
     });
 
-    test('Notification request without namespace but with namespace in prefs',
-        () async {
-      var notificationParams = NotificationParams.forUpdate(
-          AtKey.fromString('@bob:phone@alice')..metadata.namespaceAware = true);
-      var notifyVerbBuilder = await NotificationRequestTransformer(
-              '@alice',
-              AtClientPreference()..namespace = 'wavi',
-              SharedKeyEncryption(mockAtClientImpl))
-          .transform(notificationParams);
-      expect(notifyVerbBuilder.atKey.key, 'phone');
-      expect(notifyVerbBuilder.atKey.namespace, 'wavi');
-      expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
-      expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
-      expect(notifyVerbBuilder.priority, PriorityEnum.low);
-      expect(notifyVerbBuilder.strategy, StrategyEnum.all);
-      // The default duration is 24 hours - converted into milliseconds
-      expect(notifyVerbBuilder.ttln, 86400000);
+    group('Tests with simple namespace in AtClientPrefs', () {
+      test('Notification request without namespace but with namespace in prefs',
+          () async {
+        var notificationParams = NotificationParams.forUpdate(
+            AtKey.fromString('@bob:phone@alice')
+              ..metadata.namespaceAware = true);
+        var notifyVerbBuilder = await NotificationRequestTransformer(
+                '@alice',
+                AtClientPreference()..namespace = 'wavi',
+                SharedKeyEncryption(mockAtClientImpl))
+            .transform(notificationParams);
+        expect(notifyVerbBuilder.atKey.key, 'phone');
+        expect(notifyVerbBuilder.atKey.namespace, 'wavi');
+        expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
+        expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
+        expect(notifyVerbBuilder.priority, PriorityEnum.low);
+        expect(notifyVerbBuilder.strategy, StrategyEnum.all);
+        // The default duration is 24 hours - converted into milliseconds
+        expect(notifyVerbBuilder.ttln, 86400000);
+      });
+
+      test(
+          'Notification request with namespace and with same namespace in prefs',
+          () async {
+        var notificationParams = NotificationParams.forUpdate(
+            AtKey.fromString('@bob:phone.wavi@alice')
+              ..metadata.namespaceAware = true);
+        var notifyVerbBuilder = await NotificationRequestTransformer(
+                '@alice',
+                AtClientPreference()..namespace = 'wavi',
+                SharedKeyEncryption(mockAtClientImpl))
+            .transform(notificationParams);
+        expect(notifyVerbBuilder.atKey.key, 'phone');
+        expect(notifyVerbBuilder.atKey.namespace, 'wavi');
+        expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
+        expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
+        expect(notifyVerbBuilder.priority, PriorityEnum.low);
+        expect(notifyVerbBuilder.strategy, StrategyEnum.all);
+        // The default duration is 24 hours - converted into milliseconds
+        expect(notifyVerbBuilder.ttln, 86400000);
+      });
+
+      test(
+          'Notification request with a namespace but a different namespace in prefs',
+          () async {
+        var notificationParams = NotificationParams.forUpdate(
+            AtKey.fromString('@bob:phone.my_app@alice')
+              ..metadata.namespaceAware = true);
+        var notifyVerbBuilder = await NotificationRequestTransformer(
+                '@alice',
+                AtClientPreference()..namespace = 'wavi',
+                SharedKeyEncryption(mockAtClientImpl))
+            .transform(notificationParams);
+        expect(notifyVerbBuilder.atKey.key, 'phone.my_app');
+        expect(notifyVerbBuilder.atKey.namespace, 'wavi');
+        expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
+        expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
+        expect(notifyVerbBuilder.priority, PriorityEnum.low);
+        expect(notifyVerbBuilder.strategy, StrategyEnum.all);
+        // The default duration is 24 hours - converted into milliseconds
+        expect(notifyVerbBuilder.ttln, 86400000);
+      });
+
+      test(
+          'with namespace and different namespace in prefs but not namespace aware',
+          () async {
+        var notificationParams = NotificationParams.forUpdate(
+            AtKey.fromString('@bob:phone.my_app@alice')
+              ..metadata.namespaceAware = false);
+        var notifyVerbBuilder = await NotificationRequestTransformer(
+                '@alice',
+                AtClientPreference()..namespace = 'wavi',
+                SharedKeyEncryption(mockAtClientImpl))
+            .transform(notificationParams);
+        expect(notifyVerbBuilder.atKey.key, 'phone');
+        expect(notifyVerbBuilder.atKey.namespace, 'my_app');
+        expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
+        expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
+        expect(notifyVerbBuilder.priority, PriorityEnum.low);
+        expect(notifyVerbBuilder.strategy, StrategyEnum.all);
+        // The default duration is 24 hours - converted into milliseconds
+        expect(notifyVerbBuilder.ttln, 86400000);
+      });
     });
 
-    test('Notification request with namespace and with same namespace in prefs',
-        () async {
-      var notificationParams = NotificationParams.forUpdate(
-          AtKey.fromString('@bob:phone.wavi@alice')
-            ..metadata.namespaceAware = true);
-      var notifyVerbBuilder = await NotificationRequestTransformer(
-              '@alice',
-              AtClientPreference()..namespace = 'wavi',
-              SharedKeyEncryption(mockAtClientImpl))
-          .transform(notificationParams);
-      expect(notifyVerbBuilder.atKey.key, 'phone');
-      expect(notifyVerbBuilder.atKey.namespace, 'wavi');
-      expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
-      expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
-      expect(notifyVerbBuilder.priority, PriorityEnum.low);
-      expect(notifyVerbBuilder.strategy, StrategyEnum.all);
-      // The default duration is 24 hours - converted into milliseconds
-      expect(notifyVerbBuilder.ttln, 86400000);
-    });
+    group('Tests with multipart namespace in AtClientPrefs', () {
+      test(
+          'Notification request without namespace but with multi-part namespace in prefs',
+          () async {
+        var notificationParams = NotificationParams.forUpdate(
+            AtKey.fromString('@bob:phone@alice')
+              ..metadata.namespaceAware = true);
+        var notifyVerbBuilder = await NotificationRequestTransformer(
+                '@alice',
+                AtClientPreference()..namespace = 'foo.bar.baz',
+                SharedKeyEncryption(mockAtClientImpl))
+            .transform(notificationParams);
+        expect(notifyVerbBuilder.atKey.key, 'phone.foo.bar');
+        expect(notifyVerbBuilder.atKey.namespace, 'baz');
+        expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
+        expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
+        expect(notifyVerbBuilder.priority, PriorityEnum.low);
+        expect(notifyVerbBuilder.strategy, StrategyEnum.all);
+        // The default duration is 24 hours - converted into milliseconds
+        expect(notifyVerbBuilder.ttln, 86400000);
+      });
 
-    test(
-        'Notification request with a namespace but a different namespace in prefs',
-        () async {
-      var notificationParams = NotificationParams.forUpdate(
-          AtKey.fromString('@bob:phone.my_app@alice')
-            ..metadata.namespaceAware = true);
-      var notifyVerbBuilder = await NotificationRequestTransformer(
-              '@alice',
-              AtClientPreference()..namespace = 'wavi',
-              SharedKeyEncryption(mockAtClientImpl))
-          .transform(notificationParams);
-      expect(notifyVerbBuilder.atKey.key, 'phone.my_app');
-      expect(notifyVerbBuilder.atKey.namespace, 'wavi');
-      expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
-      expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
-      expect(notifyVerbBuilder.priority, PriorityEnum.low);
-      expect(notifyVerbBuilder.strategy, StrategyEnum.all);
-      // The default duration is 24 hours - converted into milliseconds
-      expect(notifyVerbBuilder.ttln, 86400000);
-    });
+      test(
+          'Notification request with namespace and with same namespace in prefs',
+          () async {
+        var notificationParams = NotificationParams.forUpdate(
+            AtKey.fromString('@bob:phone.foo.bar.baz@alice')
+              ..metadata.namespaceAware = true);
+        var notifyVerbBuilder = await NotificationRequestTransformer(
+                '@alice',
+                AtClientPreference()..namespace = 'foo.bar.baz',
+                SharedKeyEncryption(mockAtClientImpl))
+            .transform(notificationParams);
+        expect(notifyVerbBuilder.atKey.key, 'phone.foo.bar');
+        expect(notifyVerbBuilder.atKey.namespace, 'baz');
+        expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
+        expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
+        expect(notifyVerbBuilder.priority, PriorityEnum.low);
+        expect(notifyVerbBuilder.strategy, StrategyEnum.all);
+        // The default duration is 24 hours - converted into milliseconds
+        expect(notifyVerbBuilder.ttln, 86400000);
+      });
 
-    test(
-        'with namespace and different namespace in prefs but not namespace aware',
-        () async {
-      var notificationParams = NotificationParams.forUpdate(
-          AtKey.fromString('@bob:phone.my_app@alice')
-            ..metadata.namespaceAware = false);
-      var notifyVerbBuilder = await NotificationRequestTransformer(
-              '@alice',
-              AtClientPreference()..namespace = 'wavi',
-              SharedKeyEncryption(mockAtClientImpl))
-          .transform(notificationParams);
-      expect(notifyVerbBuilder.atKey.key, 'phone');
-      expect(notifyVerbBuilder.atKey.namespace, 'my_app');
-      expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
-      expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
-      expect(notifyVerbBuilder.priority, PriorityEnum.low);
-      expect(notifyVerbBuilder.strategy, StrategyEnum.all);
-      // The default duration is 24 hours - converted into milliseconds
-      expect(notifyVerbBuilder.ttln, 86400000);
+      test(
+          'Notification request with a namespace but a different namespace in prefs',
+          () async {
+        var notificationParams = NotificationParams.forUpdate(
+            AtKey.fromString('@bob:phone.my_app@alice')
+              ..metadata.namespaceAware = true);
+        var notifyVerbBuilder = await NotificationRequestTransformer(
+                '@alice',
+                AtClientPreference()..namespace = 'foo.bar.baz',
+                SharedKeyEncryption(mockAtClientImpl))
+            .transform(notificationParams);
+        expect(notifyVerbBuilder.atKey.key, 'phone.my_app.foo.bar');
+        expect(notifyVerbBuilder.atKey.namespace, 'baz');
+        expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
+        expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
+        expect(notifyVerbBuilder.priority, PriorityEnum.low);
+        expect(notifyVerbBuilder.strategy, StrategyEnum.all);
+        // The default duration is 24 hours - converted into milliseconds
+        expect(notifyVerbBuilder.ttln, 86400000);
+      });
+
+      test(
+          'with namespace and different namespace in prefs but not namespace aware',
+          () async {
+        var notificationParams = NotificationParams.forUpdate(
+            AtKey.fromString('@bob:phone.my_app@alice')
+              ..metadata.namespaceAware = false);
+        var notifyVerbBuilder = await NotificationRequestTransformer(
+                '@alice',
+                AtClientPreference()..namespace = 'foo.bar.baz',
+                SharedKeyEncryption(mockAtClientImpl))
+            .transform(notificationParams);
+        expect(notifyVerbBuilder.atKey.key, 'phone');
+        expect(notifyVerbBuilder.atKey.namespace, 'my_app');
+        expect(notifyVerbBuilder.atKey.sharedWith, '@bob');
+        expect(notifyVerbBuilder.messageType, MessageTypeEnum.key);
+        expect(notifyVerbBuilder.priority, PriorityEnum.low);
+        expect(notifyVerbBuilder.strategy, StrategyEnum.all);
+        // The default duration is 24 hours - converted into milliseconds
+        expect(notifyVerbBuilder.ttln, 86400000);
+      });
     });
 
     test(


### PR DESCRIPTION
**- What I did**
- fix: ensure that namespaces in `notify` requests aren't messed up by multipart namespaces in AtClientPreference (e.g. namespace of `foo.bar`)

Assumptions in codebase were that the AtClientPreference.namespace would always be a simple one e.g. `my_app` or `wavi` or whatever. However there is nothing stopping apps setting AtClientPreference.namespace to a multipart namespace e.g. `foo.my_app` or `bar.wavi` or even`foo.bar.baz.wavi`

This bug was exposed by [this fix](https://github.com/atsign-foundation/at_client_sdk/pull/1533)

**- How I did it**
- Fixed faulty logic in NotificationRequestTransformer which was assuming a simple (single-word) AtClientPreference.namespace. See commits.
- Added test cases to cover 

**- How to verify it**
- [x] Tests pass here
- [x] NoPorts tests pass against this branch ([test PR](https://github.com/atsign-foundation/noports/pull/2034))
