### PR TITLE
chore: get at_client, at_auth and at_onboarding_cli ready to be published

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 3.0.2
-- feat: validateAtServer(): Added progress events and atSign connectivity probing
-- fix: throw AtAuthenticationException when atSign is already onboarded
+## 3.1.0
+- feat: `validateAtServer()` now emits progress events and probes atSign connectivity before returning
+- fix: `decodeAtKeys()` now throws when an invalid passphrase is provided
+- fix: `FileAtKeysIO` now encrypts the key file with a passphrase when one is available
+- fix: throws `AtAuthenticationException` when the atSign is already onboarded
 
 ## 3.0.1
 - feat: improve `AtEnrollmentImpl`

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 3.0.2
+version: 3.1.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## 3.12.0
 
-- feat: explicit AtClient lifecycle control — cleanly stop and resume atSigns without
+- feat: explicit AtClient lifecycle control — cleanly stop and resume atClients without
   re-initialising storage or keys
-- fix: monitor delayed-start timer could not be cancelled on stop
+- feat: outgoing AtClient's sync and notification services will now be garbage collected
+- chore: deprecated `atClientManager` param in the factories of AtClient, NotificationService, and SyncService
+- fix: added null guards to AtClient service getters
 
-## 3.11.0
+## 3.11.0     
 
 - chore(deps): at_auth ^3.0.0
 - chore(deps): at_chops ^3.0.0

--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.16.0
+- feat: enrollment authorization wait can now be resumed across sessions
+- feat: atKeys files are now restricted to read/write permissions for the current user only
+- feat: atKeys file writability is verified before enrollment or onboarding begins
+- feat: activate_cli: new `decrypt` command outputs a passphrase-decrypted version of the atKeys file
+- feat: activate_cli: version is now shown via `--version`, `--help`, and `help`
+- fix: at_onboarding_cli now subscribes to at_auth progress stream events
+
 ## 1.15.0
 
 - feat: add `--root-server` option to specify root server domain


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines in CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
- Updated changelogs for at_auth, at_client and at_onboarding_cli
- Updated pubspec versions to:
   - at_client: 3.12.0 (no change in this PR as its already updated)
   - at_auth: 3.1.0 (not 3.0.2 as it throws exceptions, which it didn't earlier)
   - at_onboarding_cli: 1.16.0 (no change in this PR as its already updated)

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
