### PR TITLE
chore: update versions of packages affected by at_auth 3.0.0

### DIFF
--- a/packages/at_auth/README.md
+++ b/packages/at_auth/README.md
@@ -13,7 +13,7 @@ Package for onboarding and authentication to an atsign's secondary server
 
 Onboard an atsign
 ```dart
-final atAuth = AtAuthCreate();
+final atAuth = AtAuth.create();
 final atOnboardingRequest = AtOnboardingRequest('@alice')
   ..rootDomain = AtRootDomain('vip.ve.atsign.zone', 64)
   ..appName = 'wavi'

--- a/packages/at_auth/README.md
+++ b/packages/at_auth/README.md
@@ -13,10 +13,9 @@ Package for onboarding and authentication to an atsign's secondary server
 
 Onboard an atsign
 ```dart
-final atAuth = AtAuthImpl();
+final atAuth = AtAuthCreate();
 final atOnboardingRequest = AtOnboardingRequest('@alice')
-  ..rootDomain = 'vip.ve.atsign.zone'
-  ..enableEnrollment = true
+  ..rootDomain = AtRootDomain('vip.ve.atsign.zone', 64)
   ..appName = 'wavi'
   ..deviceName = 'iphone';
 final atOnboardingResponse = await atAuth.onboard(atOnboardingRequest, <cram_secret>);
@@ -24,9 +23,9 @@ final atOnboardingResponse = await atAuth.onboard(atOnboardingRequest, <cram_sec
 
 Authenticate an atsign
 ```dart
-final atAuth = AtAuthImpl();
+final atAuth = AtAuth.create();
 final atAuthRequest = AtAuthRequest('@alice')
-    ..rootDomain = 'vip.ve.atsign.zone'
+    ..rootDomain = AtRootDomain('vip.ve.atsign.zone', 64)
     ..atKeysFilePath = args[1];
 final atAuthResponse = await atAuth.authenticate(atAuthRequest);
 ```

--- a/packages/at_auth/lib/src/keys/at_keys_io_impl.dart
+++ b/packages/at_auth/lib/src/keys/at_keys_io_impl.dart
@@ -50,8 +50,8 @@ class FileAtKeysIo extends WrittenAtKeysIo {
   }
 }
 
-/// Taken from at_cli_commons, but I can't import it due to circular dependencies
-/// at_cli_commons depends on at_onboarding_cli....
+// Taken from at_cli_commons, but I can't import it due to circular dependencies
+// at_cli_commons depends on at_onboarding_cli....
 String getDefaultAtKeysFilePath(String homeDirectory, String atSign) {
   return '$homeDirectory/.atsign/keys/${atSign}_key.atKeys'
       .replaceAll('/', Platform.pathSeparator);

--- a/packages/at_auth/lib/src/keys/at_keys_io_impl.dart
+++ b/packages/at_auth/lib/src/keys/at_keys_io_impl.dart
@@ -4,8 +4,6 @@ import 'dart:io';
 import 'package:meta/meta.dart';
 
 import 'package:at_commons/at_commons.dart';
-import 'package:at_cli_commons/at_cli_commons.dart'
-    show getDefaultAtKeysFilePath, getHomeDirectory;
 import 'package:at_auth/src/keys/at_keys.dart';
 import 'package:at_auth/src/keys/at_keys_io.dart';
 
@@ -52,5 +50,40 @@ class FileAtKeysIo extends WrittenAtKeysIo {
   }
 }
 
-//TODO: future add simAtKeysIo
-// class SimAtKeysIo extends GeneratedAtKeysIo with KeyIOMixin {
+/// Taken from at_cli_commons, but I can't import it due to circular dependencies
+/// at_cli_commons depends on at_onboarding_cli....
+String getDefaultAtKeysFilePath(String homeDirectory, String atSign) {
+  return '$homeDirectory/.atsign/keys/${atSign}_key.atKeys'
+      .replaceAll('/', Platform.pathSeparator);
+}
+
+
+String? getHomeDirectory({bool throwIfNull = false}) {
+  String? homeDir;
+  switch (Platform.operatingSystem) {
+    case 'linux':
+    case 'macos':
+      homeDir = Platform.environment['HOME'];
+      break;
+
+    case 'windows':
+      homeDir = Platform.environment['USERPROFILE'];
+      break;
+
+    case 'android':
+      // Probably want internal storage.
+      homeDir = '/storage/sdcard0';
+      break;
+
+    case 'ios':
+    // iOS doesn't really have a home directory.
+    case 'fuchsia':
+    // I have no idea.
+    default:
+      homeDir = null;
+  }
+  if (throwIfNull && homeDir == null) {
+    throw ('\nUnable to determine your home directory: please set environment variable\n\n');
+  }
+  return homeDir;
+}

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 2.4.0
+version: 3.0.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -10,10 +10,9 @@ environment:
 resolution: workspace
 
 dependencies:
-  at_cli_commons: ^3.0.1
   at_server_status: ^1.1.0
-  at_commons: ^5.5.0
-  at_lookup: ^3.0.49
+  at_commons: ^5.7.0
+  at_lookup: ^3.4.2
   at_chops: ^3.0.0
   at_utils: ^3.0.19
   crypton: ^2.2.1

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.9.3';
+  final String atClientVersion = '3.10.0';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.9.3
+version: 3.10.0
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 
@@ -28,11 +28,11 @@ dependencies:
   internet_connection_checker: ^1.0.0+1
   async: ^2.9.0
   at_base2e15: ^1.0.0
-  at_commons: ^5.5.0
+  at_commons: ^5.7.0
   at_utils: ^3.2.0
   at_chops: ^3.0.0
   at_lookup: ^3.1.0
-  at_auth: ^2.2.0
+  at_auth: ^3.0.0
   at_persistence_secondary_server: ^4.2.0
   meta: ^1.16.0
   version: ^3.0.2

--- a/packages/at_client_flutter/example/lib/main.dart
+++ b/packages/at_client_flutter/example/lib/main.dart
@@ -1,12 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:at_client_flutter/src/widgets/atsign_rootdomain_dialog.dart';
-import 'package:at_client_flutter/src/services/registrar_service.dart';
-import 'package:at_client_flutter/src/widgets/registrar_cram_dialog.dart';
-import 'package:at_client_flutter/src/keychain/keychain_storage.dart';
-import 'package:at_client_flutter/src/widgets/pkam_dialog.dart';
-import 'package:at_client_flutter/src/widgets/cram_dialog.dart';
-import 'package:at_client_flutter/src/widgets/file_picker.dart';
-import 'package:at_client_flutter/src/keychain/keychain_io_impl.dart';
+import 'package:at_client_flutter/at_client_flutter.dart';
 import 'package:at_auth/at_auth.dart';
 
 void main() {

--- a/packages/at_client_flutter/example/pubspec.yaml
+++ b/packages/at_client_flutter/example/pubspec.yaml
@@ -32,28 +32,21 @@ dependencies:
     sdk: flutter
   at_client_flutter:
     path: ../
-  
-
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
 
 dependency_overrides:
-  at_chops:
-    path: ../../at_chops
-  at_client:
-    path: ../../at_client
   at_auth:
-    path: ../../at_auth
+    path: ../../at_auth/
   at_lookup:
-    path: ../../at_lookup
+    path: ../../at_lookup/
   at_commons:
-    path: ../../at_commons
-  at_utils:
-    path: ../../at_utils
-  at_onboarding_cli:
-    path: ../../at_onboarding_cli 
-
+    path: ../../at_commons/
+  at_chops:
+    path: ../../at_chops/
+  at_client:
+    path: ../../at_client/
 
 dev_dependencies:
   flutter_test:

--- a/packages/at_client_flutter/lib/at_client_flutter.dart
+++ b/packages/at_client_flutter/lib/at_client_flutter.dart
@@ -9,3 +9,11 @@ export 'src/keychain/keychain_io_impl.dart';
 
 export 'src/services/auth_service.dart';
 export 'src/services/enrollment_service.dart';
+
+export 'src/widgets/atsign_rootdomain_dialog.dart';
+export 'src/widgets/cram_dialog.dart';
+export 'src/widgets/pkam_dialog.dart';
+export 'src/widgets/registrar_cram_dialog.dart';
+export 'src/widgets/file_picker.dart';
+export 'src/widgets/shared/loading.dart';
+export 'src/widgets/shared/typable_dropdown.dart';

--- a/packages/at_client_flutter/pubspec.yaml
+++ b/packages/at_client_flutter/pubspec.yaml
@@ -20,9 +20,9 @@ dependencies:
   at_commons: ^5.5.0
   at_utils: ^3.0.19
   at_chops: ^3.0.0
-  at_lookup: ^3.0.51
-  at_client: ^3.7.0
-  at_auth: ^2.1.0
+  at_lookup: ^3.4.2
+  at_client: ^3.10.0
+  at_auth: ^3.0.0
   encrypt: ^5.0.3
   at_persistence_secondary_server: ^4.2.0
   flutter_riverpod: ^3.0.0

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.6.2
+version: 5.7.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.4.1
+version: 3.4.2
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_lookup
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -13,7 +13,7 @@ dependencies:
   crypton: ^2.2.1
   crypto: ^3.0.5
   at_utils: ^3.0.19
-  at_commons: ^5.5.0
+  at_commons: ^5.7.0
   mutex: ^3.0.0
   meta: ^1.16.0
   at_chops: ^3.0.0

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tools for initial client onboarding, subsequent client enrollment, and enrollment management.
-version: 1.14.1
+version: 1.15.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -22,11 +22,11 @@ dependencies:
   meta: ^1.16.0
   path: ^1.9.0
   zxing2: ^0.2.0
-  at_auth: ^2.3.0
+  at_auth: ^3.0.0
   at_chops: ^3.0.0
-  at_client: ^3.7.0
+  at_client: ^3.10.0
   at_commons: ^5.6.0
-  at_lookup: ^3.0.52
+  at_lookup: ^3.4.2
   at_server_status: ^1.0.5
   at_utils: ^3.2.0
   duration: ^4.0.3

--- a/tests/at_end2end_test/pubspec.yaml
+++ b/tests/at_end2end_test/pubspec.yaml
@@ -11,8 +11,8 @@ resolution: workspace
 
 dependencies:
   at_demo_data: ^1.2.0
-  at_auth: ^2.3.0
-  at_client: ^3.7.0
+  at_auth: ^3.0.0
+  at_client: ^3.10.0
   at_utils: ^3.2.0
 
 dev_dependencies:

--- a/tests/at_functional_test/pubspec.yaml
+++ b/tests/at_functional_test/pubspec.yaml
@@ -12,9 +12,9 @@ dependencies:
   at_demo_data: ^1.2.0
   crypto: ^3.0.5
   crypton: ^2.2.1
-  at_client: ^3.7.0
-  at_auth: ^2.2.0
-  at_lookup: ^3.0.52
+  at_client: ^3.10.0
+  at_auth: ^3.0.0
+  at_lookup: ^3.4.2
   at_utils: ^3.2.0
   at_chops: ^3.0.0
   at_commons: ^5.5.0

--- a/tests/at_onboarding_cli_functional_tests/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests/pubspec.yaml
@@ -8,8 +8,8 @@ environment:
 resolution: workspace
 
 dependencies:
-  at_lookup: ^3.0.49
-  at_client: ^3.7.0
+  at_lookup: ^3.4.2
+  at_client: ^3.10.0
   at_commons: ^5.5.0
   at_demo_data: ^1.2.0
 

--- a/tests/at_onboarding_cli_functional_tests_proxy/pubspec.yaml
+++ b/tests/at_onboarding_cli_functional_tests_proxy/pubspec.yaml
@@ -9,8 +9,7 @@ resolution: workspace
 
 dependencies:
   at_demo_data: ^1.2.0
-  at_onboarding_cli:
-    path: ../../packages/at_onboarding_cli
+  at_onboarding_cli: ^1.15.0
   uuid: ^4.5.1
 
 dev_dependencies:


### PR DESCRIPTION
**- What I did**
 - at_auth 3.0.0
 - at_lookup 3.4.2
 - at_client 3.10.0
 - at_commons 3.7.0
 - at_onboarding_cli 1.15.0
 
 - at_auth had a circular dependency with at_cli_commons and has been removed.
 - update deps in tests
 
**- How I did it**

**- How to verify it**

**- Description for the changelog**
deps: update versions of packages affected by at_auth 3.0.0
