### PR TITLE
chore(at_client_flutter): get at_client_flutter ready to publish

### DIFF
--- a/packages/at_client_flutter/CHANGELOG.md
+++ b/packages/at_client_flutter/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 1.0.0
+ - feat: `ApkamActivationDialog` introduced for apkam onboarding
+ - fix: proxy parsing on root domains
+ - chore: file_picker pinned at 10.3.10
+ - feat: list to `AtEnrollment`
+
 ## 0.1.2
 - pin file_picker to 10.3.9 (BC)
 

--- a/packages/at_client_flutter/pubspec.yaml
+++ b/packages/at_client_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client_flutter
 description: A Flutter extension to the at_client library which adds support for mobile, desktop and IoT devices.
-version: 0.1.2
+version: 1.0.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
**- What I did**
 - update CHANGELOG & pubspec version 1.0.0
 
**- How I did it**

**- How to verify it**

**- Description for the changelog**
chore(at_client_flutter): get at_client_flutter ready to publish
