### PR TITLE
fix: pin at_proxyserver docker image to `gha41`

### DIFF
--- a/tests/at_onboarding_cli_functional_tests_proxy/docker-compose.yaml
+++ b/tests/at_onboarding_cli_functional_tests_proxy/docker-compose.yaml
@@ -13,7 +13,8 @@ services:
       - default
   at_proxyserver:
     container_name: at_proxyserver
-    image: atsigncompany/at_proxyserver
+    # https://hub.docker.com/layers/atsigncompany/at_proxyserver/gha41/images/sha256-de7f513db35a3046ef25bd2195113f48b276800c9921c1eec81ced55a597cd0b
+    image: atsigncompany/at_proxyserver:gha41  
     command: "vip.ve.atsign.zone:443 vip.ve.atsign.zone:64 1443"
     ports:
       - '443:1443'


### PR DESCRIPTION
**- What I did**
- Pinned the at_proxyserver docker image to `gha41` tag in `at_onboarding_cli_functional_tests_proxy/docker-compose.yaml`

**- How to verify it**

Actions without this fix: https://github.com/atsign-foundation/at_client_sdk/actions/runs/22065841394/job/63783867954?pr=1828

Actions with this fix:

**- Description for the changelog**
fix: pin at_proxyserver docker image to `gha41`
