### PR TITLE
feat: at_client: Add RemoteLocalPref enum and AtClientPreference.remoteLocalPref field

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 3.9.3
+## 3.10.0
 
 - build(deps): Updated archive dependency to ^4.0.7
+- feat: Add RemoteLocalPref enum and AtClientPreference.remoteLocalPref field
+  to enable apps to easily default to using the remote atServer
 
 ## 3.9.2
 

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -345,12 +345,8 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   Future<String?> executeVerb(
       VerbBuilder builder, RemoteLocalPref prefForOp) async {
     switch (prefForOp) {
-      case RemoteLocalPref.localFirst:
+      case RemoteLocalPref.localOnly:
         return await localSecondary!.executeVerb(builder, sync: true);
-      case RemoteLocalPref.remoteFirst:
-        var retVal = await _remoteSecondary!.executeVerb(builder);
-        await localSecondary!.executeVerb(builder);
-        return retVal;
       case RemoteLocalPref.remoteOnly:
         return await _remoteSecondary!.executeVerb(builder);
     }

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -27,7 +27,6 @@ import 'package:at_client/src/transformer/response_transformer/get_response_tran
 import 'package:at_client/src/transformer/response_transformer/put_response_transformer.dart';
 import 'package:at_client/src/util/at_client_validation.dart';
 import 'package:at_client/src/util/constants.dart';
-import 'package:at_client/src/util/sync_util.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
@@ -46,9 +45,9 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
   AtClientPreference? get preference => _preference;
   late final String _atSign;
-  String? _namespace;
   SecondaryKeyStore? _localSecondaryKeyStore;
-  LocalSecondary? _localSecondary;
+  @visibleForTesting
+  LocalSecondary? localSecondary;
   RemoteSecondary? _remoteSecondary;
   AtClientCommitLogCompaction? _atClientCommitLogCompaction;
   AtClientConfig? _atClientConfig;
@@ -188,7 +187,6 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     _logger = AtSignLogger('AtClientImpl ($_atSign)');
     _preference = preference;
     _preference?.namespace ??= namespace;
-    _namespace = namespace;
     _atClientManager = atClientManager;
     _localSecondaryKeyStore = localSecondaryKeyStore;
 
@@ -210,7 +208,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
         await storageManager.init(_atSign, preference!.keyStoreSecret);
       }
 
-      _localSecondary = LocalSecondary(this, keyStore: _localSecondaryKeyStore);
+      localSecondary = LocalSecondary(this, keyStore: _localSecondaryKeyStore);
       _atChops ??= await _createAtChops(_atSign);
     }
 
@@ -224,7 +222,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     // Using ??= because we may be injecting an EncryptionService
     _encryptionService ??= EncryptionService(_atSign);
     _encryptionService!.remoteSecondary = _remoteSecondary;
-    _encryptionService!.localSecondary = _localSecondary;
+    _encryptionService!.localSecondary = localSecondary;
 
     putRequestTransformer.atClient = this;
 
@@ -268,16 +266,9 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     // }
   }
 
-  Secondary getSecondary() {
-    if (_preference!.isLocalStoreRequired) {
-      return _localSecondary!;
-    }
-    return _remoteSecondary!;
-  }
-
   @override
   LocalSecondary? getLocalSecondary() {
-    return _localSecondary;
+    return localSecondary;
   }
 
   @override
@@ -293,7 +284,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   Future<bool> persistPrivateKey(String privateKey) async {
     var atData = AtData();
     atData.data = privateKey.toString();
-    await _localSecondary!.keyStore!.put(AtConstants.atPkamPrivateKey, atData);
+    await localSecondary!.keyStore!.put(AtConstants.atPkamPrivateKey, atData);
     return true;
   }
 
@@ -333,6 +324,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
   Future<bool> _delete(AtKey atKey,
       {DeleteRequestOptions? deleteRequestOptions}) async {
+    deleteRequestOptions ??= DeleteRequestOptions();
     atKey.sharedBy ??= _atSign;
     // When namespace is not set in AtKey.namespace, default it to namespace from
     // AtClientPreferences
@@ -340,19 +332,35 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       atKey.namespace ??= preference?.namespace;
     }
     var builder = DeleteVerbBuilder()..atKey = atKey;
-    var secondary = getSecondary();
-    if (deleteRequestOptions != null &&
-        deleteRequestOptions.useRemoteAtServer) {
-      secondary = getRemoteSecondary()!;
-    }
-    var deleteResult = await secondary.executeVerb(builder, sync: true);
+
+    var deleteResult = await executeVerb(
+        builder,
+        SecondaryManager.getRemoteLocalPrefForOp(
+          deleteRequestOptions.useRemoteAtServer,
+          preference?.remoteLocalPref,
+        ));
 
     return deleteResult != null;
+  }
+
+  Future<String?> executeVerb(
+      VerbBuilder builder, RemoteLocalPref prefForOp) async {
+    switch (prefForOp) {
+      case RemoteLocalPref.localFirst:
+        return await localSecondary!.executeVerb(builder, sync: true);
+      case RemoteLocalPref.remoteFirst:
+        var retVal = await _remoteSecondary!.executeVerb(builder);
+        await localSecondary!.executeVerb(builder);
+        return retVal;
+      case RemoteLocalPref.remoteOnly:
+        return await _remoteSecondary!.executeVerb(builder);
+    }
   }
 
   @override
   Future<AtValue> get(AtKey atKey,
       {bool isDedicated = false, GetRequestOptions? getRequestOptions}) async {
+    getRequestOptions ??= GetRequestOptions();
     Secondary? secondary;
     try {
       // validate the get request.
@@ -361,10 +369,16 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       var verbBuilder = GetRequestTransformer(this)
           .transform(atKey, requestOptions: getRequestOptions);
       // Execute the verb.
-      if (getRequestOptions?.useRemoteAtServer == true) {
+      if (getRequestOptions.useRemoteAtServer) {
         secondary = getRemoteSecondary()!;
       } else {
-        secondary = SecondaryManager.getSecondary(this, verbBuilder);
+        secondary = SecondaryManager.getSecondary(
+            this,
+            verbBuilder,
+            SecondaryManager.getRemoteLocalPrefForOp(
+              getRequestOptions.useRemoteAtServer,
+              preference?.remoteLocalPref,
+            ));
       }
       var getResponse = await secondary.executeVerb(verbBuilder);
       // Return empty value if getResponse is null.
@@ -405,7 +419,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     bool showHiddenKeys = false,
     bool useRemoteAtServer = false,
   }) async {
-    var builder = ScanVerbBuilder()
+    var scanBuilder = ScanVerbBuilder()
       ..sharedWith = sharedWith
       ..sharedBy = sharedBy
       ..regex = regex
@@ -415,10 +429,16 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     if (useRemoteAtServer) {
       secondary = getRemoteSecondary()!;
     } else {
-      secondary = SecondaryManager.getSecondary(this, builder);
+      secondary = SecondaryManager.getSecondary(
+          this,
+          scanBuilder,
+          SecondaryManager.getRemoteLocalPrefForOp(
+            useRemoteAtServer,
+            preference?.remoteLocalPref,
+          ));
     }
 
-    var scanResult = await secondary.executeVerb(builder);
+    var scanResult = await secondary.executeVerb(scanBuilder);
     scanResult = _formatResult(scanResult);
     var result = [];
     if (scanResult.isNotEmpty) {
@@ -527,6 +547,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
   Future<AtResponse> _putInternal(
       AtKey atKey, dynamic value, PutRequestOptions? putRequestOptions) async {
+    putRequestOptions ??= PutRequestOptions();
     // Performs the put request validations.
     AtClientValidation.validatePutRequest(atKey, value, preference!);
     // Set sharedBy to currentAtSign if not set.
@@ -573,30 +594,28 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     //Get encryptionPrivateKey for public key to signData
     String? encryptionPrivateKey;
     if (atKey.metadata.isPublic == true) {
-      encryptionPrivateKey = await _localSecondary?.getEncryptionPrivateKey();
+      encryptionPrivateKey = await localSecondary?.getEncryptionPrivateKey();
     }
     // Transform put request
     // Optionally passing encryption private key to sign the public data.
-    UpdateVerbBuilder verbBuilder = await putRequestTransformer.transform(tuple,
+    UpdateVerbBuilder putBuilder = await putRequestTransformer.transform(tuple,
         encryptionPrivateKey: encryptionPrivateKey,
         requestOptions: putRequestOptions);
     // Validate the size of the value after encryption/encoding
     // Since AtClientPreference is mandatory argument in create method, _preference
     // will not be null.
-    if (verbBuilder.value.length > _preference!.maxDataSize) {
+    if (putBuilder.value.length > _preference!.maxDataSize) {
       throw BufferOverFlowException(
           'The length of value exceeds the maximum allowed length. Maximum buffer size is ${_preference!.maxDataSize} bytes. Found ${value.toString().length} bytes');
     }
 
-    Secondary secondary = SecondaryManager.getSecondary(this, verbBuilder);
-    if (putRequestOptions != null && putRequestOptions.useRemoteAtServer) {
-      secondary = getRemoteSecondary()!;
-    }
-    // DO NOT sync local keys to server
-    bool shouldSync = atKey.isLocal ? false : SyncUtil.shouldSync(atKey.key);
+    var putResponse = await executeVerb(
+        putBuilder,
+        SecondaryManager.getRemoteLocalPrefForOp(
+          putRequestOptions.useRemoteAtServer,
+          preference?.remoteLocalPref,
+        ));
 
-    var putResponse =
-        await secondary.executeVerb(verbBuilder, sync: shouldSync);
     // If putResponse is null or empty, return AtResponse with isError set to true
     if (putResponse == null || putResponse.isEmpty) {
       return AtResponse()..isError = true;
@@ -630,28 +649,21 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   }
 
   @override
-  Future<bool> putMeta(AtKey atKey) async {
-    var updateKey = atKey.key;
-    var metadata = atKey.metadata;
-    if (metadata.namespaceAware) {
-      updateKey = _getKeyWithNamespace(atKey.key);
-    }
+  Future<bool> putMeta(AtKey atKey,
+      {PutRequestOptions? putRequestOptions}) async {
+    putRequestOptions ??= PutRequestOptions();
     var builder = UpdateVerbBuilder();
     builder
       ..atKey = atKey
       ..operation = AtConstants.updateMeta;
 
-    var updateMetaResult = await getSecondary()
-        .executeVerb(builder, sync: SyncUtil.shouldSync(updateKey));
+    var updateMetaResult = await executeVerb(
+        builder,
+        SecondaryManager.getRemoteLocalPrefForOp(
+          putRequestOptions.useRemoteAtServer,
+          preference?.remoteLocalPref,
+        ));
     return updateMetaResult != null;
-  }
-
-  String _getKeyWithNamespace(String key) {
-    var keyWithNamespace = key;
-    if (_namespace != null && _namespace!.isNotEmpty) {
-      keyWithNamespace = '$keyWithNamespace.$_namespace';
-    }
-    return keyWithNamespace;
   }
 
   String? getOperation(dynamic value, Metadata? data) {
@@ -690,9 +702,9 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     AtPkamKeyPair? atPkamKeyPair;
     try {
       var encryptionPublicKey =
-          await _localSecondary!.getEncryptionPublicKey(atSign);
+          await localSecondary!.getEncryptionPublicKey(atSign);
       var encryptionPrivateKey =
-          await _localSecondary!.getEncryptionPrivateKey();
+          await localSecondary!.getEncryptionPrivateKey();
       if (encryptionPublicKey != null && encryptionPrivateKey != null) {
         atEncryptionKeyPair = AtEncryptionKeyPair.create(
             encryptionPublicKey, encryptionPrivateKey);
@@ -702,8 +714,8 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
           '_createAtChops  - Exception while getting encryption key pair from local secondary: ${e.toString()}');
     }
     try {
-      var pkamPublicKey = await _localSecondary!.getPkamPublicKey();
-      var pkamPrivateKey = await _localSecondary!.getPkamPrivateKey();
+      var pkamPublicKey = await localSecondary!.getPkamPublicKey();
+      var pkamPrivateKey = await localSecondary!.getPkamPrivateKey();
 
       if (pkamPublicKey != null && pkamPrivateKey != null) {
         atPkamKeyPair = AtPkamKeyPair.create(pkamPublicKey, pkamPrivateKey);

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -324,7 +324,6 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
   Future<bool> _delete(AtKey atKey,
       {DeleteRequestOptions? deleteRequestOptions}) async {
-    deleteRequestOptions ??= DeleteRequestOptions();
     atKey.sharedBy ??= _atSign;
     // When namespace is not set in AtKey.namespace, default it to namespace from
     // AtClientPreferences
@@ -336,7 +335,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     var deleteResult = await executeVerb(
         builder,
         SecondaryManager.getRemoteLocalPrefForOp(
-          deleteRequestOptions.useRemoteAtServer,
+          deleteRequestOptions?.useRemoteAtServer,
           preference?.remoteLocalPref,
         ));
 
@@ -360,7 +359,6 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   @override
   Future<AtValue> get(AtKey atKey,
       {bool isDedicated = false, GetRequestOptions? getRequestOptions}) async {
-    getRequestOptions ??= GetRequestOptions();
     Secondary? secondary;
     try {
       // validate the get request.
@@ -369,14 +367,14 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       var verbBuilder = GetRequestTransformer(this)
           .transform(atKey, requestOptions: getRequestOptions);
       // Execute the verb.
-      if (getRequestOptions.useRemoteAtServer) {
+      if (getRequestOptions?.useRemoteAtServer == true) {
         secondary = getRemoteSecondary()!;
       } else {
         secondary = SecondaryManager.getSecondary(
             this,
             verbBuilder,
             SecondaryManager.getRemoteLocalPrefForOp(
-              getRequestOptions.useRemoteAtServer,
+              getRequestOptions?.useRemoteAtServer,
               preference?.remoteLocalPref,
             ));
       }
@@ -417,7 +415,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     String? sharedBy,
     String? sharedWith,
     bool showHiddenKeys = false,
-    bool useRemoteAtServer = false,
+    bool? useRemoteAtServer,
   }) async {
     var scanBuilder = ScanVerbBuilder()
       ..sharedWith = sharedWith
@@ -426,7 +424,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       ..showHiddenKeys = showHiddenKeys
       ..auth = true;
     Secondary secondary;
-    if (useRemoteAtServer) {
+    if (useRemoteAtServer == true) {
       secondary = getRemoteSecondary()!;
     } else {
       secondary = SecondaryManager.getSecondary(
@@ -453,7 +451,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     String? sharedBy,
     String? sharedWith,
     bool showHiddenKeys = false,
-    bool useRemoteAtServer = false,
+    bool? useRemoteAtServer,
   }) async {
     var getKeysResult = await getKeys(
       regex: regex,
@@ -547,7 +545,6 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
   Future<AtResponse> _putInternal(
       AtKey atKey, dynamic value, PutRequestOptions? putRequestOptions) async {
-    putRequestOptions ??= PutRequestOptions();
     // Performs the put request validations.
     AtClientValidation.validatePutRequest(atKey, value, preference!);
     // Set sharedBy to currentAtSign if not set.
@@ -612,7 +609,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     var putResponse = await executeVerb(
         putBuilder,
         SecondaryManager.getRemoteLocalPrefForOp(
-          putRequestOptions.useRemoteAtServer,
+          putRequestOptions?.useRemoteAtServer,
           preference?.remoteLocalPref,
         ));
 
@@ -651,7 +648,6 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   @override
   Future<bool> putMeta(AtKey atKey,
       {PutRequestOptions? putRequestOptions}) async {
-    putRequestOptions ??= PutRequestOptions();
     var builder = UpdateVerbBuilder();
     builder
       ..atKey = atKey
@@ -660,7 +656,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     var updateMetaResult = await executeVerb(
         builder,
         SecondaryManager.getRemoteLocalPrefForOp(
-          putRequestOptions.useRemoteAtServer,
+          putRequestOptions?.useRemoteAtServer,
           preference?.remoteLocalPref,
         ));
     return updateMetaResult != null;

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -174,7 +174,7 @@ abstract class AtClient {
   ///   putMeta(key);
   /// ```
   /// If you want to set both value and metadata please use [put]
-  Future<bool> putMeta(AtKey key);
+  Future<bool> putMeta(AtKey key, {PutRequestOptions? putRequestOptions});
 
   /// Get the value of [AtKey.key] from user's cloud secondary if [AtKey.sharedBy] is set. Otherwise looks up the key from local secondary.
   /// If the key was stored with public access, set [AtKey.metadata.isPublic] to true. If the key was shared with another atSign set [AtKey.sharedWith]

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -31,11 +31,10 @@ class LocalSecondary implements Secondary {
   @visibleForTesting
   Enrollment? enrollment;
 
-  /// Executes a verb builder on the local secondary. For update and delete operation, if [sync] is
-  /// set to true then data is synced from local to remote.
-  /// if [sync] is set to false, no sync operation is done.
+  /// Executes a verb builder on the local secondary.
+  /// If [sync] is true then a sync request will be queued.
   @override
-  Future<String?> executeVerb(VerbBuilder builder, {sync}) async {
+  Future<String?> executeVerb(VerbBuilder builder, {bool? sync}) async {
     String? verbResult;
 
     try {

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -90,6 +90,8 @@ class LocalSecondary implements Secondary {
           updateResult = await keyStore!.putAll(updateKey, atData, atMetadata);
           break;
       }
+      // If we've already sent to remote atServer, update the commit log so we
+      // don't send the update again via the sync process
       return 'data:$updateResult';
     } on DataStoreException catch (e) {
       _logger.severe('exception in local update:${e.toString()}');

--- a/packages/at_client/lib/src/client/verb_builder_manager.dart
+++ b/packages/at_client/lib/src/client/verb_builder_manager.dart
@@ -53,11 +53,13 @@ class SecondaryManager {
   /// - Else return [remoteLocalPref], or [RemoteLocalPref.localFirst]
   /// if [remoteLocalPref] is null
   static RemoteLocalPref getRemoteLocalPrefForOp(
-    bool useRemoteAtServer,
+    bool? useRemoteAtServer,
     RemoteLocalPref? remoteLocalPref,
   ) {
-    if (useRemoteAtServer) {
+    if (useRemoteAtServer == true) {
       return RemoteLocalPref.remoteOnly;
+    } else if (useRemoteAtServer == false) {
+      return RemoteLocalPref.localFirst;
     } else {
       return remoteLocalPref ?? RemoteLocalPref.localFirst;
     }

--- a/packages/at_client/lib/src/client/verb_builder_manager.dart
+++ b/packages/at_client/lib/src/client/verb_builder_manager.dart
@@ -48,17 +48,44 @@ class LookUpBuilderManager {
   }
 }
 
-/// Returns the instance of [Secondary] server.
-///
-/// Basing the verb, the appropriate instance of secondary server is returned.
 class SecondaryManager {
-  static Secondary getSecondary(AtClient atClient, VerbBuilder verbBuilder) {
+  /// - If [useRemoteAtServer] is true, return RemoteLocalPref.remoteOnly
+  /// - Else return [remoteLocalPref], or [RemoteLocalPref.localFirst]
+  /// if [remoteLocalPref] is null
+  static RemoteLocalPref getRemoteLocalPrefForOp(
+    bool useRemoteAtServer,
+    RemoteLocalPref? remoteLocalPref,
+  ) {
+    if (useRemoteAtServer) {
+      return RemoteLocalPref.remoteOnly;
+    } else {
+      return remoteLocalPref ?? RemoteLocalPref.localFirst;
+    }
+  }
+
+  /// - Return the [atClient]'s localSecondary or remoteSecondary as appropriate.
+  /// - Always returns the remoteSecondary if the [verbBuilder] is Lookup,
+  /// PLookup, Notify or Stats.
+  /// - Otherwise returns local or remote based on the [prefForOp]
+  static Secondary getSecondary(
+    AtClient atClient,
+    VerbBuilder verbBuilder,
+    RemoteLocalPref prefForOp,
+  ) {
     if (verbBuilder is LookupVerbBuilder ||
         verbBuilder is PLookupVerbBuilder ||
         verbBuilder is NotifyVerbBuilder ||
         verbBuilder is StatsVerbBuilder) {
       return atClient.getRemoteSecondary()!;
     }
-    return atClient.getLocalSecondary()!;
+
+    switch (prefForOp) {
+      case RemoteLocalPref.localFirst:
+        return atClient.getLocalSecondary()!;
+      case RemoteLocalPref.remoteFirst:
+        return atClient.getRemoteSecondary()!;
+      case RemoteLocalPref.remoteOnly:
+        return atClient.getRemoteSecondary()!;
+    }
   }
 }

--- a/packages/at_client/lib/src/client/verb_builder_manager.dart
+++ b/packages/at_client/lib/src/client/verb_builder_manager.dart
@@ -50,7 +50,7 @@ class LookUpBuilderManager {
 
 class SecondaryManager {
   /// - If [useRemoteAtServer] is true, return RemoteLocalPref.remoteOnly
-  /// - Else return [remoteLocalPref], or [RemoteLocalPref.localFirst]
+  /// - Else return [remoteLocalPref], or [RemoteLocalPref.localOnly]
   /// if [remoteLocalPref] is null
   static RemoteLocalPref getRemoteLocalPrefForOp(
     bool? useRemoteAtServer,
@@ -59,9 +59,9 @@ class SecondaryManager {
     if (useRemoteAtServer == true) {
       return RemoteLocalPref.remoteOnly;
     } else if (useRemoteAtServer == false) {
-      return RemoteLocalPref.localFirst;
+      return RemoteLocalPref.localOnly;
     } else {
-      return remoteLocalPref ?? RemoteLocalPref.localFirst;
+      return remoteLocalPref ?? RemoteLocalPref.localOnly;
     }
   }
 
@@ -82,10 +82,8 @@ class SecondaryManager {
     }
 
     switch (prefForOp) {
-      case RemoteLocalPref.localFirst:
+      case RemoteLocalPref.localOnly:
         return atClient.getLocalSecondary()!;
-      case RemoteLocalPref.remoteFirst:
-        return atClient.getRemoteSecondary()!;
       case RemoteLocalPref.remoteOnly:
         return atClient.getRemoteSecondary()!;
     }

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.9.3';
+  final String atClientVersion = '3.10.0';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/preference/at_client_preference.dart
+++ b/packages/at_client/lib/src/preference/at_client_preference.dart
@@ -103,11 +103,32 @@ class AtClientPreference {
 
   AtClientParticulars atClientParticulars = AtClientParticulars();
 
-  //signing algorithm to use for pkam authentication
+  /// signing algorithm to use for pkam authentication
   SigningAlgoType signingAlgoType = SigningAlgoType.rsa2048;
 
-  //hashing algorithm to use for pkam authentication
+  /// hashing algorithm to use for pkam authentication
   HashingAlgoType hashingAlgoType = HashingAlgoType.sha256;
+
+  /// Set this to [RemoteLocalPref.remoteFirst] or [RemoteLocalPref.remoteOnly]
+  /// if you require all data operations (get / put / delete) to be performed
+  /// on the remote atServer first.
+  RemoteLocalPref remoteLocalPref = RemoteLocalPref.localFirst;
+}
+
+/// Default preference on how to handle get, put and delete requests with
+/// regards to use of local storage vs the remote atServer.
+enum RemoteLocalPref {
+  /// The default - operate on local storage, and rely on the background
+  /// sync processing to push changes to the remote atServer.
+  localFirst,
+
+  /// Operate on remote first. If there is an exception, rethrow it back to
+  /// application code. If remote operation was successful, then perform the
+  /// operation on local storage.
+  remoteFirst,
+
+  /// Operate on remote only - i.e. do not interact with local storage at all.
+  remoteOnly,
 }
 
 @Deprecated("Use SyncService")

--- a/packages/at_client/lib/src/preference/at_client_preference.dart
+++ b/packages/at_client/lib/src/preference/at_client_preference.dart
@@ -112,7 +112,7 @@ class AtClientPreference {
   /// Set this to [RemoteLocalPref.remoteFirst] or [RemoteLocalPref.remoteOnly]
   /// if you require all data operations (get / put / delete) to be performed
   /// on the remote atServer first.
-  RemoteLocalPref remoteLocalPref = RemoteLocalPref.localFirst;
+  RemoteLocalPref remoteLocalPref = RemoteLocalPref.localOnly;
 }
 
 /// Default preference on how to handle get, put and delete requests with
@@ -120,14 +120,16 @@ class AtClientPreference {
 enum RemoteLocalPref {
   /// The default - operate on local storage, and rely on the background
   /// sync processing to push changes to the remote atServer.
-  localFirst,
+  localOnly,
 
-  /// Operate on remote first. If there is an exception, rethrow it back to
-  /// application code. If remote operation was successful, then perform the
-  /// operation on local storage.
-  remoteFirst,
-
+  // /// Operate on remote first. If there is an exception, rethrow it back to
+  // /// application code. If remote operation was successful, then perform the
+  // /// operation on local storage.
+  // remoteFirst,
+  //
   /// Operate on remote only - i.e. do not interact with local storage at all.
+  /// Note that if the application is syncing, then the change will be pulled
+  /// to local from remote as part of the sync process.
   remoteOnly,
 }
 

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.9.3
+version: 3.10.0
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/test/full_stack_test.dart
+++ b/packages/at_client/test/full_stack_test.dart
@@ -13,6 +13,8 @@ import 'test_utils/no_op_services.dart';
 
 class MockRemoteSecondary extends Mock implements RemoteSecondary {}
 
+class MockLocalSecondary extends Mock implements LocalSecondary {}
+
 class MockSecondaryAddressFinder extends Mock
     implements SecondaryAddressFinder {}
 
@@ -44,7 +46,8 @@ void main() {
       ..commitLogPath = '$namespace/put/commitLog';
 
     late MockRemoteSecondary mockRemoteSecondary;
-    late AtClient atClient;
+    late AtClientImpl atClient;
+    late LocalSecondary localSecondary;
 
     var clearText = 'Some clear text';
 
@@ -96,9 +99,12 @@ void main() {
       AtChopsKeys atChopsKeys = AtChopsKeys.create(atEncryptionKeyPair, null);
       atChopsKeys.selfEncryptionKey = AESKey(selfEncryptionKey);
       AtChops atChops = AtChopsImpl(atChopsKeys);
-      atClient = await AtClientImpl.create('@alice', 'gary', fullStackPrefs,
-          remoteSecondary: mockRemoteSecondary, atChops: atChops);
+
+      atClient = (await AtClientImpl.create('@alice', 'gary', fullStackPrefs,
+          remoteSecondary: mockRemoteSecondary,
+          atChops: atChops)) as AtClientImpl;
       localStore = atClient.getLocalSecondary()!.keyStore!;
+      localSecondary = atClient.getLocalSecondary()!;
       atClient.syncService = NoOpSyncService();
 
       // Create our symmetric 'self' encryption key
@@ -122,6 +128,8 @@ void main() {
       await localStore.remove(myCopyVicSymKeyName);
       await localStore.remove(vicsCopySymKeyName);
 
+      atClient.localSecondary = localSecondary;
+      fullStackPrefs.remoteLocalPref = RemoteLocalPref.localFirst;
       remoteSecondaryAvailable = true;
 
       remotePLookupMap = {};
@@ -449,37 +457,91 @@ void main() {
         PutRequestOptions pro = PutRequestOptions();
         expect(pro.useRemoteAtServer, false);
       });
-      checkPutBehaviour(bool useRemoteAtServer) async {
+      checkPutBehaviour(
+        bool useRemoteAtServer,
+        RemoteLocalPref remoteLocalPref,
+      ) async {
         bool executedRemotely = false;
+        bool executedLocally = false;
         var atKey = (AtKey.shared('test_put')..sharedWith('@bob')).build();
-        when(() => mockRemoteSecondary.executeVerb(
+
+        MockLocalSecondary mockLocalSecondary =
+            atClient.localSecondary = MockLocalSecondary();
+
+        when(() => mockLocalSecondary.executeVerb(
             any(that: isA<UpdateVerbBuilder>()),
-            sync: true)).thenAnswer((invocation) async {
+            sync: any(named: "sync"))).thenAnswer((invocation) async {
           var builder = invocation.positionalArguments[0] as UpdateVerbBuilder;
           if (builder.atKey.toString() == atKey.toString()) {
-            print('mockRemoteSecondary.executeVerb with UpdateVerbBuilder'
-                ' for ${builder.atKey.toString()} as expected');
+            // print('mockLocalSecondary.executeVerb with UpdateVerbBuilder'
+            //     ' for ${builder.atKey.toString()} as expected');
+            executedLocally = true;
+            return 'data:20';
+          } else if (builder.atKey.toString() == '@bob:shared_key@alice') {
+            return 'data:20';
+          } else {
+            print(builder.buildCommand());
+            throw Exception(
+                'mockLocalSecondary.executeVerb called with unexpected UpdateVerbBuilder');
+          }
+        });
+
+        when(() => mockRemoteSecondary.executeVerb(
+            any(that: isA<UpdateVerbBuilder>()),
+            sync: any(named: "sync"))).thenAnswer((invocation) async {
+          var builder = invocation.positionalArguments[0] as UpdateVerbBuilder;
+          if (builder.atKey.toString() == atKey.toString()) {
+            // print('mockRemoteSecondary.executeVerb with UpdateVerbBuilder'
+            //     ' for ${builder.atKey.toString()} as expected');
             executedRemotely = true;
             return 'data:10';
-          } else if (builder.atKey.toString() != '@bob:shared_key@alice') {
+          } else if (builder.atKey.toString() == '@bob:shared_key@alice') {
+            return 'data:10';
+          } else {
             print(builder.buildCommand());
             throw Exception(
                 'mockRemoteSecondary.executeVerb called with unexpected UpdateVerbBuilder');
-          } else {
-            return 'data:10';
           }
         });
-        await atClient.put(atKey, clearText,
+
+        atClient.getPreferences()!.remoteLocalPref = remoteLocalPref;
+
+        var retVal = await atClient.put(atKey, clearText,
             putRequestOptions: PutRequestOptions()
-              ..useRemoteAtServer = useRemoteAtServer);
-        expect(executedRemotely, useRemoteAtServer);
+              ..useRemoteAtServer = useRemoteAtServer
+              ..shouldEncrypt = false);
+
+        if (useRemoteAtServer) {
+          expect(executedRemotely, true);
+          expect(executedLocally, false);
+          expect(retVal, true);
+        } else {
+          switch (remoteLocalPref) {
+            case RemoteLocalPref.localFirst:
+              expect(executedRemotely, false);
+              expect(executedLocally, true);
+              expect(retVal, true);
+            case RemoteLocalPref.remoteFirst:
+              expect(executedRemotely, true);
+              expect(executedLocally, true);
+              expect(retVal, true);
+            case RemoteLocalPref.remoteOnly:
+              expect(executedRemotely, true);
+              expect(executedLocally, false);
+              expect(retVal, true);
+          }
+        }
       }
 
       test('put behaviour when useRemoteAtServer set to true', () async {
-        await checkPutBehaviour(true);
+        await checkPutBehaviour(true, RemoteLocalPref.localFirst);
+        await checkPutBehaviour(true, RemoteLocalPref.remoteFirst);
+        await checkPutBehaviour(true, RemoteLocalPref.remoteOnly);
       });
       test('put behaviour when useRemoteAtServer set to false', () async {
-        await checkPutBehaviour(false);
+        await checkPutBehaviour(false, RemoteLocalPref.localFirst);
+        await checkPutBehaviour(false, RemoteLocalPref.remoteFirst);
+        await checkPutBehaviour(false, RemoteLocalPref.remoteOnly);
       });
     });
 
@@ -488,21 +550,42 @@ void main() {
         DeleteRequestOptions dro = DeleteRequestOptions();
         expect(dro.useRemoteAtServer, false);
       });
-      checkDeleteBehaviour(bool useRemoteAtServer) async {
+      checkDeleteBehaviour(
+        bool useRemoteAtServer,
+        RemoteLocalPref remoteLocalPref,
+      ) async {
         bool executedRemotely = false;
+        bool executedLocally = false;
         var atKey = (AtKey.shared('test_put',
                 namespace: namespace, sharedBy: atClient.getCurrentAtSign()!)
               ..sharedWith('@bob'))
             .build();
         print(atKey.toString());
+
+        MockLocalSecondary mockLocalSecondary =
+            atClient.localSecondary = MockLocalSecondary();
+        when(() => mockLocalSecondary.executeVerb(
+            any(that: isA<DeleteVerbBuilder>()),
+            sync: any(named: "sync"))).thenAnswer((invocation) async {
+          var builder = invocation.positionalArguments[0] as DeleteVerbBuilder;
+          // print('DeleteVerbBuilder: ${builder.buildCommand()}');
+          if (builder.buildKey() == atKey.toString()) {
+            executedLocally = true;
+            return 'data:20';
+          } else {
+            print(builder.buildCommand());
+            throw Exception(
+                'mockLocalSecondary.executeVerb called with unexpected DeleteVerbBuilder');
+          }
+        });
         when(() => mockRemoteSecondary.executeVerb(
             any(that: isA<DeleteVerbBuilder>()),
-            sync: true)).thenAnswer((invocation) async {
+            sync: any(named: "sync"))).thenAnswer((invocation) async {
           var builder = invocation.positionalArguments[0] as DeleteVerbBuilder;
           print('DeleteVerbBuilder: ${builder.buildCommand()}');
           if (builder.buildKey() == atKey.toString()) {
-            print('mockRemoteSecondary.executeVerb with DeleteVerbBuilder'
-                ' for ${builder.atKey.toString()} as expected');
+            // print('mockRemoteSecondary.executeVerb with DeleteVerbBuilder'
+            //     ' for ${builder.atKey.toString()} as expected');
             executedRemotely = true;
             return 'data:10';
           } else {
@@ -511,17 +594,41 @@ void main() {
                 'mockRemoteSecondary.executeVerb called with unexpected DeleteVerbBuilder');
           }
         });
-        await atClient.delete(atKey,
+        atClient.getPreferences()!.remoteLocalPref = remoteLocalPref;
+        var retVal = await atClient.delete(atKey,
             deleteRequestOptions: DeleteRequestOptions()
               ..useRemoteAtServer = useRemoteAtServer);
-        expect(executedRemotely, useRemoteAtServer);
+        if (useRemoteAtServer) {
+          expect(executedRemotely, true);
+          expect(executedLocally, false);
+          expect(retVal, true);
+        } else {
+          switch (remoteLocalPref) {
+            case RemoteLocalPref.localFirst:
+              expect(executedRemotely, false);
+              expect(executedLocally, true);
+              expect(retVal, true);
+            case RemoteLocalPref.remoteFirst:
+              expect(executedRemotely, true);
+              expect(executedLocally, true);
+              expect(retVal, true);
+            case RemoteLocalPref.remoteOnly:
+              expect(executedRemotely, true);
+              expect(executedLocally, false);
+              expect(retVal, true);
+          }
+        }
       }
 
       test('delete behaviour when useRemoteAtServer set to true', () async {
-        await checkDeleteBehaviour(true);
+        await checkDeleteBehaviour(true, RemoteLocalPref.localFirst);
+        await checkDeleteBehaviour(true, RemoteLocalPref.remoteFirst);
+        await checkDeleteBehaviour(true, RemoteLocalPref.remoteOnly);
       });
       test('delete behaviour when useRemoteAtServer set to false', () async {
-        await checkDeleteBehaviour(false);
+        await checkDeleteBehaviour(false, RemoteLocalPref.localFirst);
+        await checkDeleteBehaviour(false, RemoteLocalPref.remoteFirst);
+        await checkDeleteBehaviour(false, RemoteLocalPref.remoteOnly);
       });
     });
 
@@ -548,6 +655,28 @@ void main() {
         await atClient.getAtKeys(useRemoteAtServer: true);
         expect(executedRemotely, true);
       });
+      test(
+          'Scan when useRemoteAtServer is false, with various values of remoteLocalPref',
+          () async {
+        bool executedRemotely = false;
+        when(() => mockRemoteSecondary.executeVerb(
+            any(that: isA<ScanVerbBuilder>()))).thenAnswer((invocation) async {
+          executedRemotely = true;
+          return 'data:[]';
+        });
+        atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.localFirst;
+        await atClient.getAtKeys();
+        expect(executedRemotely, false);
+
+        atClient.getPreferences()!.remoteLocalPref =
+            RemoteLocalPref.remoteFirst;
+        await atClient.getAtKeys();
+        expect(executedRemotely, true);
+
+        atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.remoteOnly;
+        await atClient.getAtKeys();
+        expect(executedRemotely, true);
+      });
     });
     group('Tests for GetRequestOptions.useRemoteAtServer', () {
       test('GetRequestOptions.useRemoteAtServer defaults to false', () {
@@ -555,7 +684,9 @@ void main() {
         expect(gro.useRemoteAtServer, false);
       });
 
-      test('get self key when useRemoteAtServer set to false', () async {
+      test(
+          'get self key useRemoteAtServer false, various remoteLocalPref values',
+          () async {
         bool executedRemotely = false;
         // Make a self key - by default, this will be looked up locally using
         // an LLookup
@@ -567,15 +698,19 @@ void main() {
             .thenAnswer((invocation) async {
           var builder = invocation.positionalArguments[0] as LLookupVerbBuilder;
           if (builder.atKey.toString() == atKey.toString()) {
-            print('mockRemoteSecondary.executeVerb with LLookupVerbBuilder'
-                ' for ${builder.atKey.toString()} - this is NOT expected');
+            // print('mockRemoteSecondary.executeVerb with LLookupVerbBuilder'
+            //     ' for ${builder.atKey.toString()} - this is NOT expected');
             executedRemotely = true;
             return 'data:null';
           } else {
             return 'data:null';
           }
         });
+
         dynamic caught;
+
+        atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.localFirst;
+        caught = null;
         try {
           await atClient.get(atKey,
               getRequestOptions: GetRequestOptions()
@@ -585,6 +720,31 @@ void main() {
         }
         expect(caught, isA<AtKeyNotFoundException>());
         expect(executedRemotely, false);
+
+        atClient.getPreferences()!.remoteLocalPref =
+            RemoteLocalPref.remoteFirst;
+        caught = null;
+        try {
+          await atClient.get(atKey,
+              getRequestOptions: GetRequestOptions()
+                ..useRemoteAtServer = false);
+        } catch (e) {
+          caught = e;
+        }
+        expect(caught, isNull);
+        expect(executedRemotely, true);
+
+        atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.remoteOnly;
+        caught = null;
+        try {
+          await atClient.get(atKey,
+              getRequestOptions: GetRequestOptions()
+                ..useRemoteAtServer = false);
+        } catch (e) {
+          caught = e;
+        }
+        expect(caught, isNull);
+        expect(executedRemotely, true);
       });
 
       test('get self key when useRemoteAtServer set to true', () async {

--- a/packages/at_client/test/full_stack_test.dart
+++ b/packages/at_client/test/full_stack_test.dart
@@ -129,7 +129,7 @@ void main() {
       await localStore.remove(vicsCopySymKeyName);
 
       atClient.localSecondary = localSecondary;
-      fullStackPrefs.remoteLocalPref = RemoteLocalPref.localFirst;
+      fullStackPrefs.remoteLocalPref = RemoteLocalPref.localOnly;
       remoteSecondaryAvailable = true;
 
       remotePLookupMap = {};
@@ -545,12 +545,8 @@ void main() {
         } else {
           // useRemoteAtServer is null
           switch (remoteLocalPref) {
-            case RemoteLocalPref.localFirst:
+            case RemoteLocalPref.localOnly:
               expect(executedRemotely, false);
-              expect(executedLocally, true);
-              expect(retVal, true);
-            case RemoteLocalPref.remoteFirst:
-              expect(executedRemotely, true);
               expect(executedLocally, true);
               expect(retVal, true);
             case RemoteLocalPref.remoteOnly:
@@ -563,20 +559,17 @@ void main() {
 
       test('put behaviour when PutRequestOptions.useRemoteAtServer is true',
           () async {
-        await checkPutBehaviour(true, RemoteLocalPref.localFirst);
-        await checkPutBehaviour(true, RemoteLocalPref.remoteFirst);
+        await checkPutBehaviour(true, RemoteLocalPref.localOnly);
         await checkPutBehaviour(true, RemoteLocalPref.remoteOnly);
       });
       test('put behaviour when PutRequestOptions.useRemoteAtServer is false',
           () async {
-        await checkPutBehaviour(false, RemoteLocalPref.localFirst);
-        await checkPutBehaviour(false, RemoteLocalPref.remoteFirst);
+        await checkPutBehaviour(false, RemoteLocalPref.localOnly);
         await checkPutBehaviour(false, RemoteLocalPref.remoteOnly);
       });
       test('put behaviour when PutRequestOptions.useRemoteAtServer is null',
           () async {
-        await checkPutBehaviour(null, RemoteLocalPref.localFirst);
-        await checkPutBehaviour(null, RemoteLocalPref.remoteFirst);
+        await checkPutBehaviour(null, RemoteLocalPref.localOnly);
         await checkPutBehaviour(null, RemoteLocalPref.remoteOnly);
       });
     });
@@ -649,12 +642,8 @@ void main() {
         } else {
           // useRemoteAtServer is null
           switch (remoteLocalPref) {
-            case RemoteLocalPref.localFirst:
+            case RemoteLocalPref.localOnly:
               expect(executedRemotely, false);
-              expect(executedLocally, true);
-              expect(retVal, true);
-            case RemoteLocalPref.remoteFirst:
-              expect(executedRemotely, true);
               expect(executedLocally, true);
               expect(retVal, true);
             case RemoteLocalPref.remoteOnly:
@@ -668,22 +657,19 @@ void main() {
       test(
           'delete behaviour when DeleteRequestOptions.useRemoteAtServer is true',
           () async {
-        await checkDeleteBehaviour(true, RemoteLocalPref.localFirst);
-        await checkDeleteBehaviour(true, RemoteLocalPref.remoteFirst);
+        await checkDeleteBehaviour(true, RemoteLocalPref.localOnly);
         await checkDeleteBehaviour(true, RemoteLocalPref.remoteOnly);
       });
       test(
           'delete behaviour when DeleteRequestOptions.useRemoteAtServer is false',
           () async {
-        await checkDeleteBehaviour(false, RemoteLocalPref.localFirst);
-        await checkDeleteBehaviour(false, RemoteLocalPref.remoteFirst);
+        await checkDeleteBehaviour(false, RemoteLocalPref.localOnly);
         await checkDeleteBehaviour(false, RemoteLocalPref.remoteOnly);
       });
       test(
           'delete behaviour when DeleteRequestOptions.useRemoteAtServer is null',
           () async {
-        await checkDeleteBehaviour(null, RemoteLocalPref.localFirst);
-        await checkDeleteBehaviour(null, RemoteLocalPref.remoteFirst);
+        await checkDeleteBehaviour(null, RemoteLocalPref.localOnly);
         await checkDeleteBehaviour(null, RemoteLocalPref.remoteOnly);
       });
     });
@@ -720,14 +706,9 @@ void main() {
           executedRemotely = true;
           return 'data:[]';
         });
-        atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.localFirst;
+        atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.localOnly;
         await atClient.getAtKeys();
         expect(executedRemotely, false);
-
-        atClient.getPreferences()!.remoteLocalPref =
-            RemoteLocalPref.remoteFirst;
-        await atClient.getAtKeys();
-        expect(executedRemotely, true);
 
         atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.remoteOnly;
         await atClient.getAtKeys();
@@ -765,7 +746,7 @@ void main() {
 
         dynamic caught;
 
-        atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.localFirst;
+        atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.localOnly;
         caught = null;
         try {
           await atClient.get(atKey, getRequestOptions: null);
@@ -774,17 +755,6 @@ void main() {
         }
         expect(caught, isA<AtKeyNotFoundException>());
         expect(executedRemotely, false);
-
-        atClient.getPreferences()!.remoteLocalPref =
-            RemoteLocalPref.remoteFirst;
-        caught = null;
-        try {
-          await atClient.get(atKey, getRequestOptions: null);
-        } catch (e) {
-          caught = e;
-        }
-        expect(caught, isNull);
-        expect(executedRemotely, true);
 
         atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.remoteOnly;
         caught = null;
@@ -808,20 +778,7 @@ void main() {
 
         dynamic caught;
 
-        atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.localFirst;
-        caught = null;
-        try {
-          await atClient.get(atKey,
-              getRequestOptions: GetRequestOptions()
-                ..useRemoteAtServer = false);
-        } catch (e) {
-          caught = e;
-        }
-        expect(caught, isA<AtKeyNotFoundException>());
-        expect(executedRemotely, false);
-
-        atClient.getPreferences()!.remoteLocalPref =
-            RemoteLocalPref.remoteFirst;
+        atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.localOnly;
         caught = null;
         try {
           await atClient.get(atKey,

--- a/packages/at_client/test/full_stack_test.dart
+++ b/packages/at_client/test/full_stack_test.dart
@@ -458,12 +458,15 @@ void main() {
         expect(pro.useRemoteAtServer, false);
       });
       checkPutBehaviour(
-        bool useRemoteAtServer,
+        bool? useRemoteAtServer,
         RemoteLocalPref remoteLocalPref,
       ) async {
         bool executedRemotely = false;
         bool executedLocally = false;
-        var atKey = (AtKey.shared('test_put')..sharedWith('@bob')).build();
+        var atKey = (AtKey.shared('test_put')
+              ..sharedWith('@alice')
+              ..sharedBy('@alice'))
+            .build();
 
         MockLocalSecondary mockLocalSecondary =
             atClient.localSecondary = MockLocalSecondary();
@@ -476,8 +479,6 @@ void main() {
             // print('mockLocalSecondary.executeVerb with UpdateVerbBuilder'
             //     ' for ${builder.atKey.toString()} as expected');
             executedLocally = true;
-            return 'data:20';
-          } else if (builder.atKey.toString() == '@bob:shared_key@alice') {
             return 'data:20';
           } else {
             print(builder.buildCommand());
@@ -504,18 +505,45 @@ void main() {
           }
         });
 
+        var selfEncryptionKeyID = AtKey()
+          ..key =
+              '${AtConstants.atEncryptionSharedKey}.${atKey.sharedWith?.replaceAll('@', '')}'
+          ..sharedBy = atKey.sharedBy;
+
+        when(() => mockLocalSecondary
+                .executeVerb(any(that: isA<LLookupVerbBuilder>())))
+            .thenAnswer((invocation) async {
+          remoteLLookupRequestCount++;
+          var builder = invocation.positionalArguments[0] as LLookupVerbBuilder;
+          print('LLookupVerbBuilder : ${builder.buildCommand()}');
+          if (builder.atKey.toString() == selfEncryptionKeyID.toString()) {
+            return 'data:$selfEncryptionKey';
+          } else {
+            throw KeyNotFoundException(
+                'No value in mock local for LLookup: ${builder.buildCommand()}');
+          }
+        });
+
         atClient.getPreferences()!.remoteLocalPref = remoteLocalPref;
 
+        PutRequestOptions? putRequestOptions;
+        if (useRemoteAtServer != null) {
+          putRequestOptions = PutRequestOptions()
+            ..useRemoteAtServer = useRemoteAtServer;
+        }
         var retVal = await atClient.put(atKey, clearText,
-            putRequestOptions: PutRequestOptions()
-              ..useRemoteAtServer = useRemoteAtServer
-              ..shouldEncrypt = false);
+            putRequestOptions: putRequestOptions);
 
-        if (useRemoteAtServer) {
+        if (useRemoteAtServer == true) {
           expect(executedRemotely, true);
           expect(executedLocally, false);
           expect(retVal, true);
+        } else if (useRemoteAtServer == false) {
+          expect(executedRemotely, false);
+          expect(executedLocally, true);
+          expect(retVal, true);
         } else {
+          // useRemoteAtServer is null
           switch (remoteLocalPref) {
             case RemoteLocalPref.localFirst:
               expect(executedRemotely, false);
@@ -533,15 +561,23 @@ void main() {
         }
       }
 
-      test('put behaviour when useRemoteAtServer set to true', () async {
+      test('put behaviour when PutRequestOptions.useRemoteAtServer is true',
+          () async {
         await checkPutBehaviour(true, RemoteLocalPref.localFirst);
         await checkPutBehaviour(true, RemoteLocalPref.remoteFirst);
         await checkPutBehaviour(true, RemoteLocalPref.remoteOnly);
       });
-      test('put behaviour when useRemoteAtServer set to false', () async {
+      test('put behaviour when PutRequestOptions.useRemoteAtServer is false',
+          () async {
         await checkPutBehaviour(false, RemoteLocalPref.localFirst);
         await checkPutBehaviour(false, RemoteLocalPref.remoteFirst);
         await checkPutBehaviour(false, RemoteLocalPref.remoteOnly);
+      });
+      test('put behaviour when PutRequestOptions.useRemoteAtServer is null',
+          () async {
+        await checkPutBehaviour(null, RemoteLocalPref.localFirst);
+        await checkPutBehaviour(null, RemoteLocalPref.remoteFirst);
+        await checkPutBehaviour(null, RemoteLocalPref.remoteOnly);
       });
     });
 
@@ -551,7 +587,7 @@ void main() {
         expect(dro.useRemoteAtServer, false);
       });
       checkDeleteBehaviour(
-        bool useRemoteAtServer,
+        bool? useRemoteAtServer,
         RemoteLocalPref remoteLocalPref,
       ) async {
         bool executedRemotely = false;
@@ -595,14 +631,23 @@ void main() {
           }
         });
         atClient.getPreferences()!.remoteLocalPref = remoteLocalPref;
+        DeleteRequestOptions? deleteRequestOptions;
+        if (useRemoteAtServer != null) {
+          deleteRequestOptions = DeleteRequestOptions()
+            ..useRemoteAtServer = useRemoteAtServer;
+        }
         var retVal = await atClient.delete(atKey,
-            deleteRequestOptions: DeleteRequestOptions()
-              ..useRemoteAtServer = useRemoteAtServer);
-        if (useRemoteAtServer) {
+            deleteRequestOptions: deleteRequestOptions);
+        if (useRemoteAtServer == true) {
           expect(executedRemotely, true);
           expect(executedLocally, false);
           expect(retVal, true);
+        } else if (useRemoteAtServer == false) {
+          expect(executedRemotely, false);
+          expect(executedLocally, true);
+          expect(retVal, true);
         } else {
+          // useRemoteAtServer is null
           switch (remoteLocalPref) {
             case RemoteLocalPref.localFirst:
               expect(executedRemotely, false);
@@ -620,15 +665,26 @@ void main() {
         }
       }
 
-      test('delete behaviour when useRemoteAtServer set to true', () async {
+      test(
+          'delete behaviour when DeleteRequestOptions.useRemoteAtServer is true',
+          () async {
         await checkDeleteBehaviour(true, RemoteLocalPref.localFirst);
         await checkDeleteBehaviour(true, RemoteLocalPref.remoteFirst);
         await checkDeleteBehaviour(true, RemoteLocalPref.remoteOnly);
       });
-      test('delete behaviour when useRemoteAtServer set to false', () async {
+      test(
+          'delete behaviour when DeleteRequestOptions.useRemoteAtServer is false',
+          () async {
         await checkDeleteBehaviour(false, RemoteLocalPref.localFirst);
         await checkDeleteBehaviour(false, RemoteLocalPref.remoteFirst);
         await checkDeleteBehaviour(false, RemoteLocalPref.remoteOnly);
+      });
+      test(
+          'delete behaviour when DeleteRequestOptions.useRemoteAtServer is null',
+          () async {
+        await checkDeleteBehaviour(null, RemoteLocalPref.localFirst);
+        await checkDeleteBehaviour(null, RemoteLocalPref.remoteFirst);
+        await checkDeleteBehaviour(null, RemoteLocalPref.remoteOnly);
       });
     });
 
@@ -685,7 +741,7 @@ void main() {
       });
 
       test(
-          'get self key useRemoteAtServer false, various remoteLocalPref values',
+          'get self key useRemoteAtServer null, various remoteLocalPref values',
           () async {
         bool executedRemotely = false;
         // Make a self key - by default, this will be looked up locally using
@@ -712,6 +768,49 @@ void main() {
         atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.localFirst;
         caught = null;
         try {
+          await atClient.get(atKey, getRequestOptions: null);
+        } catch (e) {
+          caught = e;
+        }
+        expect(caught, isA<AtKeyNotFoundException>());
+        expect(executedRemotely, false);
+
+        atClient.getPreferences()!.remoteLocalPref =
+            RemoteLocalPref.remoteFirst;
+        caught = null;
+        try {
+          await atClient.get(atKey, getRequestOptions: null);
+        } catch (e) {
+          caught = e;
+        }
+        expect(caught, isNull);
+        expect(executedRemotely, true);
+
+        atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.remoteOnly;
+        caught = null;
+        try {
+          await atClient.get(atKey, getRequestOptions: null);
+        } catch (e) {
+          caught = e;
+        }
+        expect(caught, isNull);
+        expect(executedRemotely, true);
+      });
+
+      test(
+          'get self key useRemoteAtServer false, various remoteLocalPref values',
+          () async {
+        bool executedRemotely = false;
+
+        var atKey = AtKey.fromString('test_get_self_key_when_remote_is_false'
+            '.${atClient.getPreferences()!.namespace!}'
+            '${atClient.getCurrentAtSign()!}');
+
+        dynamic caught;
+
+        atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.localFirst;
+        caught = null;
+        try {
           await atClient.get(atKey,
               getRequestOptions: GetRequestOptions()
                 ..useRemoteAtServer = false);
@@ -731,8 +830,8 @@ void main() {
         } catch (e) {
           caught = e;
         }
-        expect(caught, isNull);
-        expect(executedRemotely, true);
+        expect(caught, isA<AtKeyNotFoundException>());
+        expect(executedRemotely, false);
 
         atClient.getPreferences()!.remoteLocalPref = RemoteLocalPref.remoteOnly;
         caught = null;
@@ -743,8 +842,8 @@ void main() {
         } catch (e) {
           caught = e;
         }
-        expect(caught, isNull);
-        expect(executedRemotely, true);
+        expect(caught, isA<AtKeyNotFoundException>());
+        expect(executedRemotely, false);
       });
 
       test('get self key when useRemoteAtServer set to true', () async {


### PR DESCRIPTION
**- What I did**
- feat: Add RemoteLocalPref enum and AtClientPreference.remoteLocalPref field to enable apps to easily specify that they want to use the remote atServer by default.
  - Behaviour is identical to existing unless apps specifically set the value of `AtClientPreference.remoteLocalPref` to something other than the default, which is `localOnly`
  - Up to now we've enabled use of remote atServer via the Get/Put/Delete RequestOptions. It is now possible to override the other way. So for example if AtClientPreference.remoteLocalPref is `remoteOnly`, application code can still force use of local by explicitly using a RequestOptions with `useRemoteAtServer = false`
- build: update pubspec, changelog for release 3.10.0

**- How I did it**
- See file diffs. The changes are fairly self-explanatory - basically, an enhancement to the existing `useRemoteAtServer` logic with regards to whether to use localSecondary or remoteSecondary, plus the inevitable little bits of cleanup, plus additional tests to cover the changes

**- How to verify it**
Tests pass
