### PR TITLE
feat: Introduce CLILoggingHandler + minor bugfix

### DIFF
--- a/packages/at_utils/CHANGELOG.md
+++ b/packages/at_utils/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.4.0
+- feat: Introduce CLILoggingHandler for command-line applications
+- fix: AtLogger.level setter is now case-insensitive
 ## 3.3.0
 - chore(deps): at_commons ^5.5.0
 - chore(deps): chalkdart ">=2.0.9<4.0.0"

--- a/packages/at_utils/lib/src/logging/atsignlogger.dart
+++ b/packages/at_utils/lib/src/logging/atsignlogger.dart
@@ -13,6 +13,8 @@ class AtSignLogger {
 
   static final ConsoleLoggingHandler consoleLoggingHandler =
       ConsoleLoggingHandler();
+  static final StdErrLoggingHandler stdErrLoggingHandler =
+      StdErrLoggingHandler();
 
   /// The default logging handler to log events.
   ///

--- a/packages/at_utils/lib/src/logging/atsignlogger.dart
+++ b/packages/at_utils/lib/src/logging/atsignlogger.dart
@@ -13,8 +13,6 @@ class AtSignLogger {
 
   static final ConsoleLoggingHandler consoleLoggingHandler =
       ConsoleLoggingHandler();
-  static final StdErrLoggingHandler stdErrLoggingHandler =
-      StdErrLoggingHandler();
 
   /// The default logging handler to log events.
   ///
@@ -62,11 +60,13 @@ class AtSignLogger {
       _hierarchicalLoggingEnabled = true;
       logging.hierarchicalLoggingEnabled = _hierarchicalLoggingEnabled;
     }
-    _level = value;
-    logger.level = LogLevel.level[_level!];
+
+    _level = value?.toLowerCase();
+    logger.level = LogLevel.level[_level];
   }
 
-  bool isLoggable(String value) => (LogLevel.level[value]! >= logger.level);
+  bool isLoggable(String value) =>
+      (LogLevel.level[value.toLowerCase()]! >= logger.level);
 
   // ignore: unnecessary_getters_setters
   bool get hierarchicalLoggingEnabled {

--- a/packages/at_utils/lib/src/logging/handlers.dart
+++ b/packages/at_utils/lib/src/logging/handlers.dart
@@ -1,12 +1,19 @@
 import 'dart:io';
+
+import 'package:chalkdart/chalk.dart';
 import 'package:logging/logging.dart';
 
-/// Handler class for AtSignLogger
+/// Handler class for AtSignLogger.
+///
+/// Implement this interface to create custom log handlers.
 abstract class LoggingHandler {
   //Can extend LogRecord if any atsign specific field has to be logged
   void call(LogRecord record);
 }
 
+/// Outputs log messages to stdout in pipe-delimited format.
+///
+/// Format: `LEVEL|timestamp|loggerName|message`
 class ConsoleLoggingHandler implements LoggingHandler {
   @override
   void call(LogRecord record) {
@@ -15,12 +22,22 @@ class ConsoleLoggingHandler implements LoggingHandler {
   }
 }
 
+/// Appends log messages to a file in pipe-delimited format.
+///
+/// Format: `LEVEL|timestamp|loggerName|message`
+///
+/// ## Usage
+/// ```dart
+/// var logger = AtSignLogger('MyApp');
+/// logger.loggingHandler = FileLoggingHandler('app.log');
+/// ```
 class FileLoggingHandler implements LoggingHandler {
   late File _file;
 
   FileLoggingHandler(String filename) {
     _file = File(filename);
   }
+
   @override
   void call(LogRecord record) {
     var f = _file.openSync(mode: FileMode.append);
@@ -30,10 +47,51 @@ class FileLoggingHandler implements LoggingHandler {
   }
 }
 
+/// Outputs log messages to stderr in pipe-delimited format.
+///
+/// Format: `LEVEL|timestamp|loggerName|message`
 class StdErrLoggingHandler implements LoggingHandler {
   @override
   void call(LogRecord record) {
     stderr.write(
         '${record.level.name}|${record.time}|${record.loggerName}|${record.message} \n');
+  }
+}
+
+/// A logging handler that outputs colored log messages to stderr for CLIs.
+///
+/// Formats logs with color-coded severity levels for better terminal readability.
+///
+/// ## Usage
+/// ```dart
+/// AtSignLogger.root_level = 'INFO';
+/// var logger = AtSignLogger('MyApp', loggingHandler: CLILoggingHandler());
+/// logger.info('Application started');
+/// ```
+class CLILoggingHandler implements LoggingHandler {
+  /// Handles a log record by writing it to stderr with color formatting.
+  ///
+  /// Output format: [LEVEL] message
+  @override
+  void call(LogRecord record) {
+    final String coloredLevel = _getColoredLevel(record.level);
+    stderr.writeln('[${chalk.bold(coloredLevel)}] ${record.message}');
+  }
+
+  /// Returns a color-coded label for the given log level.
+  String _getColoredLevel(Level level) {
+    switch (level) {
+      case Level.WARNING:
+        return chalk.yellow('WARN');
+      case Level.SEVERE:
+      case Level.SHOUT:
+        return chalk.red('ERROR');
+      case Level.INFO:
+        return chalk.blueBright('INFO');
+      case Level.FINER:
+      case Level.FINEST:
+      default:
+        return chalk.gray('FINER');
+    }
   }
 }

--- a/packages/at_utils/pubspec.yaml
+++ b/packages/at_utils/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_utils
 description: A Dart library that contains various utility classes such as atSign, atmetadata, configuration, and logger.
-version: 3.3.0
+version: 3.4.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_utils
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Introduce CLILoggingHandler that can be used for command-line applications
- bugfix: AtLogger.level setter fails to work with uppercase input

**- How I did it**
- Writes logs to stderr with color-coded tags
- Convert the 'log-level input to the setter' to lowercase before assigning it to the logger

**- How to verify it**
- tests pass here
- Manually: pass CLILoggingHandler () object to the optional loggingHandler param while creating AtSignLogger and the logs should now be minimal and color-coded

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: Introduce CLILoggingHandler