### PR TITLE
fix: at_server_status: Make it work with atServer proxy services

### DIFF
--- a/packages/at_server_status/CHANGELOG.md
+++ b/packages/at_server_status/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- fix: Make this work properly with atServer proxy services
+
 ## 1.1.0
 
 - chore(deps): remove unused dependencies

--- a/packages/at_server_status/lib/at_status_impl.dart
+++ b/packages/at_server_status/lib/at_status_impl.dart
@@ -98,6 +98,7 @@ class AtStatusImpl implements AtServerStatus {
       // ignore: omit_local_variable_types
       AtLookupImpl atLookupImpl =
           AtLookupImpl(atSign!, _rootUrl!, _rootPort!);
+      await atLookupImpl.executeCommand('from:$atSign\n');
       await atLookupImpl.scan(auth: false).then((keysList) async {
         if (keysList.isNotEmpty) {
           if (keysList.contains(testKey)) {

--- a/packages/at_server_status/pubspec.yaml
+++ b/packages/at_server_status/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_status
 description: A Dart library that provides a means to check on the status of the @‎root server as well as the secondary server for any particular @‎sign.
-version: 1.1.0
+version: 1.1.1
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_server_status
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
**- What I did**
fix: at_server_status: AtStatusImpl: send a `from:` before doing a `scan:` so that it works with atServer proxy services

**- How to verify it**
- Tests pass
- Has been manually verified via a build of the NoPorts Desktop app
