### PR TITLE
chore: removed `@experimental` annotation from mature features.

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.9.1
+
+- chore: removed `@experimental` annotation from AtRpc and AtCollection
+- chore: added `// ignore: experimental_member_use` for usages of the 
+  still-experimental AtTelemetry
+
 ## 3.9.0
 
 - feat: introduce single-responder mode in AtRpc enabling redundancy support in

--- a/packages/at_client/lib/at_client.dart
+++ b/packages/at_client/lib/at_client.dart
@@ -1,12 +1,8 @@
 import 'package:meta/meta.dart';
 
-@experimental
 export 'package:at_client/src/at_collection/collections.dart';
-@experimental
 export 'package:at_client/src/at_collection/at_collection_model.dart';
-@experimental
 export 'package:at_client/src/at_collection/at_json_collection_model.dart';
-@experimental
 export 'package:at_client/src/at_collection/at_collection_model_factory.dart';
 export 'package:at_client/src/client/at_client_impl.dart';
 export 'package:at_client/src/client/at_client_spec.dart';
@@ -20,9 +16,7 @@ export 'package:at_client/src/manager/at_client_manager.dart';
 export 'package:at_client/src/preference/at_client_preference.dart';
 export 'package:at_client/src/response/at_notification.dart';
 export 'package:at_client/src/response/enrollment.dart';
-@experimental
 export 'package:at_client/src/rpc/at_rpc.dart';
-@experimental
 export 'package:at_client/src/rpc/at_rpc_types.dart';
 export 'package:at_client/src/service/enrollment_service.dart';
 export 'package:at_client/src/service/notification_service.dart';

--- a/packages/at_client/lib/src/at_collection/at_collection_model.dart
+++ b/packages/at_client/lib/src/at_collection/at_collection_model.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:at_client/src/at_collection/at_collection_model_factory.dart';
 import 'package:at_utils/at_utils.dart';
-import 'package:meta/meta.dart';
 import 'package:uuid/uuid.dart';
 import 'at_json_collection_model.dart';
 import 'collections.dart';
@@ -10,7 +9,6 @@ import 'impl/at_collection_operations_impl.dart';
 import 'impl/at_collection_query_operations_impl.dart';
 import 'impl/at_collection_stream_operations_impl.dart';
 
-@experimental
 abstract class AtCollectionModel<T> implements AtCollectionModelOperations {
   static final _logger = AtSignLogger('AtCollectionModel');
 

--- a/packages/at_client/lib/src/at_collection/at_collection_model_factory.dart
+++ b/packages/at_client/lib/src/at_collection/at_collection_model_factory.dart
@@ -1,7 +1,5 @@
 import 'package:at_client/src/at_collection/at_collection_model.dart';
-import 'package:meta/meta.dart';
 
-@experimental
 abstract class AtCollectionModelFactory<T extends AtCollectionModel> {
   /// Expected to return an instance of T
   T create();

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -261,11 +261,11 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
   /// Does nothing unless a telemetry service has been injected
   void _cascadeSetTelemetryService() {
-    if (telemetry != null) {
-      _encryptionService?.telemetry = telemetry;
-      _localSecondary?.telemetry = telemetry;
-      _remoteSecondary?.telemetry = telemetry;
-    }
+    // if (telemetry != null) {
+    //   _encryptionService?.telemetry = telemetry;
+    //   _localSecondary?.telemetry = telemetry;
+    //   _remoteSecondary?.telemetry = telemetry;
+    // }
   }
 
   Secondary getSecondary() {
@@ -316,13 +316,18 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   @override
   Future<bool> delete(AtKey atKey,
       {bool isDedicated = false, DeleteRequestOptions? deleteRequestOptions}) {
-    _telemetry?.controller.sink
-        .add(AtTelemetryEvent('AtClient.delete called', {"key": atKey}));
+    // ignore: experimental_member_use
+    _telemetry?.controller.sink.add(
+      AtTelemetryEvent('AtClient.delete called', {"key": atKey}),
+    );
     // ignore: no_leading_underscores_for_local_identifiers
     var _deleteResult =
         _delete(atKey, deleteRequestOptions: deleteRequestOptions);
-    _telemetry?.controller.sink.add(AtTelemetryEvent('AtClient.delete complete',
-        {"key": atKey, "_deleteResult": _deleteResult}));
+    // ignore: experimental_member_use
+    _telemetry?.controller.sink.add(
+      AtTelemetryEvent('AtClient.delete complete',
+          {"key": atKey, "_deleteResult": _deleteResult}),
+    );
     return _deleteResult;
   }
 
@@ -456,8 +461,10 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   @override
   Future<bool> put(AtKey atKey, dynamic value,
       {bool isDedicated = false, PutRequestOptions? putRequestOptions}) async {
-    _telemetry?.controller.sink
-        .add(AtTelemetryEvent('AtClient.put called', {"key": atKey}));
+    // ignore: experimental_member_use
+    _telemetry?.controller.sink.add(
+      AtTelemetryEvent('AtClient.put called', {"key": atKey}),
+    );
     // If the value is neither String nor List<int> throw exception
     if (value is! String && value is! List<int>) {
       throw AtValueException(
@@ -472,8 +479,10 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       atResponse =
           await putBinary(atKey, value, putRequestOptions: putRequestOptions);
     }
-    _telemetry?.controller.sink
-        .add(AtTelemetryEvent('AtClient.put complete', {"atKey": atKey}));
+    // ignore: experimental_member_use
+    _telemetry?.controller.sink.add(
+      AtTelemetryEvent('AtClient.put complete', {"atKey": atKey}),
+    );
     return atResponse.response.isNotEmpty;
   }
 

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -316,15 +316,15 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   @override
   Future<bool> delete(AtKey atKey,
       {bool isDedicated = false, DeleteRequestOptions? deleteRequestOptions}) {
-    // ignore: experimental_member_use
     _telemetry?.controller.sink.add(
+      // ignore: experimental_member_use
       AtTelemetryEvent('AtClient.delete called', {"key": atKey}),
     );
     // ignore: no_leading_underscores_for_local_identifiers
     var _deleteResult =
         _delete(atKey, deleteRequestOptions: deleteRequestOptions);
-    // ignore: experimental_member_use
     _telemetry?.controller.sink.add(
+      // ignore: experimental_member_use
       AtTelemetryEvent('AtClient.delete complete',
           {"key": atKey, "_deleteResult": _deleteResult}),
     );
@@ -461,8 +461,8 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   @override
   Future<bool> put(AtKey atKey, dynamic value,
       {bool isDedicated = false, PutRequestOptions? putRequestOptions}) async {
-    // ignore: experimental_member_use
     _telemetry?.controller.sink.add(
+      // ignore: experimental_member_use
       AtTelemetryEvent('AtClient.put called', {"key": atKey}),
     );
     // If the value is neither String nor List<int> throw exception
@@ -479,8 +479,8 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       atResponse =
           await putBinary(atKey, value, putRequestOptions: putRequestOptions);
     }
-    // ignore: experimental_member_use
     _telemetry?.controller.sink.add(
+      // ignore: experimental_member_use
       AtTelemetryEvent('AtClient.put complete', {"atKey": atKey}),
     );
     return atResponse.response.isNotEmpty;

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -27,9 +27,6 @@ class LocalSecondary implements Secondary {
         .getSecondaryKeyStore();
   }
 
-  @experimental
-  AtTelemetryService? telemetry;
-
   // temporarily cache enrollmentDetails until we store in local secondary
   @visibleForTesting
   Enrollment? enrollment;

--- a/packages/at_client/lib/src/client/remote_secondary.dart
+++ b/packages/at_client/lib/src/client/remote_secondary.dart
@@ -13,7 +13,6 @@ import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_utils/at_utils.dart';
 import 'package:internet_connection_checker/internet_connection_checker.dart';
-import 'package:meta/meta.dart';
 
 /// Contains methods used to execute verbs on remote secondary server of the atSign.
 class RemoteSecondary implements Secondary {
@@ -77,12 +76,8 @@ class RemoteSecondary implements Secondary {
     return clientConfig;
   }
 
-  @experimental
-  AtTelemetryService? telemetry;
-
   /// Executes the command returned by [VerbBuilder] build command on a remote secondary server.
   /// Optionally [privateKey] is passed for verb builders which require authentication.
-
   @override
   Future<String> executeVerb(VerbBuilder builder, {sync = false}) async {
     try {

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.9.0';
+  final String atClientVersion = '3.9.1';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/preference/at_client_particulars.dart
+++ b/packages/at_client/lib/src/preference/at_client_particulars.dart
@@ -1,8 +1,6 @@
 import 'package:at_client/src/client/remote_secondary.dart';
-import 'package:meta/meta.dart';
 import 'package:uuid/uuid.dart';
 
-@experimental
 class AtClientParticulars {
   final String _clientId = Uuid().v4();
 

--- a/packages/at_client/lib/src/preference/at_client_preference.dart
+++ b/packages/at_client/lib/src/preference/at_client_preference.dart
@@ -1,7 +1,6 @@
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/preference/at_client_particulars.dart';
-import 'package:meta/meta.dart';
 import 'package:version/version.dart';
 
 /// Class to hold attributes for client preferences.
@@ -102,7 +101,6 @@ class AtClientPreference {
   @Deprecated('Will be removed in next major version')
   Version atProtocolEmitted = Version(2, 0, 0);
 
-  @experimental
   AtClientParticulars atClientParticulars = AtClientParticulars();
 
   //signing algorithm to use for pkam authentication

--- a/packages/at_client/lib/src/rpc/at_rpc.dart
+++ b/packages/at_client/lib/src/rpc/at_rpc.dart
@@ -14,7 +14,6 @@ abstract class AtRpcCallbacks {
   Future<void> handleResponse(AtRpcResp response);
 }
 
-@experimental
 class AtRpcClient implements AtRpcCallbacks {
   static final AtSignLogger logger = AtSignLogger(' AtRpcClient ',
       loggingHandler: AtSignLogger.stdErrLoggingHandler);
@@ -105,7 +104,6 @@ class AtRpcClient implements AtRpcCallbacks {
 /// - Responder:
 /// ```
 /// ```
-@experimental
 class AtRpc {
   static final AtSignLogger logger = AtSignLogger('AtRpc');
 

--- a/packages/at_client/lib/src/service/encryption_service.dart
+++ b/packages/at_client/lib/src/service/encryption_service.dart
@@ -10,7 +10,6 @@ import 'package:at_client/src/util/encryption_util.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_utils/at_logger.dart';
-import 'package:meta/meta.dart';
 
 class EncryptionService {
   RemoteSecondary? remoteSecondary;
@@ -20,9 +19,6 @@ class EncryptionService {
   late final String atSign;
 
   late final AtSignLogger logger;
-
-  @experimental
-  AtTelemetryService? telemetry;
 
   EncryptionService(this.atSign) {
     logger = AtSignLogger('EncryptionService ($atSign)');

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.9.0
+version: 3.9.1
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.6.2
+
+- chore: remove `@experimental` annotation from `EnrollVerbBuilder.otp`
+
 ## 5.6.1
 
 - chore: fix lint from the new `strict_top_level_inference` rule

--- a/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:at_commons/src/enroll/enrollment.dart';
 import 'package:at_commons/src/verb/abstract_verb_builder.dart';
 import 'package:at_commons/src/verb/enroll_params.dart';
-import 'package:meta/meta.dart';
 
 import 'operation_enum.dart';
 
@@ -24,7 +23,6 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
   String? apkamPublicKey;
 
   /// otp for the enroll request. otp must be fetched from an already enrolled app.
-  @experimental
   String? otp;
 
   Map<String, String>? namespaces;

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.6.1
+version: 5.6.2
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
**- What I did**
- chore: removed `@experimental` annotation from mature features. (Retained the annotation for the 'Telemetry' feature.)
- Added `ignore` comments for places where experimental features are being used.
- build: updated pubspec and changelog for new versions of at_commons and at_client with the above changes included

**- How I did it**

**- How to verify it**
Analysis passes, tests pass

