### PR TITLE
chore: deprecate at_common_flutter

### DIFF
--- a/packages/at_common_flutter/CHANGELOG.md
+++ b/packages/at_common_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.1
+
+- **DEPRECATION**: Marked `at_common_flutter` as deprecated.
+- **DEPRECATION**: Updated package metadata and documentation to direct users to `at_client_flutter`.
+
 ## 2.1.0
 
 - chore(deps): flutter_lints ^6.0.0

--- a/packages/at_common_flutter/README.md
+++ b/packages/at_common_flutter/README.md
@@ -2,6 +2,13 @@
 
 [![pub package](https://img.shields.io/pub/v/at_common_flutter)](https://pub.dev/packages/at_common_flutter) [![](https://img.shields.io/static/v1?label=Backend&message=atPlatform&color=<COLOR>)](https://atsign.dev) [![](https://img.shields.io/static/v1?label=Publisher&message=Atsign&color=F05E3E)](https://atsign.com) [![gitHub license](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
 
+## Deprecation Notice
+`at_common_flutter` is deprecated and will no longer receive updates.
+
+Use [`at_client_flutter`](https://pub.dev/packages/at_client_flutter) instead for Flutter support in the atPlatform SDK:
+- Package: https://pub.dev/packages/at_client_flutter
+- Source: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter
+
 ## Overview
 The at_common_flutter package provides custom widgets for development of other packages and apps built on atPlatform.
 

--- a/packages/at_common_flutter/pubspec.yaml
+++ b/packages/at_common_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_common_flutter
-description: A Flutter package to provide common widgets used by other atPlatform Flutter packages.
-version: 2.1.0
+description: DEPRECATED Use at_client_flutter instead. Common Flutter widgets for older atPlatform packages.
+version: 2.1.1
 homepage: https://docs.atsign.com/
 repository: https://github.com/atsign-foundation/at_widgets/tree/trunk/packages/at_common_flutter
 issue_tracker: https://github.com/atsign-foundation/at_widgets/issues


### PR DESCRIPTION
**- What I did**
 - deprecation notice for at_common_flutter
 - progresses #1657
 
**- How I did it**
 - this package is wholly obsolete, there is essentially 0 reusable code sitting in this package
 - as well, we are fledging out a proper common widget export in at_client_flutter for users. 
   - see #1866 , which was designed by @olytovchenko @Dariamarg 
   
**- How to verify it**

**- Description for the changelog**
chore: deprecate at_common_flutter
