### PR TITLE
fix: unrevoke should look for revoked status

### DIFF
--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -1049,7 +1049,7 @@ Future<void> unrevoke(ArgResults ar, AtClient atClient) async {
 
   Map toUnRevoke = await _fetchOrListAndFilter(
     atLookup,
-    EnrollmentStatus.approved.name, // must be status approved
+    EnrollmentStatus.revoked.name, // must be status revoked
     eId: ar[AuthCliArgs.argNameEnrollmentId],
     arx: ar[AuthCliArgs.argNameAppNameRegex],
     drx: ar[AuthCliArgs.argNameDeviceNameRegex],


### PR DESCRIPTION

**- What I did**
Fixed `unrevoke -D/-A` options
**- How I did it**
updated single line to only look up revoked status keys
**- How to verify it**
compile and tested by hand
**- Description for the changelog**
fix: unrevoke -D / -A now works per -h help