### PR TITLE
chore(deps): pin file_picker to 10.3.8

### DIFF
--- a/packages/at_backupkey_flutter/pubspec.yaml
+++ b/packages/at_backupkey_flutter/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   at_client_mobile: ^3.3.0
   showcaseview: ^4.0.1
   device_info_plus: ^11.3.3
-  file_picker: '>=10.0.0 <10.3.9' #10.3.9 contains non-addressed breaking change
+  file_picker: 10.3.8 #10.3.9 contains non-addressed breaking change
 
 dev_dependencies:
   flutter_test:

--- a/packages/at_backupkey_flutter/pubspec.yaml
+++ b/packages/at_backupkey_flutter/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   at_client_mobile: ^3.3.0
   showcaseview: ^4.0.1
   device_info_plus: ^11.3.3
-  file_picker: ^10.0.0
+  file_picker: '>=10.0.0 <10.3.9' #10.3.9 contains non-addressed breaking change
 
 dev_dependencies:
   flutter_test:

--- a/packages/at_chat_flutter/pubspec.yaml
+++ b/packages/at_chat_flutter/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   at_client: ^3.7.0
   at_common_flutter: ^2.1.0
   at_commons: ^5.5.0
-  file_picker: '>=10.0.0 <10.3.9' #10.3.9 contains non-addressed breaking change
+  file_picker: 10.3.8 #10.3.9 contains non-addressed breaking change
   at_client_mobile: ^3.3.0
   flutter:
     sdk: flutter

--- a/packages/at_chat_flutter/pubspec.yaml
+++ b/packages/at_chat_flutter/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   at_client: ^3.7.0
   at_common_flutter: ^2.1.0
   at_commons: ^5.5.0
-  file_picker: ^10.0.0
+  file_picker: '>=10.0.0 <10.3.9' #10.3.9 contains non-addressed breaking change
   at_client_mobile: ^3.3.0
   flutter:
     sdk: flutter

--- a/packages/at_client_flutter/CHANGELOG.md
+++ b/packages/at_client_flutter/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 0.1.2
-- constraint on file_picker 10.3.9 (BC)
+- pin file_picker to 10.3.9 (BC)
 
 ## 0.1.1
 - chore: removed unused dependencies

--- a/packages/at_client_flutter/CHANGELOG.md
+++ b/packages/at_client_flutter/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.1.2
+- constraint on file_picker 10.3.9 (BC)
+
 ## 0.1.1
 - chore: removed unused dependencies
     - flutter_keychain

--- a/packages/at_client_flutter/pubspec.yaml
+++ b/packages/at_client_flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   encrypt: ^5.0.3
   phosphor_flutter: ^2.1.0
   intl: ^0.20.2
-  file_picker: '>=10.3.8 <10.3.9' #10.3.9 contains non-addressed breaking change
+  file_picker: 10.3.8 #10.3.9 contains non-addressed breaking change
 
 dev_dependencies:
   path: ^1.9.0

--- a/packages/at_client_flutter/pubspec.yaml
+++ b/packages/at_client_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client_flutter
 description: A Flutter extension to the at_client library which adds support for mobile, desktop and IoT devices.
-version: 0.1.1
+version: 0.1.2
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -23,7 +23,7 @@ dependencies:
   encrypt: ^5.0.3
   phosphor_flutter: ^2.1.0
   intl: ^0.20.2
-  file_picker: ^10.3.8
+  file_picker: '>=10.3.8 <10.3.9' #10.3.9 contains non-addressed breaking change
 
 dev_dependencies:
   path: ^1.9.0

--- a/packages/at_contacts_group_flutter/pubspec.yaml
+++ b/packages/at_contacts_group_flutter/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   at_utils: ^3.0.19
   collection: ^1.17.0
   emoji_picker_flutter: ^4.3.0
-  file_picker: ^10.0.0
+  file_picker: '>=10.0.0 <10.3.8'
   flutter:
     sdk: flutter
   flutter_image_compress: ^2.0.4

--- a/packages/at_contacts_group_flutter/pubspec.yaml
+++ b/packages/at_contacts_group_flutter/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   at_utils: ^3.0.19
   collection: ^1.17.0
   emoji_picker_flutter: ^4.3.0
-  file_picker: '>=10.0.0 <10.3.8'
+  file_picker: '>=10.0.0 <10.3.9' #10.3.9 contains non-addressed breaking change
   flutter:
     sdk: flutter
   flutter_image_compress: ^2.0.4

--- a/packages/at_contacts_group_flutter/pubspec.yaml
+++ b/packages/at_contacts_group_flutter/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   at_utils: ^3.0.19
   collection: ^1.17.0
   emoji_picker_flutter: ^4.3.0
-  file_picker: '>=10.0.0 <10.3.9' #10.3.9 contains non-addressed breaking change
+  file_picker: 10.3.8 #10.3.9 contains non-addressed breaking change
   flutter:
     sdk: flutter
   flutter_image_compress: ^2.0.4


### PR DESCRIPTION
**- What I did**
 - Colin & Tina ran into some issues with at_client_flutter yesterday
   - same issue described as in [our packages pub score](https://pub.dev/packages/at_client_flutter/score)
   - **NOTE will need to publish this package as 0.1.1 pins to ^10.3.8**
 - file_picker released a breaking change in version 10.3.9 [see here for more](https://github.com/miguelpruivo/flutter_file_picker/issues/1946)
 
**- How I did it**
- pinned to 10.3.8 across our flutter packages
 
**- How to verify it**
 - test suite passes
 
**- Description for the changelog**
chore(deps): contrain file_picker to 10.3.8
