### PR TITLE
feat: Fallback to proxy if atDirectory is unreachable

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.5.0
+
+- feat: take up the fallback-to-proxy feature from at_lookup ^3.5.0
+
 ## 2.4.0
 
 - chore(deps): at_commons ^5.5.0

--- a/packages/at_auth/example/enrollment_request.dart
+++ b/packages/at_auth/example/enrollment_request.dart
@@ -24,8 +24,12 @@ void main(List<String> args) async {
           mandatory: false,
           defaultsTo: 'root.atsign.org');
     final argResults = parser.parse(args);
-    AtLookUp atLookUp =
-        AtLookupImpl(argResults['atsign'], argResults['rootDomain'], 64);
+    AtLookUp atLookUp = AtLookupImpl(
+      argResults['atsign'],
+      argResults['rootDomain'],
+      64,
+      proxies: await Proxies.forDirectory(argResults['rootDomain']),
+    );
 
     AtEnrollmentBase atEnrollmentBase = AtEnrollmentImpl(argResults['atsign']);
 

--- a/packages/at_auth/lib/src/at_auth_impl.dart
+++ b/packages/at_auth/lib/src/at_auth_impl.dart
@@ -72,7 +72,11 @@ class AtAuthImpl implements AtAuth {
           exceptionScenario: ExceptionScenario.invalidValueProvided);
     }
     atLookUp ??= AtLookupImpl(
-        atAuthRequest.atSign, atAuthRequest.rootDomain, atAuthRequest.rootPort);
+      atAuthRequest.atSign,
+      atAuthRequest.rootDomain,
+      atAuthRequest.rootPort,
+      proxies: await Proxies.forDirectory(atAuthRequest.rootDomain),
+    );
     // ??= to support mocking
     atChops ??= _createAtChops(atAuthKeys);
     atLookUp!.atChops = atChops;
@@ -112,8 +116,12 @@ class AtAuthImpl implements AtAuth {
     _atOnboardingRequest = atOnboardingRequest;
     var atOnboardingResponse = AtOnboardingResponse(atOnboardingRequest.atSign);
     atEnrollmentBase = AtEnrollmentImpl(atOnboardingRequest.atSign);
-    atLookUp ??= AtLookupImpl(atOnboardingRequest.atSign,
-        atOnboardingRequest.rootDomain, atOnboardingRequest.rootPort);
+    atLookUp ??= AtLookupImpl(
+      atOnboardingRequest.atSign,
+      atOnboardingRequest.rootDomain,
+      atOnboardingRequest.rootPort,
+      proxies: await Proxies.forDirectory(atOnboardingRequest.rootDomain),
+    );
 
     //1. cram auth
     cramAuthenticator ??=

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 2.4.0
+version: 2.5.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -10,8 +10,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  at_commons: ^5.5.0
-  at_lookup: ^3.0.49
+  at_commons: ^5.6.2
+  at_lookup: ^3.5.0
   at_chops: ^2.2.0
   at_utils: ^3.0.19
   crypton: ^2.2.1

--- a/packages/at_cli_commons/example/pubspec.yaml
+++ b/packages/at_cli_commons/example/pubspec.yaml
@@ -6,15 +6,8 @@ publish_to: none
 environment:
   sdk: ^3.0.6
 
-dependency_overrides:
-  at_client:
-    path: ../../at_client
-  at_cli_commons:
-    path: ..
-
 dependencies:
-  at_cli_commons:
-    path: ..
+  at_cli_commons: ^2.2.0
   at_client: ^3.7.0
 
 dev_dependencies:

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.0
+
+- feat: Take up new fallback-to-proxy feature from at_lookup 3.5.0
+
 ## 3.8.0
 
 - feat: add optional `useRemoteAtServer` flag to AtClient `getKeys` and

--- a/packages/at_client/example/pubspec.yaml
+++ b/packages/at_client/example/pubspec.yaml
@@ -5,10 +5,6 @@ version: 1.0.0
 environment:
   sdk: ">=2.15.0 <4.0.0"
 
-dependency_overrides:
-  at_client:
-    path: ../../at_client
-
 dependencies:
   at_client: ^3.7.0
 

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -69,12 +69,11 @@ class AtClientManager {
 
     _logger.info("setCurrentAtSign called with atSign $atSign");
     AtUtils.fixAtSign(atSign);
+    Proxies.proxyFallbackEnabled = preference.proxyFallbackEnabled;
     secondaryAddressFinder ??= CacheableSecondaryAddressFinder(
       preference.rootDomain,
       preference.rootPort,
-      proxies: (preference.proxyFallbackEnabled
-          ? await Proxies.forDirectory(preference.rootDomain)
-          : null),
+      proxies: await Proxies.forDirectory(preference.rootDomain),
       createSocketTimeout: preference.createSocketTimeout,
     );
     if (_currentAtClient != null &&

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -70,7 +70,13 @@ class AtClientManager {
     _logger.info("setCurrentAtSign called with atSign $atSign");
     AtUtils.fixAtSign(atSign);
     secondaryAddressFinder ??= CacheableSecondaryAddressFinder(
-        preference.rootDomain, preference.rootPort);
+      preference.rootDomain,
+      preference.rootPort,
+      proxies: (preference.proxyFallbackEnabled
+          ? await Proxies.forDirectory(preference.rootDomain)
+          : null),
+      createSocketTimeout: preference.createSocketTimeout,
+    );
     if (_currentAtClient != null &&
         _currentAtClient?.getCurrentAtSign() == atSign) {
       _logger.info(

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.8.0';
+  final String atClientVersion = '3.9.0';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/preference/at_client_preference.dart
+++ b/packages/at_client/lib/src/preference/at_client_preference.dart
@@ -1,6 +1,7 @@
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/preference/at_client_particulars.dart';
+import 'package:at_lookup/at_lookup.dart';
 import 'package:meta/meta.dart';
 import 'package:version/version.dart';
 
@@ -38,6 +39,12 @@ class AtClientPreference {
 
   /// Port of the root server. Defaults to 64
   int rootPort = 64;
+
+  /// When true, if the atDirectory is unreachable then we will fall back
+  /// to a proxy server, if configured.
+  ///
+  /// See [Proxies] for more detail.
+  bool proxyFallbackEnabled = true;
 
   /// Frequency of sync task to run in minutes. Defaults to 10 minutes.
   int syncIntervalMins = 10;
@@ -110,6 +117,8 @@ class AtClientPreference {
 
   //hashing algorithm to use for pkam authentication
   HashingAlgoType hashingAlgoType = HashingAlgoType.sha256;
+
+  Duration createSocketTimeout = AtLookUp.defaultCreateSocketTimeout;
 }
 
 @Deprecated("Use SyncService")

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.8.0
+version: 3.9.0
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 
@@ -28,11 +28,11 @@ dependencies:
   internet_connection_checker: ^1.0.0+1
   async: ^2.9.0
   at_base2e15: ^1.0.0
-  at_commons: ^5.5.0
+  at_commons: ^5.6.2
   at_utils: ^3.2.0
   at_chops: ^2.2.0
-  at_lookup: ^3.1.0
-  at_auth: ^2.2.0
+  at_lookup: ^3.5.0
+  at_auth: ^2.5.0
   at_persistence_secondary_server: ^4.2.0
   meta: ^1.16.0
   version: ^3.0.2

--- a/packages/at_client/test/samples/lookup.dart
+++ b/packages/at_client/test/samples/lookup.dart
@@ -7,7 +7,12 @@ void main(List<String> arguments) async {
 
 void lookItUp(String atSign) async {
   // ignore: no_leading_underscores_for_local_identifiers
-  var _atLookup = AtLookupImpl(atSign, 'test.do-sf2.atsign.zone', 64);
+  var _atLookup = AtLookupImpl(
+    atSign,
+    'test.do-sf2.atsign.zone',
+    64,
+    proxies: null,
+  );
   var cramSecret =
       '0f0ecff314fc3183baea1e94f125e268005557b4763dc744ea41c5693161084d8127d768566613313b1dff887c87be6a80a1fc6fc09d5234fcad093cea82d855';
   await _atLookup.cramAuthenticate(cramSecret);

--- a/packages/at_client_mobile/CHANGELOG.md
+++ b/packages/at_client_mobile/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.0
+
+- feat: Take up new fallback-to-proxy feature from at_lookup 3.5.0
+
 ## 3.3.0
 
 - chore(deps): remove unused dependencies

--- a/packages/at_client_mobile/lib/src/at_client_auth.dart
+++ b/packages/at_client_mobile/lib/src/at_client_auth.dart
@@ -41,7 +41,14 @@ class AtClientAuthenticator implements AtClientAuth {
   Future<bool> performInitialAuth(
       String atSign, AtClientPreference atClientPreference) async {
     var atLookupInitialAuth = AtLookupImpl(
-        atSign, atClientPreference.rootDomain, atClientPreference.rootPort);
+      atSign,
+      atClientPreference.rootDomain,
+      atClientPreference.rootPort,
+      proxies: atClientPreference.proxyFallbackEnabled
+          ? await Proxies.forDirectory(atClientPreference.rootDomain)
+          : null,
+      createSocketTimeout: atClientPreference.createSocketTimeout,
+    );
     // get existing keys from keychain
     final atsign = await _keyChainManager.readAtsign(name: atSign);
     var publicKey = atsign?.pkamPublicKey;
@@ -113,7 +120,7 @@ class AtClientAuthenticator implements AtClientAuth {
         logger.finer('cram secret delete response : $deleteResponse');
       }
     }
-    // Close the connection on atLookupInitalAuth.
+    // Close the connection on atLookupInitialAuth.
     await atLookupInitialAuth.close();
     return true;
   }

--- a/packages/at_client_mobile/lib/src/at_client_service.dart
+++ b/packages/at_client_mobile/lib/src/at_client_service.dart
@@ -233,8 +233,8 @@ class AtClientService {
       atChops = createAtChops(decryptedAtKeysMap);
       // Inside "_validateAtKeys", performs PKAM auth using atChops.
       // If PKAM auth fails, UnAuthenticatedException is returned which is handled in the caller method.
-      var isValidAtKeysFile = await _validateAtKeys(atChops, atsign,
-          atClientPreference.rootDomain, atClientPreference.rootPort);
+      var isValidAtKeysFile =
+          await _validateAtKeys(atChops, atsign, atClientPreference);
       if (!isValidAtKeysFile) {
         _logger.severe(
             'Authentication failed. Invalid atKeys file found for the atSign $atsign.');
@@ -329,8 +329,16 @@ class AtClientService {
   /// Performs PKAM auth on the cloud secondary.
   /// If atKeys are valid returns true; else, returns false.
   Future<bool> _validateAtKeys(AtChops atChops, String atSign,
-      String rootServerDomain, int rootServerPort) async {
-    _atLookUp ??= AtLookupImpl(atSign, rootServerDomain, rootServerPort);
+      AtClientPreference atClientPreference) async {
+    _atLookUp ??= AtLookupImpl(
+      atSign,
+      atClientPreference.rootDomain,
+      atClientPreference.rootPort,
+      proxies: atClientPreference.proxyFallbackEnabled
+          ? await Proxies.forDirectory(atClientPreference.rootDomain)
+          : null,
+      createSocketTimeout: atClientPreference.createSocketTimeout,
+    );
     _atLookUp!.atChops = atChops;
     var isAuthSuccessful = await _atLookUp!.pkamAuthenticate();
     _atLookUp!.close();

--- a/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
+++ b/packages/at_client_mobile/lib/src/auth/at_auth_service_impl.dart
@@ -257,7 +257,14 @@ class AtAuthServiceImpl implements AtAuthService {
           'Cannot submit new enrollment request until the pending enrollment request is fulfilled');
     }
     _atLookUp ??= AtLookupImpl(
-        _atSign, _atClientPreference.rootDomain, _atClientPreference.rootPort);
+      _atSign,
+      _atClientPreference.rootDomain,
+      _atClientPreference.rootPort,
+      proxies: _atClientPreference.proxyFallbackEnabled
+          ? await Proxies.forDirectory(_atClientPreference.rootDomain)
+          : null,
+      createSocketTimeout: _atClientPreference.createSocketTimeout,
+    );
     AtEnrollmentResponse atEnrollmentResponse =
         await atEnrollmentBase.submit(enrollmentRequest, _atLookUp!);
     await _atLookUp?.close();
@@ -373,7 +380,14 @@ class AtAuthServiceImpl implements AtAuthService {
   Future<bool?> _performAPKAMAuthentication(
       EnrollmentInfo enrollmentInfo) async {
     _atLookUp ??= AtLookupImpl(
-        _atSign, _atClientPreference.rootDomain, _atClientPreference.rootPort);
+      _atSign,
+      _atClientPreference.rootDomain,
+      _atClientPreference.rootPort,
+      proxies: _atClientPreference.proxyFallbackEnabled
+          ? await Proxies.forDirectory(_atClientPreference.rootDomain)
+          : null,
+      createSocketTimeout: _atClientPreference.createSocketTimeout,
+    );
     // Create the AtChops instance with the new APKAM keys to verify if enrollment
     // is approved.
     // If enrollment is approved, then apkam authentication will be successful.

--- a/packages/at_client_mobile/pubspec.yaml
+++ b/packages/at_client_mobile/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client_mobile
 description: A Flutter extension to the at_client library which adds support for mobile, desktop and IoT devices.
-version: 3.3.0
+version: 3.4.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_mobile
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -17,12 +17,12 @@ dependencies:
   biometric_storage: ^5.0.0
   hive: ^2.2.3
   crypton: ^2.2.1
-  at_commons: ^5.5.0
+  at_commons: ^5.6.2
   at_utils: ^3.0.19
   at_chops: ^2.2.0
-  at_lookup: ^3.0.51
+  at_lookup: ^3.5.0
   at_client: ^3.7.0
-  at_auth: ^2.1.0
+  at_auth: ^2.5.0
   encrypt: ^5.0.3
   at_persistence_secondary_server: ^4.2.0
 

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.6.2
+
+- feat: add `address` getter to `AtRootDomain`
+
 ## 5.6.1
 
 - chore: fix lint from the new `strict_top_level_inference` rule

--- a/packages/at_commons/lib/src/at_root_domain.dart
+++ b/packages/at_commons/lib/src/at_root_domain.dart
@@ -1,6 +1,10 @@
 import 'package:at_commons/at_commons.dart' show IllegalArgumentException;
 
 class AtRootDomain {
+  static const AtRootDomain atsignDomain = AtRootDomain('root.atsign.org', 64);
+  static const String atsignProxiesUri =
+      'https://raw.githubusercontent.com/atsign-foundation/atsign-foundation.github.io/refs/heads/add-proxies/platform/root.atsign.org/proxies.json';
+
   final String rootDomain;
   final int rootPort;
 

--- a/packages/at_commons/lib/src/at_root_domain.dart
+++ b/packages/at_commons/lib/src/at_root_domain.dart
@@ -49,4 +49,8 @@ class AtRootDomain {
   }
 
   bool get isProxyAddress => rootDomain.startsWith("proxy:");
+
+  String get address => isProxyAddress
+      ? '${rootDomain.substring("proxy:".length)}:$rootPort'
+      : '$rootDomain.$rootPort';
 }

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.6.1
+version: 5.6.2
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.5.0
+
+- feat: `CacheableSecondaryAddressFinder` now supports automatic 
+  fallback to proxies if
+  - proxies were supplied at construction time
+  - and we are timing out when connecting to atDirectory
+  - or we've repeatedly failed to connect to it for non-timeout reasons
+
 ## 3.4.1
 
 - fix: revert breaking changes

--- a/packages/at_lookup/lib/src/at_lookup.dart
+++ b/packages/at_lookup/lib/src/at_lookup.dart
@@ -4,6 +4,8 @@ import 'package:at_chops/at_chops.dart';
 import 'package:at_lookup/at_lookup.dart';
 
 abstract interface class AtLookUp {
+  static const Duration defaultCreateSocketTimeout = Duration(seconds: 10);
+
   /// update
   Future<bool> update(String key, String value,
       {String? sharedWith, Metadata? metadata});

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -54,18 +54,37 @@ class AtLookupImpl implements AtLookUp {
 
   AtChops? _atChops;
 
-  AtLookupImpl(String atSign, String rootDomain, int rootPort,
-      {this.privateKey,
-      this.cramSecret,
-      SecondaryAddressFinder? secondaryAddressFinder,
-      SecureSocketConfig? secureSocketConfig,
-      Map<String, dynamic>? clientConfig,
-      AtLookupSecureSocketFactory? secureSocketFactory,
-      AtLookupSecureSocketListenerFactory? socketListenerFactory,
-      AtLookupOutboundConnectionFactory? outboundConnectionFactory}) {
+  AtLookupImpl(
+    String atSign,
+    String rootDomain,
+    int rootPort, {
+    this.privateKey,
+    this.cramSecret,
+
+    /// When not supplied, we construct a [CacheableSecondaryAddressFinder]
+    SecondaryAddressFinder? secondaryAddressFinder,
+
+    /// if [secondaryAddressFinder] not supplied, use these proxies when
+    /// constructing our [CacheableSecondaryAddressFinder]
+    Proxies? proxies,
+
+    /// if [secondaryAddressFinder] not supplied, use this timeout when
+    /// constructing our [CacheableSecondaryAddressFinder]
+    Duration? createSocketTimeout,
+    SecureSocketConfig? secureSocketConfig,
+    Map<String, dynamic>? clientConfig,
+    AtLookupSecureSocketFactory? secureSocketFactory,
+    AtLookupSecureSocketListenerFactory? socketListenerFactory,
+    AtLookupOutboundConnectionFactory? outboundConnectionFactory,
+  }) {
     _currentAtSign = atSign;
     this.secondaryAddressFinder = secondaryAddressFinder ??
-        CacheableSecondaryAddressFinder(rootDomain, rootPort);
+        CacheableSecondaryAddressFinder(
+          rootDomain,
+          rootPort,
+          proxies: proxies,
+          createSocketTimeout: createSocketTimeout,
+        );
     _secureSocketConfig = secureSocketConfig ?? SecureSocketConfig();
     // Stores the client configurations.
     // If client configurations are not available, defaults to empty map
@@ -82,8 +101,11 @@ class AtLookupImpl implements AtLookUp {
       String atsign, String? rootDomain, int rootPort) async {
     // temporary change to preserve backward compatibility and change the callers later on to use
     // SecondaryAddressFinder.findSecondary
-    return (await CacheableSecondaryAddressFinder(rootDomain!, rootPort)
-            .findSecondary(atsign))
+    return (await CacheableSecondaryAddressFinder(
+      rootDomain!,
+      rootPort,
+      proxies: await Proxies.forDirectory(rootDomain),
+    ).findSecondary(atsign))
         .toString();
   }
 

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: unused_field, deprecated_member_use_from_same_package
+// ignore_for_file: deprecated_member_use_from_same_package
 
 import 'dart:async';
 import 'dart:convert';
@@ -30,10 +30,6 @@ class AtLookupImpl implements AtLookUp {
   late SecondaryAddressFinder secondaryAddressFinder;
 
   late String _currentAtSign;
-
-  late String _rootDomain;
-
-  late int _rootPort;
 
   @Deprecated("privateKey reference is no longer used")
   String? privateKey;
@@ -68,8 +64,6 @@ class AtLookupImpl implements AtLookUp {
       AtLookupSecureSocketListenerFactory? socketListenerFactory,
       AtLookupOutboundConnectionFactory? outboundConnectionFactory}) {
     _currentAtSign = atSign;
-    _rootDomain = rootDomain;
-    _rootPort = rootPort;
     this.secondaryAddressFinder = secondaryAddressFinder ??
         CacheableSecondaryAddressFinder(rootDomain, rootPort);
     _secureSocketConfig = secureSocketConfig ?? SecureSocketConfig();
@@ -634,8 +628,11 @@ class AtLookupImpl implements AtLookUp {
   Future<bool> createOutBoundConnection(String host, String port,
       String toAtSign, SecureSocketConfig secureSocketConfig) async {
     try {
-      SecureSocket secureSocket =
-          await socketFactory.createSocket(host, port, secureSocketConfig);
+      SecureSocket secureSocket = await socketFactory.createSocket(
+        host,
+        port,
+        secureSocketConfig,
+      );
       _connection =
           outboundConnectionFactory.createOutboundConnection(secureSocket);
       if (outboundConnectionTimeout != null) {
@@ -688,8 +685,17 @@ class AtLookupImpl implements AtLookUp {
 
 class AtLookupSecureSocketFactory {
   Future<SecureSocket> createSocket(
-      String host, String port, SecureSocketConfig socketConfig) async {
-    return await SecureSocketUtil.createSecureSocket(host, port, socketConfig);
+    String host,
+    String port,
+    SecureSocketConfig socketConfig, {
+    Duration? createSocketTimeout = AtLookUp.defaultCreateSocketTimeout,
+  }) async {
+    return await SecureSocketUtil.createSecureSocket(
+      host,
+      port,
+      socketConfig,
+      createSocketTimeout: createSocketTimeout,
+    );
   }
 }
 

--- a/packages/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
+++ b/packages/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
@@ -13,18 +13,32 @@ class CacheableSecondaryAddressFinder implements SecondaryAddressFinder {
   final Map<String, SecondaryAddressCacheEntry> _map = {};
   final _logger = AtSignLogger('AtServerAddressCacheImpl');
 
-  final String _rootDomain;
-  final int _rootPort;
-  late SecondaryUrlFinder _secondaryFinder;
+  late final SecondaryUrlFinder secondaryFinder;
 
-  CacheableSecondaryAddressFinder(this._rootDomain, this._rootPort,
-      {SecondaryUrlFinder? secondaryFinder, SecureSocketConfig? socketConfig}) {
-    _secondaryFinder = secondaryFinder ??
-        SecondaryUrlFinder(_rootDomain, _rootPort, socketConfig: socketConfig);
+  CacheableSecondaryAddressFinder(
+    String domain,
+    int port, {
+    SecondaryUrlFinder? secondaryFinder,
+    AtLookupSecureSocketFactory? socketFactory,
+    SecureSocketConfig? socketConfig,
+    Proxies? proxies,
+    Duration? createSocketTimeout = AtLookUp.defaultCreateSocketTimeout,
+  }) {
+    this.secondaryFinder = secondaryFinder ??
+        SecondaryUrlFinder(domain, port,
+            socketConfig: socketConfig,
+            createSocketTimeout: createSocketTimeout,
+            proxies: proxies,
+            socketFactory: socketFactory);
   }
 
   bool cacheContains(String atSign) {
     return _map.containsKey(stripAtSignFromAtSign(atSign));
+  }
+
+  /// Clears the cache
+  void clear() {
+    _map.clear();
   }
 
   /// Returns the expiry time of this entry in millisecondsSinceEpoch, or null if this atSign is not in cache
@@ -88,7 +102,7 @@ class CacheableSecondaryAddressFinder implements SecondaryAddressFinder {
 
   Future<void> _updateCache(String atSign, Duration cacheFor) async {
     try {
-      String? secondaryUrl = await _secondaryFinder.findSecondaryUrl(atSign);
+      String? secondaryUrl = await secondaryFinder.findSecondaryUrl(atSign);
       if (secondaryUrl == null ||
           secondaryUrl.isEmpty ||
           secondaryUrl == 'data:null') {
@@ -130,16 +144,26 @@ class SecondaryAddressCacheEntry {
 /// (a) how many retries are done, and
 /// (b) the delay before each retry
 class SecondaryUrlFinder {
-  final String _rootDomain;
-  final int _rootPort;
-  late final AtLookupSecureSocketFactory _socketFactory;
-  late final SecureSocketConfig _socketConfig;
+  late final AtRootDomain rootDomain;
+  late final AtLookupSecureSocketFactory socketFactory;
+  late final SecureSocketConfig socketConfig;
+  final Duration? createSocketTimeout;
+  final Proxies? proxies;
 
-  SecondaryUrlFinder(this._rootDomain, this._rootPort,
-      {AtLookupSecureSocketFactory? socketFactory,
-      SecureSocketConfig? socketConfig}) {
-    _socketFactory = socketFactory ?? AtLookupSecureSocketFactory();
-    _socketConfig = socketConfig ?? SecureSocketConfig();
+  /// Set when we fall back to a proxy
+  SecondaryAddress? fallback;
+
+  SecondaryUrlFinder(
+    String domain,
+    int port, {
+    AtLookupSecureSocketFactory? socketFactory,
+    SecureSocketConfig? socketConfig,
+    this.createSocketTimeout = AtLookUp.defaultCreateSocketTimeout,
+    this.proxies,
+  }) {
+    this.socketFactory = socketFactory ?? AtLookupSecureSocketFactory();
+    this.socketConfig = socketConfig ?? SecureSocketConfig();
+    rootDomain = AtRootDomain(domain, port);
   }
 
   final _logger = AtSignLogger('AtServerUrlFinder');
@@ -150,13 +174,18 @@ class SecondaryUrlFinder {
   static List<int> retryDelaysMillis = [50, 100, 150, 200];
 
   Future<String?> findSecondaryUrl(String atSign) async {
-    if (_rootDomain.startsWith("proxy:")) {
+    if (rootDomain.isProxyAddress) {
       // In order to make it easy for clients to connect to a reverse proxy
       // instead of doing a root lookup,  we adopt the convention that:
       // if the rootDomain starts with 'proxy:'
       // then the secondary domain name will be deemed to be the portion of rootDomain after 'proxy:'
       // and the secondary port will be deemed to be the rootPort
-      return '${_rootDomain.substring("proxy:".length)}:$_rootPort';
+      return rootDomain.address;
+    }
+    // Once we've fallen back to a proxy, continue to do so.
+    if (fallback != null) {
+      _logger.info('Returning proxy $fallback as we have already fallen back');
+      return fallback!.toString();
     }
     String? address;
     String lastExceptionMsg = '';
@@ -171,8 +200,19 @@ class SecondaryUrlFinder {
               ' : will retry in ${retryDelaysMillis[i]} milliseconds');
           await Future.delayed(Duration(milliseconds: retryDelaysMillis[i]));
           continue;
+        } else {
+          // We've failed repeatedly - let's fall back to a proxy if we can
+          if (proxies != null) {
+            _logger.warning(
+                'findAtServer for $atSign: Repeated failures connecting to atDirectory: $e');
+            fallback = proxies!.next();
+            _logger.warning(
+                'findAtServer for $atSign: Falling back to using proxy $fallback');
+            return fallback.toString();
+          }
         }
-        _logger.severe('findAtServer for $atSign : $e');
+        _logger.severe('findAtServer for $atSign :'
+            ' Repeated failures connecting to atDirectory: $e');
         if (e is RootServerConnectivityException) {
           rethrow;
         }
@@ -193,11 +233,32 @@ class SecondaryUrlFinder {
       var prompt = false;
       var once = true;
 
-      socket = await _socketFactory.createSocket(
-        _rootDomain,
-        '$_rootPort',
-        _socketConfig,
-      );
+      try {
+        socket = await socketFactory.createSocket(
+          rootDomain.rootDomain,
+          '${rootDomain.rootPort}',
+          socketConfig,
+          createSocketTimeout: createSocketTimeout,
+        );
+      } on SocketException catch (e) {
+        _logger.finest('Caught $e - checking if this was an OS-level timeout');
+        // See https://github.com/dart-lang/sdk/issues/60161
+        // and https://github.com/dart-lang/sdk/commit/fa3461bfad2f03f179ba653af1e9910067eb89b8
+        // for an explanation of the following code:
+        if (proxies != null &&
+            e.osError != null &&
+            e.osError!.errorCode ==
+                (Platform.isWindows
+                    ? 10060 // WSAETIMEDOUT
+                    : 110)) {
+          _logger
+              .warning('OS timeout connecting to ${rootDomain.address} : $e');
+          fallback = proxies!.next();
+          _logger.warning('Falling back to using proxy $fallback');
+          return fallback.toString();
+        }
+        rethrow;
+      }
       _logger.finer('findAtServerUrl: connection to atDirectory established');
       // listen to the received data event stream
       socket.listen((List<int> event) async {
@@ -240,14 +301,14 @@ class SecondaryUrlFinder {
       socket.destroy();
       throw AtTimeoutException('AtLookup.findAtServer timed out');
     } on Exception catch (exception) {
-      var msg = 'Connecting to $_rootDomain:$_rootPort : $exception';
+      var msg = 'Connecting to ${rootDomain.address} : $exception';
       _logger.severe(msg);
       if (socket != null) {
         socket.destroy();
       }
       throw RootServerConnectivityException(msg);
     } catch (exception, stackTrace) {
-      var msg = 'Connecting to $_rootDomain:$_rootPort : $exception';
+      var msg = 'Connecting to ${rootDomain.address} : $exception';
       _logger.severe(msg);
       _logger.severe(stackTrace);
       if (socket != null) {

--- a/packages/at_lookup/lib/src/cache/secondary_address_finder.dart
+++ b/packages/at_lookup/lib/src/cache/secondary_address_finder.dart
@@ -1,3 +1,7 @@
+import 'dart:convert';
+
+import 'package:http/http.dart' as http;
+
 abstract class SecondaryAddressFinder {
   Future<SecondaryAddress> findSecondary(String atSign);
 }
@@ -5,10 +9,72 @@ abstract class SecondaryAddressFinder {
 class SecondaryAddress {
   final String host;
   final int port;
+
   SecondaryAddress(this.host, this.port);
 
   @override
   String toString() {
     return '$host:$port';
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SecondaryAddress &&
+          runtimeType == other.runtimeType &&
+          host == other.host &&
+          port == other.port;
+
+  @override
+  int get hashCode => Object.hash(host, port);
+}
+
+class Proxies {
+  static Proxies fromJson(Map<String, dynamic> json) {
+    List<SecondaryAddress> addresses = [];
+    final l = json['proxies'] as List;
+    for (final m in l) {
+      addresses.add(SecondaryAddress(m['host'], m['port']));
+    }
+    return Proxies(addresses);
+  }
+
+  static Future<Proxies> fetchFromUri(Uri uri) async {
+    final client = http.Client();
+    final p = fromJson(jsonDecode(await client.read(uri)));
+    client.close();
+    return p;
+  }
+
+  final List<SecondaryAddress> addresses;
+
+  Proxies(this.addresses) {
+    if (addresses.isEmpty) {
+      throw ArgumentError('Need at least one proxy');
+    }
+  }
+
+  int _ix = 0;
+
+  /// round robin
+  SecondaryAddress next() {
+    final sa = addresses[_ix];
+    _ix = (_ix + 1) % addresses.length;
+    return sa;
+  }
+
+  @override
+  String toString() {
+    return 'Proxies{addresses: $addresses}';
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Proxies &&
+          runtimeType == other.runtimeType &&
+          addresses == other.addresses;
+
+  @override
+  int get hashCode => addresses.hashCode;
 }

--- a/packages/at_lookup/lib/src/cache/secondary_address_finder.dart
+++ b/packages/at_lookup/lib/src/cache/secondary_address_finder.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:at_commons/at_commons.dart';
 import 'package:http/http.dart' as http;
 
 abstract class SecondaryAddressFinder {
@@ -30,21 +31,14 @@ class SecondaryAddress {
 }
 
 class Proxies {
-  static Proxies fromJson(Map<String, dynamic> json) {
-    List<SecondaryAddress> addresses = [];
-    final l = json['proxies'] as List;
-    for (final m in l) {
-      addresses.add(SecondaryAddress(m['host'], m['port']));
-    }
-    return Proxies(addresses);
-  }
+  /// Modify this map as needed, if you are using an atDirectory other than
+  /// the default, and you wish to fetch your proxy list from a URI.
+  static final Map<String, String> hostToUriMap = {
+    AtRootDomain.atsignDomain.rootDomain: AtRootDomain.atsignProxiesUri,
+  };
 
-  static Future<Proxies> fetchFromUri(Uri uri) async {
-    final client = http.Client();
-    final p = fromJson(jsonDecode(await client.read(uri)));
-    client.close();
-    return p;
-  }
+  /// Modify this map if you don't get your proxy list from a URI.
+  static final Map<String, Proxies> hostToProxiesMap = {};
 
   final List<SecondaryAddress> addresses;
 
@@ -77,4 +71,39 @@ class Proxies {
 
   @override
   int get hashCode => addresses.hashCode;
+
+  /// - If [hostToProxiesMap] contains this [rootDomain], return what's there
+  /// - ELse if [hostToUriMap] contains this [rootDomain], call [fetchFromUri]
+  /// - Else return null
+  static Future<Proxies?> forDirectory(String rootDomain) async {
+    if (hostToProxiesMap.containsKey(rootDomain)) {
+      return hostToProxiesMap[rootDomain];
+    }
+
+    if (hostToUriMap.containsKey(rootDomain)) {
+      final p = await fetchFromUri(Uri.parse(hostToUriMap[rootDomain]!));
+      hostToProxiesMap[rootDomain] = p;
+    }
+
+    return hostToProxiesMap[rootDomain];
+  }
+
+  /// Uses [http.Client] to fetch data from [uri], then calls [fromJson]
+  static Future<Proxies> fetchFromUri(Uri uri) async {
+    final client = http.Client();
+    final p = fromJson(jsonDecode(await client.read(uri)));
+    client.close();
+    return p;
+  }
+
+  /// Expects json in the form
+  /// `{"proxies":[{"host":"foo.com.test","port":"64"},...]}`
+  static Proxies fromJson(Map<String, dynamic> json) {
+    List<SecondaryAddress> addresses = [];
+    final l = json['proxies'] as List;
+    for (final m in l) {
+      addresses.add(SecondaryAddress(m['host'], m['port']));
+    }
+    return Proxies(addresses);
+  }
 }

--- a/packages/at_lookup/lib/src/cache/secondary_address_finder.dart
+++ b/packages/at_lookup/lib/src/cache/secondary_address_finder.dart
@@ -42,6 +42,13 @@ class Proxies {
 
   final List<SecondaryAddress> addresses;
 
+  /// For now, we need a global boolean here, which should be set by
+  /// calling code, in order to ensure that disabling this feature is
+  /// consistently honoured. For example, the at_client package sets this to
+  /// the value of AtClientPreference.proxyFallbackEnabled, and the auth_cli
+  /// sets it to the value specified by the --proxy-fallback-enabled flag
+  static bool proxyFallbackEnabled = true;
+
   Proxies(this.addresses) {
     if (addresses.isEmpty) {
       throw ArgumentError('Need at least one proxy');
@@ -79,6 +86,10 @@ class Proxies {
   /// - ELse if [hostToUriMap] contains this [rootDomain], call [fetchFromUri]
   /// - Else return null
   static Future<Proxies?> forDirectory(String rootDomain) async {
+    if (! proxyFallbackEnabled) {
+      return null;
+    }
+
     if (hostToProxiesMap.containsKey(rootDomain)) {
       return hostToProxiesMap[rootDomain];
     }

--- a/packages/at_lookup/lib/src/cache/secondary_address_finder.dart
+++ b/packages/at_lookup/lib/src/cache/secondary_address_finder.dart
@@ -46,6 +46,9 @@ class Proxies {
     if (addresses.isEmpty) {
       throw ArgumentError('Need at least one proxy');
     }
+    // Shuffle so we get a reasonably random use of proxies from run to run if
+    // we have more than one proxy available.
+    addresses.shuffle();
   }
 
   int _ix = 0;

--- a/packages/at_lookup/lib/src/util/secure_socket_util.dart
+++ b/packages/at_lookup/lib/src/util/secure_socket_util.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 import 'package:at_commons/at_commons.dart';
+import 'package:at_lookup/at_lookup.dart';
 import 'package:at_utils/at_logger.dart' show AtSignLogger;
 
 class SecureSocketUtil {
@@ -7,7 +8,11 @@ class SecureSocketUtil {
 
   ///method that creates and returns a [SecureSocket]. If [decryptPackets] is set to true,the TLS keys are logged into a file.
   static Future<SecureSocket> createSecureSocket(
-      String host, String port, SecureSocketConfig secureSocketConfig) async {
+    String host,
+    String port,
+    SecureSocketConfig secureSocketConfig, {
+    Duration? createSocketTimeout = AtLookUp.defaultCreateSocketTimeout,
+  }) async {
     SecurityContext securityContext = SecurityContext.defaultContext;
 
     bool certsProvided = false;
@@ -22,6 +27,7 @@ class SecureSocketUtil {
         host,
         int.parse(port),
         context: securityContext,
+        timeout: createSocketTimeout,
       );
       aSecureSocket.setOption(SocketOption.tcpNoDelay, true);
       return aSecureSocket;
@@ -29,24 +35,21 @@ class SecureSocketUtil {
       // USE ONLY FOR DEBUGGING / DEMO PURPOSES
       _logger.warning('decryptPackets is set;'
           ' it should only be set for demo or debugging purposes');
-      try {
-        File? keysFile = secureSocketConfig.tlsKeysSavePath != null
-            ? File(secureSocketConfig.tlsKeysSavePath!)
-            : null;
-        if (!certsProvided) {
-          throw AtException(
-              'decryptPackets set to true but path to trusted certificated not provided');
-        }
-        SecureSocket aSecureSocket = await SecureSocket.connect(
-            host, int.parse(port),
-            context: securityContext,
-            keyLog: (line) =>
-                keysFile?.writeAsStringSync(line, mode: FileMode.append));
-        aSecureSocket.setOption(SocketOption.tcpNoDelay, true);
-        return aSecureSocket;
-      } catch (e) {
-        throw AtException(e.toString());
+      File? keysFile = secureSocketConfig.tlsKeysSavePath != null
+          ? File(secureSocketConfig.tlsKeysSavePath!)
+          : null;
+      if (!certsProvided) {
+        throw AtException(
+            'decryptPackets set to true but path to trusted certificated not provided');
       }
+      SecureSocket aSecureSocket = await SecureSocket.connect(
+          host, int.parse(port),
+          context: securityContext,
+          timeout: createSocketTimeout,
+          keyLog: (line) =>
+              keysFile?.writeAsStringSync(line, mode: FileMode.append));
+      aSecureSocket.setOption(SocketOption.tcpNoDelay, true);
+      return aSecureSocket;
     }
   }
 }

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   crypton: ^2.2.1
   crypto: ^3.0.5
   at_utils: ^3.0.19
-  at_commons: ^5.7.0
+  at_commons: ^5.6.2
   mutex: ^3.0.0
   meta: ^1.16.0
   at_chops: ^2.2.0

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.4.1
+version: 3.5.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_lookup
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -13,10 +13,11 @@ dependencies:
   crypton: ^2.2.1
   crypto: ^3.0.5
   at_utils: ^3.0.19
-  at_commons: ^5.5.0
+  at_commons: ^5.7.0
   mutex: ^3.0.0
   meta: ^1.16.0
   at_chops: ^2.2.0
+  http: ^1.2.1
 
 dev_dependencies:
   mocktail: ^1.0.4

--- a/packages/at_lookup/test/secondary_address_cache_test.dart
+++ b/packages/at_lookup/test/secondary_address_cache_test.dart
@@ -254,6 +254,165 @@ void main() async {
     });
   });
 
+  group('some tests using fallbacks', () {
+    registerFallbackValue(SecureSocketConfig());
+    String atSign = '@alice';
+    String noAtAtSign = atSign.replaceFirst('@', '');
+    String mockAtDirectoryHost = '127.0.0.5';
+    String timeoutAtDirectoryHost = 'no.no.no.no';
+    String mockedAtServerAddress = 'guid.swarm.zone.test:12345';
+
+    late Function socketOnDataFn;
+
+    late SecureSocket mockSocket;
+    late MockSecureSocketFactory mockSocketFactory;
+
+    late int numSocketCreateCalls;
+    late int requiredFailures;
+
+    late Proxies proxies;
+
+    SecureSocket createMockAtDirectorySocket(String address, int port) {
+      SecureSocket mss = MockSecureSocket();
+      when(() => mss.flush()).thenAnswer((invocation) => Future<void>.value());
+      when(() => mss.destroy()).thenAnswer((invocation) {
+        (mss as MockSecureSocket).destroyed = true;
+      });
+      when(() => mss.setOption(SocketOption.tcpNoDelay, true)).thenReturn(true);
+      when(() => mss.remoteAddress).thenReturn(InternetAddress(address));
+      when(() => mss.remotePort).thenReturn(port);
+      return mss;
+    }
+
+    setUp(() {
+      mockSocket = createMockAtDirectorySocket(mockAtDirectoryHost, 64);
+      mockSocketFactory = MockSecureSocketFactory();
+
+      proxies = Proxies([
+        SecondaryAddress('proxy0001.test.test', 443),
+        SecondaryAddress('proxy0002.test.test', 443),
+        SecondaryAddress('proxy0003.test.test', 443)
+      ]);
+
+      numSocketCreateCalls = 0;
+      when(() => mockSocketFactory.createSocket(
+              mockAtDirectoryHost, '64', any(),
+              createSocketTimeout: any(named: 'createSocketTimeout')))
+          .thenAnswer((invocation) {
+        print(
+            'mock create socket: numFailures $numSocketCreateCalls requiredFailures $requiredFailures');
+        if (numSocketCreateCalls++ < requiredFailures) {
+          throw SocketException('Simulating socket connection failure');
+        } else {
+          return Future<SecureSocket>.value(mockSocket);
+        }
+      });
+      when(() => mockSocketFactory.createSocket(
+              timeoutAtDirectoryHost, '64', any(),
+              createSocketTimeout: any(named: 'createSocketTimeout')))
+          .thenAnswer((invocation) async {
+        await Future.delayed(invocation.namedArguments[#createSocketTimeout]);
+        throw SocketException('Simulating socket timeout',
+            osError: OSError(
+                'Simulated timeout',
+                (Platform.isWindows
+                    ? 10060 // WSAETIMEDOUT
+                    : 110)));
+      });
+
+      when(() => mockSocket.listen(any(),
+          onError: any(named: "onError"),
+          onDone: any(named: "onDone"))).thenAnswer((Invocation invocation) {
+        socketOnDataFn = invocation.positionalArguments[0];
+        // socketOnErrorFn = invocation.namedArguments[#onError];
+        // socketOnDoneFn = invocation.namedArguments[#onDone];
+
+        socketOnDataFn('@'.codeUnits);
+        return MockStreamSubscription();
+      });
+
+      when(() => mockSocket.write('$noAtAtSign\n'))
+          .thenAnswer((Invocation invocation) async {
+        socketOnDataFn("@$mockedAtServerAddress\n".codeUnits);
+      });
+    });
+
+    test('test Proxies constructor', () {
+      expect(() => Proxies([]), throwsA(isA<ArgumentError>()));
+    });
+
+    test('test Proxies next function', () {
+      for (int i = 0; i < proxies.addresses.length * 3 + 1; i++) {
+        final p = proxies.next();
+        expect(p, proxies.addresses[i % proxies.addresses.length]);
+      }
+    });
+
+    test('test lookup of @alice with mocked atDirectory and zero failures',
+        () async {
+      CacheableSecondaryAddressFinder cachingAtServerFinder =
+          CacheableSecondaryAddressFinder(mockAtDirectoryHost, 64,
+              socketFactory: mockSocketFactory,
+              proxies: proxies,
+              createSocketTimeout: Duration(milliseconds: 25));
+
+      requiredFailures = 0;
+      SecondaryAddress sa = await cachingAtServerFinder.findSecondary(atSign);
+      expect(sa.toString(), mockedAtServerAddress);
+      expect(numSocketCreateCalls - 1, requiredFailures);
+    });
+
+    test('test fallback to proxy after 5 failures', () async {
+      CacheableSecondaryAddressFinder cachingAtServerFinder =
+          CacheableSecondaryAddressFinder(mockAtDirectoryHost, 64,
+              socketFactory: mockSocketFactory,
+              proxies: proxies,
+              createSocketTimeout: Duration(milliseconds: 25));
+      requiredFailures = 5;
+      SecondaryAddress sa = await cachingAtServerFinder.findSecondary(atSign);
+      expect(numSocketCreateCalls, requiredFailures);
+      expect(sa, isIn(proxies.addresses));
+    });
+
+    test('test fallback continues to be used', () async {
+      CacheableSecondaryAddressFinder cachingAtServerFinder =
+          CacheableSecondaryAddressFinder(mockAtDirectoryHost, 64,
+              socketFactory: mockSocketFactory,
+              proxies: proxies,
+              createSocketTimeout: Duration(milliseconds: 25));
+      requiredFailures = 5;
+      SecondaryAddress sa = await cachingAtServerFinder.findSecondary(atSign);
+      expect(numSocketCreateCalls, requiredFailures);
+      expect(sa, equals(proxies.addresses[0]));
+
+      // Clear the cache, try again, same fallback should be used
+      cachingAtServerFinder.clear();
+      numSocketCreateCalls = 0;
+      SecondaryAddress sa1 = await cachingAtServerFinder.findSecondary(atSign);
+      expect(numSocketCreateCalls, 0); // should just return proxy straight away
+      expect(
+          sa1, equals(proxies.addresses[0])); // And it should be the same proxy
+
+      // Clear the cache, unset the fallback, try again - expect socket create calls
+      cachingAtServerFinder.clear();
+      cachingAtServerFinder.secondaryFinder.fallback = null;
+      numSocketCreateCalls = 0;
+      SecondaryAddress sa2 = await cachingAtServerFinder.findSecondary(atSign);
+      expect(numSocketCreateCalls, requiredFailures);
+      expect(sa2, equals(proxies.addresses[1]));
+    });
+
+    test('test fallback to proxy after timeout', () async {
+      CacheableSecondaryAddressFinder cachingAtServerFinder =
+          CacheableSecondaryAddressFinder(timeoutAtDirectoryHost, 64,
+              socketFactory: mockSocketFactory,
+              proxies: proxies,
+              createSocketTimeout: Duration(milliseconds: 25));
+      SecondaryAddress sa = await cachingAtServerFinder.findSecondary(atSign);
+      expect(sa, isIn(proxies.addresses));
+    });
+  });
+
   group(
       'some cache tests with a real SecondaryUrlFinder but with rootDomain set to proxy:<something>',
       () {

--- a/packages/at_lookup/test/secondary_address_cache_test.dart
+++ b/packages/at_lookup/test/secondary_address_cache_test.dart
@@ -14,9 +14,11 @@ import 'at_lookup_test_utils.dart';
 void main() async {
   group('this should be moved to functional tests', () {
     test('look up @cicd1 from root.atsign.wtf:64', () async {
-      var secondaryAddress =
-          await CacheableSecondaryAddressFinder('root.atsign.wtf', 64)
-              .findSecondary('@cicd1');
+      var secondaryAddress = await CacheableSecondaryAddressFinder(
+        'root.atsign.wtf',
+        64,
+        proxies: null,
+      ).findSecondary('@cicd1');
       expect(secondaryAddress.port, isNotNull);
       expect(secondaryAddress.host, isNotNull);
       print(secondaryAddress.toString());
@@ -56,13 +58,20 @@ void main() async {
                 invocation.positionalArguments.first));
       });
 
-      cache = CacheableSecondaryAddressFinder(rootDomain, rootPort,
-          secondaryFinder: mockSecondaryFinder);
+      cache = CacheableSecondaryAddressFinder(
+        rootDomain,
+        rootPort,
+        secondaryFinder: mockSecondaryFinder,
+        proxies: null,
+      );
     });
 
     test('test lookup of @alice on non-existent atDirectory', () async {
-      CacheableSecondaryAddressFinder cache =
-          CacheableSecondaryAddressFinder('root.no.no.no', 64);
+      CacheableSecondaryAddressFinder cache = CacheableSecondaryAddressFinder(
+        'root.no.no.no',
+        64,
+        proxies: null,
+      );
       expect(() async => await cache.findSecondary('@alice'),
           throwsA(predicate((e) => e is RootServerConnectivityException)));
     });
@@ -168,9 +177,12 @@ void main() async {
       mockSocketFactory = MockSecureSocketFactory();
 
       cachingAtServerFinder = CacheableSecondaryAddressFinder(
-          mockAtDirectoryHost, 64,
-          secondaryFinder: SecondaryUrlFinder(mockAtDirectoryHost, 64,
-              socketFactory: mockSocketFactory));
+        mockAtDirectoryHost,
+        64,
+        secondaryFinder: SecondaryUrlFinder(mockAtDirectoryHost, 64,
+            socketFactory: mockSocketFactory),
+        proxies: null,
+      );
 
       numSocketCreateCalls = 0;
       when(() =>
@@ -427,7 +439,11 @@ void main() async {
     late CacheableSecondaryAddressFinder csaf;
 
     setUp(() {
-      csaf = CacheableSecondaryAddressFinder(rootDomain, rootPort);
+      csaf = CacheableSecondaryAddressFinder(
+        rootDomain,
+        rootPort,
+        proxies: null,
+      );
     });
 
     test('test simple lookup for @registeredAtSign1', () async {

--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.16.0
+
+- feat: Take up new fallback-to-proxy feature from at_lookup 3.5.0
+
 ## 1.15.0
 
 - feat: add `--root-server` option to specify root server domain

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -31,38 +31,52 @@ void _showPreOnboardingKeyWarning() {
   stdout.writeln();
   stdout.writeln(chalk.yellow('⚠️  IMPORTANT - READ CAREFULLY ⚠️'));
   stdout.writeln();
-  stdout.writeln(chalk.bold('You are about to onboard your atSign and generate a set of unique cryptographic keys.'));
-  stdout.writeln(chalk.bold('It is CRITICAL that you back up these keys to more than one place after onboarding.'));
+  stdout.writeln(chalk.bold(
+      'You are about to onboard your atSign and generate a set of unique cryptographic keys.'));
+  stdout.writeln(chalk.bold(
+      'It is CRITICAL that you back up these keys to more than one place after onboarding.'));
   stdout.writeln();
   stdout.writeln(chalk.red('LOSING ACCESS TO THESE KEYS WILL RESULT IN:'));
-  stdout.writeln('• Loss of ability to authenticate into your atSign\'s atServer');
-  stdout.writeln('• Loss of ability to decrypt any data on your atSign\'s atServer');
-  stdout.writeln('• Loss of data access to any applications/devices that use these keys');
+  stdout.writeln(
+      '• Loss of ability to authenticate into your atSign\'s atServer');
+  stdout.writeln(
+      '• Loss of ability to decrypt any data on your atSign\'s atServer');
+  stdout.writeln(
+      '• Loss of data access to any applications/devices that use these keys');
   stdout.writeln();
-  stdout.writeln(chalk.bold('If you lose these keys, you will NOT be able to recover your atSign or its data.'));
-  stdout.writeln(chalk.bold('NOT EVEN ATSIGN INC. CAN RECOVER THESE KEYS FOR YOU!'));
-  stdout.writeln(chalk.bold('You may reset your atSign\'s atServer by contacting support@atsign.com, if a new set of keys is required, but no data can be recovered.'));
+  stdout.writeln(chalk.bold(
+      'If you lose these keys, you will NOT be able to recover your atSign or its data.'));
+  stdout.writeln(
+      chalk.bold('NOT EVEN ATSIGN INC. CAN RECOVER THESE KEYS FOR YOU!'));
+  stdout.writeln(chalk.bold(
+      'You may reset your atSign\'s atServer by contacting support@atsign.com, if a new set of keys is required, but no data can be recovered.'));
   stdout.writeln();
   stdout.writeln(chalk.blue('IMPORTANT:'));
-  stdout.writeln('• After onboarding, you MUST back up your .atKeys file to a secure location');
-  stdout.writeln('• Store it in multiple secure locations (cloud storage, external drives, etc.)');
+  stdout.writeln(
+      '• After onboarding, you MUST back up your .atKeys file to a secure location');
+  stdout.writeln(
+      '• Store it in multiple secure locations (cloud storage, external drives, etc.)');
   stdout.writeln('• Keep it safe from unauthorized access');
   stdout.writeln();
-  
+
   while (true) {
-    stdout.write(chalk.blue('[Action Required] ') + chalk.bold('Do you understand that losing these keys means losing access to your atSign and all its data? (Y/N): '));
+    stdout.write(chalk.blue('[Action Required] ') +
+        chalk.bold(
+            'Do you understand that losing these keys means losing access to your atSign and all its data? (Y/N): '));
     String? response = stdin.readLineSync();
-    
+
     if (response != null) {
       String normalized = response.trim().toLowerCase();
       if (normalized == 'y' || normalized == 'yes') {
         stdout.writeln();
-        stdout.writeln(chalk.green('✓ Acknowledged. Please remember to back up your keys securely!'));
+        stdout.writeln(chalk.green(
+            '✓ Acknowledged. Please remember to back up your keys securely!'));
         stdout.writeln();
         break;
       } else if (normalized == 'n' || normalized == 'no') {
         stdout.writeln();
-        stdout.writeln(chalk.red('Onboarding cancelled. Please ensure you understand the importance of key backup before proceeding.'));
+        stdout.writeln(chalk.red(
+            'Onboarding cancelled. Please ensure you understand the importance of key backup before proceeding.'));
         exit(0);
       } else {
         stdout.writeln(chalk.yellow('Please enter Y (yes) or N (no).'));
@@ -208,8 +222,7 @@ Future<int> wrappedMain(List<String> arguments) async {
             await createAtClient(
                 atSign: commandArgResults[AuthCliArgs.argNameAtSign],
                 atKeysFilePath: commandArgResults[AuthCliArgs.argNameAtKeys],
-                rootDomain:
-                    commandArgResults[AuthCliArgs.argNameRootServer],
+                rootDomain: commandArgResults[AuthCliArgs.argNameRootServer],
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
 
       case AuthCliCommand.otp:
@@ -225,8 +238,7 @@ Future<int> wrappedMain(List<String> arguments) async {
             await createAtClient(
                 atSign: commandArgResults[AuthCliArgs.argNameAtSign],
                 atKeysFilePath: commandArgResults[AuthCliArgs.argNameAtKeys],
-                rootDomain:
-                    commandArgResults[AuthCliArgs.argNameRootServer],
+                rootDomain: commandArgResults[AuthCliArgs.argNameRootServer],
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
 
       case AuthCliCommand.interactive:
@@ -238,8 +250,7 @@ Future<int> wrappedMain(List<String> arguments) async {
             await createAtClient(
                 atSign: commandArgResults[AuthCliArgs.argNameAtSign],
                 atKeysFilePath: commandArgResults[AuthCliArgs.argNameAtKeys],
-                rootDomain:
-                    commandArgResults[AuthCliArgs.argNameRootServer],
+                rootDomain: commandArgResults[AuthCliArgs.argNameRootServer],
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
 
       case AuthCliCommand.list:
@@ -248,8 +259,7 @@ Future<int> wrappedMain(List<String> arguments) async {
             await createAtClient(
                 atSign: commandArgResults[AuthCliArgs.argNameAtSign],
                 atKeysFilePath: commandArgResults[AuthCliArgs.argNameAtKeys],
-                rootDomain:
-                    commandArgResults[AuthCliArgs.argNameRootServer],
+                rootDomain: commandArgResults[AuthCliArgs.argNameRootServer],
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
 
       case AuthCliCommand.fetch:
@@ -258,8 +268,7 @@ Future<int> wrappedMain(List<String> arguments) async {
             await createAtClient(
                 atSign: commandArgResults[AuthCliArgs.argNameAtSign],
                 atKeysFilePath: commandArgResults[AuthCliArgs.argNameAtKeys],
-                rootDomain:
-                    commandArgResults[AuthCliArgs.argNameRootServer],
+                rootDomain: commandArgResults[AuthCliArgs.argNameRootServer],
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
 
       case AuthCliCommand.approve:
@@ -268,8 +277,7 @@ Future<int> wrappedMain(List<String> arguments) async {
             await createAtClient(
                 atSign: commandArgResults[AuthCliArgs.argNameAtSign],
                 atKeysFilePath: commandArgResults[AuthCliArgs.argNameAtKeys],
-                rootDomain:
-                    commandArgResults[AuthCliArgs.argNameRootServer],
+                rootDomain: commandArgResults[AuthCliArgs.argNameRootServer],
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
 
       case AuthCliCommand.auto:
@@ -278,8 +286,7 @@ Future<int> wrappedMain(List<String> arguments) async {
             await createAtClient(
                 atSign: commandArgResults[AuthCliArgs.argNameAtSign],
                 atKeysFilePath: commandArgResults[AuthCliArgs.argNameAtKeys],
-                rootDomain:
-                    commandArgResults[AuthCliArgs.argNameRootServer],
+                rootDomain: commandArgResults[AuthCliArgs.argNameRootServer],
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
 
       case AuthCliCommand.deny:
@@ -288,8 +295,7 @@ Future<int> wrappedMain(List<String> arguments) async {
             await createAtClient(
                 atSign: commandArgResults[AuthCliArgs.argNameAtSign],
                 atKeysFilePath: commandArgResults[AuthCliArgs.argNameAtKeys],
-                rootDomain:
-                    commandArgResults[AuthCliArgs.argNameRootServer],
+                rootDomain: commandArgResults[AuthCliArgs.argNameRootServer],
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
 
       case AuthCliCommand.revoke:
@@ -298,8 +304,7 @@ Future<int> wrappedMain(List<String> arguments) async {
             await createAtClient(
                 atSign: commandArgResults[AuthCliArgs.argNameAtSign],
                 atKeysFilePath: commandArgResults[AuthCliArgs.argNameAtKeys],
-                rootDomain:
-                    commandArgResults[AuthCliArgs.argNameRootServer],
+                rootDomain: commandArgResults[AuthCliArgs.argNameRootServer],
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
 
       case AuthCliCommand.enroll:
@@ -316,8 +321,7 @@ Future<int> wrappedMain(List<String> arguments) async {
             await createAtClient(
                 atSign: commandArgResults[AuthCliArgs.argNameAtSign],
                 atKeysFilePath: commandArgResults[AuthCliArgs.argNameAtKeys],
-                rootDomain:
-                    commandArgResults[AuthCliArgs.argNameRootServer],
+                rootDomain: commandArgResults[AuthCliArgs.argNameRootServer],
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
 
       case AuthCliCommand.delete:
@@ -326,8 +330,7 @@ Future<int> wrappedMain(List<String> arguments) async {
             await createAtClient(
                 atSign: commandArgResults[AuthCliArgs.argNameAtSign],
                 atKeysFilePath: commandArgResults[AuthCliArgs.argNameAtKeys],
-                rootDomain:
-                    commandArgResults[AuthCliArgs.argNameRootServer],
+                rootDomain: commandArgResults[AuthCliArgs.argNameRootServer],
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
     }
   } on ArgumentError catch (e) {
@@ -361,21 +364,17 @@ Future<int> wrappedMain(List<String> arguments) async {
 ///  - 0 if the atServer is reachable and `public:publickey@<atsign>` exists
 Future<int> status(ArgResults ar) async {
   String atSign = AtUtils.fixAtSign(ar[AuthCliArgs.argNameAtSign]);
-  
-  // rootServer is now an alias of root-server, ArgParser handles both automatically
-  String rootServer = ar[AuthCliArgs.argNameRootServer];
-  
-  // Parse rootServer using AtRootDomain
-  AtRootDomain rootDomain;
-  try {
-    rootDomain = AtRootDomain.parse(rootServer);
-  } catch (e) {
-    stderr.writeln('Error: Invalid root server domain "$rootServer": $e');
-    exit(1);
-  }
+
+  AtOnboardingPreference atOnboardingPreference = prefFromArgResults(ar);
 
   SecondaryAddressFinder saf = CacheableSecondaryAddressFinder(
-      rootDomain.rootDomain, rootDomain.rootPort);
+    atOnboardingPreference.rootDomain,
+    atOnboardingPreference.rootPort,
+    proxies: atOnboardingPreference.proxyFallbackEnabled
+        ? await Proxies.forDirectory(atOnboardingPreference.rootDomain)
+        : null,
+    createSocketTimeout: atOnboardingPreference.createSocketTimeout,
+  );
   try {
     await saf.findSecondary(atSign);
   } on SecondaryNotFoundException {
@@ -390,8 +389,13 @@ Future<int> status(ArgResults ar) async {
   try {
     AtLookUp al = AtLookupImpl(
       atSign,
-      rootDomain.rootDomain,
-      rootDomain.rootPort,
+      atOnboardingPreference.rootDomain,
+      atOnboardingPreference.rootPort,
+      secondaryAddressFinder: saf,
+      proxies: atOnboardingPreference.proxyFallbackEnabled
+          ? await Proxies.forDirectory(atOnboardingPreference.rootDomain)
+          : null,
+      createSocketTimeout: atOnboardingPreference.createSocketTimeout,
     );
     try {
       pk = await al.executeCommand('lookup:publickey$atSign\n', auth: false);
@@ -425,8 +429,7 @@ Future<int> status(ArgResults ar) async {
 @visibleForTesting
 Future<bool> onboard(ArgResults argResults, {AtOnboardingService? svc}) async {
   svc ??= createOnboardingService(argResults);
-  logger
-      .info('Root server is ${argResults[AuthCliArgs.argNameRootServer]}');
+  logger.info('Root server is ${argResults[AuthCliArgs.argNameRootServer]}');
   logger.info(
       'Registrar url provided is ${argResults[AuthCliArgs.argNameRegistrarFqdn]}');
 
@@ -442,7 +445,8 @@ Future<bool> onboard(ArgResults argResults, {AtOnboardingService? svc}) async {
     }
     // if  -y flag is not used and --cramkey is not provided, show back up key warning message
     // --cramkey implies --yes for backwards compatibility with automation scripts
-    if (!argResults[AuthCliArgs.argNameYes] && !argResults.wasParsed(AuthCliArgs.argNameCramSecret)) {
+    if (!argResults[AuthCliArgs.argNameYes] &&
+        !argResults.wasParsed(AuthCliArgs.argNameCramSecret)) {
       _showPreOnboardingKeyWarning();
     }
     await svc.onboard(
@@ -1081,13 +1085,10 @@ Future<void> deleteEnrollment(ArgResults ar, AtClient atClient) async {
   stdout.writeln('Server response: $response');
 }
 
-@visibleForTesting
-AtOnboardingService createOnboardingService(ArgResults ar) {
-  String atSign = AtUtils.fixAtSign(ar[AuthCliArgs.argNameAtSign]);
-  
+AtOnboardingPreference prefFromArgResults(ArgResults ar) {
   // rootServer is now an alias of root-server, ArgParser handles both automatically
   String rootServer = ar[AuthCliArgs.argNameRootServer];
-  
+
   // Parse rootServer using AtRootDomain
   AtRootDomain rootDomain;
   try {
@@ -1096,8 +1097,8 @@ AtOnboardingService createOnboardingService(ArgResults ar) {
     stderr.writeln('Error: Invalid root server domain "$rootServer": $e');
     throw ArgumentError('Invalid root server domain: $e');
   }
-  
-  AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
+
+  return AtOnboardingPreference()
     ..rootDomain = rootDomain.rootDomain
     ..rootPort = rootDomain.rootPort
     ..registrarUrl = ar[AuthCliArgs.argNameRegistrarFqdn]
@@ -1106,8 +1107,13 @@ AtOnboardingService createOnboardingService(ArgResults ar) {
     ..passPhrase = ar[AuthCliArgs.argNamePassPhrase]
     ..hashingAlgoType =
         HashingAlgoType.fromString(ar[AuthCliArgs.argNameHashingAlgoType]);
+}
 
-  final impl = AtOnboardingServiceImpl(atSign, atOnboardingPreference);
+@visibleForTesting
+AtOnboardingService createOnboardingService(ArgResults ar) {
+  String atSign = AtUtils.fixAtSign(ar[AuthCliArgs.argNameAtSign]);
+
+  final impl = AtOnboardingServiceImpl(atSign, prefFromArgResults(ar));
   String lastProgressEventType = '';
   int pad = 10;
   impl.subscribeProgress().listen((pe) {

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -1108,6 +1108,7 @@ AtOnboardingPreference prefFromArgResults(ArgResults ar) {
     ..cramSecret = ar[AuthCliArgs.argNameCramSecret]
     ..atKeysFilePath = ar[AuthCliArgs.argNameAtKeys]
     ..passPhrase = ar[AuthCliArgs.argNamePassPhrase]
+    ..proxyFallbackEnabled = ar[AuthCliArgs.argNameProxyFallbackEnabled]
     ..hashingAlgoType =
         HashingAlgoType.fromString(ar[AuthCliArgs.argNameHashingAlgoType]);
 }

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -152,6 +152,9 @@ Future<int> wrappedMain(List<String> arguments) async {
     return 0;
   }
 
+  Proxies.proxyFallbackEnabled =
+      topLevelResults[AuthCliArgs.argNameProxyFallbackEnabled];
+
   final AuthCliCommand cliCommand;
   try {
     cliCommand = AuthCliCommand.values.byName(arguments.first);

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
@@ -148,6 +148,15 @@ class AuthCliArgs {
       hide: true,
     );
 
+    p.addFlag(
+      argNameProxyFallbackEnabled,
+      help: 'If not using a proxy, fallback to a proxy if the atDirectory'
+          ' is unreachable',
+      defaultsTo: true,
+      negatable: true,
+      hide: true,
+    );
+
     for (final c in AuthCliCommand.values) {
       p.addCommand(c.name, createParserForCommand(c));
     }
@@ -295,7 +304,7 @@ class AuthCliArgs {
           ' is unreachable',
       defaultsTo: true,
       negatable: true,
-      hide: true,
+      hide: hide,
     );
     return p;
   }

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
@@ -118,6 +118,7 @@ class AuthCliArgs {
   static const argNameMaxRetries = 'max-retries';
   static const argNameAllowBadRegistrarCerts = 'allow-bad-registrar-certs';
   static const argNameYes = 'yes';
+  static const argNameProxyFallbackEnabled = 'proxy-fallback-enabled';
 
   ArgParser get parser {
     return _aap;
@@ -288,6 +289,14 @@ class AuthCliArgs {
         mandatory: false,
         defaultsTo: HashingAlgoType.argon2id.name,
         hide: hide);
+    p.addFlag(
+      argNameProxyFallbackEnabled,
+      help: 'If not using a proxy, fallback to a proxy if the atDirectory'
+          ' is unreachable',
+      defaultsTo: true,
+      negatable: true,
+      hide: true,
+    );
     return p;
   }
 

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -60,27 +60,33 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   /// Sends from: command if using proxy
   /// [context] - description of the operation for logging (defaults to 'sendFromCommand')
   /// [atSign] - the atSign to send the from: command for (defaults to current atSign)
-  Future<bool> _sendFromCommandIfUsingProxy(AtLookUp atLookUp, {String context = 'sendFromCommand', String? atSign}) async {
+  Future<bool> _sendFromCommandIfUsingProxy(AtLookUp atLookUp,
+      {String context = 'sendFromCommand', String? atSign}) async {
     if (!_isUsingProxy) {
       return false;
     }
 
     String targetAtSign = atSign ?? _atSign;
     try {
-      String? fromResponse = await atLookUp.executeCommand('from:$targetAtSign\n', auth: false);
-      logger.info('$context: from: command successful for $targetAtSign, response: $fromResponse');
+      String? fromResponse =
+          await atLookUp.executeCommand('from:$targetAtSign\n', auth: false);
+      logger.info(
+          '$context: from: command successful for $targetAtSign, response: $fromResponse');
 
       if (fromResponse == null || fromResponse.isEmpty) {
-        logger.warning('$context: from: command returned empty response for $targetAtSign');
+        logger.warning(
+            '$context: from: command returned empty response for $targetAtSign');
         return false;
       }
       if (fromResponse.contains('error:')) {
-        logger.warning('$context: from: command returned error for $targetAtSign: $fromResponse');
+        logger.warning(
+            '$context: from: command returned error for $targetAtSign: $fromResponse');
         return false;
       }
       return true;
     } catch (e) {
-      logger.warning('$context: from: command failed for $targetAtSign: $e - continuing anyway');
+      logger.warning(
+          '$context: from: command failed for $targetAtSign: $e - continuing anyway');
       return false;
     }
   }
@@ -123,6 +129,10 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       _atSign,
       atOnboardingPreference.rootDomain,
       atOnboardingPreference.rootPort,
+      proxies: atOnboardingPreference.proxyFallbackEnabled
+          ? await Proxies.forDirectory(atOnboardingPreference.rootDomain)
+          : null,
+      createSocketTimeout: atOnboardingPreference.createSocketTimeout,
     );
 
     await _sendFromCommandIfUsingProxy(atLookUpImpl, context: 'onboard');
@@ -280,6 +290,10 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       _atSign,
       atOnboardingPreference.rootDomain,
       atOnboardingPreference.rootPort,
+      proxies: atOnboardingPreference.proxyFallbackEnabled
+          ? await Proxies.forDirectory(atOnboardingPreference.rootDomain)
+          : null,
+      createSocketTimeout: atOnboardingPreference.createSocketTimeout,
     );
 
     EnrollmentRequest newClientEnrollmentRequest = EnrollmentRequest(
@@ -290,8 +304,15 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     newClientEnrollmentRequest.apkamKeysExpiryDuration =
         apkamKeysExpiryDuration;
 
-    AtLookupImpl atLookUpImpl = AtLookupImpl(_atSign,
-        atOnboardingPreference.rootDomain, atOnboardingPreference.rootPort);
+    AtLookupImpl atLookUpImpl = AtLookupImpl(
+      _atSign,
+      atOnboardingPreference.rootDomain,
+      atOnboardingPreference.rootPort,
+      proxies: atOnboardingPreference.proxyFallbackEnabled
+          ? await Proxies.forDirectory(atOnboardingPreference.rootDomain)
+          : null,
+      createSocketTimeout: atOnboardingPreference.createSocketTimeout,
+    );
 
     if (_isUsingProxy) {
       // When using a proxy, send from: command to ensure correct atSign context
@@ -322,6 +343,10 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       _atSign,
       atOnboardingPreference.rootDomain,
       atOnboardingPreference.rootPort,
+      proxies: atOnboardingPreference.proxyFallbackEnabled
+          ? await Proxies.forDirectory(atOnboardingPreference.rootDomain)
+          : null,
+      createSocketTimeout: atOnboardingPreference.createSocketTimeout,
     );
 
     if (_isUsingProxy) {
@@ -705,21 +730,33 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
   @override
   Future<bool> isOnboarded() async {
-
     if (_isUsingProxy) {
       // When using a proxy, try a simple lookup command that doesn't require auth
-      AtLookUp atLookUp = AtLookupImpl(_atSign, atOnboardingPreference.rootDomain, atOnboardingPreference.rootPort);
+      AtLookUp atLookUp = AtLookupImpl(
+        _atSign,
+        atOnboardingPreference.rootDomain,
+        atOnboardingPreference.rootPort,
+        proxies: atOnboardingPreference.proxyFallbackEnabled
+            ? await Proxies.forDirectory(atOnboardingPreference.rootDomain)
+            : null,
+        createSocketTimeout: atOnboardingPreference.createSocketTimeout,
+      );
       await _sendFromCommandIfUsingProxy(atLookUp, context: 'isOnboarded');
 
       try {
-        String? pkeyResponse = await _atLookUp!.executeCommand('lookup:publickey$_atSign\n', auth: false);
-        if (pkeyResponse != null && !pkeyResponse.contains('error:') && !pkeyResponse.contains('null') && pkeyResponse.trim().isNotEmpty) {
+        String? pkeyResponse = await _atLookUp!
+            .executeCommand('lookup:publickey$_atSign\n', auth: false);
+        if (pkeyResponse != null &&
+            !pkeyResponse.contains('error:') &&
+            !pkeyResponse.contains('null') &&
+            pkeyResponse.trim().isNotEmpty) {
           _isAtsignOnboarded = true;
           return true;
         }
         return false;
       } catch (e) {
-        logger.info('isOnboarded: lookup failed, trying alternative approach: $e');
+        logger.info(
+            'isOnboarded: lookup failed, trying alternative approach: $e');
         return false;
       }
     } else {
@@ -733,7 +770,8 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
         return false;
       } catch (e) {
         stderr.writeln('${chalk.brightRed('[Error]')} $e');
-        throw AtActivateException('Could not determine atsign activation status: $e',
+        throw AtActivateException(
+            'Could not determine atsign activation status: $e',
             intent: Intent.fetchData);
       }
     }

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -33,12 +33,6 @@ dependencies:
   crypto: ^3.0.5
   chalkdart: ">=2.0.9<4.0.0" # no breaking changes in 3.0.0
 
-dependency_overrides:
-  args:
-    git:
-      ref: gkc/show-aliases-in-usage
-      url: https://github.com/gkc/args
-
 dev_dependencies:
   at_persistence_secondary_server: ^4.2.0
   alfred: ^1.1.2+1

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   zxing2: ^0.2.0
   at_auth: ^2.5.0
   at_chops: ^2.2.0
-  at_client: ^3.7.0
+  at_client: ^3.9.0
   at_commons: ^5.6.2
   at_lookup: ^3.5.0
   at_server_status: ^1.2.0

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tools for initial client onboarding, subsequent client enrollment, and enrollment management.
-version: 1.15.0
+version: 1.16.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -22,12 +22,12 @@ dependencies:
   meta: ^1.16.0
   path: ^1.9.0
   zxing2: ^0.2.0
-  at_auth: ^2.3.0
+  at_auth: ^2.5.0
   at_chops: ^2.2.0
   at_client: ^3.7.0
-  at_commons: ^5.6.0
-  at_lookup: ^3.0.52
-  at_server_status: ^1.0.5
+  at_commons: ^5.6.2
+  at_lookup: ^3.5.0
+  at_server_status: ^1.2.0
   at_utils: ^3.2.0
   duration: ^4.0.3
   crypto: ^3.0.5

--- a/packages/at_policy/example/pubspec.yaml
+++ b/packages/at_policy/example/pubspec.yaml
@@ -6,17 +6,8 @@ publish_to: none
 environment:
   sdk: ^3.0.6
 
-dependency_overrides:
-  at_policy:
-    path: ..
-  at_cli_commons:
-    path: ../../at_cli_commons
-  at_client:
-    path: ../../at_client
-
 dependencies:
-  at_policy:
-    path: ..
+  at_policy: ^1.2.0
   at_cli_commons: ^1.2.1
   at_client: ^3.7.0
 

--- a/packages/at_policy/example/pubspec.yaml
+++ b/packages/at_policy/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ^3.0.6
 
 dependencies:
-  at_policy: ^1.2.0
+  at_policy: ^1.1.0
   at_cli_commons: ^1.2.1
   at_client: ^3.7.0
 

--- a/packages/at_server_status/CHANGELOG.md
+++ b/packages/at_server_status/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- feat: Take up new fallback-to-proxy feature from at_lookup 3.5.0
+
 ## 1.1.0
 
 - chore(deps): remove unused dependencies

--- a/packages/at_server_status/lib/at_status_impl.dart
+++ b/packages/at_server_status/lib/at_status_impl.dart
@@ -96,8 +96,12 @@ class AtStatusImpl implements AtServerStatus {
       atStatus.rootStatus = RootStatus.notFound;
     } else {
       // ignore: omit_local_variable_types
-      AtLookupImpl atLookupImpl =
-          AtLookupImpl(atSign!, _rootUrl!, _rootPort!);
+      AtLookupImpl atLookupImpl = AtLookupImpl(
+        atSign!,
+        _rootUrl!,
+        _rootPort!,
+        proxies: await Proxies.forDirectory(_rootUrl!),
+      );
       await atLookupImpl.scan(auth: false).then((keysList) async {
         if (keysList.isNotEmpty) {
           if (keysList.contains(testKey)) {

--- a/packages/at_server_status/pubspec.yaml
+++ b/packages/at_server_status/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_status
 description: A Dart library that provides a means to check on the status of the @‎root server as well as the secondary server for any particular @‎sign.
-version: 1.1.0
+version: 1.2.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_server_status
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -10,7 +10,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  at_lookup: ^3.0.49
+  at_lookup: ^3.5.0
 
 dev_dependencies:
   uuid: ^4.0.0


### PR DESCRIPTION
**- What I did**
- feat: at_lookup: `CacheableSecondaryAddressFinder` now supports automatic fallback to proxies if
  - proxies were supplied at construction time
  - and we are timing out when connecting to atDirectory
  - or we've repeatedly failed to connect to it for non-timeout reasons
- feat: at_client and elsewhere: take up this change
- test: Added tests

**- How I did it**
See commits, plus comments on the diffs

**- How to verify it**
Tests pass

**Note:** Once merged, the order of package publishing will be:
- at_commons (at_lookup needs a change in here)
- at_lookup (this is where the feature is implemented)
- at_auth
- at_server_status
- at_client
- at_client_mobile
- at_onboarding_cli (uses at_client)
