### PR TITLE
fix: do not send nack when rpc request mutex not acquired + prep at_client v3.9.2 for release

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.2
+
+- fix: AtRpc - prevent NACK/ACK race when handling request mutex acquisition
+
 ## 3.9.1
 
 - chore: removed `@experimental` annotation from AtRpc and AtCollection

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.9.1';
+  final String atClientVersion = '3.9.2';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/rpc/at_rpc.dart
+++ b/packages/at_client/lib/src/rpc/at_rpc.dart
@@ -367,11 +367,8 @@ class AtRpc {
     bool mutexAcquired = enableRequestMutex &&
         await _tryAcquireSessionMutex(requestId, notification.to);
     if (enableRequestMutex && !mutexAcquired) {
-      var message =
-          'Ignoring request: could not acquire mutex for requestId $requestId';
-      // send NACK
-      await sendResponse(notification, request,
-          AtRpcResp.nack(request: request, message: message));
+      logger.shout(
+          'Ignoring request: could not acquire mutex for requestId $requestId');
       return;
     }
 

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.9.1
+version: 3.9.2
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Prevent a NACK/ACK race when running multiple parallel instances of AtRpc.
- In this case: Having multiple Policy Servers running, and when one of the Policy Servers sends a NACK(because it was unable to acquire the mutex), before the Policy Server that acquired the mutex sends an ACK, the ACK is being ignored as the NACK completed the future.
- Also update at_client version to v3.9.2 preparing it for release.

**- How I did it**
- removed the code that sends the NACK, always ensuring only a single responder

**- How to verify it**
- Tests pass here
- Manually:
   - Run two Policy Servers with the same atsign(e.g. @policy), and pass this atsign to noports daemon(e.g. @daemon)
   - Allow a third atsign (e.g. @np_client) to connect to the daemon through the Policy
   - Try to connect @np_client to the daemon, and this should work

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: do not send nack when the AtRpc request mutex is not acquired