### PR TITLE
fix(ai): automatically prepend @ symbol into text box

### DIFF
--- a/packages/at_client_flutter/lib/src/widgets/atsign_rootdomain_dialog.dart
+++ b/packages/at_client_flutter/lib/src/widgets/atsign_rootdomain_dialog.dart
@@ -192,9 +192,8 @@ class _AtSignSelectionDialogState extends State<AtSignSelectionDialog> {
               width: double.infinity,
               height: 44,
               child: ElevatedButton(
-                onPressed: _normalizedAtSignForSubmit() != null
-                    ? _handleSubmit
-                    : null,
+                onPressed:
+                    _normalizedAtSignForSubmit() != null ? _handleSubmit : null,
                 style: ElevatedButton.styleFrom(
                   backgroundColor: widget.themeData.colorScheme.secondary,
                   foregroundColor: Colors.white,

--- a/packages/at_client_flutter/lib/src/widgets/atsign_rootdomain_dialog.dart
+++ b/packages/at_client_flutter/lib/src/widgets/atsign_rootdomain_dialog.dart
@@ -1,6 +1,7 @@
 import 'package:at_auth/at_auth.dart';
 import 'package:at_client/at_client.dart';
 import 'package:at_client_flutter/src/widgets/shared/typable_dropdown.dart';
+import 'package:at_utils/at_utils.dart';
 import 'package:flutter/material.dart';
 
 /// A dialog widget that allows users to select or input an atSign and optionally a root domain.
@@ -49,11 +50,34 @@ class _AtSignSelectionDialogState extends State<AtSignSelectionDialog> {
   final TextEditingController _atSignTextController = TextEditingController();
   final TextEditingController _domainTextController = TextEditingController();
 
+  String _normalizeAtSignInput(String value) {
+    final trimmedValue = value.trim();
+    if (trimmedValue.isEmpty) {
+      return '';
+    }
+    try {
+      return AtUtils.fixAtSign(trimmedValue);
+    } catch (_) {
+      return value;
+    }
+  }
+
+  String? _normalizedAtSignForSubmit() {
+    final atSign = _selectedAtSign?.trim();
+    if (atSign == null || atSign.isEmpty) {
+      return null;
+    }
+    try {
+      return AtUtils.fixAtSign(atSign);
+    } catch (_) {
+      return null;
+    }
+  }
+
   void _handleSubmit() {
-    if (_selectedAtSign != null) {
-      AtOnboardingRequest request = AtOnboardingRequest(
-        _selectedAtSign!,
-      );
+    final normalizedAtSign = _normalizedAtSignForSubmit();
+    if (normalizedAtSign != null) {
+      AtOnboardingRequest request = AtOnboardingRequest(normalizedAtSign);
       if (_selectedDomain != null && _selectedDomain!.isNotEmpty) {
         AtRootDomain domain = AtRootDomain.parse(_selectedDomain!);
         request.rootDomain = domain;
@@ -68,9 +92,7 @@ class _AtSignSelectionDialogState extends State<AtSignSelectionDialog> {
     _domainTextController.text =
         "${firstDomain.rootDomain}:${firstDomain.rootPort}";
     return Dialog(
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
-      ),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       child: Container(
         width: 360,
         padding: const EdgeInsets.all(24),
@@ -86,6 +108,7 @@ class _AtSignSelectionDialogState extends State<AtSignSelectionDialog> {
               hint: 'Type atSign or select from existing',
               themeData: widget.themeData,
               items: widget.existingAtSigns,
+              valueNormalizer: _normalizeAtSignInput,
               onChanged: (value) {
                 setState(() {
                   _selectedAtSign = value;
@@ -145,8 +168,9 @@ class _AtSignSelectionDialogState extends State<AtSignSelectionDialog> {
                     hint: 'Type a root domain or select from existing',
                     themeData: widget.themeData,
                     items: widget.existingDomains?.values
-                        .map((domain) =>
-                            "${domain.rootDomain}:${domain.rootPort}")
+                        .map(
+                          (domain) => "${domain.rootDomain}:${domain.rootPort}",
+                        )
                         .toList(),
                     onChanged: (value) {
                       setState(() {
@@ -168,10 +192,9 @@ class _AtSignSelectionDialogState extends State<AtSignSelectionDialog> {
               width: double.infinity,
               height: 44,
               child: ElevatedButton(
-                onPressed:
-                    (_selectedAtSign != null && _selectedAtSign!.isNotEmpty)
-                        ? _handleSubmit
-                        : null,
+                onPressed: _normalizedAtSignForSubmit() != null
+                    ? _handleSubmit
+                    : null,
                 style: ElevatedButton.styleFrom(
                   backgroundColor: widget.themeData.colorScheme.secondary,
                   foregroundColor: Colors.white,
@@ -183,10 +206,7 @@ class _AtSignSelectionDialogState extends State<AtSignSelectionDialog> {
                 ),
                 child: const Text(
                   'Continue',
-                  style: TextStyle(
-                    fontSize: 15,
-                    fontWeight: FontWeight.w500,
-                  ),
+                  style: TextStyle(fontSize: 15, fontWeight: FontWeight.w500),
                 ),
               ),
             ),
@@ -213,6 +233,7 @@ class _DropdownField extends StatelessWidget {
   final String hint;
   final List<String>? items;
   final Function(String?) onChanged;
+  final String Function(String)? valueNormalizer;
 
   const _DropdownField({
     required this.controller,
@@ -222,14 +243,13 @@ class _DropdownField extends StatelessWidget {
     required this.hint,
     required this.items,
     required this.onChanged,
+    this.valueNormalizer,
   });
 
   @override
   Widget build(BuildContext context) {
     return Container(
-      decoration: BoxDecoration(
-        borderRadius: BorderRadius.circular(8),
-      ),
+      decoration: BoxDecoration(borderRadius: BorderRadius.circular(8)),
       child: Column(
         children: [
           Row(
@@ -258,6 +278,7 @@ class _DropdownField extends StatelessWidget {
             items: items ?? [],
             hintText: hint,
             initialValue: controller.text,
+            valueNormalizer: valueNormalizer,
             onChanged: onChanged,
           ),
           const SizedBox(height: 16),

--- a/packages/at_client_flutter/lib/src/widgets/shared/typable_dropdown.dart
+++ b/packages/at_client_flutter/lib/src/widgets/shared/typable_dropdown.dart
@@ -80,8 +80,7 @@ class TypableDropdown extends StatelessWidget {
         return TextField(
           controller: controller,
           focusNode: focusNode,
-          decoration:
-              decoration ??
+          decoration: decoration ??
               InputDecoration(
                 hintText: hintText ?? 'Type to search...',
                 hintStyle: TextStyle(fontSize: 12),

--- a/packages/at_client_flutter/lib/src/widgets/shared/typable_dropdown.dart
+++ b/packages/at_client_flutter/lib/src/widgets/shared/typable_dropdown.dart
@@ -5,6 +5,7 @@ class TypableDropdown extends StatelessWidget {
   final List<String> items;
   final String? initialValue;
   final ValueChanged<String?>? onChanged;
+  final String Function(String)? valueNormalizer;
   final String? hintText;
   final InputDecoration? decoration;
 
@@ -13,6 +14,7 @@ class TypableDropdown extends StatelessWidget {
     required this.items,
     this.initialValue,
     this.onChanged,
+    this.valueNormalizer,
     this.hintText,
     this.decoration,
   });
@@ -23,10 +25,15 @@ class TypableDropdown extends StatelessWidget {
       initialValue: TextEditingValue(text: initialValue ?? ''),
       optionsBuilder: (textEditingValue) {
         if (textEditingValue.text.isEmpty) return items;
-        return items.where((item) =>
-            item.toLowerCase().contains(textEditingValue.text.toLowerCase()));
+        return items.where(
+          (item) =>
+              item.toLowerCase().contains(textEditingValue.text.toLowerCase()),
+        );
       },
-      onSelected: (value) => onChanged?.call(value),
+      onSelected: (value) {
+        final normalized = valueNormalizer?.call(value) ?? value;
+        onChanged?.call(normalized);
+      },
       optionsViewBuilder: (context, onSelected, options) {
         return Align(
           alignment: Alignment.topLeft,
@@ -47,12 +54,16 @@ class TypableDropdown extends StatelessWidget {
                       onTap: () => onSelected(item),
                       child: Container(
                         padding: const EdgeInsets.symmetric(
-                            horizontal: 16.0, vertical: 12.0),
+                          horizontal: 16.0,
+                          vertical: 12.0,
+                        ),
                         decoration: BoxDecoration(
                           color: Colors.transparent,
                           border: Border(
                             bottom: BorderSide(
-                                color: Colors.grey.shade200, width: 1),
+                              color: Colors.grey.shade200,
+                              width: 1,
+                            ),
                           ),
                         ),
                         child: Text(item, style: TextStyle(fontSize: 16)),
@@ -69,7 +80,8 @@ class TypableDropdown extends StatelessWidget {
         return TextField(
           controller: controller,
           focusNode: focusNode,
-          decoration: decoration ??
+          decoration:
+              decoration ??
               InputDecoration(
                 hintText: hintText ?? 'Type to search...',
                 hintStyle: TextStyle(fontSize: 12),
@@ -82,7 +94,16 @@ class TypableDropdown extends StatelessWidget {
                   child: PhosphorIcon(PhosphorIcons.caretDown()),
                 ),
               ),
-          onChanged: (value) => onChanged?.call(value.isEmpty ? null : value),
+          onChanged: (value) {
+            var normalized = valueNormalizer?.call(value) ?? value;
+            if (normalized != value) {
+              controller.value = TextEditingValue(
+                text: normalized,
+                selection: TextSelection.collapsed(offset: normalized.length),
+              );
+            }
+            onChanged?.call(normalized.isEmpty ? null : normalized);
+          },
         );
       },
     );


### PR DESCRIPTION
**- What I did**
- Use `at_utils` `.fixAtSign` function
- The "typable dropdown" widget now accepts a prop called "valueNormalizer" which will take the input, then adjust it depending on the functions implementation. Upon normalizing the value, onChanged is then called with the normalized value.
- The dialog defines the "valueNormalizer" to be `_normalizeAtSignInput` which will adjust the string upon every input change which guarantees the @ symbol to always be the first character in the atSign string.
- Alongside that, the `_handleSubmit` function will call `_normalizedAtSignForSubmit` which double guarantees that an @ symbol is present.

**- How I did it**
- Using Codex gpt 5.3 medium

**- How to verify it**
- See comment: https://github.com/atsign-foundation/at_client_sdk/pull/1845#issuecomment-3961228201
- I've also manually tested:
  1. Upload via .atKeys with no keychain keys
  2. Upload via .atKeys with keychain keys present
  3. Switch atSign
  4. Clearing keychain then re-adding
  5. Exporting the atKeys then using those keys to reauthenticate

**- Description for the changelog**
fix(ai): automatically prepend @ symbol into text box
