### PR TITLE
chore: prepare at_client_flutter for publishing

### DIFF
--- a/packages/at_client_flutter/CHANGELOG.md
+++ b/packages/at_client_flutter/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
 ## 1.1.0
+ - feat: models NamespacePermission, Otp, ServerEnrollmentRequest, AuthorisationException
+ - feat: additional functionality on FlutterEnrollmentService
+ - rework: lifecycle on FlutterEnrollmentService
+ - feat: new widgets for Enrollment related activities
  - feat: extensions for additional functionality
  - fix: bug where example app consumes atsigns with '_' inside them
 


### PR DESCRIPTION
**- What I did**
 - pubspec is already updated to 1.1.0? [see here](https://github.com/atsign-foundation/at_client_sdk/blob/trunk/packages/at_client_flutter/pubspec.yaml)
 - updated change log
 
**- How I did it**
- will be publishing after merge

**- How to verify it**

**- Description for the changelog**
chore: prepare at_client_flutter for publishing
