### PR TITLE
fix: break flutter packages due to removing at_client_mobile

### DIFF
--- a/packages/at_backupkey_flutter/example/linux/flutter/generated_plugin_registrant.cc
+++ b/packages/at_backupkey_flutter/example/linux/flutter/generated_plugin_registrant.cc
@@ -6,18 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <at_file_saver/file_saver_plugin.h>
-#include <biometric_storage/biometric_storage_plugin.h>
-#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
-  g_autoptr(FlPluginRegistrar) at_file_saver_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSaverPlugin");
-  file_saver_plugin_register_with_registrar(at_file_saver_registrar);
-  g_autoptr(FlPluginRegistrar) biometric_storage_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "BiometricStoragePlugin");
-  biometric_storage_plugin_register_with_registrar(biometric_storage_registrar);
-  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
-      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
-  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/packages/at_backupkey_flutter/example/linux/flutter/generated_plugins.cmake
+++ b/packages/at_backupkey_flutter/example/linux/flutter/generated_plugins.cmake
@@ -3,9 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  at_file_saver
-  biometric_storage
-  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/packages/at_backupkey_flutter/example/pubspec.yaml
+++ b/packages/at_backupkey_flutter/example/pubspec.yaml
@@ -10,19 +10,12 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  at_app_flutter: ^5.2.0
-  at_client_mobile: ^3.2.19
-  at_onboarding_flutter: ^6.1.9
-  cupertino_icons: ^1.0.6
   flutter:
     sdk: flutter
   path: ^1.8.3
   path_provider: ^2.1.1
   
 
-dependency_overrides:
-  at_backupkey_flutter:
-    path: ../
 
 dev_dependencies:
   flutter_lints: ^4.0.0

--- a/packages/at_backupkey_flutter/example/windows/flutter/generated_plugin_registrant.cc
+++ b/packages/at_backupkey_flutter/example/windows/flutter/generated_plugin_registrant.cc
@@ -6,18 +6,6 @@
 
 #include "generated_plugin_registrant.h"
 
-#include <at_file_saver/file_saver_plugin.h>
-#include <permission_handler_windows/permission_handler_windows_plugin.h>
-#include <share_plus/share_plus_windows_plugin_c_api.h>
-#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
-  FileSaverPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("FileSaverPlugin"));
-  PermissionHandlerWindowsPluginRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("PermissionHandlerWindowsPlugin"));
-  SharePlusWindowsPluginCApiRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("SharePlusWindowsPluginCApi"));
-  UrlLauncherWindowsRegisterWithRegistrar(
-      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/packages/at_backupkey_flutter/example/windows/flutter/generated_plugins.cmake
+++ b/packages/at_backupkey_flutter/example/windows/flutter/generated_plugins.cmake
@@ -3,10 +3,6 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
-  at_file_saver
-  permission_handler_windows
-  share_plus
-  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/packages/at_backupkey_flutter/pubspec.yaml
+++ b/packages/at_backupkey_flutter/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   path_provider: ^2.1.1
   at_file_saver: ^0.1.2
   at_utils: ^3.0.19
-  at_client_mobile: ^3.3.0
+  at_client_flutter: ^0.1.0
   showcaseview: ^4.0.1
   device_info_plus: ^11.3.3
   file_picker: ^10.0.0

--- a/packages/at_chat_flutter/pubspec.yaml
+++ b/packages/at_chat_flutter/pubspec.yaml
@@ -13,7 +13,6 @@ resolution: workspace
 
 dependencies:
   at_client: ^3.7.0
-  at_client_mobile: ^3.3.0
   at_common_flutter: ^2.1.0
   at_commons: ^5.5.0
   file_picker: ^10.0.0

--- a/packages/at_client/example/pubspec.yaml
+++ b/packages/at_client/example/pubspec.yaml
@@ -8,6 +8,14 @@ environment:
 dependency_overrides:
   at_client:
     path: ../../at_client
+  at_commons:
+    path: ../../at_commons
+  at_chops:
+    path: ../../at_chops
+  at_auth:
+    path: ../../at_auth
+  at_lookup:
+    path: ../../at_lookup
 
 dependencies:
   at_client: ^3.7.0

--- a/packages/at_contacts_flutter/pubspec.yaml
+++ b/packages/at_contacts_flutter/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
   flutter:
     sdk: flutter
   at_client: ^3.7.0
-  at_client_mobile: ^3.3.0
   at_common_flutter: ^2.1.0
   at_contact: ^3.0.9
   at_lookup: ^3.0.49

--- a/packages/at_contacts_group_flutter/pubspec.yaml
+++ b/packages/at_contacts_group_flutter/pubspec.yaml
@@ -12,7 +12,6 @@ environment:
 resolution: workspace
 
 dependencies:
-  at_client_mobile: ^3.3.0
   at_common_flutter: ^2.1.0
   at_commons: ^5.5.0
   at_contact: ^3.0.9

--- a/packages/at_events_flutter/pubspec.yaml
+++ b/packages/at_events_flutter/pubspec.yaml
@@ -13,7 +13,6 @@ resolution: workspace
 
 dependencies:
   at_client: ^3.7.0
-  at_client_mobile: ^3.3.0
   at_common_flutter: ^2.1.0
   at_commons: ^5.5.0
   at_contact: ^3.0.9

--- a/packages/at_follows_flutter/pubspec.yaml
+++ b/packages/at_follows_flutter/pubspec.yaml
@@ -14,7 +14,6 @@ resolution: workspace
 
 dependencies:
   at_client: ^3.7.0
-  at_client_mobile: ^3.3.0
   at_commons: ^5.5.0
   at_server_status: ^1.0.5
   at_utils: ^3.0.19

--- a/packages/at_invitation_flutter/pubspec.yaml
+++ b/packages/at_invitation_flutter/pubspec.yaml
@@ -11,8 +11,6 @@ environment:
 resolution: workspace
 
 dependencies:
-  at_client_mobile: ^3.3.0
-  at_common_flutter: ^2.1.0
   at_utils: ^3.0.19
   flutter:
     sdk: flutter

--- a/packages/at_location_flutter/pubspec.yaml
+++ b/packages/at_location_flutter/pubspec.yaml
@@ -13,7 +13,6 @@ resolution: workspace
 
 dependencies:
   async: ^2.11.0
-  at_client_mobile: ^3.3.0
   at_common_flutter: ^2.1.0
   at_commons: ^5.5.0
   at_contact: ^3.0.9

--- a/packages/at_login_flutter/pubspec.yaml
+++ b/packages/at_login_flutter/pubspec.yaml
@@ -12,7 +12,6 @@ resolution: workspace
 
 dependencies:
   at_client: ^3.7.0
-  at_client_mobile: ^3.3.0
   at_server_status: ^1.0.5
   at_utils: ^3.0.19
   basic_utils: ^5.6.1

--- a/packages/at_lookup/example/pubspec.yaml
+++ b/packages/at_lookup/example/pubspec.yaml
@@ -12,6 +12,8 @@ dependency_overrides:
     path: ../../at_commons
   at_lookup:
     path: ../../at_lookup
+  at_chops:
+    path: ../../at_chops
 
 dependencies:
   at_utils: ^3.0.2

--- a/packages/at_notify_flutter/pubspec.yaml
+++ b/packages/at_notify_flutter/pubspec.yaml
@@ -13,7 +13,6 @@ resolution: workspace
 
 dependencies:
   at_client: ^3.7.0
-  at_client_mobile: ^3.3.0
   at_common_flutter: ^2.1.0
   flutter:
     sdk: flutter

--- a/packages/at_policy/example/pubspec.yaml
+++ b/packages/at_policy/example/pubspec.yaml
@@ -13,6 +13,14 @@ dependency_overrides:
     path: ../../at_cli_commons
   at_client:
     path: ../../at_client
+  at_commons:
+    path: ../../at_commons
+  at_chops:
+    path: ../../at_chops
+  at_auth:
+    path: ../../at_auth
+  at_lookup:
+    path: ../../at_lookup
 
 dependencies:
   at_policy:

--- a/packages/at_sync_ui_flutter/pubspec.yaml
+++ b/packages/at_sync_ui_flutter/pubspec.yaml
@@ -13,7 +13,6 @@ resolution: workspace
 
 dependencies:
   at_client: ^3.7.0
-  at_client_mobile: ^3.3.0
   flutter:
     sdk: flutter
 

--- a/packages/at_theme_flutter/pubspec.yaml
+++ b/packages/at_theme_flutter/pubspec.yaml
@@ -12,7 +12,6 @@ environment:
 resolution: workspace
 
 dependencies:
-  at_client_mobile: ^3.3.0
   at_common_flutter: ^2.1.0
   at_utils: ^3.0.19
   flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ workspace:
   - packages/at_cli_commons
   - packages/at_client
   - packages/at_client_flutter
-  - packages/at_client_mobile
   - packages/at_commons
   - packages/at_common_flutter
   - packages/at_contact
@@ -27,7 +26,6 @@ workspace:
   - packages/at_lookup
   - packages/at_notify_flutter
   - packages/at_onboarding_cli
-  - packages/at_onboarding_flutter
   - packages/at_policy
   - packages/at_server_status
   - packages/at_sync_ui_flutter


### PR DESCRIPTION
**- What I did**
 - all flutter packages and their examples aren't resolving due to at_client_mobile
   - these packages will be rewritten into example code snippets instead of packages see `#1657`

**- How I did it**
 - removed at_client_mobile references
 - override example dependencies with path
 
**- How to verify it**
 - please verify, not sure if this is how I should go about this.
 
**- Description for the changelog**
fix: break flutter packages due to removing at_client_mobile
