### PR TITLE
feat: introduce AtBytes.equals

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Next
+- feat: use AtBytes.equals in `AtKeys` (requires at_commons: ^5.8.1)
+
 ## 3.0.2
 - feat: validateAtServer(): Added progress events and atSign connectivity probing
 - fix: throw AtAuthenticationException when atSign is already onboarded

--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Next
-- feat: use AtBytes.equals in `AtKeys` (requires at_commons: ^5.8.1)
+- feat: use AtBytes.equals in `AtKeys` (requires at_commons: ^5.9.0)
 
 ## 3.0.2
 - feat: validateAtServer(): Added progress events and atSign connectivity probing

--- a/packages/at_auth/lib/src/keys/at_keys.dart
+++ b/packages/at_auth/lib/src/keys/at_keys.dart
@@ -14,22 +14,17 @@ class AtKeys {
 
   AtKeys();
 
-  //TODO: AtBytes needs an equality operator so we can avoid this...
-  // I can't even use the strEquals in the AtBytes
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! AtKeys) return false;
     return enrollmentId == other.enrollmentId &&
-        apkamPublicKey?.toString() == other.apkamPublicKey?.toString() &&
-        apkamPrivateKey?.toString() == other.apkamPrivateKey?.toString() &&
-        defaultEncryptionPublicKey?.toString() ==
-            other.defaultEncryptionPublicKey?.toString() &&
-        defaultEncryptionPrivateKey?.toString() ==
-            other.defaultEncryptionPrivateKey?.toString() &&
-        defaultSelfEncryptionKey?.toString() ==
-            other.defaultSelfEncryptionKey?.toString() &&
-        apkamSymmetricKey?.toString() == other.apkamSymmetricKey?.toString();
+        AtBytes.equals(apkamPublicKey, other.apkamPublicKey) &&
+        AtBytes.equals(apkamPrivateKey, other.apkamPrivateKey) &&
+        AtBytes.equals(defaultEncryptionPublicKey, other.defaultEncryptionPublicKey) &&
+        AtBytes.equals(defaultEncryptionPrivateKey, other.defaultEncryptionPrivateKey) &&
+        AtBytes.equals(defaultSelfEncryptionKey, other.defaultSelfEncryptionKey) &&
+        AtBytes.equals(apkamSymmetricKey, other.apkamSymmetricKey);
   }
 
   @override

--- a/packages/at_auth/lib/src/keys/at_keys.dart
+++ b/packages/at_auth/lib/src/keys/at_keys.dart
@@ -19,12 +19,12 @@ class AtKeys {
     if (identical(this, other)) return true;
     if (other is! AtKeys) return false;
     return enrollmentId == other.enrollmentId &&
-        AtBytes.equals(apkamPublicKey, other.apkamPublicKey) &&
-        AtBytes.equals(apkamPrivateKey, other.apkamPrivateKey) &&
-        AtBytes.equals(defaultEncryptionPublicKey, other.defaultEncryptionPublicKey) &&
-        AtBytes.equals(defaultEncryptionPrivateKey, other.defaultEncryptionPrivateKey) &&
-        AtBytes.equals(defaultSelfEncryptionKey, other.defaultSelfEncryptionKey) &&
-        AtBytes.equals(apkamSymmetricKey, other.apkamSymmetricKey);
+        apkamPublicKey == other.apkamPublicKey &&
+        apkamPrivateKey == other.apkamPrivateKey &&
+        defaultEncryptionPublicKey == other.defaultEncryptionPublicKey &&
+        defaultEncryptionPrivateKey == other.defaultEncryptionPrivateKey &&
+        defaultSelfEncryptionKey == other.defaultSelfEncryptionKey &&
+        apkamSymmetricKey == other.apkamSymmetricKey;
   }
 
   @override

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -11,7 +11,7 @@ resolution: workspace
 
 dependencies:
   at_server_status: ^1.1.0
-  at_commons: ^5.7.0
+  at_commons: ^5.9.0
   at_lookup: ^3.4.2
   at_chops: ^3.0.0
   at_utils: ^3.0.19

--- a/packages/at_auth/test/at_keys_test.dart
+++ b/packages/at_auth/test/at_keys_test.dart
@@ -36,7 +36,7 @@ void main() {
     });
 
     test('fromJson -> should return AtKeys instance', () async {
-      expect(AtKeys.fromJson(encryptedAtKeysMap), createKeys());
+      expect(AtKeys.fromJson(encryptedAtKeysMap), equals(createKeys()));
     });
 
     test('toJson -> should be nullable', () async {

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.9.0
+- feat: add equals method for `AtBytes`
+
 ## 5.8.0
 
 - feat: add `AtBytes` supporting hardware acceleration in `at_chops`

--- a/packages/at_commons/lib/src/key/atbytes.dart
+++ b/packages/at_commons/lib/src/key/atbytes.dart
@@ -19,7 +19,11 @@ class AtBytes {
   bool operator ==(Object other) {
     if (other is! AtBytes) return false;
     if (identical(this, other)) return true;
-    return strEquals(other.toString());
+    if (bytes.length != other.bytes.length) return false;
+    for (int i = 0; i < bytes.length; i++) {
+      if (bytes[i] != other.bytes[i]) return false;
+    }
+    return true;
   }
 
   @override

--- a/packages/at_commons/lib/src/key/atbytes.dart
+++ b/packages/at_commons/lib/src/key/atbytes.dart
@@ -15,10 +15,13 @@ class AtBytes {
 
   bool strEquals(String str) => toString() == str;
 
-  /// Equality check on two AtBytes?, if both are null it will return true.
-  static bool equals(AtBytes? a, AtBytes? b){
-    if (identical(a, b)) return true;
-    if (a == null || b == null) return false;
-    return a.strEquals(b.toString());
+  @override
+  bool operator ==(Object other) {
+    if (other is! AtBytes) return false;
+    if (identical(this, other)) return true;
+    return strEquals(other.toString());
   }
+
+  @override
+  int get hashCode => Object.hashAll(bytes);
 }

--- a/packages/at_commons/lib/src/key/atbytes.dart
+++ b/packages/at_commons/lib/src/key/atbytes.dart
@@ -14,4 +14,11 @@ class AtBytes {
   String toString() => base64Encode(bytes);
 
   bool strEquals(String str) => toString() == str;
+
+  /// Equality check on two AtBytes?, if both are null it will return true.
+  static bool equals(AtBytes? a, AtBytes? b){
+    if (identical(a, b)) return true;
+    if (a == null || b == null) return false;
+    return a.strEquals(b.toString());
+  }
 }

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.8.0
+version: 5.9.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_commons/test/at_bytes_test.dart
+++ b/packages/at_commons/test/at_bytes_test.dart
@@ -26,8 +26,8 @@ void main() {
     });
 
     test('AtBytes.equals should work regardless of nullity', () {
-      AtBytes a = AtBytes.fromString('str');
-      AtBytes b = AtBytes.fromString('str');
+      AtBytes a = AtBytes.fromString('bone');
+      AtBytes b = AtBytes.fromString('bone');
       AtBytes c = AtBytes.fromString('string');
       AtBytes? d;
       AtBytes? e;

--- a/packages/at_commons/test/at_bytes_test.dart
+++ b/packages/at_commons/test/at_bytes_test.dart
@@ -28,7 +28,7 @@ void main() {
     test('AtBytes.equals should work regardless of nullity', () {
       AtBytes a = AtBytes.fromString('bone');
       AtBytes b = AtBytes.fromString('bone');
-      AtBytes c = AtBytes.fromString('string');
+      AtBytes c = AtBytes.fromString('stringss');
       AtBytes? d;
       AtBytes? e;
       // Verify toString() matches

--- a/packages/at_commons/test/at_bytes_test.dart
+++ b/packages/at_commons/test/at_bytes_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('strEquals should compare AtBytes with String by value', () {
       // Create test data
       final testData =
-      Uint8List.fromList([72, 101, 108, 108, 111]); // "Hello" in ASCII
+          Uint8List.fromList([72, 101, 108, 108, 111]); // "Hello" in ASCII
       final atBytes = AtBytes(testData);
 
       // The base64 encoded string of "Hello" is "SGVsbG8="
@@ -33,11 +33,21 @@ void main() {
       AtBytes? e;
       // Verify toString() matches
       expect(a.strEquals(b.toString()), isTrue);
-      expect(AtBytes.equals(a, b), isTrue);
-      expect(AtBytes.equals(a, c), isFalse);
+      expect(a == b, isTrue);
+      expect(a == c, isFalse);
       // Verify null cases
-      expect(AtBytes.equals(a, d), isFalse);
-      expect(AtBytes.equals(d, e), isTrue);
+      expect(a == d, isFalse);
+      expect(d == e, isTrue);
+    });
+
+    test('equal AtBytes instances should have the same hashCode', () {
+      final a = AtBytes(Uint8List.fromList([72, 101, 108, 108, 111]));
+      final b = AtBytes(Uint8List.fromList([72, 101, 108, 108, 111]));
+      final c = AtBytes(Uint8List.fromList([72, 101, 108, 108, 112]));
+
+      expect(a == b, isTrue);
+      expect(a.hashCode, b.hashCode);
+      expect(a.hashCode == c.hashCode, isFalse);
     });
   });
 }

--- a/packages/at_commons/test/at_bytes_test.dart
+++ b/packages/at_commons/test/at_bytes_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('strEquals should compare AtBytes with String by value', () {
       // Create test data
       final testData =
-          Uint8List.fromList([72, 101, 108, 108, 111]); // "Hello" in ASCII
+      Uint8List.fromList([72, 101, 108, 108, 111]); // "Hello" in ASCII
       final atBytes = AtBytes(testData);
 
       // The base64 encoded string of "Hello" is "SGVsbG8="
@@ -23,6 +23,21 @@ void main() {
 
       // Verify toString() matches the expected base64 string
       expect(atBytes.toString(), expectedBase64String);
+    });
+
+    test('AtBytes.equals should work regardless of nullity', () {
+      AtBytes a = AtBytes.fromString('str');
+      AtBytes b = AtBytes.fromString('str');
+      AtBytes c = AtBytes.fromString('string');
+      AtBytes? d;
+      AtBytes? e;
+      // Verify toString() matches
+      expect(a.strEquals(b.toString()), isTrue);
+      expect(AtBytes.equals(a, b), isTrue);
+      expect(AtBytes.equals(a, c), isFalse);
+      // Verify null cases
+      expect(AtBytes.equals(a, d), isFalse);
+      expect(AtBytes.equals(d, e), isTrue);
     });
   });
 }


### PR DESCRIPTION
**- What I did**
- #1840
- TLDR; AtKeys have a lot of nullable AtBytes, cannot preform strEquals reliably due to null case.
 
**- How I did it**
- created an equals() method that compares two (AtBytes? a, AtBytes? b)

**- How to verify it**
 - see at_keys_test.dart in at_auth
 - added tests in at_bytes_test.dart
 
**- Description for the changelog**
feat: introduce AtBytes.equals
