### PR TITLE
feat: at_activate --version, version, --help, and help all show package version

### DIFF
--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -14,6 +14,7 @@ import 'package:at_utils/at_utils.dart';
 import 'package:chalkdart/chalk.dart';
 import 'package:duration/duration.dart';
 import 'package:meta/meta.dart';
+import '../version.dart' show packageVersion;
 
 import 'auth_cli_arg_validation.dart';
 
@@ -102,6 +103,7 @@ Future<int> main(List<String> arguments) async {
 
 Future<int> wrappedMain(List<String> arguments) async {
   if (arguments.isEmpty) {
+    stderr.writeln('Version: $packageVersion\n');
     stderr.writeln('You must supply a command.');
     aca.parser.printAllCommandsUsage(showSubCommandParams: false);
     stderr.writeln('\n'

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -113,7 +113,7 @@ Future<int> wrappedMain(List<String> arguments) async {
   }
 
   final first = arguments.first;
-  if (first.startsWith('-') && first != '-h' && first != '--help') {
+  if (first.startsWith('-') && first != '-h' && first != '--help' && first != '--version') {
     // no command found ... legacy ... insert 'onboard' as the command
     arguments = ['onboard', ...arguments];
   }
@@ -134,6 +134,11 @@ Future<int> wrappedMain(List<String> arguments) async {
         .printAllCommandsUsage(header: 'Arguments common to all commands: ');
     aca.parser.printAllCommandsUsage(showSubCommandParams: true);
     stderr.writeln();
+    return 0;
+  }
+
+  if (topLevelResults.wasParsed(AuthCliArgs.argNameVersion)) {
+    stdout.writeln('Version: $packageVersion');
     return 0;
   }
 
@@ -329,6 +334,8 @@ Future<int> wrappedMain(List<String> arguments) async {
                 rootDomain:
                     commandArgResults[AuthCliArgs.argNameRootServer],
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
+      case AuthCliCommand.version:
+        stdout.writeln('Version: $packageVersion');
     }
   } on ArgumentError catch (e) {
     stderr
@@ -424,6 +431,10 @@ Future<int> status(ArgResults ar) async {
 /// secret from the registrar.
 @visibleForTesting
 Future<bool> onboard(ArgResults argResults, {AtOnboardingService? svc}) async {
+  if(argResults[AuthCliArgs.argNameVersion]) {
+    stdout.writeln('Version: $packageVersion');
+    return false;
+  }
   svc ??= createOnboardingService(argResults);
   logger.info('Root server is ${argResults[AuthCliArgs.argNameRootServer]}');
   logger.info(
@@ -689,6 +700,8 @@ Future<void> interactive(ArgResults argResults, AtClient atClient) async {
 
         case AuthCliCommand.delete:
           await deleteEnrollment(commandArgResults, atClient);
+        case AuthCliCommand.version:
+          stdout.writeln('Version: $packageVersion');
       }
     } on ArgumentError catch (e) {
       stderr.writeln(

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -103,7 +103,7 @@ Future<int> main(List<String> arguments) async {
 
 Future<int> wrappedMain(List<String> arguments) async {
   if (arguments.isEmpty) {
-    stderr.writeln('Version: $packageVersion\n');
+    stderr.writeln('Version: $packageVersion');
     stderr.writeln('You must supply a command.');
     aca.parser.printAllCommandsUsage(showSubCommandParams: false);
     stderr.writeln('\n'
@@ -129,6 +129,7 @@ Future<int> wrappedMain(List<String> arguments) async {
   }
 
   if (topLevelResults.wasParsed(AuthCliArgs.argNameHelp)) {
+    stderr.writeln('Version: $packageVersion');
     aca.sharedArgsParser
         .printAllCommandsUsage(header: 'Arguments common to all commands: ');
     aca.parser.printAllCommandsUsage(showSubCommandParams: true);
@@ -178,6 +179,7 @@ Future<int> wrappedMain(List<String> arguments) async {
   try {
     switch (cliCommand) {
       case AuthCliCommand.help:
+        stderr.writeln('Version: $packageVersion');
         aca.parser.printAllCommandsUsage(showSubCommandParams: true);
         break;
 

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -9,14 +9,12 @@ import 'package:at_client/at_client.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
-import 'package:at_onboarding_cli/src/util/create_at_client_cli.dart';
 import 'package:at_utils/at_progress.dart';
 import 'package:at_utils/at_utils.dart';
 import 'package:chalkdart/chalk.dart';
 import 'package:duration/duration.dart';
 import 'package:meta/meta.dart';
 
-import '../util/onboarding_util.dart';
 import 'auth_cli_arg_validation.dart';
 
 final AtSignLogger logger = AtSignLogger(' CLI ');

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli_args.dart
@@ -66,7 +66,11 @@ enum AuthCliCommand {
           ' be delivered to some other program(s) which have'
           ' permission to approve or deny the requests. Typically that will be'
           ' the program which first onboarded; however it can also be an enrolled'
-          ' program which has "rw" access to the "__manage" namespace.');
+          ' program which has "rw" access to the "__manage" namespace.'),
+  version(
+    usage: 'Print version. The version printed is the at_onboarding_cli '
+          'package version. It prints a format similar to "Version: x.xx.x"',
+  );
 
   const AuthCliCommand({this.usage = ''});
 
@@ -114,6 +118,7 @@ class AuthCliArgs {
   static const argNameMaxRetries = 'max-retries';
   static const argNameAllowBadRegistrarCerts = 'allow-bad-registrar-certs';
   static const argNameYes = 'yes';
+  static const argNameVersion = 'version';
 
   ArgParser get parser {
     return _aap;
@@ -139,6 +144,12 @@ class AuthCliArgs {
     p.addFlag(
       argNameHelp,
       abbr: 'h',
+      negatable: false,
+      hide: true,
+    );
+
+    p.addFlag(
+      argNameVersion,
       negatable: false,
       hide: true,
     );
@@ -194,9 +205,10 @@ class AuthCliArgs {
 
       case AuthCliCommand.unrevoke:
         return createUnRevokeCommandParser();
-
       case AuthCliCommand.delete:
         return createDeleteCommandParser();
+      case AuthCliCommand.version:
+        return createVersionCommandParser();
     }
   }
 
@@ -319,6 +331,13 @@ class AuthCliArgs {
       defaultsTo: false,
       negatable: false,
       hide: false,
+    );
+    p.addFlag(
+      argNameVersion,
+      help: 'Print version',
+      defaultsTo: false,
+      negatable: false,
+      hide: true,
     );
 
     return p;
@@ -541,6 +560,12 @@ class AuthCliArgs {
   ArgParser createDeleteCommandParser() {
     ArgParser p = createSharedArgParser(hide: true);
     _addEnrollmentIdOption(p, mandatory: true);
+    return p;
+  }
+
+  @visibleForTesting
+  ArgParser createVersionCommandParser() {
+    ArgParser p = createSharedArgParser(hide: true, forOnboard: false);
     return p;
   }
 }

--- a/packages/at_onboarding_cli/lib/src/version.dart
+++ b/packages/at_onboarding_cli/lib/src/version.dart
@@ -1,0 +1,2 @@
+// Generated code. Do not modify.
+const packageVersion = '1.15.0';

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tools for initial client onboarding, subsequent client enrollment, and enrollment management.
-version: 1.15.0
+version: 1.16.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -40,3 +40,4 @@ dev_dependencies:
   test: ^1.25.0
   at_demo_data: ^1.2.0
   mocktail: ^1.0.4
+  build_version: ^2.1.1


### PR DESCRIPTION
**- What I did**
- Added `build_version` to dev_dependencies
- Show package version of at_onboarding_cli when: `--version`, `version`, `--help`, and `help`

**- How to verify it**
`--help`

<img width="467" height="69" alt="image" src="https://github.com/user-attachments/assets/2a59eefd-24ce-40f3-908c-b140639b0460" />

`help`

<img width="451" height="90" alt="image" src="https://github.com/user-attachments/assets/6ffff4c0-2040-4305-a53a-c0f48ff5ac92" />

`--version`

<img width="535" height="63" alt="image" src="https://github.com/user-attachments/assets/b86e3e7f-bdbe-4008-8f26-f551592206d8" />

`version`

<img width="437" height="96" alt="image" src="https://github.com/user-attachments/assets/8e2d5e26-0745-49c1-9fad-36a6b42a1ff3" />

**- Description for the changelog**
feat: at_activate --version, version, --help, and help all show package version