### PR TITLE
build(deps): Updated archive dependency to ^4.0.7

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.9.3
+
+- build(deps): Updated archive dependency to ^4.0.7
+
 ## 3.9.2
 
 - fix: AtRpc - prevent NACK/ACK race when handling request mutex acquisition

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.9.2';
+  final String atClientVersion = '3.9.3';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -23,6 +23,7 @@ dependencies:
   encrypt: ^5.0.3
   cron: ^0.5.1
   uuid: ^4.0.0
+  archive: ^4.0.7
   http: ^1.2.1
   internet_connection_checker: ^1.0.0+1
   async: ^2.9.0

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.9.2
+version: 3.9.3
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 
@@ -23,7 +23,7 @@ dependencies:
   encrypt: ^5.0.3
   cron: ^0.5.1
   uuid: ^4.0.0
-  archive: ^3.6.1
+  archive: ^4.0.7
   http: ^1.2.1
   internet_connection_checker: ^1.0.0+1
   async: ^2.9.0

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   encrypt: ^5.0.3
   cron: ^0.5.1
   uuid: ^4.0.0
-  archive: ^4.0.7
   http: ^1.2.1
   internet_connection_checker: ^1.0.0+1
   async: ^2.9.0

--- a/packages/at_client_mobile/pubspec.yaml
+++ b/packages/at_client_mobile/pubspec.yaml
@@ -9,9 +9,6 @@ environment:
   sdk: ^3.6.0
 resolution: workspace
 
-dependency_overrides:
-  archive: ^4.0.7
-
 dependencies:
   flutter:
     sdk: flutter

--- a/packages/at_client_mobile/pubspec.yaml
+++ b/packages/at_client_mobile/pubspec.yaml
@@ -9,6 +9,9 @@ environment:
   sdk: ^3.6.0
 resolution: workspace
 
+dependency_overrides:
+  archive: ^4.0.7
+
 dependencies:
   flutter:
     sdk: flutter

--- a/packages/at_onboarding_flutter/lib/screen/at_onboarding_home_screen.dart
+++ b/packages/at_onboarding_flutter/lib/screen/at_onboarding_home_screen.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+// ignore: depend_on_referenced_packages
 import 'package:archive/archive.dart';
 import 'package:at_client_mobile/at_client_mobile.dart';
 import 'package:at_onboarding_flutter/at_onboarding_result.dart';

--- a/packages/at_onboarding_flutter/pubspec.yaml
+++ b/packages/at_onboarding_flutter/pubspec.yaml
@@ -12,9 +12,6 @@ environment:
   flutter: ">=3.29.2"
 resolution: workspace
 
-dependency_overrides:
-  archive: ^4.0.7
-
 dependencies:
   archive: ^4.0.7
   at_backupkey_flutter: ^4.0.18

--- a/packages/at_onboarding_flutter/pubspec.yaml
+++ b/packages/at_onboarding_flutter/pubspec.yaml
@@ -12,6 +12,9 @@ environment:
   flutter: ">=3.29.2"
 resolution: workspace
 
+dependency_overrides:
+  archive: ^4.0.7
+
 dependencies:
   archive: ^4.0.7
   at_backupkey_flutter: ^4.0.18

--- a/packages/at_onboarding_flutter/pubspec.yaml
+++ b/packages/at_onboarding_flutter/pubspec.yaml
@@ -13,7 +13,6 @@ environment:
 resolution: workspace
 
 dependencies:
-  archive: ^4.0.7
   at_backupkey_flutter: ^4.0.18
   at_client_mobile: ^3.3.0
   at_server_status: ^1.0.4

--- a/packages/at_onboarding_flutter/pubspec.yaml
+++ b/packages/at_onboarding_flutter/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 resolution: workspace
 
 dependencies:
-  archive: ^3.4.10
+  archive: ^4.0.7
   at_backupkey_flutter: ^4.0.18
   at_client_mobile: ^3.3.0
   at_server_status: ^1.0.4

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   flutter:
     sdk: flutter
   # normal dependencies
+  archive: ^4.0.7
   args: ^2.6.0
   asn1lib: ^1.5.3
   async: ^2.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
   flutter:
     sdk: flutter
   # normal dependencies
-  archive: ^3.6.1
+  archive: ^4.0.7
   args: ^2.6.0
   asn1lib: ^1.5.3
   async: ^2.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,7 +45,6 @@ dependencies:
   flutter:
     sdk: flutter
   # normal dependencies
-  archive: ^4.0.7
   args: ^2.6.0
   asn1lib: ^1.5.3
   async: ^2.9.0


### PR DESCRIPTION
**- What I did**
Upgrade dependency on archive package to ^4.0.7

**- How I did it**
With difficulty, muttering curses to myself. See commits.

**- How to verify it**
Tests pass.

Note 1: the archive package is used in a couple of the at_tools packages but not in conjunction with at_client so there is no dependency clash there.

Note 2: Why am I doing this? Because I wanted to use the archive package in `noports` and noticed we're not using latest major version of `archive` here in at_client