### PR TITLE
feat: Introduce direct programmatic control of AtClient lifecycle

### DIFF
--- a/packages/at_chops/lib/src/at_chops_impl.dart
+++ b/packages/at_chops/lib/src/at_chops_impl.dart
@@ -251,10 +251,16 @@ class AtChopsImpl extends AtChops {
       return signingInput.signingAlgorithm;
     } else if (signingInput.signingMode != null &&
         signingInput.signingMode == AtSigningMode.pkam) {
+      if (atChopsKeys.atPkamKeyPair == null) {
+        throw AtSigningException('PKAM Keypair required for signing');
+      }
       return PkamSigningAlgo(
           atChopsKeys.atPkamKeyPair!, signingInput.hashingAlgoType);
     } else if (signingInput.signingMode != null &&
         signingInput.signingMode == AtSigningMode.data) {
+      if (atChopsKeys.atEncryptionKeyPair == null){
+        throw AtSigningException('Encryption keypair required for signing');
+      }
       return DefaultSigningAlgo(
           atChopsKeys.atEncryptionKeyPair!, signingInput.hashingAlgoType);
     } else {

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.12.0
+
+- feat: explicit AtClient lifecycle control — cleanly stop and resume atSigns without
+  re-initialising storage or keys
+- fix: monitor delayed-start timer could not be cancelled on stop
+
 ## 3.11.0
 
 - chore(deps): at_auth ^3.0.0

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -17,6 +17,8 @@ import 'package:at_client/src/preference/at_client_config.dart';
 import 'package:at_client/src/response/response.dart';
 import 'package:at_client/src/service/encryption_service.dart';
 import 'package:at_client/src/service/file_transfer_service.dart';
+import 'package:at_client/src/service/notification_service_impl.dart';
+import 'package:at_client/src/service/sync_service_impl.dart';
 import 'package:at_client/src/stream/at_stream_notification.dart';
 import 'package:at_client/src/stream/at_stream_response.dart';
 import 'package:at_client/src/stream/file_transfer_object.dart';
@@ -80,6 +82,9 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   @override
   set atChops(AtChops? atChops) {
     _atChops = atChops;
+    if (_remoteSecondary != null) {
+      _remoteSecondary!.atChops = atChops;
+    }
   }
 
   @override
@@ -124,8 +129,6 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   @override
   EncryptionService? get encryptionService => _encryptionService;
 
-  late final AtClientManager _atClientManager;
-
   late final AtSignLogger _logger;
 
   @override
@@ -167,8 +170,7 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
       await atClientImpl._init(atLookUp: atLookUp);
     }
 
-    await atClientImpl!.startCompactionJob();
-    atClientManager.listenToAtSignChange(atClientImpl);
+    await atClientImpl!.start();
 
     atClientInstanceMap[currentAtSign] = atClientImpl;
     return atClientInstanceMap[currentAtSign];
@@ -192,7 +194,6 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     _logger = AtSignLogger('AtClientImpl ($_atSign)');
     _preference = preference;
     _preference?.namespace ??= namespace;
-    _atClientManager = atClientManager;
     _localSecondaryKeyStore = localSecondaryKeyStore;
 
     if (_localSecondaryKeyStore != null && !_preference!.isLocalStoreRequired) {
@@ -232,6 +233,61 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
     putRequestTransformer.atClient = this;
 
     _cascadeSetTelemetryService();
+  }
+
+  bool _isStopped = false;
+
+  @override
+  bool get isStopped => _isStopped;
+
+  Future<void> start() async {
+    if (!_isStopped) {
+      _logger.finer('start() called, but atClient is not stopped. Ignoring');
+      return;
+    }
+    _isStopped = false;
+    await startCompactionJob();
+  }
+
+  @override
+  Future<void> stop() async {
+    if (_isStopped) {
+      _logger.info('close() called, but client is already closed. Ignoring.');
+      return;
+    }
+
+    _isStopped = true;
+    _logger.info('close() called: stopping at_client for $_atSign');
+
+    await _stopBackgroundProcesses();
+  }
+
+  Future<void> _stopBackgroundProcesses() async {
+    try {
+      await stopCompactionJob();
+    } catch (e) {
+      _logger.warning('Error while stopping compaction job: $e');
+    }
+
+    try {
+      await (syncService as SyncServiceImpl).stop();
+    } catch (e) {
+      _logger.warning('Error while closing sync service: $e');
+    }
+
+    try {
+      await (notificationService as NotificationServiceImpl).stop();
+    } catch (e) {
+      _logger.warning('Error while closing notification service: $e');
+    }
+
+    if (_remoteSecondary != null) {
+      try {
+        await _remoteSecondary!.closeConnection();
+      } catch (e) {
+        _logger.warning('Error while closing remote secondary connection: $e');
+      }
+    }
   }
 
   @override
@@ -1005,13 +1061,8 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
 
   @override
   void listenToAtSignChange(SwitchAtSignEvent switchAtSignEvent) {
-    // Checks if the instance of AtClientImpl belongs to previous atSign. If Yes,
-    // the compaction job is stopped and removed from changeListener list.
-    if (switchAtSignEvent.previousAtClient?.getCurrentAtSign() ==
-        getCurrentAtSign()) {
-      _atClientCommitLogCompaction!.stopCompactionJob();
-      _atClientManager.removeChangeListeners(this);
-    }
+    // do nothing
+    // AtClientImpl does not register a change listener anymore
   }
 
   // TODO v4 - remove the follow methods in version 4 of at_client package

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -251,12 +251,12 @@ class AtClientImpl implements AtClient {
   @override
   Future<void> stop() async {
     if (_isStopped) {
-      _logger.info('close() called, but client is already closed. Ignoring.');
+      _logger.info('stop() called: but client is already stopped. Ignoring.');
       return;
     }
 
     _isStopped = true;
-    _logger.info('close() called: stopping at_client for $_atSign');
+    _logger.info('stop() called: stopping at_client for $_atSign');
 
     await _stopBackgroundProcesses();
   }

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -9,7 +9,6 @@ import 'package:at_client/src/client/secondary.dart';
 import 'package:at_client/src/client/verb_builder_manager.dart';
 import 'package:at_client/src/compaction/at_commit_log_compaction.dart';
 import 'package:at_client/src/listener/at_sign_change_listener.dart';
-import 'package:at_client/src/listener/switch_at_sign_event.dart';
 import 'package:at_client/src/manager/storage_manager.dart';
 import 'package:at_client/src/manager/sync_manager.dart';
 import 'package:at_client/src/manager/sync_manager_impl.dart';
@@ -41,7 +40,7 @@ import 'package:uuid/uuid.dart';
 ///
 /// Implements to [AtSignChangeListener] to get notified on switch atSign event. On switch atSign event,
 /// pause's the compaction job on currentAtSign and start/resume the compaction job on the new atSign
-class AtClientImpl implements AtClient, AtSignChangeListener {
+class AtClientImpl implements AtClient {
   AtClientPreference? _preference;
 
   AtClientPreference? get preference => _preference;
@@ -1057,12 +1056,6 @@ class AtClientImpl implements AtClient, AtSignChangeListener {
   @override
   AtClientPreference? getPreferences() {
     return _preference;
-  }
-
-  @override
-  void listenToAtSignChange(SwitchAtSignEvent switchAtSignEvent) {
-    // do nothing
-    // AtClientImpl does not register a change listener anymore
   }
 
   // TODO v4 - remove the follow methods in version 4 of at_client package

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -53,6 +53,22 @@ abstract class AtClient {
 
   AtClientPreference? getPreferences();
 
+  /// Whether this client has been stopped via [AtClientManager].
+  ///
+  /// Once true, the instance is unusable — all sub-services have been torn down
+  /// and the instance has been removed from the internal cache.
+  bool get isStopped;
+
+  /// Stops all background services (sync, notifications, monitor) and closes
+  /// local storage for this atSign.
+  ///
+  /// After calling [stop], the instance remains in the internal cache and can
+  /// be resumed by calling [AtClientManager.setCurrentAtSign] for the same
+  /// atSign, which will reopen storage and wire up fresh services.
+  ///
+  /// To permanently discard this instance, call [dispose] instead.
+  Future<void> stop();
+
   /// Updates value of [AtKey.key] is if it is already present. Otherwise creates a new key. Set [AtKey.sharedWith] if the key
   /// has to be shared with another atSign. Set [AtKey.metadata.isBinary] if you are updating binary value e.g image,file.
   /// By default namespace that is used to create the [AtClient] instance will be appended to the key. phone@alice will be saved as

--- a/packages/at_client/lib/src/client/remote_secondary.dart
+++ b/packages/at_client/lib/src/client/remote_secondary.dart
@@ -24,11 +24,18 @@ class RemoteSecondary implements Secondary {
 
   late AtLookUp atLookUp;
 
-  final AtChops? atChops;
+  AtChops? _atChops;
+
+  AtChops? get atChops => _atChops;
+
+  set atChops(AtChops? value) {
+    _atChops = value;
+    atLookUp.atChops = value;
+  }
 
   RemoteSecondary(String atSign, AtClientPreference preference,
       {String? privateKey,
-      this.atChops,
+      AtChops? atChops,
       AtLookUp? atLookUp,
       String? enrollmentId}) {
     _atSign = AtUtils.fixAtSign(atSign);
@@ -39,6 +46,7 @@ class RemoteSecondary implements Secondary {
       ..decryptPackets = preference.decryptPackets
       ..pathToCerts = preference.pathToCerts
       ..tlsKeysSavePath = preference.tlsKeysSavePath;
+    _atChops = atChops;
     this.atLookUp = atLookUp ??
         AtLookupImpl(atSign, preference.rootDomain, preference.rootPort,
             privateKey: privateKey,
@@ -205,5 +213,9 @@ class RemoteSecondary implements Secondary {
       return Intent.syncData;
     }
     return Intent.fetchData;
+  }
+
+  Future<void> closeConnection() async {
+    await atLookUp.close();
   }
 }

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:at_auth/at_auth.dart';
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
@@ -55,10 +57,17 @@ class AtClientManager {
     }
   }
 
-  /// * Can provide an [AtServiceFactory] to control what types of AtClients, NotificationServices and SyncServices get created
-  /// by this method.
-  /// * Can provide an [AtChops] instance if available; setCurrentAtSign will ensure that it is injected into objects that
-  /// can use it
+  /// Switches the active atSign and (re)creates its associated services.
+  ///
+  /// The outgoing client is stopped via [AtClient.stop] and its instance
+  /// remains in cache for resumption. Calling this method again for the same
+  /// atSign resumes it with fresh services.
+  ///
+  /// Use [AtClient.stop] only when permanently finished with an atSign (e.g.,
+  /// logout or app shutdown).
+  ///
+  /// * [serviceFactory] - Overrides service creation (primarily for testing).
+  /// * [atChops] - Shared crypto context for the new services.
   Future<AtClientManager> setCurrentAtSign(
       String atSign, String? namespace, AtClientPreference preference,
       {AtServiceFactory? serviceFactory,
@@ -71,23 +80,19 @@ class AtClientManager {
     AtUtils.fixAtSign(atSign);
     secondaryAddressFinder ??= CacheableSecondaryAddressFinder(
         preference.rootDomain, preference.rootPort);
-    if (_currentAtClient != null &&
-        _currentAtClient?.getCurrentAtSign() == atSign) {
-      _logger.info(
-          'previous currentAtSign ${_currentAtClient?.getCurrentAtSign()} is same as new atSign $atSign - doing nothing, returning');
-      return this;
-    }
 
     _logger.info(
-        'Switching atSigns from ${_currentAtClient?.getCurrentAtSign()} to $atSign');
+        'Switching atSigns ${_currentAtClient?.getCurrentAtSign()} -> $atSign');
+
+    // Stop the outgoing atsign
     _atSign = atSign;
-    var previousAtClient = _currentAtClient;
+    final previousAtClient = _currentAtClient;
+    await previousAtClient?.stop();
+
+    // Spin up the new atClient
     _currentAtClient = await serviceFactory.atClient(
         _atSign, namespace, preference, this,
         atChops: atChops, atLookUp: atLookUp, enrollmentId: enrollmentId);
-    final switchAtSignEvent =
-        SwitchAtSignEvent(previousAtClient, _currentAtClient!);
-    _notifyListeners(switchAtSignEvent);
 
     var notificationService =
         await serviceFactory.notificationService(_currentAtClient!, this);
@@ -100,6 +105,14 @@ class AtClientManager {
     EnrollmentService enrollmentService =
         serviceFactory.enrollmentService(_currentAtClient!);
     _currentAtClient!.enrollmentService = enrollmentService;
+
+    // notify the subscribed listeners about atsign switch
+    if (!identical(previousAtClient?.getCurrentAtSign(),
+        _currentAtClient?.getCurrentAtSign())) {
+      final switchAtSignEvent =
+          SwitchAtSignEvent(previousAtClient, _currentAtClient!);
+      _notifyListeners(switchAtSignEvent);
+    }
 
     _logger.info("setCurrentAtSign complete");
 
@@ -154,6 +167,10 @@ class AtClientManager {
   }
 }
 
+/// Abstraction over the construction of the core services managed by [AtClientManager].
+///
+/// The default production implementation is [DefaultAtServiceFactory].
+/// Override this in tests to inject fakes or mocks without subclassing [AtClientManager].
 abstract class AtServiceFactory {
   Future<AtClient> atClient(String atSign, String? namespace,
       AtClientPreference preference, AtClientManager atClientManager,
@@ -162,8 +179,8 @@ abstract class AtServiceFactory {
   Future<NotificationService> notificationService(
       AtClient atClient, AtClientManager atClientManager);
 
-  /// [notificationService] parameter is ignored, the sync service should
-  /// get that from the [atClient]
+  /// The [notificationService] parameter is ignored — the sync service retrieves
+  /// its notification dependency directly from [atClient] after construction.
   Future<SyncService> syncService(AtClient atClient,
       AtClientManager atClientManager, NotificationService notificationService);
 

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.11.0';
+  final String atClientVersion = '3.12.0';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -4,8 +4,6 @@ import 'dart:convert';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/encryption_service/encryption_manager.dart';
-import 'package:at_client/src/listener/at_sign_change_listener.dart';
-import 'package:at_client/src/listener/switch_at_sign_event.dart';
 import 'package:at_client/src/manager/monitor.dart';
 import 'package:at_client/src/response/default_response_parser.dart';
 import 'package:at_client/src/response/notification_response_parser.dart';
@@ -20,8 +18,7 @@ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.
 import 'package:at_utils/at_utils.dart';
 import 'package:meta/meta.dart';
 
-class NotificationServiceImpl extends NotificationService
-    implements AtSignChangeListener {
+class NotificationServiceImpl extends NotificationService {
   final Map<NotificationConfig, StreamController> _streamListeners =
       HashMap(equals: _compareNotificationConfig, hashCode: _generateHashCode);
   final emptyRegex = '';
@@ -166,7 +163,7 @@ class NotificationServiceImpl extends NotificationService
   }
 
   @visibleForTesting
-  bool isClosed = false;
+  bool isStopped = false;
 
   Future<void> stop() async {
     stopAllSubscriptions();
@@ -174,12 +171,12 @@ class NotificationServiceImpl extends NotificationService
 
   @override
   void stopAllSubscriptions({bool stopNotificationsListener = true}) {
-    if (isClosed) {
+    if (isStopped) {
       logger.info(
           'stopAllSubscriptions() called, but service is already closed. Ignoring.');
       return;
     }
-    isClosed = true;
+    isStopped = true;
 
     if (stopNotificationsListener) {
       stopListening();
@@ -464,12 +461,6 @@ class NotificationServiceImpl extends NotificationService
   /// Returns the hashcode for the [NotificationConfig.regex]
   static int _generateHashCode(NotificationConfig notificationConfig) {
     return notificationConfig.regex.hashCode;
-  }
-
-  @override
-  void listenToAtSignChange(SwitchAtSignEvent switchAtSignEvent) {
-    // do nothing
-    // NotificationService does not subscribe to SwitchAtsign event anymore
   }
 
   @override

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -173,7 +173,7 @@ class NotificationServiceImpl extends NotificationService {
   void stopAllSubscriptions({bool stopNotificationsListener = true}) {
     if (isStopped) {
       logger.info(
-          'stopAllSubscriptions() called, but service is already closed. Ignoring.');
+          'stopAllSubscriptions() called, but service is already stopped. Ignoring.');
       return;
     }
     isStopped = true;

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -77,7 +77,6 @@ class NotificationServiceImpl extends NotificationService
           getLastNotificationTime: getLastNotificationTime,
           secondaryAddressFinder: atClientManager.secondaryAddressFinder!,
         );
-    atClientManager.listenToAtSignChange(this);
     lastReceivedNotificationAtKey = AtKey.local(
             lastReceivedNotificationKey, atClient.getCurrentAtSign()!,
             namespace: atClient.getPreferences()!.namespace)
@@ -166,14 +165,30 @@ class NotificationServiceImpl extends NotificationService
     return null;
   }
 
+  @visibleForTesting
+  bool isClosed = false;
+
+  Future<void> stop() async {
+    stopAllSubscriptions();
+  }
+
   @override
   void stopAllSubscriptions({bool stopNotificationsListener = true}) {
+    if (isClosed) {
+      logger.info(
+          'stopAllSubscriptions() called, but service is already closed. Ignoring.');
+      return;
+    }
+    isClosed = true;
+
     if (stopNotificationsListener) {
       stopListening();
     }
 
     _streamListeners.forEach((regex, streamController) {
-      if (!streamController.isClosed) () => streamController.close();
+      if (!streamController.isClosed) {
+        streamController.close();
+      }
     });
     _streamListeners.clear();
   }
@@ -453,11 +468,8 @@ class NotificationServiceImpl extends NotificationService
 
   @override
   void listenToAtSignChange(SwitchAtSignEvent switchAtSignEvent) {
-    atClientManager.removeChangeListeners(this);
-
-    logger.finer(
-        'stopping notification listeners for ${atClient.getCurrentAtSign()}');
-    stopAllSubscriptions();
+    // do nothing
+    // NotificationService does not subscribe to SwitchAtsign event anymore
   }
 
   @override
@@ -541,12 +553,12 @@ class NotificationServiceImpl extends NotificationService
 
   @override
   void startListening() {
-    if (monitor.targetState != NotificationListenerState.listening) {
-      logger.info('startListening() called: starting notification listener');
-      monitor.start();
-    } else {
-      logger.info('startListening() called, but already listening');
+    if (monitor.targetState == NotificationListenerState.listening) {
+      logger.info('startListening() called, but already targeting listening');
+      return;
     }
+    logger.info('startListening(): starting notification listener');
+    monitor.start();
   }
 
   @override

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -12,7 +12,8 @@ import 'package:at_client/src/util/logger_util.dart';
 import 'package:at_client/src/util/sync_util.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_lookup/at_lookup.dart';
-import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart'
+    hide AtNotification;
 import 'package:at_utils/at_utils.dart';
 import 'package:cron/cron.dart';
 import 'package:meta/meta.dart';
@@ -27,6 +28,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   final RemoteSecondary _remoteSecondary;
   @visibleForTesting
   late AtKeyDecryptionManager atKeyDecryptionManager;
+  StreamSubscription<AtNotification>? _statsNotificationSubscription;
 
   /// utility method to reduce code verbosity in this file
   /// Does nothing if a telemetryService has not been injected
@@ -49,8 +51,6 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
 
   late final AtSignLogger _logger;
 
-  final AtClientManager _atClientManager;
-
   // "^shared_key\..+@.+" matches the key that starts-with shared_key.<someone>@<me>
   // "@.+:shared_key@.+" matches the key that starts-with @<someone>:shared_key@<me>
   @visibleForTesting
@@ -72,22 +72,19 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     remoteSecondary ??= RemoteSecondary(
         atClient.getCurrentAtSign()!, atClient.getPreferences()!,
         atChops: atClient.atChops, enrollmentId: atClient.enrollmentId);
-    final syncService =
-        SyncServiceImpl._(atClientManager, atClient, remoteSecondary);
+    final syncService = SyncServiceImpl._(atClient, remoteSecondary);
     await syncService.statsServiceListener();
     syncService._scheduleSyncRun();
     return syncService;
   }
 
-  SyncServiceImpl._(
-      this._atClientManager, this._atClient, this._remoteSecondary) {
+  SyncServiceImpl._(this._atClient, this._remoteSecondary) {
     _logger = AtSignLogger('SyncService (${_atClient.getCurrentAtSign()})');
     _lastReceivedServerCommitIdAtKey =
         AtKey.local('lastreceivedservercommitid', currentAtSign).build();
     _skipDeletesUntilCommitId =
         AtKey.local('skipdeletesuntil', currentAtSign).build();
     atKeyDecryptionManager = AtKeyDecryptionManager(_atClient);
-    _atClientManager.listenToAtSignChange(this);
   }
 
   void _scheduleSyncRun() {
@@ -136,7 +133,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   Future<void> statsServiceListener() async {
     // Setting the regex to 'statsNotification' to receive only the notifications
     // from stats notification service.
-    _atClient.notificationService
+    _statsNotificationSubscription = _atClient.notificationService
         .subscribe(regex: 'statsNotification')
         .listen((notification) async {
       _logger.finer(_logger.getLogMessageWithClientParticulars(
@@ -1077,16 +1074,76 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
         _atClient.getCurrentAtSign()!);
   }
 
+  @visibleForTesting
+  bool isStopped = false;
+
   @override
   void listenToAtSignChange(SwitchAtSignEvent switchAtSignEvent) {
-    _atClientManager.removeChangeListeners(this);
+    // do nothing
+    // SyncService does not subscribe to SwitchAtsign event anymore
+  }
 
-    _syncRequests.clear();
+  Future<void> stop() async {
+    if (isStopped) {
+      _logger.info('close() called, but service is already closed. Ignoring.');
+      return;
+    }
+    isStopped = true;
+    _logger.info('Closing sync service for $currentAtSign');
+
+    _drainSyncQueue();
+
+    _logger.finer('stopping stats notification subscription');
+    try {
+      await _statsNotificationSubscription?.cancel();
+    } catch (e) {
+      _logger.warning(
+          'Error while cancelling stats notification subscription: $e');
+    }
 
     _logger.finer('stopping cron');
-    _cron.close();
+    try {
+      await _cron.close();
+    } catch (e) {
+      _logger.warning('Error while closing cron: $e');
+    }
 
     removeAllProgressListeners();
+  }
+
+  void _drainSyncQueue() {
+    // 1. Drain the sync request queue with errors
+    final exception = AtClientException(
+        error_codes['AtClientException'], 'SyncService has been closed');
+
+    while (_syncRequests.isNotEmpty) {
+      var request = _syncRequests.removeFirst();
+      try {
+        if (request.onError != null) {
+          request.onError!(SyncResult()
+            ..syncStatus = SyncStatus.failure
+            ..atClientException = exception);
+        }
+      } catch (e) {
+        _logger.warning('Error while draining sync request: $e');
+      }
+    }
+
+    // 2. Notify progress listeners of the failure
+    var progress = SyncProgress()
+      ..atSign = currentAtSign
+      ..syncStatus = SyncStatus.failure
+      ..atClientException = exception
+      ..message = 'SyncService closed';
+
+    for (var listener in _syncProgressListeners) {
+      try {
+        listener.onSyncProgressEvent(progress);
+      } catch (e) {
+        _logger.warning('Error notifying progress listener during stop: $e');
+      }
+    }
+    _syncProgressListeners.clear();
   }
 
   @override

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -1109,7 +1109,7 @@ class SyncServiceImpl implements SyncService {
   void _drainSyncQueue() {
     // 1. Drain the sync request queue with errors
     final exception = AtClientException(
-        error_codes['AtClientException'], 'SyncService has been closed');
+        error_codes['AtClientException'], 'SyncService has been stopped');
 
     while (syncRequests.isNotEmpty) {
       var request = syncRequests.removeFirst();
@@ -1129,7 +1129,7 @@ class SyncServiceImpl implements SyncService {
       ..atSign = currentAtSign
       ..syncStatus = SyncStatus.failure
       ..atClientException = exception
-      ..message = 'SyncService closed';
+      ..message = 'SyncService stopped';
 
     for (var listener in _syncProgressListeners) {
       try {

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -4,8 +4,6 @@ import 'dart:convert';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/decryption_service/decryption_manager.dart';
-import 'package:at_client/src/listener/at_sign_change_listener.dart';
-import 'package:at_client/src/listener/switch_at_sign_event.dart';
 import 'package:at_client/src/response/default_response_parser.dart';
 import 'package:at_client/src/response/json_utils.dart';
 import 'package:at_client/src/util/logger_util.dart';
@@ -19,7 +17,7 @@ import 'package:cron/cron.dart';
 import 'package:meta/meta.dart';
 
 ///A [SyncService] object is used to ensure data in local secondary(e.g mobile device) and cloud secondary are in sync.
-class SyncServiceImpl implements SyncService, AtSignChangeListener {
+class SyncServiceImpl implements SyncService {
   static int syncRequestThreshold = 3,
       syncRequestTriggerInSeconds = 3,
       syncRunIntervalSeconds = 5,
@@ -41,7 +39,10 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
 
   final List<SyncProgressListener> _syncProgressListeners = [];
   late final Cron _cron;
-  final _syncRequests = ListQueue<SyncRequest>(queueSize);
+
+  @visibleForTesting
+  final syncRequests = ListQueue<SyncRequest>(queueSize);
+
   bool _syncInProgress = false;
 
   @override
@@ -198,15 +199,15 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
       return;
     }
     if (respectSyncRequestQueueSizeAndRequestTriggerDuration) {
-      if (_syncRequests.isEmpty ||
-          (_syncRequests.length < syncRequestThreshold &&
-              (_syncRequests.isNotEmpty &&
+      if (syncRequests.isEmpty ||
+          (syncRequests.length < syncRequestThreshold &&
+              (syncRequests.isNotEmpty &&
                   DateTime.now()
                           .toUtc()
-                          .difference(_syncRequests.elementAt(0).requestedOn)
+                          .difference(syncRequests.elementAt(0).requestedOn)
                           .inSeconds <
                       syncRequestTriggerInSeconds))) {
-        _logger.finest('skipping sync - queue length ${_syncRequests.length}');
+        _logger.finest('skipping sync - queue length ${syncRequests.length}');
         return;
       }
     }
@@ -290,11 +291,11 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   /// Fetches the first app request from the queue. If there are no app requests, the first element of the
   /// queue is returned.
   SyncRequest _getSyncRequest() {
-    return _syncRequests.firstWhere(
+    return syncRequests.firstWhere(
         (syncRequest) =>
             syncRequest.requestSource == SyncRequestSource.app &&
             syncRequest.onDone != null,
-        orElse: () => _syncRequests.removeFirst());
+        orElse: () => syncRequests.removeFirst());
   }
 
   void _syncError(SyncRequest syncRequest) {
@@ -337,17 +338,17 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
 
   void _addSyncRequestToQueue(SyncRequest syncRequest) {
     hasHadNoSyncRequests = false;
-    if (_syncRequests.length == queueSize) {
-      _syncRequests.removeLast();
+    if (syncRequests.length == queueSize) {
+      syncRequests.removeLast();
     }
-    _syncRequests.addLast(syncRequest);
+    syncRequests.addLast(syncRequest);
   }
 
   void _clearQueue() {
     _logger.finer(_logger.getLogMessageWithClientParticulars(
         _atClient.getPreferences()!.atClientParticulars,
         'Clearing sync queue'));
-    _syncRequests.clear();
+    syncRequests.clear();
   }
 
   @visibleForTesting
@@ -1077,19 +1078,13 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   @visibleForTesting
   bool isStopped = false;
 
-  @override
-  void listenToAtSignChange(SwitchAtSignEvent switchAtSignEvent) {
-    // do nothing
-    // SyncService does not subscribe to SwitchAtsign event anymore
-  }
-
   Future<void> stop() async {
     if (isStopped) {
-      _logger.info('close() called, but service is already closed. Ignoring.');
+      _logger.info('stop() called, but service is already stopped. Ignoring.');
       return;
     }
     isStopped = true;
-    _logger.info('Closing sync service for $currentAtSign');
+    _logger.info('Stopping sync service for $currentAtSign');
 
     _drainSyncQueue();
 
@@ -1105,7 +1100,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     try {
       await _cron.close();
     } catch (e) {
-      _logger.warning('Error while closing cron: $e');
+      _logger.warning('Error while stopping cron: $e');
     }
 
     removeAllProgressListeners();
@@ -1116,8 +1111,8 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
     final exception = AtClientException(
         error_codes['AtClientException'], 'SyncService has been closed');
 
-    while (_syncRequests.isNotEmpty) {
-      var request = _syncRequests.removeFirst();
+    while (syncRequests.isNotEmpty) {
+      var request = syncRequests.removeFirst();
       try {
         if (request.onError != null) {
           request.onError!(SyncResult()
@@ -1165,7 +1160,7 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
   ///Clears all in-memory entities belonging to the syncService
   @visibleForTesting
   void clearSyncEntities() {
-    _syncRequests.clear();
+    syncRequests.clear();
     _syncProgressListeners.clear();
   }
 
@@ -1178,6 +1173,6 @@ class SyncServiceImpl implements SyncService, AtSignChangeListener {
 
   @visibleForTesting
   int getSyncRequestQueueSize() {
-    return _syncRequests.length;
+    return syncRequests.length;
   }
 }

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.11.0
+version: 3.12.0
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/test/at_client_impl_test.dart
+++ b/packages/at_client/test/at_client_impl_test.dart
@@ -77,34 +77,28 @@ void main() {
     AtClientPreference atClientPreference = AtClientPreference()
       ..hiveStoragePath = 'test/hive'
       ..commitLogPath = 'test/hive/path';
+
     setUp(() async {
       AtClientImpl.atClientInstanceMap.remove(atSign);
       AtClientManager.getInstance().removeAllChangeListeners();
     });
+
     tearDown(() async {
       AtClientImpl.atClientInstanceMap.remove(atSign);
       AtClientManager.getInstance().removeAllChangeListeners();
     });
-    test('A test to verify switch atSign event clears the inactive listeners',
-        () async {
+
+    test('A test to verify change', () async {
       var atClientManager = await AtClientManager.getInstance()
           .setCurrentAtSign(atSign, namespace, atClientPreference);
-      expect(atClientManager.getChangeListenersSize(), 3);
+
+      expect(atClientManager.getChangeListenersSize(), 0);
       atClientManager = await AtClientManager.getInstance()
           .setCurrentAtSign('@bob', namespace, atClientPreference);
-      expect(atClientManager.getChangeListenersSize(), 3);
-      // Verify the listeners in [AtClientManager._changeListeners] list belongs
-      // to the new atSign. Here @bob.
-      var itr = atClientManager.getItemsInChangeListeners();
-      while (itr.moveNext()) {
-        if (itr.current is NotificationService) {
-          expect((itr.current as NotificationServiceImpl).atSign, '@bob');
-        } else if (itr.current is SyncService) {
-          expect((itr.current as SyncServiceImpl).currentAtSign, '@bob');
-        } else if (itr.current is AtClientImpl) {
-          expect((itr.current as AtClientImpl).getCurrentAtSign(), '@bob');
-        }
-      }
+      expect(atClientManager.getChangeListenersSize(), 0);
+
+      // Notification Service, Sync Service and AtClientImpl do not register
+      // change listeners anymore
     });
 
     test(
@@ -117,7 +111,8 @@ void main() {
         ..commitLogPath = 'test/hive/path';
       var atClientManager = await AtClientManager.getInstance()
           .setCurrentAtSign(atSign, namespace, atClientPreference);
-      expect(atClientManager.getChangeListenersSize(), 3);
+
+      expect(atClientManager.getChangeListenersSize(), 0);
       atClientManager = await AtClientManager.getInstance()
           .setCurrentAtSign(atSign, namespace, atClientPreference);
       atClientManager = await AtClientManager.getInstance()
@@ -126,19 +121,10 @@ void main() {
           .setCurrentAtSign(atSign, namespace, atClientPreference);
       atClientManager = await AtClientManager.getInstance()
           .setCurrentAtSign(atSign, namespace, atClientPreference);
-      expect(atClientManager.getChangeListenersSize(), 3);
-      // Verify the listeners in [AtClientManager._changeListeners] list belongs
-      // to the new atSign. Here @alice.
-      var itr = atClientManager.getItemsInChangeListeners();
-      while (itr.moveNext()) {
-        if (itr.current is NotificationService) {
-          expect((itr.current as NotificationServiceImpl).atSign, atSign);
-        } else if (itr.current is SyncService) {
-          expect((itr.current as SyncServiceImpl).currentAtSign, atSign);
-        } else if (itr.current is AtClientImpl) {
-          expect((itr.current as AtClientImpl).getCurrentAtSign(), atSign);
-        }
-      }
+      expect(atClientManager.getChangeListenersSize(), 0);
+
+      // Notification Service, Sync Service and AtClientImpl do not register
+      // change listeners anymore
     });
 
     test('A test to verify atSigns switched multiple times', () async {
@@ -347,8 +333,13 @@ void main() {
         'A test to verify exception is thrown when SPP contains special characters',
         () async {
       String invalidSPP = 'abc#12';
-      var atClientManager = await AtClientManager.getInstance()
-          .setCurrentAtSign(atSign, 'wavi', AtClientPreference());
+      var atClientManager =
+          await AtClientManager.getInstance().setCurrentAtSign(
+              atSign,
+              'wavi',
+              AtClientPreference()
+                ..hiveStoragePath = 'test/hive'
+                ..commitLogPath = 'test/hive/path');
       expect(
           () async => await atClientManager.atClient.setSPP(invalidSPP),
           throwsA(predicate((dynamic e) =>

--- a/packages/at_client/test/at_client_termination_test.dart
+++ b/packages/at_client/test/at_client_termination_test.dart
@@ -231,7 +231,8 @@ void main() {
 
         expect((atClient2.syncService as SyncServiceImpl).isStopped, false);
         expect(
-            (atClient2.notificationService as NotificationServiceImpl).isClosed,
+            (atClient2.notificationService as NotificationServiceImpl)
+                .isStopped,
             false);
       });
     });

--- a/packages/at_client/test/at_client_termination_test.dart
+++ b/packages/at_client/test/at_client_termination_test.dart
@@ -1,0 +1,239 @@
+import 'dart:async';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_client/at_client.dart';
+import 'package:at_client/src/manager/monitor.dart';
+import 'package:at_client/src/service/notification_service_impl.dart';
+import 'package:at_client/src/service/sync_service_impl.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockAtLookup extends Mock implements AtLookUp {}
+
+class MockAtChops extends Mock implements AtChops {}
+
+class MockSecondaryAddressFinder extends Mock
+    implements SecondaryAddressFinder {}
+
+class MockRemoteSecondary extends Mock implements RemoteSecondary {}
+
+class MockSecondaryPersistenceStore extends Mock
+    implements SecondaryPersistenceStore {}
+
+class MockHivePersistenceManager extends Mock
+    implements HivePersistenceManager {}
+
+AtClientPreference _createPreference(String storagePath) => AtClientPreference()
+  ..hiveStoragePath = 'test/hive/$storagePath'
+  ..commitLogPath = 'test/hive/$storagePath';
+
+Future<AtClient> _initializeAtClient(String atSign) async {
+  final atClientManager = AtClientManager.getInstance();
+  await atClientManager.setCurrentAtSign(
+      atSign, 'test', _createPreference(atSign.replaceAll('@', '')));
+  return atClientManager.atClient;
+}
+
+void main() {
+  tearDown(() async {
+    final activeInstances =
+        List<AtClient>.from(AtClientImpl.atClientInstanceMap.values);
+    for (var client in activeInstances) {
+      await (client as AtClientImpl).stop();
+    }
+    AtClientImpl.atClientInstanceMap.clear();
+  });
+
+  group('validate stop() behaviour', () {
+    group('Client termination tests', () {
+      test('close() should be idempotent and remove client from instance map',
+          () async {
+        final atSign = '@stop_integration';
+        final atClient = await AtClientImpl.create(
+                atSign, 'test', _createPreference('stop_integration'))
+            as AtClientImpl;
+
+        expect(AtClientImpl.atClientInstanceMap.containsKey(atSign), true);
+
+        // Call close multiple times to verify idempotency
+        await atClient.stop();
+        await atClient.stop();
+        await atClient.stop();
+
+        expect(AtClientImpl.atClientInstanceMap.containsKey(atSign), true);
+        expect(atClient.isStopped, true);
+      });
+
+      test('close() should handle errors gracefully and continue cleanup',
+          () async {
+        final atSign = '@stop_errors';
+        final mockRemoteSecondary = MockRemoteSecondary();
+
+        when(() => mockRemoteSecondary.closeConnection())
+            .thenThrow(Exception('Connection close error'));
+
+        final atClient = await AtClientImpl.create(
+            atSign, 'test', _createPreference('stop_errors'),
+            remoteSecondary: mockRemoteSecondary) as AtClientImpl;
+
+        await atClient.stop();
+        expect(AtClientImpl.atClientInstanceMap.containsKey(atSign), true);
+      });
+
+      test('close() should close RemoteSecondary connection', () async {
+        final mockAtLookup = MockAtLookup();
+        bool calledFlag = false;
+        when(() => mockAtLookup.close()).thenAnswer((_) async {
+          calledFlag = true;
+        });
+
+        final remoteSecondary = RemoteSecondary(
+          '@test',
+          AtClientPreference(),
+          atLookUp: mockAtLookup,
+        );
+
+        await remoteSecondary.closeConnection();
+        expect(calledFlag, true);
+      });
+    });
+
+    group('Monitor lifecycle tests', () {
+      late Monitor monitor;
+      late MockAtLookup mockAtLookup;
+      late MockAtChops mockAtChops;
+      late MockSecondaryAddressFinder mockAddressFinder;
+
+      setUp(() {
+        mockAtLookup = MockAtLookup();
+        mockAtChops = MockAtChops();
+        mockAddressFinder = MockSecondaryAddressFinder();
+        when(() => mockAtLookup.close()).thenAnswer((_) async => {});
+
+        monitor = Monitor(
+          atSign: '@test',
+          atClientPreference: AtClientPreference(),
+          atChops: mockAtChops,
+          enrollmentId: null,
+          secondaryAddressFinder: mockAddressFinder,
+          handleNotification: (String jsonEncoded) async {},
+          getLastNotificationTime: () async => null,
+        );
+      });
+
+      test('stop() should set targetState to notConnected and be idempotent',
+          () async {
+        monitor.start();
+        await Future.delayed(Duration(milliseconds: 10));
+        monitor.stop();
+        expect(monitor.targetState, NotificationListenerState.notConnected);
+
+        monitor.stop();
+        expect(monitor.targetState, NotificationListenerState.notConnected);
+      });
+
+      test('stop() should emit notConnected as final state', () async {
+        final stateHistory = <NotificationListenerState>[];
+        final subscription =
+            monitor.currentStateStream.listen(stateHistory.add);
+
+        monitor.start();
+        await Future.delayed(Duration(milliseconds: 10));
+        monitor.stop();
+        await Future.delayed(Duration(milliseconds: 10));
+
+        expect(stateHistory.last, NotificationListenerState.notConnected,
+            reason: 'Monitor should end in notConnected state after stop()');
+        await subscription.cancel();
+      });
+    });
+
+    group('AtSign switching tests', () {
+      test('should maintain correct client instances in map', () async {
+        final firstAtSign = '@alice_switch';
+        final secondAtSign = '@bob_switch';
+
+        final atClient1 =
+            await _initializeAtClient(firstAtSign) as AtClientImpl;
+        expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), true);
+
+        await _initializeAtClient(secondAtSign);
+
+        expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), true);
+        expect(
+            AtClientImpl.atClientInstanceMap.containsKey(secondAtSign), true);
+
+        expect(atClient1.isStopped, true);
+
+        // Verify switching back returns the same cached instance
+        final reusedAtClient = await _initializeAtClient(firstAtSign);
+        expect(identical(atClient1, reusedAtClient), true);
+      });
+
+      test('should handle Hive storage correctly on switch', () async {
+        final atSign1 = '@hive_soft';
+        final atSign2 = '@hive_soft2';
+
+        await _initializeAtClient(atSign1);
+
+        // Get persistence store for first atSign
+        final persistenceStore1 = SecondaryPersistenceStoreFactory.getInstance()
+            .getSecondaryPersistenceStore(atSign1);
+        final hiveManager1 = persistenceStore1?.getHivePersistenceManager();
+
+        // Switch to second atSign
+        await _initializeAtClient(atSign2);
+
+        // Hive should remain accessible
+        expect(AtClientImpl.atClientInstanceMap.containsKey(atSign1), true,
+            reason: 'First client should remain in cache');
+
+        final persistenceStoreAfter =
+            SecondaryPersistenceStoreFactory.getInstance()
+                .getSecondaryPersistenceStore(atSign1);
+        expect(persistenceStoreAfter, isNotNull,
+            reason: 'Hive storage should still be accessible');
+
+        final hiveManagerAfter =
+            persistenceStoreAfter?.getHivePersistenceManager();
+        expect(hiveManagerAfter, isNotNull);
+        expect(identical(hiveManager1, hiveManagerAfter), true);
+        expect(AtClientImpl.atClientInstanceMap.containsKey(atSign1), true);
+      });
+
+      test('switching to same atSign should handle correctly', () async {
+        final atSign = '@test_same_atsign';
+
+        // init both atClients with same atSign
+        final atClient1 = await _initializeAtClient(atSign);
+        final atClient2 = await _initializeAtClient(atSign);
+
+        // AtClientImpl.create() caches by default regardless of useClientCaching
+        // useClientCaching only affects behavior on atSign SWITCH, not create()
+        // So without close() between calls, both modes return the same instance
+        expect(identical(atClient1, atClient2), true,
+            reason:
+                'create() returns cached instance when not closed between calls');
+      });
+
+      test('switching to same atSign after close should create new instance',
+          () async {
+        final atSign = '@test_same_atsign_close';
+
+        final atClient1 = await _initializeAtClient(atSign);
+        await atClient1.stop();
+
+        final atClient2 = await _initializeAtClient(atSign);
+
+        expect(identical(atClient1, atClient2), true);
+
+        expect((atClient2.syncService as SyncServiceImpl).isStopped, false);
+        expect(
+            (atClient2.notificationService as NotificationServiceImpl).isClosed,
+            false);
+      });
+    });
+  });
+}

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -1347,6 +1347,25 @@ void main() {
       expect(lastReceivedNotification.isLocal, true);
     });
   });
+
+  group('validate stop() behaviour', () {
+    test('stop() sets isStopped to true', () async {
+      when(() => mockAtClientManager.secondaryAddressFinder)
+          .thenReturn(MockSecondaryAddressFinder());
+      final notificationService = await NotificationServiceImpl.create(
+          mockAtClientImpl,
+          atClientManager: mockAtClientManager) as NotificationServiceImpl;
+
+      await notificationService.stop();
+      expect(notificationService.isStopped, true);
+      expect(notificationService.currentListenerState,
+          NotificationListenerState.notConnected);
+      expect(notificationService.monitor.currentState,
+          NotificationListenerState.notConnected);
+      expect(notificationService.monitor.targetState,
+          NotificationListenerState.notConnected);
+    });
+  });
 }
 
 class StatsAtKeyMatcher extends Matcher {

--- a/packages/at_client/test/switch_atsign_test.dart
+++ b/packages/at_client/test/switch_atsign_test.dart
@@ -46,7 +46,9 @@ void main() {
     test('test switch atsign - check progress listener cleared', () async {
       final aliceAtSign = '@alice';
       final atClientManager = AtClientManager(aliceAtSign);
-      final alicePreference = AtClientPreference();
+      final alicePreference = AtClientPreference()
+        ..hiveStoragePath = 'test/hive'
+        ..commitLogPath = 'test/hive/path';
       await atClientManager.setCurrentAtSign(
           aliceAtSign, 'wavi', alicePreference);
       expect(atClientManager.atClient.getCurrentAtSign(), aliceAtSign);

--- a/packages/at_client/test/sync_service_test.dart
+++ b/packages/at_client/test/sync_service_test.dart
@@ -328,6 +328,83 @@ void main() async {
       mockCommitLogStore.clear();
     });
   });
+
+  group('Validate SyncService stop() behaviour', () {
+    test('stop() should stop the sync service', () async {
+      await syncServiceImpl.stop();
+      expect(syncServiceImpl.isStopped, true);
+    });
+
+    test('stop() should not stop the sync service if it is already stopped',
+        () async {
+      await syncServiceImpl.stop();
+      expect(syncServiceImpl.isStopped, true);
+    });
+
+    test('stop() should drain the pending requests', () async {
+      syncServiceImpl.sync();
+      syncServiceImpl.sync();
+      syncServiceImpl.sync();
+      expect(syncServiceImpl.syncRequests.length, 3);
+
+      await syncServiceImpl.stop();
+      expect(syncServiceImpl.isStopped, true);
+      expect(syncServiceImpl.syncRequests.length, 0);
+    });
+
+    test('stop() should gracefully close mid-sync and notify listeners',
+        () async {
+      registerFallbackValue(FakeUpdateVerbBuilder());
+      registerFallbackValue(FakeAtKey());
+
+      // local has uncommitted DELETE entries while server is at commit 5 —
+      // isSyncInProgress will be true while the batch push is in-flight
+      when(() => mockRemoteSecondary
+              .executeVerb(any(that: isA<StatsVerbBuilder>())))
+          .thenAnswer((_) => Future.value('data:${jsonEncode([
+                    {"id": "3", "name": "lastCommitID", "value": "5"}
+                  ])}'));
+      when(() =>
+              mockAtClient.get(any(that: LastReceivedServerCommitIdMatcher())))
+          .thenAnswer((_) => Future.value(AtValue()..value = '5'));
+      when(() => mockAtCommitLog.lastSyncedEntry())
+          .thenAnswer((_) => Future.value(null));
+      // uncommitted local entries → _isInSync() returns false
+      when(() => mockAtCommitLog.getChanges(any(), any()))
+          .thenAnswer((_) => Future.value([
+                CommitEntry('phone.wavi', CommitOp.DELETE, DateTime.now()),
+                CommitEntry('mobile.wavi', CommitOp.DELETE, DateTime.now()),
+              ]));
+      when(() => mockRemoteSecondary.executeCommand(any(), auth: true))
+          .thenAnswer((_) async {
+        await Future.delayed(Duration(milliseconds: 300));
+        return 'data:[{"id":1,"response":{"data":"10"}},{"id":2,"response":{"data":"11"}}]';
+      });
+
+      MockSyncProgressListener syncProgressListener =
+          MockSyncProgressListener();
+      syncServiceImpl.addProgressListener(syncProgressListener);
+
+      int syncFailureCount = 0;
+      // queue requests and start processing, then stop mid-sync
+      syncServiceImpl.sync(onError: () => syncFailureCount++);
+      syncServiceImpl.sync(onError: () => syncFailureCount++);
+      syncServiceImpl.sync(onError: () => syncFailureCount++);
+      syncServiceImpl.sync(onError: () => syncFailureCount++);
+      syncServiceImpl.sync(onError: () => syncFailureCount++);
+
+      expect(syncServiceImpl.syncRequests.length, 5);
+      unawaited(syncServiceImpl.processSyncRequests(
+          respectSyncRequestQueueSizeAndRequestTriggerDuration: false));
+      await Future.delayed(Duration(milliseconds: 200));
+      expect(syncServiceImpl.isSyncInProgress, true);
+
+      await syncServiceImpl.stop();
+      expect(syncServiceImpl.isStopped, true);
+      expect(syncServiceImpl.syncRequests.length, 0);
+      expect(syncProgressListener.syncFailed, true);
+    });
+  });
 }
 
 class MySyncProgressListener extends SyncProgressListener {
@@ -340,6 +417,17 @@ class MySyncProgressListener extends SyncProgressListener {
       syncComplete = true;
     }
     return;
+  }
+}
+
+class MockSyncProgressListener extends SyncProgressListener {
+  bool syncFailed = false;
+
+  @override
+  void onSyncProgressEvent(SyncProgress syncProgress) {
+    if (syncProgress.syncStatus == SyncStatus.failure) {
+      syncFailed = true;
+    }
   }
 }
 

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -52,7 +52,6 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     atOnboardingPreference.hiveStoragePath ??=
         HomeDirectoryUtil.getHiveStoragePath(_atSign,
             enrollmentId: enrollmentId);
-    atOnboardingPreference.isLocalStoreRequired = true;
     atOnboardingPreference.atKeysFilePath ??=
         HomeDirectoryUtil.getAtKeysPath(_atSign);
   }
@@ -876,7 +875,9 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
         (_atLookUp as AtLookupImpl).isConnectionAvailable()) {
       await _atLookUp!.close();
     }
-    atClient?.notificationService.stopAllSubscriptions();
+    if (atClient != null) {
+      await atClient!.stop();
+    }
     _atLookUp = null;
     atClient = null;
     logger.info('Closed');

--- a/tests/at_end2end_test/lib/src/test_initializers.dart
+++ b/tests/at_end2end_test/lib/src/test_initializers.dart
@@ -70,6 +70,7 @@ class TestSuiteInitializer {
       assert(result == AtCredentials.credentialsMap[atSign]![TestConstants.ENCRYPTION_PRIVATE_KEY].toString());
     } on Exception catch (e) {
       print('Exception in setting the encryption: $e');
+      rethrow;
     }
   }
 

--- a/tests/at_functional_test/test/at_client_lifecycle_functional_test.dart
+++ b/tests/at_functional_test/test/at_client_lifecycle_functional_test.dart
@@ -1,0 +1,178 @@
+import 'package:at_client/at_client.dart';
+import 'package:at_functional_test/src/config_util.dart';
+import 'package:test/test.dart';
+import 'test_utils.dart';
+
+void main() {
+  late String firstAtSign;
+  late String secondAtSign;
+  final namespace = 'lifecycletest';
+
+  setUpAll(() async {
+    firstAtSign = ConfigUtil.getYaml()['atSign']['firstAtSign'];
+    secondAtSign = ConfigUtil.getYaml()['atSign']['secondAtSign'];
+  });
+
+  tearDown(() async {
+    final activeInstances =
+        List<AtClient>.from(AtClientImpl.atClientInstanceMap.values);
+    for (var client in activeInstances) {
+      await (client as AtClientImpl).stop();
+    }
+    AtClientImpl.atClientInstanceMap.clear();
+  });
+
+  group('AtClient lifecycle tests', () {
+    test('create, use, and stop AtClient successfully', () async {
+      var atClientManager =
+          await TestUtils.initAtClient(firstAtSign, namespace);
+      var atClient = atClientManager.atClient;
+
+      final phoneKey = AtKey()
+        ..key = 'phone'
+        ..sharedWith = secondAtSign;
+      await atClient.put(phoneKey, '+1234567890');
+
+      final AtValue result = await atClient.get(phoneKey);
+      expect(result.value, '+1234567890');
+
+      await (atClient as AtClientImpl).stop();
+      expect(
+        AtClientImpl.atClientInstanceMap.containsKey(firstAtSign),
+        true,
+        reason: 'Client instance should remain in map even after stop',
+      );
+    });
+
+    test('close() is idempotent and handles active operations', () async {
+      var atClientManager =
+          await TestUtils.initAtClient(secondAtSign, namespace);
+      var atClient = atClientManager.atClient as AtClientImpl;
+
+      await atClient.put(AtKey()..key = 'location', 'San Francisco');
+      atClient.syncService.sync(); // Trigger sync
+
+      // Close immediately while operations in process
+      await atClient.stop();
+      await atClient.stop();
+
+      expect(AtClientImpl.atClientInstanceMap.containsKey(secondAtSign), true);
+    });
+
+    test('stop with active notifications cleans up gracefully', () async {
+      var atClientManager =
+          await TestUtils.initAtClient(firstAtSign, namespace);
+      var atClient = atClientManager.atClient;
+
+      final receivedNotifications = <AtNotification>[];
+      atClient.notificationService
+          .subscribe(regex: '.$namespace')
+          .listen(receivedNotifications.add);
+
+      atClient.notificationService.notify(
+        NotificationParams.forUpdate(
+            AtKey()
+              ..key = 'testnotif'
+              ..sharedWith = firstAtSign,
+            value: 'test value'),
+      );
+
+      await (atClient as AtClientImpl).stop();
+    });
+  });
+
+  group('Implicit client caching behavior', () {
+    test('keeps both clients in cache when switching atSigns', () async {
+      final atClient1 = (await TestUtils.initAtClient(firstAtSign, namespace))
+          .atClient;
+      var atKey = AtKey()
+        ..key = 'alice_data'
+        ..namespace = namespace;
+      await atClient1.put(atKey, 'Alice value');
+
+      final atClient2 = (await TestUtils.initAtClient(secondAtSign, namespace))
+          .atClient;
+      atKey = AtKey()..key = 'bob_data';
+      await atClient2.put(atKey, 'Bob value');
+
+      expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), true);
+      expect(AtClientImpl.atClientInstanceMap.containsKey(secondAtSign), true);
+
+      // Verify current atSign is correct
+      expect(AtClientManager.getInstance().atClient.getCurrentAtSign(),
+          equals(secondAtSign));
+
+      // Verify operations work
+      final verifyKey = AtKey()
+        ..key = 'verify_read'
+        ..namespace = namespace;
+      await AtClientManager.getInstance().atClient.put(verifyKey, 'test');
+      final result = await AtClientManager.getInstance().atClient.get(verifyKey);
+      expect(result.value, 'test');
+
+      await (atClient1 as AtClientImpl).stop();
+      await (atClient2 as AtClientImpl).stop();
+    });
+
+    test('reuses cached instance when switching back to same atSign', () async {
+      final atClient1 = (await TestUtils.initAtClient(firstAtSign, namespace))
+          .atClient;
+      final key = AtKey()
+        ..key = 'alice_reuse'
+        ..namespace = namespace;
+      await atClient1.put(key, 'Alice value');
+
+      await TestUtils.initAtClient(secondAtSign, namespace);
+      final reusedAtClient = (await TestUtils.initAtClient(
+              firstAtSign, namespace))
+          .atClient;
+
+      expect(identical(atClient1, reusedAtClient), true);
+
+      final AtValue result = await reusedAtClient.get(key);
+      expect(result.value, 'Alice value');
+
+      await (reusedAtClient as AtClientImpl).stop();
+    });
+
+    test('soft-close stops services but keeps instance in cache', () async {
+      final atClient1 = (await TestUtils.initAtClient(firstAtSign, namespace))
+          .atClient as AtClientImpl;
+      final atClientManager = await TestUtils.initAtClient(
+          secondAtSign, namespace);
+
+      expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), true);
+      expect(atClient1.isStopped, true);
+
+      await atClient1.stop();
+      await (atClientManager.atClient as AtClientImpl).stop();
+    });
+
+    test('rapid switching preserves all instances', () async {
+      final atClientManager = AtClientManager.getInstance();
+      final switchSequence = [
+        firstAtSign,
+        secondAtSign,
+        firstAtSign,
+        secondAtSign,
+        firstAtSign,
+        firstAtSign,
+        firstAtSign,
+        secondAtSign
+      ];
+      for (var atSignToSwitch in switchSequence) {
+        await TestUtils.initAtClient(atSignToSwitch, namespace);
+        await atClientManager.atClient.put(
+            AtKey()
+              ..key = 'rapid'
+              ..namespace = namespace,
+            'v');
+      }
+
+      expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), true);
+      expect(AtClientImpl.atClientInstanceMap.containsKey(secondAtSign), true);
+
+      await (atClientManager.atClient as AtClientImpl).stop();
+    });
+  });
+}

--- a/tests/at_functional_test/test/test_utils.dart
+++ b/tests/at_functional_test/test/test_utils.dart
@@ -18,7 +18,6 @@ class TestUtils {
     var preference = AtClientPreference();
     preference.hiveStoragePath = 'test/hive/client/$atsign';
     preference.commitLogPath = 'test/hive/client/$atsign';
-    preference.isLocalStoreRequired = true;
     preference.rootDomain = 'vip.ve.atsign.zone';
     preference.decryptPackets = false;
     preference.tlsKeysSavePath = 'test/tlsKeysFile';


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->
Closes https://github.com/atsign-foundation/at_client_sdk/issues/1801

**- What I did**
 - Added `stop()` to the `AtClient` interface and `start()` to `AtClientImpl. stop()` gracefully shuts down all
  background services (sync, notifications, monitor, remote connection) without evicting the instance
  from the internal cache, so switching back to the same atSign is fast.
  - `SyncServiceImpl.stop()`: drains the pending sync queue (callers receive `SyncStatus.failure` via their
  onError callback), cancels the stats-notification subscription, stops the cron scheduler, and notifies
  progress listeners.
  - `NotificationServiceImpl.stop()`: Just calls `stopAllSubscriptions()` which is now idempotent via an isClosed guard and also triggers a closure of the monitor instance it uses.
  - Neither `SyncServiceImpl` nor `NotificationServiceImpl` registers as `AtSignChangeListeners` anymore —
  teardown is explicitly handled by `AtClientImpl.stop()`.
  - `AtClientManager.setCurrentAtSign` no longer returns early when an instance of `AtClient` it's trying to switch to is already in the `atClientMap`. It now always stops the outgoing client and spins up fresh NotificationService and SyncService instances.
  - RemoteSecondary: converted atChops from a final field to a getter/setter that cascades the value down
   to `atLookUp.atChops`, and added `closeConnection()`. AtClientImpl's atChops setter now propagates to
  `_remoteSecondary`.
  - `AtChopsImpl._getSigningAlgorithm`: throws `AtSigningException` when the required PKAM or encryption
  keypair is null, instead of crashing with a null-assertion error.
  - `AtOnboardingServiceImpl.close()`: calls `atClient!.stop()`.

**- How I did it**
  - `AtClientImpl.create()` now calls `start()` (which re-enables the compaction job). This means a cached, previously
  stopped instance is cleanly resumed.
  - `setCurrentAtSign` calls `previousAtClient?.stop()` before creating the next client, then always creates
  fresh notification and sync services via the `AtServiceFactory` and injects them into the (potentially
  reused) `AtClientImpl`.
  - `SyncServiceImpl` stores the StreamSubscription returned by `notificationService.subscribe(regex:
  'statsNotification')` so it can be cancelled on stop().
  - The `_atClientManager` field was removed from AtClientImpl and SyncServiceImpl since neither registers
  or removes its own change listeners anymore.

**- How to verify it**
- Tests pass here (Including the newly added unit and functional tests)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
feat: explicit start and stop methods in AtClient to introduce explicit life-cycle control