### PR TITLE
fix: FileAtKeysIO fails to write atKeys file when parent dir missing + fix unit test failure

### DIFF
--- a/packages/at_auth/lib/src/keys/at_keys_io_impl.dart
+++ b/packages/at_auth/lib/src/keys/at_keys_io_impl.dart
@@ -12,7 +12,7 @@ import 'package:at_auth/src/keys/at_keys_io.dart';
 /// The [FileAtKeysIo] class can be configured with an optional [filePath] and [passPhrase].
 ///
 /// Optional Parameters:
-/// If [filePath] is a format function derived from your atSign. Defaults to using %HOME%/.atsign/keys/$atsign_key.t atKeys 
+/// If [filePath] is a format function derived from your atSign. Defaults to using %HOME%/.atsign/keys/$atsign_key.t atKeys
 /// The [passPhrase] is used for atKeys files that are password protected.
 class FileAtKeysIo extends WrittenAtKeysIo {
   @visibleForTesting
@@ -46,7 +46,11 @@ class FileAtKeysIo extends WrittenAtKeysIo {
   Future write(String atSign, AtKeys atKeys) async {
     String atKeysData =
         await encryptAtKeysWithSelfEncKey(atKeys, PkamAuthMode.keysFile);
-    await File(filePath!(atSign)).writeAsString(atKeysData);
+    String path = filePath!(atSign);
+    if (!Directory(path).parent.existsSync()) {
+      await Directory(path).parent.create(recursive: true);
+    }
+    await File(path).writeAsString(atKeysData);
   }
 }
 
@@ -56,7 +60,6 @@ String getDefaultAtKeysFilePath(String homeDirectory, String atSign) {
   return '$homeDirectory/.atsign/keys/${atSign}_key.atKeys'
       .replaceAll('/', Platform.pathSeparator);
 }
-
 
 String? getHomeDirectory({bool throwIfNull = false}) {
   String? homeDir;

--- a/packages/at_client/test/local_secondary_test.dart
+++ b/packages/at_client/test/local_secondary_test.dart
@@ -78,8 +78,9 @@ void main() {
           atClientManager: atClientManager);
       final localSecondary = LocalSecondary(atClient);
       final pkamPrivateKey = RSAKeypair.fromRandom().privateKey.toString();
-      await localSecondary.putValue(
+      final success = await localSecondary.putValue(
           AtConstants.atPkamPrivateKey, pkamPrivateKey);
+      expect(success, true);
       expect(await localSecondary.getPkamPrivateKey(), pkamPrivateKey);
     });
 
@@ -93,7 +94,8 @@ void main() {
           atClientManager: atClientManager);
       final localSecondary = LocalSecondary(atClient);
       final pkamPublicKey = RSAKeypair.fromRandom().publicKey.toString();
-      await localSecondary.putValue(AtConstants.atPkamPublicKey, pkamPublicKey);
+      final success = await localSecondary.putValue(AtConstants.atPkamPublicKey, pkamPublicKey);
+      expect(success, true);
       expect(await localSecondary.getPkamPublicKey(), pkamPublicKey);
     });
 
@@ -108,8 +110,9 @@ void main() {
       final localSecondary = LocalSecondary(atClient);
       final encryptionPrivateKey =
           RSAKeypair.fromRandom().privateKey.toString();
-      await localSecondary.putValue(
+      final success = await localSecondary.putValue(
           AtConstants.atEncryptionPrivateKey, encryptionPrivateKey);
+      expect(success, true);
       expect(
           await localSecondary.getEncryptionPrivateKey(), encryptionPrivateKey);
     });
@@ -124,8 +127,9 @@ void main() {
           atClientManager: atClientManager);
       final localSecondary = LocalSecondary(atClient);
       final encryptionPublicKey = RSAKeypair.fromRandom().publicKey.toString();
-      await localSecondary.putValue(
+      final success = await localSecondary.putValue(
           '${AtConstants.atEncryptionPublicKey}$atSign', encryptionPublicKey);
+      expect(success, true);
       expect(await localSecondary.getEncryptionPublicKey(atSign),
           encryptionPublicKey);
     });
@@ -140,8 +144,9 @@ void main() {
           atClientManager: atClientManager);
       final localSecondary = LocalSecondary(atClient);
       final selfEncryptionKey = EncryptionUtil.generateAESKey();
-      await localSecondary.putValue(
+      final success = await localSecondary.putValue(
           AtConstants.atEncryptionSelfKey, selfEncryptionKey);
+      expect(success, true);
       expect(await localSecondary.getEncryptionSelfKey(), selfEncryptionKey);
     });
   });

--- a/packages/at_client/test/local_secondary_test.dart
+++ b/packages/at_client/test/local_secondary_test.dart
@@ -61,6 +61,11 @@ void main() {
   group('A group of local secondary get keys test', () {
     setUp(() async {
       AtClientImpl.atClientInstanceMap.remove(atSign);
+      // Delete storage directory before setup to ensure clean state
+      var dir = Directory(storageDir);
+      if (dir.existsSync()) {
+        dir.deleteSync(recursive: true);
+      }
       await setupLocalStorage(storageDir, atSign);
     });
     tearDown(() async {
@@ -94,7 +99,8 @@ void main() {
           atClientManager: atClientManager);
       final localSecondary = LocalSecondary(atClient);
       final pkamPublicKey = RSAKeypair.fromRandom().publicKey.toString();
-      final success = await localSecondary.putValue(AtConstants.atPkamPublicKey, pkamPublicKey);
+      final success = await localSecondary.putValue(
+          AtConstants.atPkamPublicKey, pkamPublicKey);
       expect(success, true);
       expect(await localSecondary.getPkamPublicKey(), pkamPublicKey);
     });
@@ -794,6 +800,10 @@ Future<void> setupLocalStorage(String storageDir, String atSign) async {
 
 Future<void> tearDownLocalStorage(String storageDir) async {
   try {
+    // Close factories BEFORE deleting storage (prevents open file handles)
+    await SecondaryPersistenceStoreFactory.getInstance().close();
+    await AtCommitLogManagerImpl.getInstance().close();
+
     var isExists = await Directory(storageDir).exists();
     if (isExists) {
       Directory(storageDir).deleteSync(recursive: true);

--- a/packages/at_client/test/local_secondary_test.dart
+++ b/packages/at_client/test/local_secondary_test.dart
@@ -61,11 +61,6 @@ void main() {
   group('A group of local secondary get keys test', () {
     setUp(() async {
       AtClientImpl.atClientInstanceMap.remove(atSign);
-      // Delete storage directory before setup to ensure clean state
-      var dir = Directory(storageDir);
-      if (dir.existsSync()) {
-        dir.deleteSync(recursive: true);
-      }
       await setupLocalStorage(storageDir, atSign);
     });
     tearDown(() async {

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -199,10 +199,10 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
       logger.finer(
           'Onboarding successful.Generating keyfile in path: ${atOnboardingPreference.atKeysFilePath}');
       stderr.writeln();
-      await _generateAtKeysFile(
-        atOnboardingResponse.atAuthKeys!,
-        enrollmentId: atOnboardingResponse.enrollmentId,
-      );
+      //     await _generateAtKeysFile(
+      //     atOnboardingResponse.atAuthKeys!,
+      //   enrollmentId: atOnboardingResponse.enrollmentId,
+      //);
 
       if (autoCompleteActivation) {
         await completeActivation();
@@ -667,8 +667,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
   @override
   Future<bool> authenticate({String? enrollmentId}) async {
     atAuth ??= AtAuth.create();
-    var atAuthRequest = AtAuthRequest(
-        _atSign,
+    var atAuthRequest = AtAuthRequest(_atSign,
         atKeysIo: FileAtKeysIo(
             filePath: !atOnboardingPreference.atKeysFilePath.isNull
                 ? (_) => atOnboardingPreference.atKeysFilePath!

--- a/tests/at_onboarding_cli_functional_tests/check_test_env.dart
+++ b/tests/at_onboarding_cli_functional_tests/check_test_env.dart
@@ -42,7 +42,6 @@ Future<SecureSocket> secureSocketConnection(String host, int port) async {
     } catch (e, stackTrace) {
       print('retrying for connection.. $retryCount');
       print('Error: $e');
-      print('Error type: ${e.runtimeType}');
       if (retryCount == 1) {
         print('Stack trace: $stackTrace');
       }

--- a/tests/at_onboarding_cli_functional_tests/check_test_env.dart
+++ b/tests/at_onboarding_cli_functional_tests/check_test_env.dart
@@ -39,8 +39,13 @@ Future<SecureSocket> secureSocketConnection(String host, int port) async {
       if (socket != null || retryCount > maxRetryCount) {
         break;
       }
-    } on Exception {
+    } catch (e, stackTrace) {
       print('retrying for connection.. $retryCount');
+      print('Error: $e');
+      print('Error type: ${e.runtimeType}');
+      if (retryCount == 1) {
+        print('Stack trace: $stackTrace');
+      }
       await Future<void>.delayed(const Duration(seconds: 5));
       retryCount++;
     }


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- unit_tests failure in at_client/local_secondary_test.dart
   - Cause: All the tests in group`A group of local secondary get keys test` use the same atsign. And clearing the test storage without actually closing the hive boxes did not clear the hive files. This became an issue with the latest versions of Dart because they do not allow deleting Hive files without closing the box first.
- Functional test failure in at_onboarding_cli_functional_tests:
   - Cause: `FileAtKeysIO` was unable to write the atKeys file, when the parent directory of the provided atKeysFilePath did not exist

**- How I did it**
- at_auth:
   - Ensure the parent dir exists before writing atKeys files
- onb_cli_functional_tests
   - Close `SecondaryPersistenceStoreFactory` and `AtCommitLogManager` before deleting the test storage.
   - Improve error logging in `check_test_env` when the socket connection fails
- onb_cli:
   - Comment out the _generateAtKeysFile method call in onboard() as this is now redundant with at_auth writing the atKeys files through FileAtKeysIO

**- How to verify it**
- tests pass here

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: Ensure the parent dir exists before writing atKeys files through FileAtKeysIO