### PR TITLE
feat: macos apple support for xl-atchat

### DIFF
--- a/packages/at_chat_flutter/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/at_chat_flutter/example/macos/Runner/DebugProfile.entitlements
@@ -8,7 +8,11 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
     <key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.keychain</key>
 	<true/>
 </dict>
 </plist>

--- a/packages/at_chat_flutter/example/macos/Runner/Release.entitlements
+++ b/packages/at_chat_flutter/example/macos/Runner/Release.entitlements
@@ -4,7 +4,11 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.keychain</key>
 	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
**- What I did**
- Added network and keychain permissions for at_chat_flutter/example

**- How I did it**
- See changes

**- How to verify it**
- `cd packages/at_chat_flutter/example && flutter run -d macos` on an Apple machine

**- Description for the changelog**
feat: macos apple support for xl-atchat
