### PR TITLE
fix: monitor delayed start is cancelled when stopAllSubscriptions is called (NotificationServiceImpl)

### DIFF
--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -377,7 +377,12 @@ class NotificationServiceImpl extends NotificationService
     return status;
   }
 
+  @visibleForTesting
   Timer? delayedStartListeningTimer;
+
+  @visibleForTesting
+  Duration? delayedStartListeningTimerDuration;
+
   @override
   Stream<AtNotification> subscribe(
       {String? regex, bool shouldDecrypt = false}) {
@@ -420,8 +425,9 @@ class NotificationServiceImpl extends NotificationService
     // much better clear control over the notification listening lifecycle.
     if (atClient.getPreferences()?.monitorAutoStart == true) {
       if (regex == 'statsNotification') {
+        delayedStartListeningTimerDuration ??= Duration(seconds: 30);
         delayedStartListeningTimer =
-            Timer(Duration(seconds: 30), startListening);
+            Timer(delayedStartListeningTimerDuration!, startListening);
       } else {
         startListening();
       }

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -169,7 +169,7 @@ class NotificationServiceImpl extends NotificationService
   @override
   void stopAllSubscriptions({bool stopNotificationsListener = true}) {
     if (stopNotificationsListener) {
-      monitor.stop();
+      stopListening();
     }
 
     _streamListeners.forEach((regex, streamController) {
@@ -377,6 +377,7 @@ class NotificationServiceImpl extends NotificationService
     return status;
   }
 
+  Timer? delayedStartListeningTimer;
   @override
   Stream<AtNotification> subscribe(
       {String? regex, bool shouldDecrypt = false}) {
@@ -419,7 +420,8 @@ class NotificationServiceImpl extends NotificationService
     // much better clear control over the notification listening lifecycle.
     if (atClient.getPreferences()?.monitorAutoStart == true) {
       if (regex == 'statsNotification') {
-        Future.delayed(Duration(seconds: 30), () async => startListening());
+        delayedStartListeningTimer =
+            Timer(Duration(seconds: 30), startListening);
       } else {
         startListening();
       }
@@ -543,13 +545,18 @@ class NotificationServiceImpl extends NotificationService
 
   @override
   void stopListening() {
-    if (monitor.targetState != NotificationListenerState.notConnected) {
-      logger.info('stopListening() called: stopping notification listener');
-      monitor.stop();
-    } else {
+    if (delayedStartListeningTimer != null) {
+      delayedStartListeningTimer!.cancel();
+      delayedStartListeningTimer = null;
+    }
+    if (monitor.targetState == NotificationListenerState.notConnected) {
       logger.info('stopListening() called, but'
           ' target state is already ${monitor.targetState}');
+      return;
     }
+
+    logger.info('stopListening() called: stopping notification listener');
+    monitor.stop();
   }
 
   @override

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -913,6 +913,28 @@ void main() {
       expect(received, isNotEmpty);
       expect(received[0].value, 'Got it');
     });
+
+    test('delayedStartListeningTimer is cancelled when stopListening called',
+        () async {
+      when(() => mockAtClientImpl.getPreferences()).thenAnswer((_) =>
+          AtClientPreference()
+            ..namespace = 'wavi'
+            ..monitorAutoStart = true);
+
+      var notificationService = await NotificationServiceImpl.create(
+        mockAtClientImpl,
+        atClientManager: mockAtClientManager,
+        monitor: fakeMonitor,
+      ) as NotificationServiceImpl;
+
+      notificationService.subscribe(regex: 'statsNotification');
+      expect(notificationService.delayedStartListeningTimer, isNotNull);
+
+      notificationService.stopListening();
+      // Timer cancelled and monitor not started
+      expect(notificationService.delayedStartListeningTimer, isNull);
+      expect(fakeMonitor.currentState, NotificationListenerState.notConnected);
+    });
   });
 
   group('A group of tests to validate notification subscribe method', () {
@@ -1287,6 +1309,7 @@ void main() {
       expect(lastReceivedNotification.isLocal, true);
     });
   });
+
 }
 
 class StatsAtKeyMatcher extends Matcher {

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -916,8 +916,8 @@ void main() {
 
     test('delayedStartListeningTimer is cancelled when stopListening called',
         () async {
-      when(() => mockAtClientImpl.getPreferences()).thenAnswer((_) =>
-          AtClientPreference()
+      when(() => mockAtClientImpl.getPreferences())
+          .thenAnswer((_) => AtClientPreference()
             ..namespace = 'wavi'
             ..monitorAutoStart = true);
 
@@ -1309,7 +1309,6 @@ void main() {
       expect(lastReceivedNotification.isLocal, true);
     });
   });
-
 }
 
 class StatsAtKeyMatcher extends Matcher {

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -935,6 +935,44 @@ void main() {
       expect(notificationService.delayedStartListeningTimer, isNull);
       expect(fakeMonitor.currentState, NotificationListenerState.notConnected);
     });
+
+    test('delayedStartListeningTimer is cancelled with custom Duration',
+        () async {
+      when(() => mockAtClientImpl.getPreferences())
+          .thenAnswer((_) => AtClientPreference()
+            ..namespace = 'wavi_1234'
+            ..monitorAutoStart = true);
+
+      var notificationService = await NotificationServiceImpl.create(
+        mockAtClientImpl,
+        atClientManager: mockAtClientManager,
+        monitor: fakeMonitor,
+      ) as NotificationServiceImpl;
+
+      // inject a custom duration of 10 milliseconds
+      notificationService.delayedStartListeningTimerDuration =
+          Duration(milliseconds: 10);
+
+      // subscribe to statsNotification and ensure that the timer has started
+      notificationService.subscribe(regex: 'statsNotification');
+      expect(notificationService.delayedStartListeningTimer, isNotNull);
+      expect(notificationService.monitor.targetState,
+          NotificationListenerState.notConnected);
+
+      // stop NotificationService and ensure the timer is removed
+      notificationService.stopAllSubscriptions();
+      expect(notificationService.delayedStartListeningTimer, isNull);
+      expect(notificationService.monitor.targetState,
+          NotificationListenerState.notConnected);
+
+      // await for more time than we set as the delayed start duration
+      // validate that the monitor in fact did not start
+      await Future.delayed(Duration(milliseconds: 20));
+      expect(notificationService.monitor.currentState,
+          NotificationListenerState.notConnected);
+      expect(notificationService.monitor.targetState,
+          NotificationListenerState.notConnected);
+    });
   });
 
   group('A group of tests to validate notification subscribe method', () {


### PR DESCRIPTION
Closes https://github.com/atsign-foundation/at_client_sdk/issues/1838
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- When stopAllSubscriptions() is called on NotificationServiceImpl, cancel the delayed start monitor call

**- How I did it**
- Introduced a timer to store the delayed start call 
- Cancel the timer when trying to stop the NotificationService

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
fix: monitor delayed start is cancelled when stopAllSubscriptions is called (NotificationServiceImpl)