### PR TITLE
chore(at_onboarding_cli): bump version down to 1.13.0 (from 1.15.0)

### DIFF
--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,20 +1,14 @@
-## 1.15.0
-
-- feat: add `--root-server` option to specify root server domain
-- feat: add `--license-key` alias for `--cramkey`
-- chore(deps): at_commons: ^5.6.0
-- chore(deps): args gkc/show-aliases-in-usage dependency override
-
-## 1.14.0
-
-- Added proxy support for: `at_activate onboard --rootServer proxy:<host>:<port>`
-- Added proxy support for: `at_activate enroll --rootServer proxy:<host>:<port>`
-
 ## 1.13.0
 
 - add a warning message before onboarding attempts to cut keys that presents a message explaining importance of backing up keys and prompting the user asking if they understand the risks of not backing up keys
 - made it so that passing `--cramkey` to the `onboard` command will skip the warning message inherently
 - add a `--yes` | `-y` flag to the `onboard` command to skip this warning message
+- Added proxy support for: `at_activate onboard --rootServer proxy:<host>:<port>`
+- Added proxy support for: `at_activate enroll --rootServer proxy:<host>:<port>`
+- feat: add `--root-server` option to specify root server domain
+- feat: add `--license-key` alias for `--cramkey`
+- chore(deps): at_commons: ^5.6.0
+- chore(deps): args gkc/show-aliases-in-usage dependency override
 
 ## 1.12.0
 

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tools for initial client onboarding, subsequent client enrollment, and enrollment management.
-version: 1.15.0
+version: 1.13.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
**- What I did**
- Bumped version of `at_onboarding_cli` down to 1.13.0 (originally 1.15.0)
- at_onboarding_cli's latest version on pub.dev is 1.12.0
- Goal here is to publish 1.13.0 so that there isn't a huge minor version jump

**- How I did it**
- Put all changelogs from 1.14.0 and 1.15.0 to be under 1.13.0

**- How to verify it**
[https://pub.dev/packages/at_onboarding_cli/versions](https://pub.dev/packages/at_onboarding_cli/versions)

**- Description for the changelog**
chore(at_onboarding_cli): bump version down to 1.13.0 (from 1.15.0)
