### PR TITLE
feat(at_commons): add AtRootDomain class with parsing of proxy included

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.6.0
+
+- feat: add `AtRootDomain` with basic parsing including proxy.
+
 ## 5.5.0
 
 - chore(deps): bump uuid to "^4.0.0"

--- a/packages/at_commons/lib/at_commons.dart
+++ b/packages/at_commons/lib/at_commons.dart
@@ -5,6 +5,7 @@ import 'package:meta/meta.dart';
 export 'package:at_commons/atsign.dart';
 export 'package:at_commons/src/at_constants.dart';
 export 'package:at_commons/src/at_message.dart';
+export 'package:at_commons/src/at_root_domain.dart';
 export 'package:at_commons/src/buffer/at_buffer.dart';
 export 'package:at_commons/src/buffer/at_buffer_impl.dart';
 export 'package:at_commons/src/exception/at_client_exceptions.dart';

--- a/packages/at_commons/lib/src/at_root_domain.dart
+++ b/packages/at_commons/lib/src/at_root_domain.dart
@@ -4,7 +4,7 @@ class AtRootDomain {
   String rootDomain;
   int rootPort;
 
-  AtRootDomain(this.rootDomain, this.rootPort);
+  const AtRootDomain(this.rootDomain, this.rootPort);
 
   static int _parseRootPort(String value) {
     try {

--- a/packages/at_commons/lib/src/at_root_domain.dart
+++ b/packages/at_commons/lib/src/at_root_domain.dart
@@ -1,0 +1,52 @@
+import 'package:at_commons/at_commons.dart' show IllegalArgumentException;
+
+class AtRootDomain {
+  String rootDomain;
+  int rootPort;
+
+  AtRootDomain(this.rootDomain, this.rootPort);
+
+  static int _parseRootPort(String value) {
+    try {
+      var port = int.parse(value);
+      if (port < 1 || port > 65535) {
+        throw IllegalArgumentException("$value is not a valid port number");
+      }
+      return port;
+    } catch (_) {
+      throw IllegalArgumentException(
+        "$value is not a valid integer for root port",
+      );
+    }
+  }
+
+  factory AtRootDomain.parse(String value) {
+    if (value.isEmpty) {
+      throw IllegalArgumentException("Invalid root: value to parse is empty");
+    }
+    var parts = value.split(":");
+    switch (parts.length) {
+      case 1:
+        return AtRootDomain(value, 64);
+      case 2:
+        if (parts[0] == "proxy") {
+          return AtRootDomain(value, 64);
+        }
+        return AtRootDomain(parts[0], _parseRootPort(parts[1]));
+      case 3:
+        if (parts[0] != "proxy") {
+          throw IllegalArgumentException(
+            "Got three parts for root, expected proxy as the first but got: ${parts[0]}",
+          );
+        }
+        return AtRootDomain(
+          "${parts[0]}:${parts[1]}",
+          _parseRootPort(parts[2]),
+        );
+      default:
+        throw IllegalArgumentException("Invalid root domain: $value");
+    }
+  }
+
+  bool get isProxyAddress => rootDomain.startsWith("proxy:");
+}

--- a/packages/at_commons/lib/src/at_root_domain.dart
+++ b/packages/at_commons/lib/src/at_root_domain.dart
@@ -1,8 +1,8 @@
 import 'package:at_commons/at_commons.dart' show IllegalArgumentException;
 
 class AtRootDomain {
-  String rootDomain;
-  int rootPort;
+  final String rootDomain;
+  final int rootPort;
 
   const AtRootDomain(this.rootDomain, this.rootPort);
 

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.5.0
+version: 5.6.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_commons/test/at_root_domain_test.dart
+++ b/packages/at_commons/test/at_root_domain_test.dart
@@ -1,0 +1,64 @@
+import 'package:at_commons/at_commons.dart'
+    show AtRootDomain, IllegalArgumentException;
+
+import 'package:test/test.dart';
+
+void validParseTest(String input, String expectedRootDomain, int expectedPort) {
+  test('Parses "$input" successfully', () {
+    var root = AtRootDomain.parse(input);
+    expect(root.rootDomain, expectedRootDomain);
+    expect(root.rootPort, expectedPort);
+  });
+}
+
+void invalidParseTest<T>(String input) {
+  test('Throws parsing "$input"', () {
+    expect(() => AtRootDomain.parse(input), throwsA(TypeMatcher<T>()));
+  });
+}
+
+void main() {
+  group("AtRootDomain - Valid parse", () {
+    // Only domain
+    validParseTest("root.atsign.org", "root.atsign.org", 64);
+    validParseTest("root.atsign.wtf", "root.atsign.wtf", 64);
+    validParseTest("vip.ve.atsign.zone", "vip.ve.atsign.zone", 64);
+    validParseTest("my.foobar.root", "my.foobar.root", 64);
+
+    // domain:port
+    validParseTest("root.atsign.org:64", "root.atsign.org", 64);
+    validParseTest("root.atsign.wtf:64", "root.atsign.wtf", 64);
+    validParseTest("vip.ve.atsign.zone:64", "vip.ve.atsign.zone", 64);
+    validParseTest("my.foobar.root:64", "my.foobar.root", 64);
+
+    // proxy:domain
+    validParseTest(
+      "proxy:proxy0001.atsign.org",
+      "proxy:proxy0001.atsign.org",
+      64,
+    );
+    validParseTest(
+      "proxy:my.foobar.proxy",
+      "proxy:my.foobar.proxy",
+      64,
+    );
+
+    // proxy:domain:port
+    validParseTest(
+      "proxy:proxy0001.atsign.org:64",
+      "proxy:proxy0001.atsign.org",
+      64,
+    );
+    validParseTest(
+      "proxy:my.foobar.proxy:64",
+      "proxy:my.foobar.proxy",
+      64,
+    );
+  });
+  group("AtRootDomain - Invalid parse", () {
+    invalidParseTest<IllegalArgumentException>("");
+    invalidParseTest<IllegalArgumentException>("foo:bar:baz");
+    invalidParseTest<IllegalArgumentException>("proxy:root.atsign.com:baz");
+    invalidParseTest<IllegalArgumentException>("root.atsign.com:baz");
+  });
+}

--- a/packages/at_commons/test/at_root_domain_test.dart
+++ b/packages/at_commons/test/at_root_domain_test.dart
@@ -57,8 +57,11 @@ void main() {
   });
   group("AtRootDomain - Invalid parse", () {
     invalidParseTest<IllegalArgumentException>("");
-    invalidParseTest<IllegalArgumentException>("foo:bar:baz");
-    invalidParseTest<IllegalArgumentException>("proxy:root.atsign.com:baz");
-    invalidParseTest<IllegalArgumentException>("root.atsign.com:baz");
+    invalidParseTest<IllegalArgumentException>("foo:root.atsign.org");
+    invalidParseTest<IllegalArgumentException>("foo:root.atsign.org:64");
+    invalidParseTest<IllegalArgumentException>("proxy:root.atsign.org:baz");
+    invalidParseTest<IllegalArgumentException>("root.atsign.org:baz");
+    invalidParseTest<IllegalArgumentException>("root.atsign.org:0");
+    invalidParseTest<IllegalArgumentException>("root.atsign.org:65536");
   });
 }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

- Added AtRootDomain class which stores the root domain and port.
- Based on how AtClientPreference expects proxies
  rootDomain in AtClientPreference should be "proxy:<domain>"

- AtRootDomain.parse factory which allows the following formats:
  - "domain"
  - "domain:port"
  - "proxy:domain"
  - "proxy:domain:port"

Validation included:
- Port is always checked for a valid integer and port number(1-65535).
- Domain: unchecked
- Proxy:
  - Checked that it's "proxy" when we have a 3 part string
  - When it's a 2 part string and not "proxy", it assumes domain:port.
    Thus something like `prozy:proxy0001.atsign.org` will be parsed as domain:port
    and fail because `proxy0001.atsign.org` is not a valid port.

**- How I did it**

**- How to verify it**

See at_root_domain_test.dart tests.

**- Description for the changelog**
feat(at_commons): add AtRootDomain class with parsing of proxy included
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
