### PR TITLE
feat: support for resuming enrollments (requester side)

### DIFF
--- a/packages/at_auth/lib/src/enroll/models/at_enrollment_response.dart
+++ b/packages/at_auth/lib/src/enroll/models/at_enrollment_response.dart
@@ -83,4 +83,21 @@ class AtEnrollmentResponse {
   String toString() {
     return 'AtEnrollmentResponse{enrollmentId: $enrollmentId, enrollStatus: $enrollStatus}';
   }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'enrollmentId': enrollmentId,
+      'enrollStatus': enrollStatus.name,
+      if (atSign != null) 'atSign': atSign,
+    };
+  }
+
+  factory AtEnrollmentResponse.fromJson(Map<String, dynamic> json) {
+    String enrollmentId = json['enrollmentId'];
+    EnrollmentStatus enrollmentStatus = EnrollmentStatus.values
+        .firstWhere((es) => es.name == json['enrollStatus']);
+    String? atSign = json['atSign'];
+
+    return AtEnrollmentResponse(enrollmentId, enrollmentStatus, atSign: atSign);
+  }
 }

--- a/packages/at_auth/test/enrollment_test.dart
+++ b/packages/at_auth/test/enrollment_test.dart
@@ -1,10 +1,7 @@
 import 'dart:convert';
 
-import 'package:at_auth/src/enroll/at_enrollment.dart';
+import 'package:at_auth/at_auth.dart';
 import 'package:at_auth/src/enroll/at_enrollment_impl.dart';
-import 'package:at_auth/src/enroll/models/at_enrollment_response.dart';
-import 'package:at_auth/src/enroll/models/at_enrollment_request.dart';
-import 'package:at_auth/src/enroll/models/enrollment_request_decision.dart';
 import 'package:at_chops/at_chops.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_commons/at_commons.dart';
@@ -190,6 +187,82 @@ void main() {
       expect(atEnrollmentResponse.enrollmentId,
           '4be2d358-074d-4e3b-99f3-64c4da01532f');
       expect(atEnrollmentResponse.enrollStatus, EnrollmentStatus.denied);
+    });
+  });
+
+  group('AtEnrollmentResponse toJson / fromJson', () {
+    test('toJson includes enrollmentId and enrollStatus', () {
+      final response = AtEnrollmentResponse(
+        'enroll-123',
+        EnrollmentStatus.approved,
+      );
+
+      final json = response.toJson();
+
+      expect(json['enrollmentId'], 'enroll-123');
+      expect(json['enrollStatus'], 'approved');
+    });
+
+    test('toJson includes atSign when set', () {
+      final response = AtEnrollmentResponse(
+        'enroll-123',
+        EnrollmentStatus.pending,
+        atSign: '@alice',
+      );
+
+      expect(response.toJson()['atSign'], '@alice');
+    });
+
+    test('toJson does not include atAuthKeys', () {
+      final response = AtEnrollmentResponse(
+        'enroll-123',
+        EnrollmentStatus.approved,
+        atAuthKeys: AtKeys(),
+      );
+
+      expect(response.toJson().containsKey('atAuthKeys'), false);
+    });
+
+    test('fromJson restores enrollmentId and enrollStatus', () {
+      final json = {
+        'enrollmentId': 'enroll-456',
+        'enrollStatus': 'denied',
+      };
+
+      final response = AtEnrollmentResponse.fromJson(json);
+
+      expect(response.enrollmentId, 'enroll-456');
+      expect(response.enrollStatus, EnrollmentStatus.denied);
+    });
+
+    test('fromJson sets atAuthKeys to null when present', () {
+      final json = {
+        'enrollmentId': 'enroll-456',
+        'enrollStatus': 'pending',
+        'atAuthKeys': AtKeys()
+      };
+      expect(AtEnrollmentResponse.fromJson(json).atAuthKeys, isNull);
+    });
+
+    test('fromJson throws when enrollStatus is unknown', () {
+      final json = {
+        'enrollmentId': 'enroll-456',
+        'enrollStatus': 'invalidStatus',
+      };
+
+      expect(
+        () => AtEnrollmentResponse.fromJson(json),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('fromJson throws when enrollmentId is missing', () {
+      final json = {'enrollStatus': 'approved'};
+
+      expect(
+        () => AtEnrollmentResponse.fromJson(json),
+        throwsA(anything),
+      );
     });
   });
 }

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -337,6 +337,7 @@ Future<int> wrappedMain(List<String> arguments) async {
                 passPhrase: commandArgResults[AuthCliArgs.argNamePassPhrase]));
       case AuthCliCommand.decrypt:
         await passPhraseDecryptAtKeys(commandArgResults);
+
       case AuthCliCommand.version:
         stdout.writeln('Version: $packageVersion');
     }
@@ -488,17 +489,6 @@ Future<bool> enroll(ArgResults argResults, {AtOnboardingService? svc}) async {
     throw ArgumentError('The --${AuthCliArgs.argNameAtKeys} option is'
         ' mandatory for the "enroll" command');
   }
-
-  File f = File(argResults[AuthCliArgs.argNameAtKeys]);
-
-  if (f.existsSync()) {
-    throw StateError('Error: atKeys file ${f.path} already exists');
-  }
-
-  if (!canCreateFile(f)) {
-    throw StateError('Error: Unable to open $f for writing');
-  }
-
   svc ??= createOnboardingService(argResults);
 
   Map<String, String> namespaces = {};
@@ -511,25 +501,23 @@ Future<bool> enroll(ArgResults argResults, {AtOnboardingService? svc}) async {
     namespaces[namespace] = permission;
   }
 
-  // If apkam Keys expiry is not set, then APKAM keys should lives forever.
+  // If apkam Keys expiry is not set, then APKAM keys should live forever.
   // Therefore set to 0ms (0 milliseconds) and TTL will not be set.
   String apkamKeysExpiry = argResults[AuthCliArgs.argNameExpiry] ?? '0ms';
-  AtEnrollmentResponse er = await svc.sendEnrollRequest(
-      argResults[AuthCliArgs.argNameAppName],
-      argResults[AuthCliArgs.argNameDeviceName],
-      argResults[AuthCliArgs.argNamePasscode],
-      namespaces,
-      apkamKeysExpiryDuration: parseDuration(apkamKeysExpiry));
-  stdout.writeln('Enrollment ID: ${er.enrollmentId}');
 
-  stderr.writeln('Waiting for approval; will check every 10 seconds');
-  await svc.awaitApproval(er,
-      retryInterval: AtOnboardingService.defaultApkamRetryInterval,
-      logProgress: true,
-      maxRetries: int.parse(argResults[AuthCliArgs.argNameMaxRetries]));
+  String? atKeysPath = argResults[AuthCliArgs.argNameAtKeys];
+  File? atKeysFile = atKeysPath != null ? File(atKeysPath) : null;
 
-  stderr.writeln('Creating atKeys file');
-  await svc.createAtKeysFile(er, allowOverwrite: false);
+  await svc.enroll(
+    argResults[AuthCliArgs.argNameAppName],
+    argResults[AuthCliArgs.argNameDeviceName],
+    argResults[AuthCliArgs.argNamePasscode],
+    namespaces,
+    atKeysFile: atKeysFile,
+    apkamKeysExpiryDuration: parseDuration(apkamKeysExpiry),
+    maxRetries: int.parse(argResults[AuthCliArgs.argNameMaxRetries]),
+    retryInterval: AtOnboardingService.defaultApkamRetryInterval,
+  );
 
   return true;
 }
@@ -1168,7 +1156,7 @@ AtOnboardingService createOnboardingService(ArgResults ar) {
     if (stdout.hasTerminal && viewableLength > (stdout.terminalColumns - 3)) {
       output = '${output.substring(0, stdout.terminalColumns - 3 + diff)}...';
     }
-    stderr.write('\r\x1b[K$output');
+    stderr.writeln('\r\x1b[K$output');
   });
 
   return impl;

--- a/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/cli/auth_cli.dart
@@ -463,7 +463,6 @@ Future<bool> onboard(ArgResults argResults, {AtOnboardingService? svc}) async {
       maxRetries: int.parse(argResults[AuthCliArgs.argNameMaxRetries]),
       retryInterval: AtOnboardingService.defaultActivationCheckInterval,
     );
-    stderr.writeln();
     return true;
   } catch (e) {
     await Future.delayed(Duration(milliseconds: 10));
@@ -522,50 +521,6 @@ Future<bool> enroll(ArgResults argResults, {AtOnboardingService? svc}) async {
   return true;
 }
 
-/// Checks if the specified [file] is writable.
-///
-/// This function attempts to create the directories for the given [file] if they do not exist,
-/// and then tries to open the file in write mode to verify write permissions.
-/// If the file can be opened for writing, it is immediately closed and deleted.
-///
-/// Returns:
-/// - `true` if the file is writable, or
-/// - `false` if the file is not writable due to existing files, lack of permissions,
-///   or any other exceptions encountered during the process.
-///
-/// [file]: The [File] instance to check for write access.
-///
-/// Exceptions:
-/// - If the file does not have write permissions, a [PathAccessException] is caught, and an error message is printed to stderr.
-/// - Any other exceptions are caught and logged, indicating a failure to determine write access.
-@visibleForTesting
-bool canCreateFile(File file) {
-  try {
-    // If the directories do not exist, create them.
-    // "recursive" is set to true to ensure that any missing parent directories are created.
-    // "exclusive" is set to true to prevent creation of file if it already exists.
-    file.createSync(recursive: true, exclusive: true);
-    // Try opening the file in write mode, which requires write permissions
-    RandomAccessFile raf = file.openSync(mode: FileMode.write);
-    raf.closeSync();
-    // In [AtOnboardingServiceImpl._generateAtKeysFile] method, there is a check which returns error
-    // if the file already exists. Therefore, delete the file here after checking for write permissions.
-    // This does not delete the existing file. Deletes only if the new file is created to verify write permissions.
-    file.deleteSync();
-    return true;
-  } on PathExistsException {
-    stderr.writeln('Error : atKeys file ${file.path} already exists');
-    rethrow;
-  } on PathAccessException {
-    stderr.writeln(
-        'Error : atKeys file ${file.path} does not have write permissions');
-    return false;
-  } catch (e) {
-    // If any exception occurs, we assume the file is not writable
-    stderr.writeln('Error in writing to atKeys file: ${e.toString()}');
-    return false;
-  }
-}
 
 @visibleForTesting
 Future<void> setSpp(ArgResults argResults, AtClient atClient) async {

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
@@ -43,8 +43,10 @@ abstract class AtOnboardingService implements ProgressPublisher {
   ///
   /// If the request is denied, or times out, an exception will be thrown.
   ///
-  /// Calling this method is exactly equivalent to calling
-  /// [sendEnrollRequest], [awaitApproval] and [createAtKeysFile] in turn.
+  /// This method internally calls [sendEnrollRequest], [awaitApproval], and
+  /// [createAtKeysFile]. It supports resuming interrupted enrollments via a
+  /// local checkpoint file; if a valid checkpoint is found, it skips the initial
+  /// request and proceeds directly to [awaitApproval].
   ///
   /// [appName] - application name of the client e.g wavi,buzz, atmosphere etc.,
   ///
@@ -92,6 +94,8 @@ abstract class AtOnboardingService implements ProgressPublisher {
 
   /// Create a file in the standardized format which apps may use to
   /// authenticate to an atServer.
+  ///
+  /// [allowOverwrite] if true, allows overwriting of the existing atKeys file
   Future<File> createAtKeysFile(
     AtEnrollmentResponse er, {
     File? atKeysFile,

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
@@ -69,6 +69,7 @@ abstract class AtOnboardingService implements ProgressPublisher {
     File? atKeysFile,
     Duration retryInterval = defaultApkamRetryInterval,
     int maxRetries = defaultMaxApkamRetries,
+    Duration? apkamKeysExpiryDuration,
   });
 
   /// Sends enrollment request. Application code may subsequently call

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service.dart
@@ -94,8 +94,6 @@ abstract class AtOnboardingService implements ProgressPublisher {
 
   /// Create a file in the standardized format which apps may use to
   /// authenticate to an atServer.
-  ///
-  /// [allowOverwrite] if true, allows overwriting of the existing atKeys file
   Future<File> createAtKeysFile(
     AtEnrollmentResponse er, {
     File? atKeysFile,

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -43,6 +43,9 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
   AtEnrollment? _atEnrollment;
 
+  @visibleForTesting
+  late EnrollmentCheckpoint enrollCheckpoint;
+
   AtOnboardingServiceImpl(
     String atsign,
     this.atOnboardingPreference, {
@@ -52,6 +55,8 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     // performs atSign format checks on the atSign
     _atSign = AtUtils.fixAtSign(atsign);
     _atEnrollment ??= AtEnrollment.create();
+    enrollCheckpoint = EnrollmentCheckpoint(_atSign);
+
     // set default LocalStorage paths for this instance
     atOnboardingPreference.commitLogPath ??=
         HomeDirectoryUtil.getCommitLogPath(_atSign, enrollmentId: enrollmentId);
@@ -223,9 +228,6 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   Future<void> completeActivation() async {
     await atAuth!.completeActivation();
   }
-
-  @visibleForTesting
-  late EnrollmentCheckpoint enrollCheckpoint = EnrollmentCheckpoint(_atSign);
 
   @override
   Future<AtEnrollmentResponse> enroll(

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -28,7 +28,7 @@ import 'helpers/enrollment_checkpoint.dart';
 ///
 /// Also has implementation to create, approve, deny and revoke enrollments.
 class AtOnboardingServiceImpl implements AtOnboardingService {
-  late final String _atSign;
+  final Atsign _atSign;
   bool _isAtsignOnboarded = false;
   AtSignLogger logger = AtSignLogger('OnboardingCli');
   AtOnboardingPreference atOnboardingPreference;
@@ -51,9 +51,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     this.atOnboardingPreference, {
     this.atServiceFactory,
     String? enrollmentId,
-  }) {
-    // performs atSign format checks on the atSign
-    _atSign = AtUtils.fixAtSign(atsign);
+  }): _atSign = atsign.toAtsign() {
     _atEnrollment ??= AtEnrollment.create();
     enrollCheckpoint = EnrollmentCheckpoint(_atSign);
 

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -134,8 +134,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     int maxRetries = AtOnboardingService.defaultMaxActivationCheckRetries,
   }) async {
     // Fails early if the filePath already exists (or) isn't writable
-    AtFileUtil.validateFileIsCreatable(
-        File(atOnboardingPreference.atKeysFilePath!));
+    AtFileUtil.ensureWritable(File(atOnboardingPreference.atKeysFilePath!));
 
     // Ensure we have an AtLookUp instance and send from: command if using proxy
     AtLookupImpl atLookUpImpl = AtLookupImpl(
@@ -191,6 +190,8 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     var atOnboardingRequest = AtOnboardingRequest(_atSign);
     atOnboardingRequest.rootDomain = AtRootDomain(
         atOnboardingPreference.rootDomain, atOnboardingPreference.rootPort);
+    atOnboardingRequest.retryOptions =
+        RetryOptions(maxRetries: maxRetries, retryDelay: retryInterval);
     atOnboardingRequest.atKeysIo = FileAtKeysIo(
       filePath: atOnboardingPreference.atKeysFilePath != null
           ? (_) => atOnboardingPreference.atKeysFilePath!
@@ -205,7 +206,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
     logger.finer('Onboarding Response: $atOnboardingResponse');
     if (atOnboardingResponse.isSuccessful) {
-      logger.finer('Onboarding successful. Generating keyfile in'
+      stdout.writeln('[Success] Your keyfile stored at'
           ' path: ${atOnboardingPreference.atKeysFilePath}');
       await AtFileUtil.setSecureFilePermissions(
           atOnboardingPreference.atKeysFilePath!);
@@ -240,7 +241,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   }) async {
     // Fails early if the filePath already exists (or) isn't writable
     if (atKeysFile != null) {
-      AtFileUtil.validateFileIsCreatable(atKeysFile);
+      AtFileUtil.ensureWritable(atKeysFile);
     }
 
     // Resume from checkpoint if a previous enrollment was interrupted,
@@ -260,7 +261,8 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       );
       logger.finer('EnrollmentResponse from server: $enrollmentResponse');
       await enrollCheckpoint.save(
-          enrollmentResponse, appName, deviceName, namespaces, expiry: apkamKeysExpiryDuration);
+          enrollmentResponse, appName, deviceName, namespaces,
+          expiry: apkamKeysExpiryDuration);
     }
 
     stdout.writeln('Enrollment ID: ${enrollmentResponse.enrollmentId}');
@@ -534,9 +536,6 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   }
 
   /// Retries PKAM auth until an enrollment is approved/denied/expired
-  ///
-  /// This method is no longer needed here. Use AtAuthImpl.validateAtServer()
-  /// ToDo: Marking this for removal
   Future<void> _waitForPkamAuthSuccess(
     AtLookUp atLookUp,
     String enrollmentIdFromServer,

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -20,7 +20,9 @@ import 'package:image/image.dart';
 import 'package:meta/meta.dart';
 import 'package:zxing2/qrcode.dart';
 
+import '../util/at_file_util.dart';
 import '../util/home_directory_util.dart';
+import 'helpers/enrollment_checkpoint.dart';
 
 /// Service implementation responsible for onboarding and authenticating atSigns.
 ///
@@ -41,8 +43,12 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
   AtEnrollment? _atEnrollment;
 
-  AtOnboardingServiceImpl(String atsign, this.atOnboardingPreference,
-      {this.atServiceFactory, String? enrollmentId}) {
+  AtOnboardingServiceImpl(
+    String atsign,
+    this.atOnboardingPreference, {
+    this.atServiceFactory,
+    String? enrollmentId,
+  }) {
     // performs atSign format checks on the atSign
     _atSign = AtUtils.fixAtSign(atsign);
     _atEnrollment ??= AtEnrollment.create();
@@ -127,6 +133,10 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     Duration retryInterval = AtOnboardingService.defaultActivationCheckInterval,
     int maxRetries = AtOnboardingService.defaultMaxActivationCheckRetries,
   }) async {
+    // Fails early if the filePath already exists (or) isn't writable
+    AtFileUtil.validateFileIsCreatable(
+        File(atOnboardingPreference.atKeysFilePath!));
+
     // Ensure we have an AtLookUp instance and send from: command if using proxy
     AtLookupImpl atLookUpImpl = AtLookupImpl(
       _atSign,
@@ -195,13 +205,10 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
 
     logger.finer('Onboarding Response: $atOnboardingResponse');
     if (atOnboardingResponse.isSuccessful) {
-      logger.finer(
-          'Onboarding successful.Generating keyfile in path: ${atOnboardingPreference.atKeysFilePath}');
-      stderr.writeln();
-      //     await _generateAtKeysFile(
-      //     atOnboardingResponse.atAuthKeys!,
-      //   enrollmentId: atOnboardingResponse.enrollmentId,
-      //);
+      logger.finer('Onboarding successful. Generating keyfile in'
+          ' path: ${atOnboardingPreference.atKeysFilePath}');
+      await AtFileUtil.setSecureFilePermissions(
+          atOnboardingPreference.atKeysFilePath!);
 
       if (autoCompleteActivation) {
         await completeActivation();
@@ -216,6 +223,9 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     await atAuth!.completeActivation();
   }
 
+  @visibleForTesting
+  late EnrollmentCheckpoint enrollCheckpoint = EnrollmentCheckpoint(_atSign);
+
   @override
   Future<AtEnrollmentResponse> enroll(
     String appName,
@@ -225,30 +235,64 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     Duration retryInterval = AtOnboardingService.defaultApkamRetryInterval,
     int maxRetries = AtOnboardingService.defaultMaxApkamRetries,
     File? atKeysFile,
+    Duration? apkamKeysExpiryDuration,
     bool allowOverwrite = false,
   }) async {
-    AtEnrollmentResponse enrollmentResponse = await sendEnrollRequest(
-      appName,
-      deviceName,
-      otp,
-      namespaces,
+    // Fails early if the filePath already exists (or) isn't writable
+    if (atKeysFile != null) {
+      AtFileUtil.validateFileIsCreatable(atKeysFile);
+    }
+
+    // Resume from checkpoint if a previous enrollment was interrupted,
+    // otherwise submit a new enrollment request and save a checkpoint.
+    AtEnrollmentResponse? enrollmentResponse =
+        enrollCheckpoint.load(appName, deviceName, namespaces);
+
+    if (enrollmentResponse != null) {
+      logger.info('Resuming from enrollment checkpoint...');
+    } else {
+      enrollmentResponse = await sendEnrollRequest(
+        appName,
+        deviceName,
+        otp,
+        namespaces,
+        apkamKeysExpiryDuration: apkamKeysExpiryDuration,
+      );
+      logger.finer('EnrollmentResponse from server: $enrollmentResponse');
+      await enrollCheckpoint.save(
+          enrollmentResponse, appName, deviceName, namespaces, expiry: apkamKeysExpiryDuration);
+    }
+
+    stdout.writeln('Enrollment ID: ${enrollmentResponse.enrollmentId}');
+    _addProgress('Enroll', 'Enrollment ID: ${enrollmentResponse.enrollmentId}',
+        ProgressEventType.info);
+
+    try {
+      await awaitApproval(
+        enrollmentResponse,
+        retryInterval: retryInterval,
+        maxRetries: maxRetries,
+      );
+    } finally {
+      // Checkpoint is always removed after approval attempt, whether it
+      // succeeds or throws
+      enrollCheckpoint.delete(appName, deviceName, namespaces);
+    }
+
+    await _initAtClient(
+      _atLookUp!.atChops!,
+      enrollmentId: enrollmentResponse.enrollmentId,
     );
-    logger.finer('EnrollmentResponse from server: $enrollmentResponse');
 
-    await awaitApproval(enrollmentResponse, retryInterval: retryInterval);
-
-    await _initAtClient(_atLookUp!.atChops!,
-        enrollmentId: enrollmentResponse.enrollmentId);
-    var enrollmentDetails = EnrollmentDetails();
-    enrollmentDetails.namespace = namespaces;
+    // Store enrollment details in local secondary.
     var localEnrollmentKey = AtKey()
       ..isLocal = true
       ..key = enrollmentResponse.enrollmentId
       ..sharedBy = atClient!.getCurrentAtSign();
+    EnrollmentDetails enrollmentDetails = EnrollmentDetails()
+      ..namespace = namespaces;
     await atClient!.getLocalSecondary()!.putValue(
-          localEnrollmentKey.toString(),
-          jsonEncode(enrollmentDetails.toJson()),
-        );
+        localEnrollmentKey.toString(), jsonEncode(enrollmentDetails.toJson()));
 
     await createAtKeysFile(
       enrollmentResponse,
@@ -490,6 +534,9 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   }
 
   /// Retries PKAM auth until an enrollment is approved/denied/expired
+  ///
+  /// This method is no longer needed here. Use AtAuthImpl.validateAtServer()
+  /// ToDo: Marking this for removal
   Future<void> _waitForPkamAuthSuccess(
     AtLookUp atLookUp,
     String enrollmentIdFromServer,
@@ -626,6 +673,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     fileWriter.write(encodedAtKeysString);
     await fileWriter.flush();
     await fileWriter.close();
+    await AtFileUtil.setSecureFilePermissions(atKeysFile.path);
     stdout.writeln(
         '${chalk.green('[Success]')} Your .atKeys file saved at ${atKeysFile.path}\n');
 

--- a/packages/at_onboarding_cli/lib/src/onboard/helpers/enrollment_checkpoint.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/helpers/enrollment_checkpoint.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:at_auth/at_auth.dart';
+import 'package:at_onboarding_cli/src/util/at_file_util.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:meta/meta.dart';
+import 'package:crypto/crypto.dart';
+import 'package:path/path.dart' as path;
+
+/// Manages the enrollment checkpoint file used to resume interrupted enrollments.
+///
+/// The checkpoint file is named `<hash>.enrollment.checkpoint` where the hash
+/// is a SHA-256 digest of the atSign + enrollment parameters. The atSign is
+/// intentionally absent from the filename so that the file does not reveal
+/// which atSign it belongs to.
+class EnrollmentCheckpoint {
+  final String _atSign;
+  static const Duration defaultCheckpointExpiry = Duration(hours: 24);
+  final AtSignLogger _logger = AtSignLogger('EnrollmentCheckpoint');
+
+  EnrollmentCheckpoint(this._atSign);
+
+  /// Returns a deterministic SHA-256 hash used as the checkpoint filename.
+  ///
+  /// The hash is derived from [atSign], [appName], [deviceName], and
+  /// [namespaces] (sorted by key for determinism). Including [atSign] ensures
+  /// that two different atSigns enrolling with identical parameters produce
+  /// different filenames and cannot interfere with each other's checkpoints.
+  ///
+  /// The atSign is intentionally kept out of the filename itself — it is only
+  /// used as hash input — so the resulting filename reveals nothing about which
+  /// atSign the checkpoint belongs to.
+  static String _paramsHash(String atSign, String appName, String deviceName,
+      Map<String, String> namespaces) {
+    final sortedNamespaces = (namespaces.entries.toList()
+          ..sort((a, b) => a.key.compareTo(b.key)))
+        .map((e) => '${e.key}:${e.value}')
+        .join(',');
+    return sha256
+        .convert(utf8.encode('$atSign$appName$deviceName$sortedNamespaces'))
+        .toString();
+  }
+
+  @visibleForTesting
+  File getFile(String appName, String deviceName,
+          Map<String, String> namespaces) =>
+      File(path.join(Directory.current.path,
+          '${_paramsHash(_atSign, appName, deviceName, namespaces)}.enrollment.checkpoint'));
+
+  /// Writes the checkpoint to disk with secure file permissions (chmod 600).
+  /// Any existing checkpoint for different params is deleted first.
+  Future<void> save(
+    AtEnrollmentResponse er,
+    String appName,
+    String deviceName,
+    Map<String, String> namespaces, {
+    Duration? expiry,
+  }) async {
+    expiry ??= defaultCheckpointExpiry;
+
+    final Map<String, dynamic> json = er.toJson();
+    json.remove('atSign'); // do not reveal which atSign this checkpoint belongs to
+    json['atAuthKeys'] = er.atAuthKeys?.toJson();
+    json['validTill'] = DateTime.now().add(expiry).millisecondsSinceEpoch;
+
+    final file = getFile(appName, deviceName, namespaces);
+    file.writeAsStringSync(jsonEncode(json));
+    
+    await AtFileUtil.setSecureFilePermissions(file.path);
+    _logger.info('Saved checkpoint for ${er.enrollmentId}');
+  }
+
+  /// Loads the checkpoint if one exists for the given params and has not
+  /// expired. Returns `null` and deletes the file if it is expired or corrupt.
+  AtEnrollmentResponse? load(
+      String appName, String deviceName, Map<String, String> namespaces) {
+    final file = getFile(appName, deviceName, namespaces);
+    if (!file.existsSync()) return null;
+
+    try {
+      final data = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+
+      final expiresAt =
+          DateTime.fromMillisecondsSinceEpoch(data['validTill'] as int);
+      if (expiresAt.isBefore(DateTime.now())) {
+        file.deleteSync();
+        return null;
+      }
+
+      final er = AtEnrollmentResponse.fromJson(data);
+      if (data['atAuthKeys'] != null) {
+        er.atAuthKeys =
+            AtKeys.fromJson(data['atAuthKeys'] as Map<String, dynamic>);
+      }
+      return er;
+    } catch (e) {
+      _logger.warning('Failed to load checkpoint — deleting: $e');
+      file.deleteSync();
+      return null;
+    }
+  }
+
+  /// Deletes the checkpoint for the given params if it exists.
+  void delete(
+      String appName, String deviceName, Map<String, String> namespaces) {
+    final file = getFile(appName, deviceName, namespaces);
+    if (file.existsSync()) file.deleteSync();
+  }
+
+}

--- a/packages/at_onboarding_cli/lib/src/onboard/helpers/enrollment_checkpoint.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/helpers/enrollment_checkpoint.dart
@@ -28,7 +28,7 @@ class EnrollmentCheckpoint {
   /// that two different atSigns enrolling with identical parameters produce
   /// different filenames and cannot interfere with each other's checkpoints.
   ///
-  /// The atSign is intentionally kept out of the filename itself — it is only
+  /// The [atSign] is intentionally kept out of the filename itself — it is only
   /// used as hash input — so the resulting filename reveals nothing about which
   /// atSign the checkpoint belongs to.
   static String _paramsHash(String atSign, String appName, String deviceName,
@@ -49,7 +49,9 @@ class EnrollmentCheckpoint {
           '${_paramsHash(_atSign, appName, deviceName, namespaces)}.enrollment.checkpoint'));
 
   /// Writes the checkpoint to disk with secure file permissions (chmod 600).
-  /// Any existing checkpoint for different params is deleted first.
+  ///
+  /// Maintains expiry for each checkpoint, defaults to [defaultCheckpointExpiry].
+  /// Expired checkpoints are invalidated and deleted by [load]
   Future<void> save(
     AtEnrollmentResponse er,
     String appName,

--- a/packages/at_onboarding_cli/lib/src/util/at_file_util.dart
+++ b/packages/at_onboarding_cli/lib/src/util/at_file_util.dart
@@ -1,0 +1,57 @@
+import 'dart:io';
+
+import 'package:at_utils/at_logger.dart';
+
+/// Utility class for file system operations.
+class AtFileUtil {
+  static final AtSignLogger _logger = AtSignLogger('AtFileUtil');
+
+  /// Sets secure file permissions (owner read/write only).
+  ///
+  /// On POSIX systems, uses chmod 600.
+  ///
+  /// On Windows, uses icacls to remove inherited permissions and grant full
+  /// control only to the current user.
+  static Future<void> setSecureFilePermissions(String filePath) async {
+    try {
+      if (Platform.isWindows) {
+        _logger.finer('Setting secure permissions on file: $filePath');
+        final username =
+            Platform.environment['USERNAME'] ?? Platform.environment['USER'];
+        if (username == null) {
+          throw StateError('Could not determine username');
+        }
+
+        final result = await Process.run('icacls', [
+          filePath,
+          '/inheritance:r',
+          '/grant:r',
+          '$username:F',
+        ]);
+
+        if (result.exitCode != 0) {
+          _logger.warning('icacls failed: ${result.stderr}');
+        }
+      } else if (Platform.isLinux || Platform.isMacOS || Platform.isAndroid) {
+        await Process.run('chmod', ['600', filePath]);
+      } else {
+        _logger.warning(
+            'Unsupported platform: ${Platform.operatingSystem}');
+      }
+    } catch (e) {
+      _logger.warning('Could not set file permissions on $filePath | $e');
+    }
+  }
+
+  /// Validates that [file] does not already exist and that the path is
+  /// writable. Throws [StateError] if the file exists, or re-throws any
+  /// [FileSystemException] if the path cannot be written to.
+  static void validateFileIsCreatable(File file) {
+    if (file.existsSync()) {
+      throw StateError('Error: file ${file.path} already exists');
+    }
+    // Checks write access by creating and immediately deleting the file.
+    file.createSync(recursive: true, exclusive: true);
+    file.deleteSync();
+  }
+}

--- a/packages/at_onboarding_cli/lib/src/util/at_file_util.dart
+++ b/packages/at_onboarding_cli/lib/src/util/at_file_util.dart
@@ -1,7 +1,9 @@
 import 'dart:io';
 
 import 'package:at_auth/at_auth.dart';
+import 'package:at_client/at_client.dart';
 import 'package:at_utils/at_logger.dart';
+import 'package:path/path.dart' as path;
 
 /// Utility class for file system operations.
 class AtFileUtil {
@@ -23,8 +25,9 @@ class AtFileUtil {
           throw StateError('Could not determine username');
         }
 
+        final normalizedFilePath = path.windows.normalize(filePath);
         final result = await Process.run('icacls', [
-          filePath,
+          normalizedFilePath,
           '/inheritance:r',
           '/grant:r',
           '$username:F',
@@ -36,8 +39,7 @@ class AtFileUtil {
       } else if (Platform.isLinux || Platform.isMacOS || Platform.isAndroid) {
         await Process.run('chmod', ['600', filePath]);
       } else {
-        _logger.warning(
-            'Unsupported platform: ${Platform.operatingSystem}');
+        _logger.warning('Unsupported platform: ${Platform.operatingSystem}');
       }
     } catch (e) {
       _logger.warning('Could not set file permissions on $filePath | $e');
@@ -50,9 +52,9 @@ class AtFileUtil {
   /// and then tries to open the file in write mode to verify write permissions.
   /// If the file can be opened for writing, it is immediately closed and deleted.
   ///
-  /// Throws a [PathExistsException] if [file] already exists, a
-  /// [PathAccessException] if the path lacks write permissions, or the
-  /// underlying platform exception for any other I/O failure.
+  /// Throws [AtKeysFileOverwriteException] if [file] already exists,
+  /// or [AtException] if the path lacks write permissions or any other
+  /// I/O failure occurs.
   static void ensureWritable(File file) {
     try {
       // If the directories do not exist, create them.
@@ -65,13 +67,14 @@ class AtFileUtil {
       // Deletes only if the new file is created to verify write permissions.
       file.deleteSync();
     } on PathExistsException {
-      throw AtKeysFileOverwriteException('Keys file already exists at ${file.path}');
-    } on PathAccessException {
-      stderr.writeln('Path: ${file.path} does not have write permissions');
-      rethrow;
+      throw AtKeysFileOverwriteException(
+          'Keys file already exists at ${file.path}');
+    } on PathAccessException catch (e) {
+      _logger.severe('Caught: $e');
+      throw AtException('Keys file path is not writable: ${file.path}');
     } catch (e) {
-      stderr.writeln('Error in writing keys file to path: ${file.path}');
-      rethrow;
+      _logger.severe('Caught: $e');
+      throw AtException('Failed to write file at ${file.path}');
     }
   }
 }

--- a/packages/at_onboarding_cli/lib/src/util/at_file_util.dart
+++ b/packages/at_onboarding_cli/lib/src/util/at_file_util.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:at_auth/at_auth.dart';
 import 'package:at_utils/at_logger.dart';
 
 /// Utility class for file system operations.
@@ -43,15 +44,34 @@ class AtFileUtil {
     }
   }
 
-  /// Validates that [file] does not already exist and that the path is
-  /// writable. Throws [StateError] if the file exists, or re-throws any
-  /// [FileSystemException] if the path cannot be written to.
-  static void validateFileIsCreatable(File file) {
-    if (file.existsSync()) {
-      throw StateError('Error: file ${file.path} already exists');
+  /// Checks if the specified [file] is writable and does not already exist.
+  ///
+  /// This function attempts to create the directories for the given [file] if they do not exist,
+  /// and then tries to open the file in write mode to verify write permissions.
+  /// If the file can be opened for writing, it is immediately closed and deleted.
+  ///
+  /// Throws a [PathExistsException] if [file] already exists, a
+  /// [PathAccessException] if the path lacks write permissions, or the
+  /// underlying platform exception for any other I/O failure.
+  static void ensureWritable(File file) {
+    try {
+      // If the directories do not exist, create them.
+      // "recursive" is set to true to ensure that any missing parent directories are created.
+      // "exclusive" is set to true to prevent creation of file if it already exists.
+      file.createSync(recursive: true, exclusive: true);
+      // Try opening the file in write mode, which requires write permissions
+      RandomAccessFile raf = file.openSync(mode: FileMode.write);
+      raf.closeSync();
+      // Deletes only if the new file is created to verify write permissions.
+      file.deleteSync();
+    } on PathExistsException {
+      throw AtKeysFileOverwriteException('Keys file already exists at ${file.path}');
+    } on PathAccessException {
+      stderr.writeln('Path: ${file.path} does not have write permissions');
+      rethrow;
+    } catch (e) {
+      stderr.writeln('Error in writing keys file to path: ${file.path}');
+      rethrow;
     }
-    // Checks write access by creating and immediately deleting the file.
-    file.createSync(recursive: true, exclusive: true);
-    file.deleteSync();
   }
 }

--- a/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
+++ b/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
@@ -219,11 +219,7 @@ void main() {
 
       File file = File(f.path);
       expect(file.existsSync(), true);
-      if (!Platform.isWindows) {
-        final stat = await FileStat.stat(file.path);
-        expect(stat.mode & 0x1FF, equals(0x180),
-            reason: 'atKeys file must have chmod 600 (owner read/write only)');
-      }
+      await expectSecureFilePermissions(file);
       // Delete the file at the end of the test.
       file.deleteSync(recursive: true);
     });
@@ -255,11 +251,7 @@ void main() {
 
       File file = File(f.path);
       expect(file.existsSync(), true);
-      if (!Platform.isWindows) {
-        final stat = await FileStat.stat(file.path);
-        expect(stat.mode & 0x1FF, equals(0x180),
-            reason: 'atKeys file must have chmod 600 (owner read/write only)');
-      }
+      await expectSecureFilePermissions(file);
       // Delete the file at the end of the test.
       file.deleteSync(recursive: true);
     });
@@ -291,11 +283,7 @@ void main() {
 
       File file = File(f.path);
       expect(file.existsSync(), true);
-      if (!Platform.isWindows) {
-        final stat = await FileStat.stat(file.path);
-        expect(stat.mode & 0x1FF, equals(0x180),
-            reason: 'atKeys file must have chmod 600 (owner read/write only)');
-      }
+      await expectSecureFilePermissions(file);
       // Delete the file at the end of the test.
       file.deleteSync(recursive: true);
     });
@@ -327,11 +315,7 @@ void main() {
 
       File file = File(f.path);
       expect(file.existsSync(), true);
-      if (!Platform.isWindows) {
-        final stat = await FileStat.stat(file.path);
-        expect(stat.mode & 0x1FF, equals(0x180),
-            reason: 'atKeys file must have chmod 600 (owner read/write only)');
-      }
+      await expectSecureFilePermissions(file);
       // Delete the file at the end of the test.
       file.deleteSync(recursive: true);
     });
@@ -799,4 +783,29 @@ Future<void> setupLocalStorage(String atSign) async {
   var persistenceManager = SecondaryPersistenceStoreFactory.getInstance()
       .getSecondaryPersistenceStore(atSign)!;
   await persistenceManager.getHivePersistenceManager()!.init(storageDir);
+}
+
+/// Asserts that [file] has secure (owner-only) permissions.
+///
+/// On POSIX: expects chmod 600 (mode bits 0x180).
+/// On Windows: expects only the current user has Full control via icacls.
+Future<void> expectSecureFilePermissions(File file) async {
+  if (Platform.isWindows) {
+    final username =
+        Platform.environment['USERNAME'] ?? Platform.environment['USER'];
+    final result = await Process.run('icacls', [file.path]);
+    final output = result.stdout as String;
+    final permEntries = output
+        .split('\n')
+        .where((l) => l.contains(':(') && !l.startsWith('Successfully'))
+        .toList();
+    expect(permEntries.length, equals(1),
+        reason: 'only the current user should have access');
+    expect(permEntries.first, contains('$username:(F)'),
+        reason: 'current user must have Full control');
+  } else {
+    final stat = await FileStat.stat(file.path);
+    expect(stat.mode & 0x1FF, equals(0x180),
+        reason: 'file must have chmod 600 (owner read/write only)');
+  }
 }

--- a/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
+++ b/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
@@ -7,6 +7,7 @@ import 'package:at_client/at_client.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+import 'package:at_onboarding_cli/src/onboard/helpers/enrollment_checkpoint.dart';
 
 // ignore: depend_on_referenced_packages
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
@@ -24,7 +25,11 @@ class FakeAtAuthRequest extends Fake implements AtAuthRequest {}
 
 class MockAtClient extends Mock implements AtClient {}
 
-class MockEnrollmentBase extends Mock implements AtEnrollment{}
+class MockEnrollmentBase extends Mock implements AtEnrollment {}
+
+class MockEnrollmentRequest extends Mock implements EnrollmentRequest {}
+
+class FakeEnrollmentRequest extends Fake implements EnrollmentRequest {}
 
 void main() {
   AtSignLogger.root_level = 'INFO';
@@ -44,7 +49,8 @@ void main() {
       registerFallbackValue(FakeAtAuthRequest());
     });
 
-    test('A test to check atOnboardingService.authenticate() returns true', () async {
+    test('A test to check atOnboardingService.authenticate() returns true',
+        () async {
       final atSign = '@alice🛠';
       AtOnboardingPreference onboardingPreference = AtOnboardingPreference()
         ..atKeysFilePath = 'test/data/@alice🛠_key.atKeys'
@@ -213,6 +219,11 @@ void main() {
 
       File file = File(f.path);
       expect(file.existsSync(), true);
+      if (!Platform.isWindows) {
+        final stat = await FileStat.stat(file.path);
+        expect(stat.mode & 0x1FF, equals(0x180),
+            reason: 'atKeys file must have chmod 600 (owner read/write only)');
+      }
       // Delete the file at the end of the test.
       file.deleteSync(recursive: true);
     });
@@ -244,6 +255,11 @@ void main() {
 
       File file = File(f.path);
       expect(file.existsSync(), true);
+      if (!Platform.isWindows) {
+        final stat = await FileStat.stat(file.path);
+        expect(stat.mode & 0x1FF, equals(0x180),
+            reason: 'atKeys file must have chmod 600 (owner read/write only)');
+      }
       // Delete the file at the end of the test.
       file.deleteSync(recursive: true);
     });
@@ -275,6 +291,11 @@ void main() {
 
       File file = File(f.path);
       expect(file.existsSync(), true);
+      if (!Platform.isWindows) {
+        final stat = await FileStat.stat(file.path);
+        expect(stat.mode & 0x1FF, equals(0x180),
+            reason: 'atKeys file must have chmod 600 (owner read/write only)');
+      }
       // Delete the file at the end of the test.
       file.deleteSync(recursive: true);
     });
@@ -306,8 +327,410 @@ void main() {
 
       File file = File(f.path);
       expect(file.existsSync(), true);
+      if (!Platform.isWindows) {
+        final stat = await FileStat.stat(file.path);
+        expect(stat.mode & 0x1FF, equals(0x180),
+            reason: 'atKeys file must have chmod 600 (owner read/write only)');
+      }
       // Delete the file at the end of the test.
       file.deleteSync(recursive: true);
+    });
+  });
+
+  group('Tests to assert enroll resume behaviour', () {
+    MockEnrollmentBase mockEnrollmentBase = MockEnrollmentBase();
+
+    setUp(() {
+      reset(mockAtLookup);
+      reset(mockAtAuth);
+      reset(mockEnrollmentBase);
+      registerFallbackValue(FakeAtAuthRequest());
+      registerFallbackValue(FakeEnrollmentRequest());
+      registerFallbackValue(
+          AtEnrollmentResponse('123', EnrollmentStatus.pending));
+      registerFallbackValue(MockAtLookupImpl());
+      registerFallbackValue(AtKey.fromString('public:test_key.test@alice'));
+    });
+
+    test('when available enroll should use the checkpoint', () async {
+      // also validates the checkpoint file is deleted after approval
+      final atsign = '@syrax';
+      final dummyEnrollmentId = '1234';
+
+      await setupLocalStorage(atsign);
+
+      MockAtClient mockAtClient = MockAtClient();
+      var keyStore = SecondaryPersistenceStoreFactory.getInstance()
+          .getSecondaryPersistenceStore(atsign)
+          ?.getSecondaryKeyStore();
+      LocalSecondary localSecondary =
+          LocalSecondary(mockAtClient, keyStore: keyStore);
+
+      AtOnboardingPreference pref = getOnboardingPreference()
+        ..atKeysFilePath = 'test/storage/keys/${atsign}_key.atKeys';
+      AtOnboardingServiceImpl svc = AtOnboardingServiceImpl(atsign, pref);
+      svc.atClient = mockAtClient;
+      svc.enrollmentBase = mockEnrollmentBase;
+      svc.atLookUp = mockAtLookup;
+      svc.atAuth = mockAtAuth;
+
+      // setup AtChopsKeys and AtKeys
+      final atChopsKeys = getRandomAtChopsKeys();
+      AtKeys atAuthKeys = getAtAuthKeysFromAtChopsKeys(atChopsKeys);
+      AtEnrollmentResponse enrollmentResponse = AtEnrollmentResponse(
+          dummyEnrollmentId, EnrollmentStatus.pending,
+          atAuthKeys: atAuthKeys);
+
+      // encrypt the keys with APKAMSymmetricKey
+      String encryptedEncryptionPrivateKey = EncryptionUtil.encryptValue(
+          atAuthKeys.defaultEncryptionPrivateKey!.toString(),
+          atAuthKeys.apkamSymmetricKey!.toString());
+      String encryptedSelfEncryptionKey = EncryptionUtil.encryptValue(
+          atAuthKeys.defaultSelfEncryptionKey!.toString(),
+          atAuthKeys.apkamSymmetricKey!.toString());
+      String fetchEncryptionPrivateKeyCommand =
+          'keys:get:keyName:$dummyEnrollmentId.${AtConstants.defaultEncryptionPrivateKey}.__manage$atsign\n';
+      String fetchSelfEncryptionKeyCommand =
+          'keys:get:keyName:$dummyEnrollmentId.${AtConstants.defaultSelfEncryptionKey}.__manage$atsign\n';
+
+      // setup mock behaviour
+      when(() => mockEnrollmentBase.submit(any(), any()))
+          .thenAnswer((_) => Future.value(enrollmentResponse));
+      when(() => mockAtLookup.pkamAuthenticate(enrollmentId: dummyEnrollmentId))
+          .thenAnswer((_) => Future.value(true));
+      when(() => mockAtLookup.atChops).thenReturn(AtChopsImpl(atChopsKeys));
+      when(() => mockAtClient.getCurrentAtSign()).thenReturn(atsign);
+      when(() => mockAtClient.getLocalSecondary()).thenReturn(localSecondary);
+      when(() => mockAtClient.put(any(), any())).thenAnswer((i) async {
+        AtKey atKey = i.positionalArguments[0];
+        dynamic value = i.positionalArguments[1];
+        return await localSecondary.putValue(atKey.toString(), value);
+      });
+      when(() => mockAtLookup.executeCommand(fetchEncryptionPrivateKeyCommand,
+              auth: true))
+          .thenAnswer((_) => Future.value(
+              'data:${jsonEncode({'value': encryptedEncryptionPrivateKey})}'));
+      when(() => mockAtLookup.executeCommand(fetchSelfEncryptionKeyCommand,
+              auth: true))
+          .thenAnswer((_) => Future.value(
+              'data:${jsonEncode({'value': encryptedSelfEncryptionKey})}'));
+
+      final appName = 'enroll_test_1';
+      final device = 'unit_test_1';
+      final namespaces = {'test': 'rw'};
+
+      // manually create a checkpoint
+      await svc.enrollCheckpoint
+          .save(enrollmentResponse, appName, device, namespaces);
+
+      final checkpointFile =
+          svc.enrollCheckpoint.getFile(appName, device, namespaces);
+      expect(checkpointFile.existsSync(), isTrue);
+
+      // the mocks will mimic enrollment approval and fetching keys from server
+      // using the keys:get commands
+      await svc.enroll(appName, device, 'ABCDE', namespaces);
+
+      // ensure that after enroll() returns, the checkpoint is removed
+      expect(checkpointFile.existsSync(), isFalse);
+      expect(File(pref.atKeysFilePath!).existsSync(), isTrue);
+      // assert that a new enrollment was not submitted
+      verifyNever(() => mockEnrollmentBase.submit(any(), any()));
+    });
+
+    test('assert checkpoint deletion when enrollment is denied', () async {
+      final atsign = '@caraxes';
+      final dummyEnrollmentId = '1234abcdxyz';
+
+      await setupLocalStorage(atsign);
+
+      AtOnboardingPreference atOnboardingPreference = getOnboardingPreference()
+        ..atKeysFilePath = 'test/storage/keys/${atsign}_key.atKeys';
+      AtOnboardingServiceImpl svc =
+          AtOnboardingServiceImpl(atsign, atOnboardingPreference);
+      svc.atLookUp = mockAtLookup;
+
+      // setup AtChopsKeys and AtKeys
+      final atChopsKeys = getRandomAtChopsKeys();
+      AtKeys atAuthKeys = getAtAuthKeysFromAtChopsKeys(atChopsKeys);
+      AtEnrollmentResponse enrollmentResponse = AtEnrollmentResponse(
+          dummyEnrollmentId, EnrollmentStatus.pending,
+          atAuthKeys: atAuthKeys);
+
+      // setup mock behaviour
+      when(() => mockAtLookup.pkamAuthenticate(enrollmentId: dummyEnrollmentId))
+          .thenThrow(UnAuthenticatedException(
+              'error:AT0025')); // mimic enrollment denial
+
+      // pre-seed checkpoint — params must match the enroll() call below
+      await svc.enrollCheckpoint.save(
+          enrollmentResponse, 'enroll_test_1', 'unit_test_1', {'test': 'rw'});
+
+      final checkpointFile = svc.enrollCheckpoint
+          .getFile('enroll_test_1', 'unit_test_1', {'test': 'rw'});
+      expect(checkpointFile.existsSync(), isTrue);
+
+      await expectLater(
+          () => svc
+              .enroll('enroll_test_1', 'unit_test_1', 'ABCDE', {'test': 'rw'}),
+          throwsA(isA<AtEnrollmentException>()));
+      expect(checkpointFile.existsSync(), isFalse);
+    });
+
+    test('enroll() creates a checkpoint', () async {
+      final atsign = '@perrytheplatypus';
+      final dummyEnrollmentId = 'xyz123abc';
+
+      final atChopsKeys = getRandomAtChopsKeys();
+      AtKeys atAuthKeys = getAtAuthKeysFromAtChopsKeys(atChopsKeys);
+      AtEnrollmentResponse enrollmentResponse = AtEnrollmentResponse(
+          dummyEnrollmentId, EnrollmentStatus.pending,
+          atAuthKeys: atAuthKeys);
+
+      AtOnboardingPreference pref = getOnboardingPreference();
+      AtOnboardingServiceImpl svc = AtOnboardingServiceImpl(atsign, pref);
+      svc.enrollmentBase = mockEnrollmentBase;
+      svc.atLookUp = mockAtLookup;
+
+      expect(
+          svc.enrollCheckpoint
+              .getFile('myApp', 'myDevice', {'test': 'rw'}).existsSync(),
+          isFalse);
+
+      bool checkpointExistedDuringApproval = false;
+
+      when(() => mockEnrollmentBase.submit(any(), any()))
+          .thenAnswer((_) => Future.value(enrollmentResponse));
+      // check whether the checkpoint file exists during awaitApproval() execution
+      when(() => mockAtLookup.pkamAuthenticate(enrollmentId: dummyEnrollmentId))
+          .thenAnswer((_) {
+        checkpointExistedDuringApproval = svc.enrollCheckpoint
+            .getFile('myApp', 'myDevice', {'test': 'rw'}).existsSync();
+        throw UnAuthenticatedException('error:AT0025');
+      });
+
+      await expectLater(
+        () => svc.enroll('myApp', 'myDevice', 'OTP123', {'test': 'rw'}),
+        throwsA(isA<AtEnrollmentException>()),
+      );
+
+      expect(checkpointExistedDuringApproval, isTrue);
+      // finally ensure its removed after enroll() returns
+      expect(
+          svc.enrollCheckpoint
+              .getFile('myApp', 'myDevice', {'test': 'rw'}).existsSync(),
+          isFalse);
+    });
+
+    tearDown(() async => await tearDownFunc());
+  });
+  group('Validate enroll checkpoint methods', () {
+    const appName = 'testApp';
+    const deviceName = 'testDevice';
+    final namespaces = {'ns': 'rw'};
+
+    test('checkpoint.getFile() - filename does not contain atSign', () {
+      final cp = EnrollmentCheckpoint('@lima');
+      final file = cp.getFile(appName, deviceName, namespaces);
+      expect(file.path, endsWith('.enrollment.checkpoint'));
+      expect(file.path, isNot(contains('@lima')));
+    });
+
+    test(
+        'checkpoint.getFile() - same params different atSigns produce different files',
+        () {
+      final checkpoint1 = EnrollmentCheckpoint('@dreamfyre')
+          .getFile(appName, deviceName, namespaces);
+      final checkpoint2 = EnrollmentCheckpoint('@sunfyre')
+          .getFile(appName, deviceName, namespaces);
+      expect(checkpoint1.path, isNot(equals(checkpoint2.path)));
+    });
+
+    test('checkpoint.save() - creates a checkpoint', () async {
+      final cp = EnrollmentCheckpoint('@syrax');
+      final atAuthKeys = getAtAuthKeysFromAtChopsKeys(getRandomAtChopsKeys());
+      await cp.save(
+          AtEnrollmentResponse('1234', EnrollmentStatus.pending,
+              atAuthKeys: atAuthKeys),
+          appName,
+          deviceName,
+          namespaces);
+
+      final file = cp.getFile(appName, deviceName, namespaces);
+      expect(file.existsSync(), isTrue);
+      if (!Platform.isWindows) {
+        final stat = await FileStat.stat(file.path);
+        expect(stat.mode & 0x1FF, equals(0x180),
+            reason: 'checkpoint file must have chmod 600');
+      }
+      final data = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+      expect(data['enrollmentId'], '1234');
+      expect(data['enrollStatus'], EnrollmentStatus.pending.name);
+      expect(data['atAuthKeys'], atAuthKeys.toJson());
+      expect(data['validTill'],
+          greaterThan(DateTime.now().millisecondsSinceEpoch));
+    });
+
+    test('checkpoint.save() - overwrites an existing checkpoint', () async {
+      final ckp = EnrollmentCheckpoint('@silverwing');
+      final firstKeys = getAtAuthKeysFromAtChopsKeys(getRandomAtChopsKeys());
+      final secondKeys = getAtAuthKeysFromAtChopsKeys(getRandomAtChopsKeys());
+
+      await ckp.save(
+          AtEnrollmentResponse('first-id', EnrollmentStatus.pending,
+              atAuthKeys: firstKeys),
+          appName,
+          deviceName,
+          namespaces);
+      await ckp.save(
+          AtEnrollmentResponse('second-id', EnrollmentStatus.pending,
+              atAuthKeys: secondKeys),
+          appName,
+          deviceName,
+          namespaces);
+
+      expect(
+          ckp.load(appName, deviceName, namespaces)!.enrollmentId, 'second-id');
+
+      ckp.delete(appName, deviceName, namespaces);
+    });
+
+    test('checkpoint.load() - loads the checkpoint file', () async {
+      final cp = EnrollmentCheckpoint('@caraxes');
+      final atAuthKeys = getAtAuthKeysFromAtChopsKeys(getRandomAtChopsKeys());
+      final er = AtEnrollmentResponse('abc321', EnrollmentStatus.pending,
+          atAuthKeys: atAuthKeys);
+
+      await cp.save(er, appName, deviceName, namespaces);
+
+      final loaded = cp.load(appName, deviceName, namespaces);
+      expect(loaded, isNotNull);
+      expect(loaded!.enrollmentId, er.enrollmentId);
+      expect(loaded.enrollStatus, er.enrollStatus);
+      expect(loaded.atAuthKeys!.apkamPublicKey.toString(),
+          atAuthKeys.apkamPublicKey.toString());
+      expect(loaded.atAuthKeys!.apkamPrivateKey.toString(),
+          atAuthKeys.apkamPrivateKey.toString());
+      expect(loaded.atAuthKeys!.defaultEncryptionPublicKey.toString(),
+          atAuthKeys.defaultEncryptionPublicKey.toString());
+      expect(loaded.atAuthKeys!.defaultSelfEncryptionKey.toString(),
+          atAuthKeys.defaultSelfEncryptionKey.toString());
+      expect(loaded.atAuthKeys!.apkamSymmetricKey.toString(),
+          atAuthKeys.apkamSymmetricKey.toString());
+    });
+
+    test('checkpoint.load() - returns null when file is missing', () {
+      expect(
+          EnrollmentCheckpoint('@rhaegar')
+              .load(appName, deviceName, namespaces),
+          isNull);
+    });
+
+    test('checkpoint.load() - returns null for corrupt JSON', () async {
+      final cp = EnrollmentCheckpoint('@vermithor');
+      File checkpoint = cp.getFile(appName, deviceName, namespaces);
+      checkpoint.writeAsStringSync('not valid json {{{');
+      expect(cp.load(appName, deviceName, namespaces), isNull);
+      expect(checkpoint.existsSync(), false);
+    });
+
+    test('checkpoint.load() - returns null for different params', () async {
+      final cp = EnrollmentCheckpoint('@sheepstealer');
+      final atAuthKeys = getAtAuthKeysFromAtChopsKeys(getRandomAtChopsKeys());
+
+      await cp.save(
+          AtEnrollmentResponse('mismatch-test', EnrollmentStatus.pending,
+              atAuthKeys: atAuthKeys),
+          'app1',
+          'device1',
+          {'ns': 'rw'});
+
+      expect(cp.load('app2', 'device2', {'ns': 'rw'}), isNull);
+
+      // in-case of mismatch, the checkpoint is not automatically removed
+      cp.delete('app1', 'device1', {'ns': 'rw'});
+    });
+
+    test('checkpoint.load() - returns null and deletes file when expired',
+        () async {
+      final cp = EnrollmentCheckpoint('@moondancer');
+      final atAuthKeys = getAtAuthKeysFromAtChopsKeys(getRandomAtChopsKeys());
+
+      await cp.save(
+          AtEnrollmentResponse('expired-test', EnrollmentStatus.pending,
+              atAuthKeys: atAuthKeys),
+          appName,
+          deviceName,
+          namespaces,
+          expiry: Duration.zero);
+
+      final file = cp.getFile(appName, deviceName, namespaces);
+      expect(file.existsSync(), isTrue);
+      expect(cp.load(appName, deviceName, namespaces), isNull);
+      // checkpoint is deleted as it's expired
+      expect(file.existsSync(), isFalse);
+    });
+
+    test('checkpoint.delete() - deletes existing checkpoint file', () async {
+      final cp = EnrollmentCheckpoint('@meraxes');
+      final atAuthKeys = getAtAuthKeysFromAtChopsKeys(getRandomAtChopsKeys());
+
+      await cp.save(
+          AtEnrollmentResponse('del-test', EnrollmentStatus.pending,
+              atAuthKeys: atAuthKeys),
+          appName,
+          deviceName,
+          namespaces);
+      expect(cp.getFile(appName, deviceName, namespaces).existsSync(), isTrue);
+
+      cp.delete(appName, deviceName, namespaces);
+      expect(cp.getFile(appName, deviceName, namespaces).existsSync(), isFalse);
+    });
+
+    test('checkpoint.delete() - is a no-op when file does not exist', () {
+      expect(
+          () => EnrollmentCheckpoint('@quicksilver')
+              .delete(appName, deviceName, namespaces),
+          returnsNormally);
+    });
+
+    test(
+        'checkpoint files are created per atSign — same params generate different files',
+        () async {
+      final cp1 = EnrollmentCheckpoint('@dreamfyre');
+      final cp2 = EnrollmentCheckpoint('@sunfyre');
+      final keys1 = getAtAuthKeysFromAtChopsKeys(getRandomAtChopsKeys());
+      final keys2 = getAtAuthKeysFromAtChopsKeys(getRandomAtChopsKeys());
+
+      await cp1.save(
+          AtEnrollmentResponse('id-for-dreamfyre', EnrollmentStatus.pending,
+              atAuthKeys: keys1),
+          appName,
+          deviceName,
+          namespaces);
+      await cp2.save(
+          AtEnrollmentResponse('id-for-sunfyre', EnrollmentStatus.pending,
+              atAuthKeys: keys2),
+          appName,
+          deviceName,
+          namespaces);
+
+      expect(cp1.load(appName, deviceName, namespaces)!.enrollmentId,
+          'id-for-dreamfyre');
+      expect(cp2.load(appName, deviceName, namespaces)!.enrollmentId,
+          'id-for-sunfyre');
+
+      cp1.delete(appName, deviceName, namespaces);
+      cp2.delete(appName, deviceName, namespaces);
+    });
+
+    tearDown(() {
+      // clean up any leftover checkpoint files from this group
+      Directory(Directory.current.path)
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.enrollment.checkpoint'))
+          .forEach((f) => f.deleteSync());
     });
   });
 }
@@ -323,7 +746,6 @@ AtClientPreference getAtClientPreferenceAlice() {
   var preference = AtClientPreference();
   preference.hiveStoragePath = 'test/storage/hive/client';
   preference.commitLogPath = 'test/storage/hive/client/commit';
-  preference.isLocalStoreRequired = true;
   preference.rootDomain = 'vip.ve.atsign.zone';
   return preference;
 }
@@ -332,8 +754,7 @@ AtOnboardingPreference getOnboardingPreference() {
   return AtOnboardingPreference()
     ..hiveStoragePath = 'test/storage/hive/client'
     ..commitLogPath = 'test/storage/hive/client/commit'
-    ..atKeysFilePath = 'test/storage'
-    ..isLocalStoreRequired = true;
+    ..atKeysFilePath = 'test/storage';
 }
 
 // creates an instance of AtAuthKeys by using the keys in AtChopsKeys

--- a/packages/at_onboarding_cli/test/auth_cli_test.dart
+++ b/packages/at_onboarding_cli/test/auth_cli_test.dart
@@ -17,7 +17,7 @@ void main() {
     final dirPath = '$baseDirPath/@alice-apkam-keys.atKeys';
 
     test(
-        'A test to verify ensureWritable returns false if directory has read-only permissions',
+        'ensureWritable throws PathAccessException if directory has read-only permissions',
         () async {
       final directory = Directory(dirPath);
       // Create the directory first to ensure it exists before calling isWritable.
@@ -28,7 +28,7 @@ void main() {
     });
 
     test(
-        'A test verify ensureWritable doesnt throw if directory does not have a file already',
+        'ensureWritable doesnt throw if directory does not have a file already',
         () {
           expect(() => AtFileUtil.ensureWritable(File(dirPath)), returnsNormally);
     });

--- a/packages/at_onboarding_cli/test/auth_cli_test.dart
+++ b/packages/at_onboarding_cli/test/auth_cli_test.dart
@@ -5,6 +5,8 @@ import 'package:at_chops/at_chops.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_onboarding_cli/src/cli/auth_cli.dart';
 import 'package:at_onboarding_cli/src/cli/auth_cli_args.dart';
+
+import 'package:at_onboarding_cli/src/util/at_file_util.dart';
 import 'package:test/test.dart';
 import 'at_onboarding_cli_test.dart';
 
@@ -15,20 +17,20 @@ void main() {
     final dirPath = '$baseDirPath/@alice-apkam-keys.atKeys';
 
     test(
-        'A test to verify isWritable returns false if directory has read-only permissions',
+        'A test to verify ensureWritable returns false if directory has read-only permissions',
         () async {
       final directory = Directory(dirPath);
       // Create the directory first to ensure it exists before calling isWritable.
       await directory.create(recursive: true);
       // Set permission to read only.
       await Process.run('chmod', ['444', baseDirPath]);
-      expect(canCreateFile(File(dirPath)), false);
+      expect(() => AtFileUtil.ensureWritable(File(dirPath)), throwsA(isA<PathAccessException>()));
     });
 
     test(
-        'A test verify isWritable returns true if directory does not have a file already',
+        'A test verify ensureWritable doesnt throw if directory does not have a file already',
         () {
-      expect(canCreateFile(File(dirPath)), true);
+          expect(() => AtFileUtil.ensureWritable(File(dirPath)), returnsNormally);
     });
   });
 

--- a/packages/at_onboarding_cli/test/auth_cli_test.dart
+++ b/packages/at_onboarding_cli/test/auth_cli_test.dart
@@ -24,7 +24,7 @@ void main() {
       await directory.create(recursive: true);
       // Set permission to read only.
       await Process.run('chmod', ['444', baseDirPath]);
-      expect(() => AtFileUtil.ensureWritable(File(dirPath)), throwsA(isA<PathAccessException>()));
+      expect(() => AtFileUtil.ensureWritable(File(dirPath)), throwsA(isA<AtException>()));
     });
 
     test(


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Closes https://github.com/atsign-foundation/at_client_sdk/issues/1747

**- What I did**
- set `chmod 600` for all atKeys files
- `enroll` and `onboard` in `AtOnboardingService` now perform a pre-check to ensure the atKeys file is creatable.
- `OnboardingService.enroll()` saves checkpoints that can be used to resume interrupted `awaitApproval()` flow.
- Introduced `toJson` and `fromJson` in `AtEnrollmentResponse.`

**- How I did it**
- Introduced `AtFileUtil` that has methods:
   - `setSecureFilePermissions`: sets `chmod 600` for the atKeys file on POSIX. Attempts to do the equivalent on Windows using the `icacls` command.
   - `validateFileIsCreatable`: Ensures file does not already exist. Also writes and deletes a dummy file to ensure the provided path is writable.
 - Introduced `EnrollmentCheckpoint` class that holds all the checkpoint read-write ops.
    - The checkpoint file names use a hash of atsign + appname + deviceName + namespaces. This ensures that the checkpoint is created per atsign-params combo. So sending and enrollment requests with a different atsign or enroll params will not cause collisions.
    - The checkpoint is deleted as soon as the enrollment is approved or denied.
    - The checkpoint has an internal expiry: it uses the `apkamKeysExpiry` or has a fallback value of 24 hours.
    - In case the checkpoint is expired or corrupted, that file is deleted.

**- How to verify it**
- Existing tests pass
- Newly added checkpoint-specific tests pass
- Manually: 
   - Try running an enroll command using activate_cli.
   - Interrupt the process while waiting for approval
   - Try running the same command again
   - activate_cli should pick up the checkpoint and resume awaiting approval

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: set `chmod 600` for all atKeys files
feat: support resuming enrollments