### PR TITLE
feat: add a flag that controls the AtRpc mutex

### DIFF
--- a/packages/at_client/lib/src/rpc/at_rpc.dart
+++ b/packages/at_client/lib/src/rpc/at_rpc.dart
@@ -301,7 +301,7 @@ class AtRpc {
   /// - sends an [AtRpcRespType.nack] response if deserialization or validation fails
   /// - sends an [AtRpcRespType.nack] response otherwise
   /// - Acquires session mutex if [enableRequestMutex] is true
-  /// - sends an [AtRpcRespType.nack] response if fails to acquire mutex
+  /// - sends an [AtRpcRespType.nack] response if mutex cannot be acquired
   /// - calls [AtRpcCallbacks.handleRequest]
   /// - calls [sendResponse] with the response from [AtRpcCallbacks.handleRequest]
   @visibleForTesting

--- a/packages/at_client/lib/src/rpc/at_rpc.dart
+++ b/packages/at_client/lib/src/rpc/at_rpc.dart
@@ -169,6 +169,13 @@ class AtRpc {
   final bool isClient;
   final bool isServer;
 
+  /// Enables the mutex in [handleRequestNotification] to ensure redundancy
+  /// handling across all services that use [AtRpc].
+  ///
+  /// When enabled, it prevents multiple [AtRpc] responses from being sent for
+  /// the same request.
+  final bool enableRequestMutex;
+
   AtRpc({
     required this.atClient,
     required this.baseNameSpace,
@@ -179,6 +186,7 @@ class AtRpc {
     this.allowAll = false,
     this.isClient = true,
     this.isServer = true,
+    this.enableRequestMutex = false,
   }) {
     if (!isClient && !isServer) {
       throw IllegalArgumentException('isClient or isServer must be true');
@@ -292,7 +300,7 @@ class AtRpc {
   /// - parses and validates
   /// - sends an [AtRpcRespType.nack] response if deserialization or validation fails
   /// - sends an [AtRpcRespType.nack] response otherwise
-  /// - tries to acquire mutex
+  /// - Acquires session mutex if [enableRequestMutex] is true
   /// - sends an [AtRpcRespType.nack] response if fails to acquire mutex
   /// - calls [AtRpcCallbacks.handleRequest]
   /// - calls [sendResponse] with the response from [AtRpcCallbacks.handleRequest]
@@ -358,9 +366,9 @@ class AtRpc {
       return;
     }
 
-    bool mutexAcquired =
+    bool mutexAcquired = enableRequestMutex &&
         await _tryAcquireSessionMutex(requestId, notification.to);
-    if (!mutexAcquired) {
+    if (enableRequestMutex && !mutexAcquired) {
       var message =
           'Ignoring request: could not acquire mutex for requestId $requestId';
       // send NACK


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Added a flag to AtRpc class called `enableRequestMutex` that defaults to false. It's immutable once set through the AtRpc constructor.
- This flag controls the changes made in https://github.com/atsign-foundation/at_client_sdk/pull/1692

**- How to verify it**
- Tests pass here
- Backwards Compatibility: 
   - NoPorts tests passing with this current branch as a dep override: [NoPort tests run](https://github.com/atsign-foundation/noports/pull/2260)
- Steps to manually test this in https://github.com/atsign-foundation/at_client_sdk/pull/1692

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: add a flag that controls the AtRpc mutex