### PR TITLE
fix: json encode serialize atrpcs

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -3,6 +3,8 @@
 - build(deps): Updated archive dependency to ^4.0.7
 - feat: Add RemoteLocalPref enum and AtClientPreference.remoteLocalPref field
   to enable apps to easily default to using the remote atServer
+- fix: ensure AtRpcResp and AtRpcReq `.toString()` methods are JSON serialized
+  strings
 
 ## 3.9.2
 

--- a/packages/at_client/lib/src/rpc/at_rpc_types.dart
+++ b/packages/at_client/lib/src/rpc/at_rpc_types.dart
@@ -92,11 +92,11 @@ class AtRpcResp {
   }
 
   Map<String, dynamic> toJson() => {
-    'reqId': reqId,
-    'respType': respType.name,
-    'payload': payload,
-    'message': message
-  };
+        'reqId': reqId,
+        'respType': respType.name,
+        'payload': payload,
+        'message': message
+      };
 
   @override
   String toString() => jsonEncode(toJson());

--- a/packages/at_client/lib/src/rpc/at_rpc_types.dart
+++ b/packages/at_client/lib/src/rpc/at_rpc_types.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 /// Simple data structure whose JSON is transmitted as the payload of the
 /// notification which is sent from the requester to the responder
 class AtRpcReq {
@@ -22,7 +24,7 @@ class AtRpcReq {
   }
 
   @override
-  String toString() => toJson().toString();
+  String toString() => jsonEncode(toJson());
 }
 
 /// The types of responses which the responder can send back to the requester
@@ -97,5 +99,5 @@ class AtRpcResp {
       };
 
   @override
-  String toString() => toJson().toString();
+  String toString() => jsonEncode(toJson());
 }

--- a/packages/at_client/lib/src/rpc/at_rpc_types.dart
+++ b/packages/at_client/lib/src/rpc/at_rpc_types.dart
@@ -92,11 +92,11 @@ class AtRpcResp {
   }
 
   Map<String, dynamic> toJson() => {
-        'reqId': reqId,
-        'respType': respType.name,
-        'payload': payload,
-        'message': message
-      };
+    'reqId': reqId,
+    'respType': respType.name,
+    'payload': payload,
+    'message': message
+  };
 
   @override
   String toString() => jsonEncode(toJson());

--- a/packages/at_client/test/rpc/at_rpc_types_test.dart
+++ b/packages/at_client/test/rpc/at_rpc_types_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:at_client/at_client.dart';
 import 'package:test/test.dart';
 
@@ -39,7 +41,8 @@ Future<void> main() async {
 
         // now try parsing it and reading values
         final Map<String, dynamic> parsedJson =
-            resp.toJson(); // Using toJson for parsing
+            jsonDecode(toStringOutput);
+
         expect(parsedJson['reqId'], equals(1));
         expect(parsedJson['respType'], equals('success'));
         expect(parsedJson['payload']['key'], equals('value'));
@@ -93,7 +96,7 @@ Future<void> main() async {
 
         // now try parsing it and reading values
         final Map<String, dynamic> parsedJson =
-            resp.toJson(); // Using toJson for parsing
+            jsonDecode(toStringOutput);
         expect(parsedJson['reqId'], equals(2));
         expect(parsedJson['respType'], equals('success'));
         expect(parsedJson['payload']['level1']['level2']['level3']['key'],
@@ -144,7 +147,7 @@ Future<void> main() async {
 
         // now try parsing it and reading values
         final Map<String, dynamic> parsedJson =
-            req.toJson(); // Using toJson for parsing
+            jsonDecode(toStringOutput);
         expect(parsedJson['reqId'], equals(10));
         expect(parsedJson['payload']['param1'], equals('value1'));
         expect(parsedJson['payload']['param2'], equals(100));
@@ -183,8 +186,7 @@ Future<void> main() async {
         expect(toStringOutput, equals(expectedStringOutput));
 
         // now try parsing it and reading values
-        final Map<String, dynamic> parsedJson =
-            req.toJson(); // Using toJson for parsing
+        final Map<String, dynamic> parsedJson = jsonDecode(toStringOutput);
         expect(parsedJson['reqId'], equals(20));
         expect(parsedJson['payload']['config']['settings']['optionA'],
             equals(true));

--- a/packages/at_client/test/rpc/at_rpc_types_test.dart
+++ b/packages/at_client/test/rpc/at_rpc_types_test.dart
@@ -15,11 +15,10 @@ Future<void> main() async {
         'key6': []
       };
       final AtRpcResp resp = AtRpcResp(
-        reqId: 1,
-        respType: AtRpcRespType.success,
-        payload: payload,
-        message: 'Test message'
-      ); 
+          reqId: 1,
+          respType: AtRpcRespType.success,
+          payload: payload,
+          message: 'Test message');
       test('toJson', () {
         final Map<String, dynamic> toJsonOutput = resp.toJson();
         final Map<String, dynamic> expectedJsonOutput = {
@@ -32,10 +31,10 @@ Future<void> main() async {
       });
       test('toString', () {
         final String toStringOutput = resp.toString();
-        final String expectedStringOutput = 
-          '{"reqId":1,"respType":"success","payload":{"key":"value","key2":'
-          '42,"key3":true,"key4":null,"key5":3.14,"key6":[]},"message":"Test'
-          'message"}';
+        final String expectedStringOutput =
+            '{"reqId":1,"respType":"success","payload":{"key":"value","key2":'
+            '42,"key3":true,"key4":null,"key5":3.14,"key6":[]},"message":"Test'
+            'message"}';
         expect(toStringOutput, equals(expectedStringOutput));
       });
     });
@@ -46,17 +45,21 @@ Future<void> main() async {
           'level2': {
             'level3': {
               'key': 'deepValue',
-              'list': [1, 2, 3, {'nestedKey': 'nestedValue'}]
+              'list': [
+                1,
+                2,
+                3,
+                {'nestedKey': 'nestedValue'}
+              ]
             }
           }
         }
       };
       final AtRpcResp resp = AtRpcResp(
-        reqId: 2,
-        respType: AtRpcRespType.success,
-        payload: payload,
-        message: 'Deep payload test'
-      );
+          reqId: 2,
+          respType: AtRpcRespType.success,
+          payload: payload,
+          message: 'Deep payload test');
       test('toJson', () {
         final Map<String, dynamic> toJsonOutput = resp.toJson();
         final Map<String, dynamic> expectedJsonOutput = {
@@ -69,10 +72,10 @@ Future<void> main() async {
       });
       test('toString', () {
         final String toStringOutput = resp.toString();
-        final String expectedStringOutput = 
-          '{"reqId":2,"respType":"success","payload":{"level1":{"level2":'
-          '{"level3":{"key":"deepValue","list":[1,2,3,{"nestedKey":"nestedV'
-          'alue"}]}}}},"message":"Deep payload test"}';
+        final String expectedStringOutput =
+            '{"reqId":2,"respType":"success","payload":{"level1":{"level2":'
+            '{"level3":{"key":"deepValue","list":[1,2,3,{"nestedKey":"nestedV'
+            'alue"}]}}}},"message":"Deep payload test"}';
         expect(toStringOutput, equals(expectedStringOutput));
       });
     });
@@ -88,11 +91,8 @@ Future<void> main() async {
         'param4': null,
         'param5': 2.71,
         'param6': []
-      }; 
-      final AtRpcReq req = AtRpcReq(
-        reqId: 10,
-        payload: payload
-      );
+      };
+      final AtRpcReq req = AtRpcReq(reqId: 10, payload: payload);
       test('toJson', () {
         final Map<String, dynamic> toJsonOutput = req.toJson();
         final Map<String, dynamic> expectedJsonOutput = {
@@ -103,9 +103,9 @@ Future<void> main() async {
       });
       test('toString', () {
         final String toStringOutput = req.toString();
-        final String expectedStringOutput = 
-          '{"reqId":10,"payload":{"param1":"value1","param2":100,"param3":'
-          'false,"param4":null,"param5":2.71,"param6":[]}}';
+        final String expectedStringOutput =
+            '{"reqId":10,"payload":{"param1":"value1","param2":100,"param3":'
+            'false,"param4":null,"param5":2.71,"param6":[]}}';
         expect(toStringOutput, equals(expectedStringOutput));
       });
     });
@@ -121,10 +121,7 @@ Future<void> main() async {
           }
         }
       };
-      final AtRpcReq req = AtRpcReq(
-        reqId: 20,
-        payload: payload
-      );
+      final AtRpcReq req = AtRpcReq(reqId: 20, payload: payload);
       test('toJson', () {
         final Map<String, dynamic> toJsonOutput = req.toJson();
         final Map<String, dynamic> expectedJsonOutput = {
@@ -135,12 +132,11 @@ Future<void> main() async {
       });
       test('toString', () {
         final String toStringOutput = req.toString();
-        final String expectedStringOutput = 
-          '{"reqId":20,"payload":{"config":{"settings":{"optionA":true,'
-          '"optionB":{"subOption1":"subValue1","subOption2":[10,20,30]}}}}}';
+        final String expectedStringOutput =
+            '{"reqId":20,"payload":{"config":{"settings":{"optionA":true,'
+            '"optionB":{"subOption1":"subValue1","subOption2":[10,20,30]}}}}}';
         expect(toStringOutput, equals(expectedStringOutput));
-      }); 
+      });
     });
   });
 }
-

--- a/packages/at_client/test/rpc/at_rpc_types_test.dart
+++ b/packages/at_client/test/rpc/at_rpc_types_test.dart
@@ -40,8 +40,7 @@ Future<void> main() async {
         expect(toStringOutput, equals(expectedStringOutput));
 
         // now try parsing it and reading values
-        final Map<String, dynamic> parsedJson =
-            jsonDecode(toStringOutput);
+        final Map<String, dynamic> parsedJson = jsonDecode(toStringOutput);
 
         expect(parsedJson['reqId'], equals(1));
         expect(parsedJson['respType'], equals('success'));
@@ -95,22 +94,19 @@ Future<void> main() async {
         expect(toStringOutput, equals(expectedStringOutput));
 
         // now try parsing it and reading values
-        final Map<String, dynamic> parsedJson =
-            jsonDecode(toStringOutput);
+        final Map<String, dynamic> parsedJson = jsonDecode(toStringOutput);
         expect(parsedJson['reqId'], equals(2));
         expect(parsedJson['respType'], equals('success'));
         expect(parsedJson['payload']['level1']['level2']['level3']['key'],
             equals('deepValue'));
-        expect(
-            parsedJson['payload']['level1']['level2']['level3']['list'][0],
+        expect(parsedJson['payload']['level1']['level2']['level3']['list'][0],
             equals(1));
-        expect(
-            parsedJson['payload']['level1']['level2']['level3']['list'][1],
+        expect(parsedJson['payload']['level1']['level2']['level3']['list'][1],
             equals(2));
-        expect(
-            parsedJson['payload']['level1']['level2']['level3']['list'][2],
+        expect(parsedJson['payload']['level1']['level2']['level3']['list'][2],
             equals(3));
-        expect(parsedJson['payload']['level1']['level2']['level3']['list'][3]
+        expect(
+            parsedJson['payload']['level1']['level2']['level3']['list'][3]
                 ['nestedKey'],
             equals('nestedValue'));
         expect(parsedJson['message'], equals('Deep payload test'));
@@ -146,8 +142,7 @@ Future<void> main() async {
         expect(toStringOutput, equals(expectedStringOutput));
 
         // now try parsing it and reading values
-        final Map<String, dynamic> parsedJson =
-            jsonDecode(toStringOutput);
+        final Map<String, dynamic> parsedJson = jsonDecode(toStringOutput);
         expect(parsedJson['reqId'], equals(10));
         expect(parsedJson['payload']['param1'], equals('value1'));
         expect(parsedJson['payload']['param2'], equals(100));
@@ -190,20 +185,21 @@ Future<void> main() async {
         expect(parsedJson['reqId'], equals(20));
         expect(parsedJson['payload']['config']['settings']['optionA'],
             equals(true));
-        expect(parsedJson['payload']['config']['settings']['optionB']
+        expect(
+            parsedJson['payload']['config']['settings']['optionB']
                 ['subOption1'],
             equals('subValue1'));
         expect(
-          parsedJson['payload']['config']['settings']['optionB']
-            ['subOption2'][0],
+            parsedJson['payload']['config']['settings']['optionB']['subOption2']
+                [0],
             equals(10));
         expect(
-          parsedJson['payload']['config']['settings']['optionB']
-            ['subOption2'][1],
+            parsedJson['payload']['config']['settings']['optionB']['subOption2']
+                [1],
             equals(20));
         expect(
-          parsedJson['payload']['config']['settings']['optionB']
-            ['subOption2'][2],
+            parsedJson['payload']['config']['settings']['optionB']['subOption2']
+                [2],
             equals(30));
       });
     });

--- a/packages/at_client/test/rpc/at_rpc_types_test.dart
+++ b/packages/at_client/test/rpc/at_rpc_types_test.dart
@@ -34,7 +34,7 @@ Future<void> main() async {
         final String expectedStringOutput =
             '{"reqId":1,"respType":"success","payload":{"key":"value","key2":'
             '42,"key3":true,"key4":null,"key5":3.14,"key6":[]},"message":"Test'
-            'message"}';
+            ' message"}';
         expect(toStringOutput, equals(expectedStringOutput));
       });
     });

--- a/packages/at_client/test/rpc/at_rpc_types_test.dart
+++ b/packages/at_client/test/rpc/at_rpc_types_test.dart
@@ -33,7 +33,9 @@ Future<void> main() async {
       test('toString', () {
         final String toStringOutput = resp.toString();
         final String expectedStringOutput = 
-          '{"reqId":1,"respType":"success","payload":{"key":"value","key2":42,"key3":true,"key4":null,"key5":3.14,"key6":[]},"message":"Test message"}';
+          '{"reqId":1,"respType":"success","payload":{"key":"value","key2":'
+          '42,"key3":true,"key4":null,"key5":3.14,"key6":[]},"message":"Test'
+          'message"}';
         expect(toStringOutput, equals(expectedStringOutput));
       });
     });
@@ -68,7 +70,9 @@ Future<void> main() async {
       test('toString', () {
         final String toStringOutput = resp.toString();
         final String expectedStringOutput = 
-          '{"reqId":2,"respType":"success","payload":{"level1":{"level2":{"level3":{"key":"deepValue","list":[1,2,3,{"nestedKey":"nestedValue"}]}}}},"message":"Deep payload test"}';
+          '{"reqId":2,"respType":"success","payload":{"level1":{"level2":'
+          '{"level3":{"key":"deepValue","list":[1,2,3,{"nestedKey":"nestedV'
+          'alue"}]}}}},"message":"Deep payload test"}';
         expect(toStringOutput, equals(expectedStringOutput));
       });
     });
@@ -100,7 +104,8 @@ Future<void> main() async {
       test('toString', () {
         final String toStringOutput = req.toString();
         final String expectedStringOutput = 
-          '{"reqId":10,"payload":{"param1":"value1","param2":100,"param3":false,"param4":null,"param5":2.71,"param6":[]}}';
+          '{"reqId":10,"payload":{"param1":"value1","param2":100,"param3":'
+          'false,"param4":null,"param5":2.71,"param6":[]}}';
         expect(toStringOutput, equals(expectedStringOutput));
       });
     });
@@ -131,7 +136,8 @@ Future<void> main() async {
       test('toString', () {
         final String toStringOutput = req.toString();
         final String expectedStringOutput = 
-          '{"reqId":20,"payload":{"config":{"settings":{"optionA":true,"optionB":{"subOption1":"subValue1","subOption2":[10,20,30]}}}}}';
+          '{"reqId":20,"payload":{"config":{"settings":{"optionA":true,'
+          '"optionB":{"subOption1":"subValue1","subOption2":[10,20,30]}}}}}';
         expect(toStringOutput, equals(expectedStringOutput));
       }); 
     });

--- a/packages/at_client/test/rpc/at_rpc_types_test.dart
+++ b/packages/at_client/test/rpc/at_rpc_types_test.dart
@@ -36,6 +36,19 @@ Future<void> main() async {
             '42,"key3":true,"key4":null,"key5":3.14,"key6":[]},"message":"Test'
             ' message"}';
         expect(toStringOutput, equals(expectedStringOutput));
+
+        // now try parsing it and reading values
+        final Map<String, dynamic> parsedJson =
+            resp.toJson(); // Using toJson for parsing
+        expect(parsedJson['reqId'], equals(1));
+        expect(parsedJson['respType'], equals('success'));
+        expect(parsedJson['payload']['key'], equals('value'));
+        expect(parsedJson['payload']['key2'], equals(42));
+        expect(parsedJson['payload']['key3'], equals(true));
+        expect(parsedJson['payload']['key4'], isNull);
+        expect(parsedJson['payload']['key5'], equals(3.14));
+        expect(parsedJson['payload']['key6'], equals([]));
+        expect(parsedJson['message'], equals('Test message'));
       });
     });
 
@@ -77,6 +90,27 @@ Future<void> main() async {
             '{"level3":{"key":"deepValue","list":[1,2,3,{"nestedKey":"nestedV'
             'alue"}]}}}},"message":"Deep payload test"}';
         expect(toStringOutput, equals(expectedStringOutput));
+
+        // now try parsing it and reading values
+        final Map<String, dynamic> parsedJson =
+            resp.toJson(); // Using toJson for parsing
+        expect(parsedJson['reqId'], equals(2));
+        expect(parsedJson['respType'], equals('success'));
+        expect(parsedJson['payload']['level1']['level2']['level3']['key'],
+            equals('deepValue'));
+        expect(
+            parsedJson['payload']['level1']['level2']['level3']['list'][0],
+            equals(1));
+        expect(
+            parsedJson['payload']['level1']['level2']['level3']['list'][1],
+            equals(2));
+        expect(
+            parsedJson['payload']['level1']['level2']['level3']['list'][2],
+            equals(3));
+        expect(parsedJson['payload']['level1']['level2']['level3']['list'][3]
+                ['nestedKey'],
+            equals('nestedValue'));
+        expect(parsedJson['message'], equals('Deep payload test'));
       });
     });
   });
@@ -107,6 +141,17 @@ Future<void> main() async {
             '{"reqId":10,"payload":{"param1":"value1","param2":100,"param3":'
             'false,"param4":null,"param5":2.71,"param6":[]}}';
         expect(toStringOutput, equals(expectedStringOutput));
+
+        // now try parsing it and reading values
+        final Map<String, dynamic> parsedJson =
+            req.toJson(); // Using toJson for parsing
+        expect(parsedJson['reqId'], equals(10));
+        expect(parsedJson['payload']['param1'], equals('value1'));
+        expect(parsedJson['payload']['param2'], equals(100));
+        expect(parsedJson['payload']['param3'], equals(false));
+        expect(parsedJson['payload']['param4'], isNull);
+        expect(parsedJson['payload']['param5'], equals(2.71));
+        expect(parsedJson['payload']['param6'], equals([]));
       });
     });
     group('Deep payload', () {
@@ -136,6 +181,28 @@ Future<void> main() async {
             '{"reqId":20,"payload":{"config":{"settings":{"optionA":true,'
             '"optionB":{"subOption1":"subValue1","subOption2":[10,20,30]}}}}}';
         expect(toStringOutput, equals(expectedStringOutput));
+
+        // now try parsing it and reading values
+        final Map<String, dynamic> parsedJson =
+            req.toJson(); // Using toJson for parsing
+        expect(parsedJson['reqId'], equals(20));
+        expect(parsedJson['payload']['config']['settings']['optionA'],
+            equals(true));
+        expect(parsedJson['payload']['config']['settings']['optionB']
+                ['subOption1'],
+            equals('subValue1'));
+        expect(
+          parsedJson['payload']['config']['settings']['optionB']
+            ['subOption2'][0],
+            equals(10));
+        expect(
+          parsedJson['payload']['config']['settings']['optionB']
+            ['subOption2'][1],
+            equals(20));
+        expect(
+          parsedJson['payload']['config']['settings']['optionB']
+            ['subOption2'][2],
+            equals(30));
       });
     });
   });

--- a/packages/at_client/test/rpc/at_rpc_types_test.dart
+++ b/packages/at_client/test/rpc/at_rpc_types_test.dart
@@ -1,0 +1,140 @@
+import 'package:at_client/at_client.dart';
+import 'package:test/test.dart';
+
+Future<void> main() async {
+  // Test that AtRpcResp payloads are JSON parsable
+  group('AtRpcResp', () {
+    group('Non-deep payload', () {
+      // A payload that is not deeply nested with JSON objects
+      final Map<String, dynamic> payload = {
+        'key': 'value',
+        'key2': 42,
+        'key3': true,
+        'key4': null,
+        'key5': 3.14,
+        'key6': []
+      };
+      final AtRpcResp resp = AtRpcResp(
+        reqId: 1,
+        respType: AtRpcRespType.success,
+        payload: payload,
+        message: 'Test message'
+      ); 
+      test('toJson', () {
+        final Map<String, dynamic> toJsonOutput = resp.toJson();
+        final Map<String, dynamic> expectedJsonOutput = {
+          'reqId': resp.reqId,
+          'respType': AtRpcRespType.success.name,
+          'payload': payload,
+          'message': resp.message,
+        };
+        expect(toJsonOutput, equals(expectedJsonOutput));
+      });
+      test('toString', () {
+        final String toStringOutput = resp.toString();
+        final String expectedStringOutput = 
+          '{"reqId":1,"respType":"success","payload":{"key":"value","key2":42,"key3":true,"key4":null,"key5":3.14,"key6":[]},"message":"Test message"}';
+        expect(toStringOutput, equals(expectedStringOutput));
+      });
+    });
+
+    group('Deep payload', () {
+      final Map<String, dynamic> payload = {
+        'level1': {
+          'level2': {
+            'level3': {
+              'key': 'deepValue',
+              'list': [1, 2, 3, {'nestedKey': 'nestedValue'}]
+            }
+          }
+        }
+      };
+      final AtRpcResp resp = AtRpcResp(
+        reqId: 2,
+        respType: AtRpcRespType.success,
+        payload: payload,
+        message: 'Deep payload test'
+      );
+      test('toJson', () {
+        final Map<String, dynamic> toJsonOutput = resp.toJson();
+        final Map<String, dynamic> expectedJsonOutput = {
+          'reqId': resp.reqId,
+          'respType': AtRpcRespType.success.name,
+          'payload': payload,
+          'message': resp.message,
+        };
+        expect(toJsonOutput, equals(expectedJsonOutput));
+      });
+      test('toString', () {
+        final String toStringOutput = resp.toString();
+        final String expectedStringOutput = 
+          '{"reqId":2,"respType":"success","payload":{"level1":{"level2":{"level3":{"key":"deepValue","list":[1,2,3,{"nestedKey":"nestedValue"}]}}}},"message":"Deep payload test"}';
+        expect(toStringOutput, equals(expectedStringOutput));
+      });
+    });
+  });
+
+  // Test that AtRpcReq payloads are JSON parsable
+  group('AtRpcReq', () {
+    group('Non deep payload', () {
+      final Map<String, dynamic> payload = {
+        'param1': 'value1',
+        'param2': 100,
+        'param3': false,
+        'param4': null,
+        'param5': 2.71,
+        'param6': []
+      }; 
+      final AtRpcReq req = AtRpcReq(
+        reqId: 10,
+        payload: payload
+      );
+      test('toJson', () {
+        final Map<String, dynamic> toJsonOutput = req.toJson();
+        final Map<String, dynamic> expectedJsonOutput = {
+          'reqId': req.reqId,
+          'payload': payload,
+        };
+        expect(toJsonOutput, equals(expectedJsonOutput));
+      });
+      test('toString', () {
+        final String toStringOutput = req.toString();
+        final String expectedStringOutput = 
+          '{"reqId":10,"payload":{"param1":"value1","param2":100,"param3":false,"param4":null,"param5":2.71,"param6":[]}}';
+        expect(toStringOutput, equals(expectedStringOutput));
+      });
+    });
+    group('Deep payload', () {
+      final Map<String, dynamic> payload = {
+        'config': {
+          'settings': {
+            'optionA': true,
+            'optionB': {
+              'subOption1': 'subValue1',
+              'subOption2': [10, 20, 30]
+            }
+          }
+        }
+      };
+      final AtRpcReq req = AtRpcReq(
+        reqId: 20,
+        payload: payload
+      );
+      test('toJson', () {
+        final Map<String, dynamic> toJsonOutput = req.toJson();
+        final Map<String, dynamic> expectedJsonOutput = {
+          'reqId': req.reqId,
+          'payload': payload,
+        };
+        expect(toJsonOutput, equals(expectedJsonOutput));
+      });
+      test('toString', () {
+        final String toStringOutput = req.toString();
+        final String expectedStringOutput = 
+          '{"reqId":20,"payload":{"config":{"settings":{"optionA":true,"optionB":{"subOption1":"subValue1","subOption2":[10,20,30]}}}}}';
+        expect(toStringOutput, equals(expectedStringOutput));
+      }); 
+    });
+  });
+}
+


### PR DESCRIPTION
closes #1765 

**- What I did**

- Changed `.toJson().toString()` to `jsonEncode()`

**- How to verify it**

See AtRpc Logs

The response String has `"` quotations so now it is JSON parsable

```
INFO|2025-12-22 14:16:39.763431| AtRpcClient |Got ack : {"reqId":1766430998869659,"respType":"ack","payload":{},"m
essage":null} 
INFO|2025-12-22 14:16:39.818674| AtRpcClient |Got response {success: true, message: 1 clients found., value: [{id:
 1, name: Jeremy, atSign: @jeremy}]} 
INFO|2025-12-22 14:16:39.818857| AtRpcClient |Got success response : {"reqId":1766430998869659,"respType":"success
","payload":{"success":true,"message":"1 clients found.","value":[{"id":"1","name":"Jeremy","atSign":"@jeremy"}]},
"message":"1 clients found."} 
```

**- Description for the changelog**
fix: json encode serialize atrpcs
