### PR TITLE
ci: Ensure that SHAs aren't empty

### DIFF
--- a/.github/workflows/flutter-channel.yaml
+++ b/.github/workflows/flutter-channel.yaml
@@ -28,6 +28,10 @@ jobs:
               https://api.github.com/repos/flutter/flutter/branches/${{ matrix.channel }} |
             jq -r '.commit.sha'
           )
+          if [ -z "$sha" ] || [ "$sha" == "null" ]; then
+            echo "Error: Could not retrieve SHA for ${{ matrix.channel }}"
+            exit 1
+          fi
           echo "$sha" >flutter_ref-${{ matrix.channel }}
         working-directory: ./actions/setup-flutter-and-dart/
 

--- a/actions/setup-flutter-and-dart/action.yaml
+++ b/actions/setup-flutter-and-dart/action.yaml
@@ -22,6 +22,10 @@ runs:
         sha=$(
         cat flutter_ref-${{ inputs.flutter-channel }}
         )
+        if [ -z "$sha" ] || [ "$sha" == "null" ]; then
+          echo "Error: Empty or null SHA found in flutter_ref-${{ inputs.flutter-channel }}"
+          exit 1
+        fi
         echo "sha=$sha" >> "$GITHUB_OUTPUT"
       working-directory: ./actions/setup-flutter-and-dart/
 


### PR DESCRIPTION
The `flutter-channel.yaml` workflow sometimes raises PRs with empty SHAs like #1857 

**- What I did**

Added checks to ensure that SHAs are populated.

**- How I did it**

Gemini CLI:

> There's a GitHub Actions workflow defined by flutter-channel.yaml in this repo that sometimes raises pull requests with an empty SHA, likely due to poor error checking. I'd like to ensure that the workflow only raises a PR for valid SHAs.

**- How to verify it**

We will start to see workflow failures when the SHA hasn't been retrieved correctly from upstream (rather than bad PRs)

**- Description for the changelog**

ci: Ensure that SHAs aren't empty
