### PR TITLE
chore: pin file_picker to 10.3.10

### DIFF
--- a/packages/at_backupkey_flutter/pubspec.yaml
+++ b/packages/at_backupkey_flutter/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   at_client_mobile: ^3.3.0
   showcaseview: ^4.0.1
   device_info_plus: ^11.3.3
-  file_picker: 10.3.8 #10.3.9 contains non-addressed breaking change
+  file_picker: 10.3.10
 
 dev_dependencies:
   flutter_test:

--- a/packages/at_client_flutter/pubspec.yaml
+++ b/packages/at_client_flutter/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   encrypt: ^5.0.3
   phosphor_flutter: ^2.1.0
   intl: ^0.20.2
-  file_picker: 10.3.8 #10.3.9 contains non-addressed breaking change
+  file_picker: 10.3.10
 
 dev_dependencies:
   path: ^1.9.0

--- a/packages/at_contacts_group_flutter/pubspec.yaml
+++ b/packages/at_contacts_group_flutter/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   at_utils: ^3.0.19
   collection: ^1.17.0
   emoji_picker_flutter: ^4.3.0
-  file_picker: 10.3.8 #10.3.9 contains non-addressed breaking change
+  file_picker: 10.3.10
   flutter:
     sdk: flutter
   flutter_image_compress: ^2.0.4


### PR DESCRIPTION
**- What I did**
 - #1800 
 
**- How I did it**
 - at_chat_flutter got changed and now uses `at_client_flutter` (file_picker turned transitive)
 - pinned the following to 10.3.10 after discussing how we should be pinning external packages to avoid these problems
   - at_client_flutter
   - at_backup_key_flutter
   - at_contact_groups_flutter

**- How to verify it**

**- Description for the changelog**
deps(flutter): pin file_picker to 10.3.10