### PR TITLE
ci: add workflow_dispatch to at_client_sdk.yaml and at_libraries.yaml

### DIFF
--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -6,6 +6,7 @@
 name: at_client_sdk
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - trunk

--- a/.github/workflows/at_libraries.yaml
+++ b/.github/workflows/at_libraries.yaml
@@ -4,6 +4,7 @@
 name: at_libraries
 
 on:
+  workflow_dispatch:
   push:
     tags:
       - "v*.*.*"


### PR DESCRIPTION
**- What I did**
- Added `workflow_dispatch` to `at_client_sdk.yaml` and `at_libraries.yaml` so that we can run CI manually

**- Description for the changelog**
ci: add workflow_dispatch to at_client_sdk.yaml and at_libraries.yaml