### PR TITLE
chore(at_client_flutter): remove unused dependecies and update links in pubspec

### DIFF
--- a/packages/at_client_flutter/CHANGELOG.md
+++ b/packages/at_client_flutter/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 0.1.1
+- chore: removed unused dependencies
+    - flutter_keychain
+    - hive
+    - crypton
+    - flutter_riverpod
+    - at_persistence_secondary_server
+- docs: Update README with more documentation
+- fix: broken links in README
+
 ## 0.1.0
 
 - Initial version, consolidating in functionality from legacy packages

--- a/packages/at_client_flutter/README.md
+++ b/packages/at_client_flutter/README.md
@@ -79,12 +79,54 @@ AtAuthRequest request = AtAuthRequest(
 AtAuthResponse response = await PkamDialog.show(context, request: request);
 ```
 
+#### Keychain Authentication
+Keychain Authentication is handled by providing a KeychainAtKeysIo instance in your AuthRequest
+
+```
+KeychainAtKeysIo keychainAtKeysIo = KeychainAtKeysIo();
+```
+This class handles necessary reading and writing of your AtKeys to your keychain during authentication.
+
+Any futher manipulation of the keychain is handled via `KeychainStorage`.
+
+#### Keychain Storage
+```
+final KeychainStorage keychainStorage = KeychainStorage();
+// Get a specific atsign's keys
+AtKeys? alice = await keychainStorage.getAtsign("@alice");
+
+// Get all atsigns in the keychain
+List<String> atsigns = await keychainStorage.getAllAtsigns();
+
+// Append atKeys to the keychain
+await keychainStorage.appendAtKeysToKeychain(atKeys);
+
+// Remove atSign from keychain
+await keychainStorage.removeAtsignFromKeychain("@alice");
+
+// Delete all atKeys data for this app
+await keychainStorage.deleteAllAtKeysData();
+```
+
 
 - If your app supports windows platform then add `biometric_storage` in app's dependencies
 
 ```
 dependencies:
  biometric_storage: ^4.1.3
+```
+
+#### Enrollments in the keychain
+
+Storing enrollment data for ongoing/approved/denied enrollments are managed by the KeychainStorage class
+```
+await keychainStorage.readEnrollmentData("@alice");
+
+await keychainStorage.writeEnrollmentData("@alice", enrollmentData);
+
+await keychainStorage.deleteEnrollmentData("@alice");
+
+bool isValidated = await keychainStorage.validateEnrollment("@alice");
 ```
 
 ## Example

--- a/packages/at_client_flutter/README.md
+++ b/packages/at_client_flutter/README.md
@@ -23,7 +23,7 @@ We call giving people control of access to their data "*flipping the internet*".
 ## Get Started
 
 > Before using this package for the first time, you should follow the
-> [getting started guide](https://docs.atsign.com/start/)
+> [getting started guide](https://docs.atsign.com/)
 
 You may find it useful to read the [atPlatform overview](https://docs.atsign.com/).
 
@@ -59,7 +59,7 @@ String cramKey = await RegistrarCramDialog.show(
 ```
 AtOnboardingResponse response = await CramDialog.show(
     context, 
-    request: authRequest, 
+    request: onboardingRequest, 
     cramKey: cramKey,
     progressBuilder: progressBuilder,
     onOnboardingComplete: onOnboardingComplete,
@@ -72,7 +72,7 @@ AtOnboardingResponse response = await CramDialog.show(
 ```
 AtAuthRequest request = AtAuthRequest(
     authRequest.atSign,
-    atKeysIo,
+    atKeysIo: atKeysIo,
     rootDomain: authRequest.rootDomain,
 );
 

--- a/packages/at_client_flutter/lib/src/keychain/keychain_storage.dart
+++ b/packages/at_client_flutter/lib/src/keychain/keychain_storage.dart
@@ -48,7 +48,7 @@ class KeychainStorage {
     return null;
   }
 
-	/// Get atSign from keychain storage
+  /// Get atSign from keychain storage
   Future<AtKeys?> getAtsign(String atSign) async {
     final atKeysData = await readAtKeysData();
     if (atKeysData == null) {
@@ -67,7 +67,7 @@ class KeychainStorage {
     return null;
   }
 
-	/// Get all atSigns from the keychain
+  /// Get all atSigns from the keychain
   Future<List<String>> getAllAtsigns() async {
     final atKeysData = await readAtKeysData();
     if (atKeysData == null) {
@@ -85,8 +85,8 @@ class KeychainStorage {
     return atSigns.toList();
   }
 
-	/// Append an atKeys instance to the Keychain
-	/// Note: atSign must be included in to AtKeys metadata field
+  /// Append an atKeys instance to the Keychain
+  /// Note: atSign must be included in to AtKeys metadata field
   Future<void> appendAtKeysToKeychain({
     required AtKeys keys,
   }) async {

--- a/packages/at_client_flutter/lib/src/keychain/keychain_storage.dart
+++ b/packages/at_client_flutter/lib/src/keychain/keychain_storage.dart
@@ -48,6 +48,7 @@ class KeychainStorage {
     return null;
   }
 
+	/// Get atSign from keychain storage
   Future<AtKeys?> getAtsign(String atSign) async {
     final atKeysData = await readAtKeysData();
     if (atKeysData == null) {
@@ -66,6 +67,7 @@ class KeychainStorage {
     return null;
   }
 
+	/// Get all atSigns from the keychain
   Future<List<String>> getAllAtsigns() async {
     final atKeysData = await readAtKeysData();
     if (atKeysData == null) {
@@ -83,6 +85,8 @@ class KeychainStorage {
     return atSigns.toList();
   }
 
+	/// Append an atKeys instance to the Keychain
+	/// Note: atSign must be included in to AtKeys metadata field
   Future<void> appendAtKeysToKeychain({
     required AtKeys keys,
   }) async {

--- a/packages/at_client_flutter/pubspec.yaml
+++ b/packages/at_client_flutter/pubspec.yaml
@@ -12,22 +12,18 @@ resolution: workspace
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus: ^8.0.0
-  biometric_storage: ^5.0.0
-  hive: ^2.2.3
-  crypton: ^2.2.1
-  at_commons: ^5.5.0
-  at_utils: ^3.0.19
+  package_info_plus: ^8.3.1
+  biometric_storage: ^5.0.1
+  at_commons: ^5.8.0
+  at_utils: ^3.4.0
   at_chops: ^3.0.0
-  at_lookup: ^3.4.2
+  at_lookup: ^3.5.0
   at_auth: ^3.0.0
   at_client: ^3.11.0
   encrypt: ^5.0.3
-  at_persistence_secondary_server: ^4.2.0
-  flutter_riverpod: ^3.0.0
   phosphor_flutter: ^2.1.0
   intl: ^0.20.2
-  file_picker: ^10.3.7
+  file_picker: ^10.3.8
 
 dev_dependencies:
   path: ^1.9.0

--- a/packages/at_client_flutter/pubspec.yaml
+++ b/packages/at_client_flutter/pubspec.yaml
@@ -1,7 +1,7 @@
 name: at_client_flutter
 description: A Flutter extension to the at_client library which adds support for mobile, desktop and IoT devices.
 version: 0.1.0
-repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_mobile
+repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
 
@@ -13,7 +13,6 @@ dependencies:
   flutter:
     sdk: flutter
   package_info_plus: ^8.0.0
-  flutter_keychain: ^2.2.1
   biometric_storage: ^5.0.0
   hive: ^2.2.3
   crypton: ^2.2.1

--- a/packages/at_client_flutter/pubspec.yaml
+++ b/packages/at_client_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client_flutter
 description: A Flutter extension to the at_client library which adds support for mobile, desktop and IoT devices.
-version: 0.1.0
+version: 0.1.1
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
**- What I did**
Preparing to make a minor release 0.1.1
 - update the broken links in the pubspec
 - update changelog
 - add more documentation into the readme
 - remove:
    - flutter_keychain
    - hive
    - crypton
    - flutter_riverpod
    - at_persistence_secondary_server
  - also addressing problems in [our pub score](https://pub.dev/packages/at_client_flutter/score)

**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore(at_client_flutter): remove flutter_keychain and update links in pubspec
