### PR TITLE
feat: extend `info` verb syntax

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.7.0
+
+- feat: extend syntax of `info` verb, adding `info:mtls` and `info:mtlsbrief`
+
 ## 5.6.2
 
 - chore: remove `@experimental` annotation from `EnrollVerbBuilder.otp`

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -128,7 +128,7 @@ class VerbSyntax {
       r'(?<forAtSign>(([^:\s])+)?(,([^:\s]+))*)'
       r'(:(?<atKey>[^@:\s]+))(@(?<atSign>[^@:\s]+))?(:(?<value>.+))?$';
   static const batch = r'^batch:(?<json>.+)$';
-  static const info = r'^info(:brief)?$';
+  static const info = r'^info(:(brief|mtls|mtlsbrief))?$';
   static const noOp = r'^noop:(?<delayMillis>\d+)$';
   static const notifyRemove = r'notify:remove:(?<id>[\w\d\-\_]+)';
   static const enroll =

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.6.2
+version: 5.7.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
**- What I did**
Extend syntax for `info` to allow `info:mtls` and `info:mtlsbrief`

**- How I did it**
See commits

**- How to verify it**
Verified via https://github.com/atsign-foundation/at_server/pull/2482