### PR TITLE
fix(bug): AtRpc namespaceAware=false

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 3.9.0
 
 - fix!: fixed a bug where at_rpc was adding the AtClientPreference's namespace
-  to the notifications used by at_rpc.
+  to the notifications used by at_rpc
+  (https://github.com/atsign-foundation/at_client_sdk/pull/1670).
 
 ## 3.8.0
 

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.9.0
+
+- fix!: fixed a bug where at_rpc was adding the AtClientPreference's namespace
+  to the notifications used by at_rpc.
+
 ## 3.8.0
 
 - feat: add optional `useRemoteAtServer` flag to AtClient `getKeys` and

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,9 +1,3 @@
-## 3.9.0
-
-- fix!: fixed a bug where at_rpc was adding the AtClientPreference's namespace
-  to the notifications used by at_rpc
-  (https://github.com/atsign-foundation/at_client_sdk/pull/1670).
-
 ## 3.8.0
 
 - feat: add optional `useRemoteAtServer` flag to AtClient `getKeys` and
@@ -11,6 +5,9 @@
   than the local datastore.
 - fix: set `isClient` to true and `isServer` to false in AtRpcClient,
   enabling same atSign communication of AtRpc clients and servers.
+- fix!: fixed a bug where at_rpc was adding the AtClientPreference's namespace
+  to the notifications used by at_rpc
+  (https://github.com/atsign-foundation/at_client_sdk/pull/1670).
 
 ## 3.7.0
 

--- a/packages/at_client/lib/src/rpc/at_rpc.dart
+++ b/packages/at_client/lib/src/rpc/at_rpc.dart
@@ -283,7 +283,9 @@ class AtRpc {
   final Metadata _defaultMetaData = Metadata()
     ..isPublic = false
     ..isEncrypted = true
-    ..namespaceAware = false; // THIS IS SET TO FALSE FOR A REASON: https://github.com/atsign-foundation/at_client_sdk/pull/1670
+    // namespaceAware IS SET TO FALSE FOR A REASON:
+    // https://github.com/atsign-foundation/at_client_sdk/pull/1670
+    ..namespaceAware = false;
 
   /// Not part of API, but visibleForTesting.
   /// Receives 'request' notifications, and

--- a/packages/at_client/lib/src/rpc/at_rpc.dart
+++ b/packages/at_client/lib/src/rpc/at_rpc.dart
@@ -283,7 +283,7 @@ class AtRpc {
   final Metadata _defaultMetaData = Metadata()
     ..isPublic = false
     ..isEncrypted = true
-    ..namespaceAware = false;
+    ..namespaceAware = false; // THIS IS SET TO FALSE FOR A REASON: https://github.com/atsign-foundation/at_client_sdk/pull/1670
 
   /// Not part of API, but visibleForTesting.
   /// Receives 'request' notifications, and

--- a/packages/at_client/lib/src/rpc/at_rpc.dart
+++ b/packages/at_client/lib/src/rpc/at_rpc.dart
@@ -283,7 +283,7 @@ class AtRpc {
   final Metadata _defaultMetaData = Metadata()
     ..isPublic = false
     ..isEncrypted = true
-    ..namespaceAware = true;
+    ..namespaceAware = false;
 
   /// Not part of API, but visibleForTesting.
   /// Receives 'request' notifications, and


### PR DESCRIPTION
**- What I did**
- In AtRpc, I set `namespaceAware=false` to the default metadata
- Added a comment linking to this PR

**- Why I did it**

The problem is that the AtClientPreference's namespace is being added to the notifications being sent in at_rpc, when we don't want it to be. We specifically specify the `baseNamespace` and we expect that to be the baseNamespace. We want it to be manually set because when we are sending rpcs to other apps, we might have to chance the baseNamespace a bit (example, we may want to send an rpc from NOPorts Desktop, which has a namespace of `noports` to a sshnoports process which has a namespace of `sshnp`). When there is a clashing namespace, it would be nice to be able to explicitly set the namespace from the public interface.

Client execution WITHOUT these changes does:

`INFO|2025-10-03 13:24:42.141531|AtRpc|Notification @tastelessbanana:request.1759512281641353.npp_atserver_heartbeat.__rpcs.aa.meow@tastelessbanana sent`

Client execution WITH these changes does:

`INFO|2025-10-03 13:23:50.499639|AtRpc|Notification @tastelessbanana:request.1759512229996831.npp_atserver_heartbeat.__rpcs.aa@tastelessbanana sent`

The latter is the expected outcome. 

The client code sets baseNamespace to `aa`. The original functionality sends the notification to `aa.meow` when it should be `aa`.

**- How to verify it**

Full logs and code can be found in this [comment](https://github.com/atsign-foundation/at_client_sdk/pull/1670#issuecomment-3366629295)

**- Description for the changelog**
fix(bug): AtRpc namespaceAware=false
