### PR TITLE
Chore bump intl and fix example errors

### DIFF
--- a/packages/at_contact/pubspec.yaml
+++ b/packages/at_contact/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  intl: ^0.19.0
+  intl: ^0.20.2
   at_client: ^3.7.0
   at_utils: ^3.0.19
   uuid: ^4.0.0

--- a/packages/at_follows_flutter/example/lib/services/notification_service.dart
+++ b/packages/at_follows_flutter/example/lib/services/notification_service.dart
@@ -38,9 +38,6 @@ class NotificationService {
       requestAlertPermission: true,
       requestBadgePermission: true,
       requestSoundPermission: false,
-      onDidReceiveLocalNotification: (id, title, body, payload) async {
-        print('id $id, title $title, body $body, payload $payload');
-      },
     );
 
     initializationSettings = InitializationSettings(

--- a/packages/at_follows_flutter/example/lib/services/notification_service.dart
+++ b/packages/at_follows_flutter/example/lib/services/notification_service.dart
@@ -21,7 +21,7 @@ class NotificationService {
       _requestIOSPermissions();
     }
     initializePlatformSpecifics();
-    print('initialiazed notification service');
+    print('initialized notification service');
   }
 
   setOnNotificationClick(Function onNotificationClick) async {

--- a/packages/at_follows_flutter/example/pubspec.yaml
+++ b/packages/at_follows_flutter/example/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_keychain: ^2.3.0
-  flutter_local_notifications: ^17.2.2
+  flutter_local_notifications: ^19.0.0
   path_provider: ^2.1.1
 
 dev_dependencies:

--- a/packages/at_follows_flutter/lib/services/notification_service.dart
+++ b/packages/at_follows_flutter/lib/services/notification_service.dart
@@ -25,7 +25,7 @@ class NotificationService {
       _requestIOSPermissions();
     }
     initializePlatformSpecifics();
-    _logger.info('initialiazed notification service');
+    _logger.info('initialized notification service');
   }
 
   ///Gets called when user clicks on notification

--- a/packages/at_location_flutter/example/lib/main.dart
+++ b/packages/at_location_flutter/example/lib/main.dart
@@ -57,7 +57,7 @@ class _MyAppState extends State<MyApp> {
             colorScheme: ThemeData.light().colorScheme.copyWith(
                   primary: const Color(0xFFf4533d),
                 ),
-            bottomAppBarTheme: const BottomAppBarTheme(color: Colors.white),
+            bottomAppBarTheme: const BottomAppBarThemeData(color: Colors.white),
             scaffoldBackgroundColor: Colors.white,
           ),
           darkTheme: ThemeData().copyWith(
@@ -66,7 +66,7 @@ class _MyAppState extends State<MyApp> {
             colorScheme: ThemeData.dark().colorScheme.copyWith(
                   primary: Colors.blue,
                 ),
-            bottomAppBarTheme: BottomAppBarTheme(color: Colors.grey[850]),
+            bottomAppBarTheme: BottomAppBarThemeData(color: Colors.grey[850]),
             scaffoldBackgroundColor: Colors.grey[850],
           ),
           themeMode: themeMode,

--- a/packages/at_login_flutter/lib/services/notification_service.dart
+++ b/packages/at_login_flutter/lib/services/notification_service.dart
@@ -22,7 +22,7 @@ class NotificationService {
       _requestIOSPermissions();
     }
     initializePlatformSpecifics();
-    _logger.info('initialiazed notification service');
+    _logger.info('initialized notification service');
   }
 
   setOnNotificationClick(Function onNotificationClick) async {

--- a/packages/at_onboarding_flutter/example/pubspec.yaml
+++ b/packages/at_onboarding_flutter/example/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
-  intl: ^0.19.0
+  intl: ^0.20.2
   path_provider: ^2.1.3
 
 dependency_overrides:

--- a/packages/at_onboarding_flutter/pubspec.yaml
+++ b/packages/at_onboarding_flutter/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
     sdk: flutter
   http: ^1.2.1
   image: ^4.1.7
-  intl: ^0.19.0
+  intl: ^0.20.2
   path_provider: ^2.1.2
   permission_handler: ^12.0.0
   pin_code_fields: ^8.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   # meta and intl are pinned in flutter test, be diligent to ensure you
   # never bump this past flutter stable's current pinned version
   meta: ^1.16.0
-  intl: ^0.19.0 # TODO: pin to the Flutter SDK and assess the damage
+  intl: ^0.20.2 # TODO: pin to the Flutter SDK and assess the damage
   flutter:
     sdk: flutter
   # normal dependencies


### PR DESCRIPTION
**- What I did**
- build(deps): update intl to 0.20.2 (because it is at 0.20.2 in the latest flutter stable version)
- fix(deps): make at_follows_flutter/example/pubpsec.yaml use same version of flutter_local_notifications as its parent package
- fix: removed code which no longer compiles from at_follows_flutter/example
- fix: fixed code which no longer compiled in at_location_flutter/example
- chore: fixed typo (initialiazed -> initialized) in a few places

**- How I did it**
See commits

**- How to verify it**
CI checks pass
