### PR TITLE
feat: at_cli_commons: some backwards and forwards compatibility changes

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,1 @@
+titleOnly: true

--- a/packages/at_cli_commons/CHANGELOG.md
+++ b/packages/at_cli_commons/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 3.0.1
+
+- feat: Add support for legacy `-d` option. By default, this will be
+  available, but if you want to use `-d` for something else you may specify
+  `addLegacyRootDomainArg: false` when calling `CLIBase.fromCommandLineArgs`
+  or `CLIBase.createArgsParser`
+- feat: for better balance between backwards compatibility and
+  forward-looking functionality, removed the `rootPort` field from CLIBase. The
+  CLIBase constructor will now accept **either** `rootDomain` (a String) or  
+  `atRootDomain` (an AtRootDomain) and will set CLIBase.atRootDomain (an
+  AtRootDomain) accordingly.
+- feat: updated the example programs
+
 ## 3.0.0
 
 - feat!: changed `-d` (root-domain) option to `-r`

--- a/packages/at_cli_commons/CHANGELOG.md
+++ b/packages/at_cli_commons/CHANGELOG.md
@@ -1,13 +1,13 @@
 ## 3.0.1
 
-- feat: Add support for legacy `-d` option. By default, this will be
-  available, but if you want to use `-d` for something else you may specify
-  `addLegacyRootDomainArg: false` when calling `CLIBase.fromCommandLineArgs`
-  or `CLIBase.createArgsParser`
-- feat: for better balance between backwards compatibility and
-  forward-looking functionality, removed the `rootPort` field from CLIBase. The
-  CLIBase constructor will now accept **either** `rootDomain` (a String) or  
-  `atRootDomain` (an AtRootDomain) and will set CLIBase.atRootDomain (an
+- feat: Add support for legacy `-d` option. This will be added to the default
+  CLIBase ArgParser but, if you wish to use `-d` for some other purpose in your
+  program, you may specify `addLegacyRootDomainArg: false` when calling
+  `CLIBase.fromCommandLineArgs` or `CLIBase.createArgsParser`
+- feat: for better balance between backwards compatibility and forward-looking
+  feature, removed the `rootPort` field from CLIBase; instead CLIBase
+  constructor will accept *either* `rootDomain` (a String, backwards compatible)
+  or `atRootDomain` (an AtRootDomain) and will set CLIBase.atRootDomain (an
   AtRootDomain) accordingly.
 - feat: updated the example programs
 

--- a/packages/at_cli_commons/example/bin/put_and_get_example.dart
+++ b/packages/at_cli_commons/example/bin/put_and_get_example.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:at_cli_commons/at_cli_commons.dart';
 import 'package:at_client/at_client.dart';
 
@@ -11,7 +12,7 @@ import 'package:at_client/at_client.dart';
 /// - fetch it back as it is stored
 /// - fetch it back and decrypt it
 Future<void> main(List<String> args) async {
-  final parser = CLIBase.createArgsParser(
+  final ArgParser parser = CLIBase.createArgsParser(
       namespace: 'example', addLegacyRootDomainArg: false);
   try {
     AtClient atClient =

--- a/packages/at_cli_commons/example/bin/put_and_get_example.dart
+++ b/packages/at_cli_commons/example/bin/put_and_get_example.dart
@@ -11,14 +11,18 @@ import 'package:at_client/at_client.dart';
 /// - fetch it back as it is stored
 /// - fetch it back and decrypt it
 Future<void> main(List<String> args) async {
+  final parser = CLIBase.createArgsParser(
+      namespace: 'example', addLegacyRootDomainArg: false);
   try {
-    AtClient atClient = (await CLIBase.fromCommandLineArgs(args)).atClient;
+    AtClient atClient =
+        (await CLIBase.fromCommandLineArgs(args, parser: parser)).atClient;
 
     String example = 'put_and_get_example';
     AtKey id = AtKey()
       ..namespace = atClient.getPreferences()!.namespace!
       ..key = example
-      ..sharedBy = atClient.getCurrentAtSign();
+      ..sharedBy = atClient.getCurrentAtSign()
+      ..metadata = (Metadata()..ttl = 5000); // ttl 5 seconds
 
     // Store it. Will talk direct to the remote atServer rather than use the
     // local datastore, so we don't have to wait for a local-to-atServer sync
@@ -26,26 +30,33 @@ Future<void> main(List<String> args) async {
     PutRequestOptions pro = PutRequestOptions()..useRemoteAtServer = true;
     await atClient.put(id, 'hello, world', putRequestOptions: pro);
 
-    var scanResult = (await atClient
-            .getRemoteSecondary()!
-            .executeCommand('scan $example\n'))!
-        .replaceFirst(RegExp(r'^data:'), '');
+    var scanResult =
+        (await atClient.getAtKeys(regex: example, useRemoteAtServer: true));
     print("Stored to: $scanResult");
 
     print('Fetching $id');
 
-    // Fetch it direct from remote
+    // Fetch it via atProtocol llookup command
     var asStored =
         (await atClient.getRemoteSecondary()!.executeCommand('llookup:$id\n'))!
             .replaceFirst(RegExp(r'^data:'), '');
     print('As stored: $asStored');
 
-    // Fetch it from local
-    print("Decrypted: ${(await atClient.get(id)).value}");
+    // Fetch it via atClient
+    GetRequestOptions gro = GetRequestOptions()..useRemoteAtServer = true;
+    print(
+        "Decrypted: ${(await atClient.get(id, getRequestOptions: gro)).value}");
 
+    await atClient.delete(id,
+        deleteRequestOptions: DeleteRequestOptions()..useRemoteAtServer = true);
     exit(0);
-  } catch (e) {
+  } catch (e, st) {
     print(e);
-    print(CLIBase.argsParser.usage);
+    if (e is ArgumentError || e is FormatException) {
+      print(parser.usage);
+    } else {
+      print('Stack Trace:\n$st');
+    }
+    exit(1);
   }
 }

--- a/packages/at_cli_commons/example/bin/scan_example.dart
+++ b/packages/at_cli_commons/example/bin/scan_example.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:at_cli_commons/at_cli_commons.dart';
 
 /// scan_example.dart
@@ -8,7 +9,7 @@ import 'package:at_cli_commons/at_cli_commons.dart';
 /// Create an atClient and list the identifiers of all the records stored
 /// in its atServer
 Future<void> main(List<String> args) async {
-  final parser = CLIBase.createArgsParser(
+  final ArgParser parser = CLIBase.createArgsParser(
       namespace: 'example', addLegacyRootDomainArg: true);
   try {
     var atClient =

--- a/packages/at_cli_commons/example/bin/scan_example.dart
+++ b/packages/at_cli_commons/example/bin/scan_example.dart
@@ -8,14 +8,21 @@ import 'package:at_cli_commons/at_cli_commons.dart';
 /// Create an atClient and list the identifiers of all the records stored
 /// in its atServer
 Future<void> main(List<String> args) async {
+  final parser = CLIBase.createArgsParser(
+      namespace: 'example', addLegacyRootDomainArg: true);
   try {
-    var atClient = (await CLIBase.fromCommandLineArgs(args)).atClient;
-    var allDataKeys =
-        await atClient.getRemoteSecondary()!.executeCommand('scan\n');
+    var atClient =
+        (await CLIBase.fromCommandLineArgs(args, parser: parser)).atClient;
+    var allDataKeys = await atClient.getKeys(useRemoteAtServer: true);
     print(allDataKeys);
     exit(0);
-  } catch (e) {
+  } catch (e, st) {
     print(e);
-    print(CLIBase.argsParser.usage);
+    if (e is ArgumentError || e is FormatException) {
+      print(parser.usage);
+    } else {
+      print('Stack Trace:\n$st');
+    }
+    exit(1);
   }
 }

--- a/packages/at_cli_commons/example/pubspec.yaml
+++ b/packages/at_cli_commons/example/pubspec.yaml
@@ -6,16 +6,11 @@ publish_to: none
 environment:
   sdk: ^3.0.6
 
-dependency_overrides:
-  at_client:
-    path: ../../at_client
-  at_cli_commons:
-    path: ..
-
 dependencies:
   at_cli_commons:
     path: ..
-  at_client: ^3.7.0
+  at_client: ^3.8.0
+  args: ^2.7.0
 
 dev_dependencies:
   lints: ^2.1.1

--- a/packages/at_cli_commons/lib/src/cli_base.dart
+++ b/packages/at_cli_commons/lib/src/cli_base.dart
@@ -45,7 +45,10 @@ class CLIBase {
   /// CLIBase cliBase = await CLIBase.fromCommandLineArgs(args, parser: argsParser);
   /// ```
   ///
-  ///
+  /// If [addLegacyRootDomainArg] is true (the default) then an option called
+  /// `legacy-root-domain` is added with the `-d` abbreviation. If it is false
+  /// then the option is added but without the `-d` abbreviation so that `-d`
+  /// can be used by calling programs for different purposes.
   static ArgParser createArgsParser({
     String? namespace,
     Set<String> hide = const {},
@@ -137,6 +140,9 @@ class CLIBase {
   ///
   /// If [parser] is not supplied then we will call [createArgsParser] with
   /// the [namespace] and [hide] parameters
+  ///
+  /// See [createArgsParser] for explanation of the `addLegacyRootDomainArg`
+  /// parameter
   static Future<CLIBase> fromCommandLineArgs(
     List<String> args, {
     ArgParser? parser,
@@ -217,6 +223,9 @@ class CLIBase {
   /// Validation rules:
   /// - homeDir must be non-null when any of the atKeysFilePath, storageDir or
   ///   downloadDir parameters are null
+  /// - either `atRootDomain` or `rootDomain` parameters must be non-null. If
+  ///   `atRootDomain` is non-null then it is used, otherwise we parse
+  ///   `rootDomain` to create an [AtRootDomain] and we use that.
   ///
   /// <br/>
   /// Also configures the default AtSignLogger log level to be either INFO

--- a/packages/at_cli_commons/lib/src/cli_base.dart
+++ b/packages/at_cli_commons/lib/src/cli_base.dart
@@ -12,7 +12,6 @@ import 'package:logging/logging.dart';
 class CLIBase {
   static const defaultMaxConnectAttempts = 20;
 
-
   static const Set<String> hideableArgs = {
     'key-file',
     'home-dir',
@@ -50,9 +49,10 @@ class CLIBase {
   static ArgParser createArgsParser({
     String? namespace,
     Set<String> hide = const {},
+    bool addLegacyRootDomainArg = true,
   }) {
     int? usageLineLength = stdout.hasTerminal ? stdout.terminalColumns : null;
-    return ArgParser(usageLineLength: usageLineLength)
+    ArgParser p = ArgParser(usageLineLength: usageLineLength)
       ..addFlag('help', negatable: false, help: 'Usage instructions')
       ..addOption('atsign',
           abbr: 'a', mandatory: true, help: 'The atSign to use')
@@ -81,8 +81,8 @@ class CLIBase {
           aliases: const ['root-domain'],
           abbr: 'r',
           mandatory: false,
-          help: 'Root server domain (e.g., root.atsign.org)',
-          defaultsTo: 'root.atsign.org',
+          help: 'Root server (e.g., root.atsign.org:64)',
+          defaultsTo: 'root.atsign.org:64',
           hide: hide.contains('root-server'))
       ..addFlag('verbose', abbr: 'v', negatable: false, help: 'More logging')
       ..addFlag('never-sync',
@@ -101,6 +101,13 @@ class CLIBase {
               'Pass Phrase to encrypt/decrypt the password protected atKeys file',
           mandatory: false,
           hide: hide.contains('pass-phrase'));
+
+    p.addOption('legacy-root-domain',
+        abbr: addLegacyRootDomainArg ? 'd' : null,
+        mandatory: false,
+        help: 'Deprecated abbreviation option for --root-server',
+        hide: !addLegacyRootDomainArg);
+    return p;
   }
 
   /// An ArgParser which has all of the options and flags required by [CLIBase]
@@ -135,8 +142,13 @@ class CLIBase {
     ArgParser? parser,
     String? namespace,
     Set<String> hide = const {},
+    bool addLegacyRootDomainArg = true,
   }) async {
-    parser ??= createArgsParser(namespace: namespace, hide: hide);
+    parser ??= createArgsParser(
+      namespace: namespace,
+      hide: hide,
+      addLegacyRootDomainArg: addLegacyRootDomainArg,
+    );
     ArgResults parsedArgs = parser.parse(args);
 
     if (parsedArgs['help'] == true) {
@@ -144,16 +156,29 @@ class CLIBase {
       exit(0);
     }
 
-    // root-domain is now an alias of root-server, ArgParser handles both automatically
-    String finalRootDomain = parsedArgs['root-server'];
-    AtRootDomain parsedRootDomain = AtRootDomain.parse(finalRootDomain);
+    String rootDomainString;
+    // root-domain is now an alias of root-server, option abbreviation -r
+    // we also keep optional support for the previous abbreviation, -d
+    if (parsedArgs.wasParsed('legacy-root-domain')) {
+      rootDomainString = parsedArgs['legacy-root-domain'];
+    } else {
+      rootDomainString = parsedArgs['root-server'];
+    }
+    try {
+      AtRootDomain.parse(rootDomainString);
+    } catch (e) {
+      if (e is IllegalArgumentException) {
+        throw ArgumentError(e.message);
+      } else {
+        rethrow;
+      }
+    }
 
     CLIBase cliBase = CLIBase(
         atSign: parsedArgs['atsign'],
         atKeysFilePath: parsedArgs['key-file'],
         nameSpace: parsedArgs['namespace'],
-        rootDomain: parsedRootDomain.rootDomain,
-        rootPort: parsedRootDomain.rootPort,
+        rootDomain: rootDomainString,
         homeDir: getHomeDirectory(),
         storageDir: parsedArgs['storage-dir'],
         verbose: parsedArgs['verbose'],
@@ -168,8 +193,7 @@ class CLIBase {
 
   late final String atSign;
   final String nameSpace;
-  final String rootDomain;
-  final int rootPort;
+  late final AtRootDomain atRootDomain;
   final String? homeDir;
 
   final String? atKeysFilePath;
@@ -203,12 +227,12 @@ class CLIBase {
   ///     AtSignLogger.root_level = 'FINEST';
   ///     cliBase.logger.logger.level = Level.FINEST;
   /// ```
-  /// Throws an [IllegalArgumentException] if the parameters fail validation.
+  /// Throws an [ArgumentError] if the parameters fail validation.
   CLIBase(
       {required String atSign,
       required this.nameSpace,
-      required this.rootDomain,
-      required this.rootPort,
+      String? rootDomain,
+      AtRootDomain? atRootDomain,
       this.homeDir,
       this.verbose = false,
       this.atKeysFilePath,
@@ -220,17 +244,26 @@ class CLIBase {
     this.atSign = AtUtils.fixAtSign(atSign);
     if (homeDir == null) {
       if (atKeysFilePath == null) {
-        throw IllegalArgumentException(
+        throw ArgumentError(
             'homeDir must be provided when atKeysFilePath is not provided');
       }
       if (storageDir == null) {
-        throw IllegalArgumentException(
+        throw ArgumentError(
             'homeDir must be provided when storageDir is not provided');
       }
       if (downloadDir == null) {
-        throw IllegalArgumentException(
+        throw ArgumentError(
             'homeDir must be provided when downloadDir is not provided');
       }
+    }
+
+    if (atRootDomain != null) {
+      this.atRootDomain = atRootDomain;
+    } else if (rootDomain != null) {
+      this.atRootDomain = AtRootDomain.parse(rootDomain);
+    } else {
+      throw ArgumentError('You must supply either rootDomain (String)'
+          ' or atRootDomain (AtRootDomain)');
     }
 
     atKeysFilePathToUse =
@@ -276,8 +309,8 @@ class CLIBase {
       ..isLocalStoreRequired = true
       ..commitLogPath = '$localStoragePathToUse/commitLog'
           .replaceAll('/', Platform.pathSeparator)
-      ..rootDomain = rootDomain
-      ..rootPort = rootPort
+      ..rootDomain = atRootDomain.rootDomain
+      ..rootPort = atRootDomain.rootPort
       ..fetchOfflineNotifications = true
       ..atKeysFilePath = atKeysFilePathToUse
       ..passPhrase = passPhrase;

--- a/packages/at_cli_commons/pubspec.yaml
+++ b/packages/at_cli_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_cli_commons
 description: Library of useful stuff when building cli programs which use the AtClient SDK
-version: 3.0.0
+version: 3.0.1
 
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_cli_commons
 homepage: https://atsign.com


### PR DESCRIPTION
**- What I did**
- feat: Add support for legacy `-d` option. This will be added to the default CLIBase ArgParser but, if you wish to use `-d` for some other purpose in your program, you may specify `addLegacyRootDomainArg: false` when calling `CLIBase.fromCommandLineArgs` or `CLIBase.createArgsParser`
- feat: for better balance between backwards compatibility and forward-looking feature, removed the `rootPort` field from CLIBase; instead CLIBase constructor will accept *either* `rootDomain` (a String, backwards compatible) or `atRootDomain` (an AtRootDomain) and will set CLIBase.atRootDomain (an AtRootDomain) accordingly.
- feat: updated the example programs - one of them now sets `addLegacyRootDomainArg` to `true`, the other sets it to `false`. Also improved the example program code in a few other ways while I was there.

**- How I did it**
See diffs

**- How to verify it**
- Tests pass
- Verified via a NoPorts PR test run : See [e2e_all](https://github.com/atsign-foundation/noports/actions/runs/18258913559) and [unit_tests](https://github.com/atsign-foundation/noports/actions/runs/18258913536)
