### PR TITLE
test: revert pinning of at_proxyserver container image

### DIFF
--- a/tests/at_onboarding_cli_functional_tests_proxy/docker-compose.yaml
+++ b/tests/at_onboarding_cli_functional_tests_proxy/docker-compose.yaml
@@ -6,6 +6,8 @@ services:
     ports:
       - '127.0.0.1:6379:6379'
       - '127.0.0.1:9001:9001'
+      - '64:64'
+      - "25000-25999:25000-25999"
     extra_hosts:
       - 'vip.ve.atsign.zone:127.0.0.1'
     hostname: vip.ve.atsign.zone
@@ -14,7 +16,7 @@ services:
   at_proxyserver:
     container_name: at_proxyserver
     # https://hub.docker.com/layers/atsigncompany/at_proxyserver/gha41/images/sha256-de7f513db35a3046ef25bd2195113f48b276800c9921c1eec81ced55a597cd0b
-    image: atsigncompany/at_proxyserver:gha41  
+    image: atsigncompany/at_proxyserver
     command: "vip.ve.atsign.zone:443 vip.ve.atsign.zone:64 1443"
     ports:
       - '443:1443'

--- a/tests/at_onboarding_cli_functional_tests_proxy/test/cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests_proxy/test/cli_test.dart
@@ -20,18 +20,33 @@ final Uuid _uuid = Uuid();
 final logger = AtSignLogger('AtOnboardingFunctionalTestsProxy');
 
 void main() {
-  group('System Readiness', () {
-    test('fresh docker environment setup', () async {
+  group('Enrollment Workflow Tests', () {
+    late String atSign;
+    late String masterKeyFile;
+    late String deviceName;
+    late String enrollmentKeyFile;
+    late String generatedOtp;
+    late List<String> filesToCleanup;
+
+    setUpAll(() async {
+      const int atSignIndex = 31;
+      atSign = allAtsigns[atSignIndex];
+      masterKeyFile = '${atSign}_master_${_uuid.v4()}_key.atKeys';
+      deviceName = _uuid.v4();
+      enrollmentKeyFile = '${atSign}_enrolled_${deviceName}_key.atKeys';
+      filesToCleanup = [];
+
       try {
         logger.info('Stopping existing docker compose services (if any)');
-        await runDockerComposeDown();
+        await runDockerComposeDown().timeout(Duration(seconds: 10));
       } catch (e) {
         logger.warning('Exception while stopping existing, will ignore: $e');
       }
 
       try {
         logger.info('Removing at_proxyserver and at_virtualenv containers');
-        await removeDockerContainers(['at_proxyserver', 'at_virtualenv']);
+        await removeDockerContainers(['at_proxyserver', 'at_virtualenv'])
+            .timeout(Duration(seconds: 10));
       } catch (e) {
         logger.warning('Exception while removing containers, will ignore: $e');
       }
@@ -45,24 +60,6 @@ void main() {
       bool isReady = await checkDockerContainers();
       expect(isReady, isTrue,
           reason: 'System should be ready with fresh Docker Compose');
-    });
-  });
-
-  group('Enrollment Workflow Tests', () {
-    late String atSign;
-    late String masterKeyFile;
-    late String deviceName;
-    late String enrollmentKeyFile;
-    late String generatedOtp;
-    late List<String> filesToCleanup;
-
-    setUpAll(() {
-      const int atSignIndex = 31;
-      atSign = allAtsigns[atSignIndex];
-      masterKeyFile = '${atSign}_master_${_uuid.v4()}_key.atKeys';
-      deviceName = _uuid.v4();
-      enrollmentKeyFile = '${atSign}_enrolled_${deviceName}_key.atKeys';
-      filesToCleanup = [];
 
       logger.info('Setup: Using atSign: $atSign for enrollment workflow');
     });

--- a/tests/at_onboarding_cli_functional_tests_proxy/test/cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests_proxy/test/cli_test.dart
@@ -20,42 +20,31 @@ final Uuid _uuid = Uuid();
 final logger = AtSignLogger('AtOnboardingFunctionalTestsProxy');
 
 void main() {
-	group('System Readiness', () {
+  group('System Readiness', () {
     test('fresh docker environment setup', () async {
-      logger.info('Checking current docker state...');
+      try {
+        logger.info('Stopping existing docker compose services (if any)');
+        await runDockerComposeDown();
+      } catch (e) {
+        logger.warning('Exception while stopping existing, will ignore: $e');
+      }
 
-      // Check if docker compose services are running
-      bool composeRunning = await isDockerComposeRunning();
-
-      // Check if specific containers are running
-      bool containersRunning = await areContainersRunning(['at_proxyserver', 'at_virtualenv']);
-
-      if (composeRunning || containersRunning) {
-        logger.info('Found running containers/services, cleaning up...');
-        try {
-          if (composeRunning) {
-            logger.info('Stopping Docker Compose services...');
-            await runDockerComposeDown();
-          }
-
-          if (containersRunning) {
-            logger.info('Removing specific containers...');
-            await removeDockerContainers(['at_proxyserver', 'at_virtualenv']);
-          }
-        } catch (e) {
-          logger.warning('Error during cleanup: $e');
-        }
-      } else {
-        logger.info('No running containers found, skipping cleanup');
+      try {
+        logger.info('Removing at_proxyserver and at_virtualenv containers');
+        await removeDockerContainers(['at_proxyserver', 'at_virtualenv']);
+      } catch (e) {
+        logger.warning('Exception while removing containers, will ignore: $e');
       }
 
       logger.info('Starting fresh Docker Compose services...');
       bool restartSuccess = await restartDockerCompose();
-      expect(restartSuccess, isTrue, reason: 'Docker Compose restart should succeed');
+      expect(restartSuccess, isTrue,
+          reason: 'Docker Compose restart should succeed');
 
       logger.info('Checking system readiness...');
       bool isReady = await checkDockerContainers();
-      expect(isReady, isTrue, reason: 'System should be ready with fresh Docker Compose');
+      expect(isReady, isTrue,
+          reason: 'System should be ready with fresh Docker Compose');
     });
   });
 
@@ -89,45 +78,64 @@ void main() {
 
       String cramKey = cramKeyMap[atSign] ?? '';
 
-      bool success = await onboardAtSign(atSign, cramKey, masterKeyFile, rootServer);
-      expect(success, isTrue, reason: 'Onboarding should succeed and generate master key file');
+      bool success =
+          await onboardAtSign(atSign, cramKey, masterKeyFile, rootServer);
+      expect(success, isTrue,
+          reason: 'Onboarding should succeed and generate master key file');
 
       filesToCleanup.add('../../packages/at_onboarding_cli/$masterKeyFile');
     }, timeout: Timeout(Duration(minutes: 3)));
 
     test('step 2: generate OTP using master keys', () async {
-      generatedOtp = await generateOtpWithExistingKeys(atSign, masterKeyFile, rootServer);
-      expect(generatedOtp.isNotEmpty, isTrue, reason: 'OTP should be generated successfully');
+      generatedOtp =
+          await generateOtpWithExistingKeys(atSign, masterKeyFile, rootServer);
+      expect(generatedOtp.isNotEmpty, isTrue,
+          reason: 'OTP should be generated successfully');
       logger.info('Generated OTP: $generatedOtp');
     });
 
-    test('step 3 & 4: submit enrollment request and approve concurrently', () async {
+    test('step 3 & 4: submit enrollment request and approve concurrently',
+        () async {
       filesToCleanup.add('../../packages/at_onboarding_cli/$enrollmentKeyFile');
 
       // Start enrollment request (this will wait for approval)
-      Future<bool> enrollmentFuture = submitEnrollmentRequest(generatedOtp, atSign, deviceName, enrollmentKeyFile, rootServer, appName, namespaces);
+      Future<bool> enrollmentFuture = submitEnrollmentRequest(
+          generatedOtp,
+          atSign,
+          deviceName,
+          enrollmentKeyFile,
+          rootServer,
+          appName,
+          namespaces);
 
       // Give enrollment request a moment to be submitted and start waiting
       await Future.delayed(Duration(seconds: 5));
 
       // Find and approve the enrollment while Step 3 is waiting
-      List<String> enrollmentIds = await listPendingEnrollments(atSign, rootServer, keyFile: masterKeyFile);
-      expect(enrollmentIds.isNotEmpty, isTrue, reason: 'Should find pending enrollment requests');
+      List<String> enrollmentIds = await listPendingEnrollments(
+          atSign, rootServer,
+          keyFile: masterKeyFile);
+      expect(enrollmentIds.isNotEmpty, isTrue,
+          reason: 'Should find pending enrollment requests');
 
       String enrollmentId = enrollmentIds.first;
-      bool approvalSuccess = await approveEnrollment(atSign, enrollmentId, masterKeyFile, rootServer);
-      expect(approvalSuccess, isTrue, reason: 'Enrollment should be approved successfully');
+      bool approvalSuccess = await approveEnrollment(
+          atSign, enrollmentId, masterKeyFile, rootServer);
+      expect(approvalSuccess, isTrue,
+          reason: 'Enrollment should be approved successfully');
 
       // Wait for enrollment to complete (should finish after approval)
       bool enrollmentSuccess = await enrollmentFuture;
-      expect(enrollmentSuccess, isTrue, reason: 'Enrollment request should complete successfully after approval');
+      expect(enrollmentSuccess, isTrue,
+          reason:
+              'Enrollment request should complete successfully after approval');
     }, timeout: Timeout(Duration(minutes: 5)));
 
     test('step 5: validate enrollment keys with list command', () async {
-      bool success = await validateEnrollmentKeys(atSign, enrollmentKeyFile, rootServer);
-      expect(success, isTrue, reason: 'Enrollment keys should be valid and functional for listing');
+      bool success =
+          await validateEnrollmentKeys(atSign, enrollmentKeyFile, rootServer);
+      expect(success, isTrue,
+          reason: 'Enrollment keys should be valid and functional for listing');
     });
-
   });
-
 }

--- a/tests/at_onboarding_cli_functional_tests_proxy/test/cli_test.dart
+++ b/tests/at_onboarding_cli_functional_tests_proxy/test/cli_test.dart
@@ -1,7 +1,6 @@
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
 import 'package:at_utils/at_logger.dart';
-import '../check_docker_readiness.dart';
 import 'package:at_demo_data/at_demo_data.dart';
 import '../lib/features/onboard_command.dart';
 import '../lib/features/otp_command.dart';
@@ -10,7 +9,6 @@ import '../lib/features/list_enrollments_command.dart';
 import '../lib/features/approve_command.dart';
 import '../lib/features/validate_keys.dart';
 import '../lib/features/cleanup_utils.dart';
-import '../lib/docker_utils.dart';
 
 const String rootServer = 'proxy:vip.ve.atsign.zone:443';
 const String appName = 'noports';
@@ -36,38 +34,11 @@ void main() {
       enrollmentKeyFile = '${atSign}_enrolled_${deviceName}_key.atKeys';
       filesToCleanup = [];
 
-      try {
-        logger.info('Stopping existing docker compose services (if any)');
-        await runDockerComposeDown().timeout(Duration(seconds: 10));
-      } catch (e) {
-        logger.warning('Exception while stopping existing, will ignore: $e');
-      }
-
-      try {
-        logger.info('Removing at_proxyserver and at_virtualenv containers');
-        await removeDockerContainers(['at_proxyserver', 'at_virtualenv'])
-            .timeout(Duration(seconds: 10));
-      } catch (e) {
-        logger.warning('Exception while removing containers, will ignore: $e');
-      }
-
-      logger.info('Starting fresh Docker Compose services...');
-      bool restartSuccess = await restartDockerCompose();
-      expect(restartSuccess, isTrue,
-          reason: 'Docker Compose restart should succeed');
-
-      logger.info('Checking system readiness...');
-      bool isReady = await checkDockerContainers();
-      expect(isReady, isTrue,
-          reason: 'System should be ready with fresh Docker Compose');
-
       logger.info('Setup: Using atSign: $atSign for enrollment workflow');
     });
 
     tearDownAll(() async {
       await cleanupTestFiles(filesToCleanup);
-
-      await stopDockerServices();
     });
 
     test('step 1: fresh onboard to generate master keys', () async {


### PR DESCRIPTION
**- What I did**
- test: revert pinning of at_proxyserver container image
- chore: remove the docker start / stop stuff from the dart test code as this is already done by the github action workflow (I'm guessing this was a convenience for local testing but it is unnecessary and confusing for normal behaviour, and when running locally it is very easy to run `docker compose down / up` before running `dart test`

**- How I did it**

**- How to verify it**
Tests pass
