### PR TITLE
feat(commons): at_cli_commons 3.1.0 + at_commons 5.10.0

### DIFF
--- a/packages/at_cli_commons/CHANGELOG.md
+++ b/packages/at_cli_commons/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.1.0
+
+- feat: `CLIBase` constructor and `CLIBase.fromCommandLineArgs` now accept an
+  optional `preference` parameter (`AtOnboardingPreference`). When supplied,
+  `init()` updates that instance in place rather than creating a new one,
+  allowing callers to pre-set fields that `CLIBase` does not manage.
+
 ## 3.0.1
 
 - feat: Add support for legacy `-d` option. This will be added to the default

--- a/packages/at_cli_commons/README.md
+++ b/packages/at_cli_commons/README.md
@@ -1,29 +1,68 @@
-## Summary
+# at_cli_commons
 
-A library of generic / reusable stuff which is useful when building cli programs
-which use the [AtClient SDK](https://pub.dev/packages/at_client)
+Small helper library for **Dart CLI / server programs** that use the
+[`at_client`](../at_client) SDK. Wraps the boilerplate of parsing
+command-line flags, loading keys, and producing an authenticated
+`AtClient` behind a single call.
 
-The simplest usage would be
+## Usage
+
 ```dart
-  AtClient atClient = (await CLIBase.fromCommandLineArgs(args)).atClient;
+import 'package:at_cli_commons/at_cli_commons.dart';
+
+Future<void> main(List<String> args) async {
+  final atClient = (await CLIBase.fromCommandLineArgs(args)).atClient;
+  // atClient is authenticated and ready to use
+}
 ```
-For further usage examples, see 
-- In the example/bin/ directory
-  - `scan_example.dart`
-  - `put_and_get_example.dart`
-- The demo software [here](https://github.com/atsign-foundation/at_lorawan)
 
-## Features
+`CLIBase.fromCommandLineArgs(...)` parses the standard at-SDK flags
+(`-a <atsign>`, `-k <keys-file>`, `-n <namespace>`, `-r <root-domain>`,
+etc.), loads the user's `.atKeys` file, runs PKAM authentication via
+[`at_onboarding_cli`](../at_onboarding_cli), and hands back a ready
+`AtClient`.
 
-- The CLIBase class in cli_base.dart takes care of all the boilerplate
-  involved in getting from program startup to having an AtClient object you can
-  use - parsing command-line arguments, standard configuration, loading
-  authentication keys, etc.
-- There are a few other small utilities in utils.dart which CLIBase uses
+Two worked examples live under [`example/bin/`](example/bin):
+
+- [`scan_example.dart`](example/bin/scan_example.dart) — list every key
+  on the atServer
+- [`put_and_get_example.dart`](example/bin/put_and_get_example.dart) —
+  end-to-end put / get round-trip with TTL
+
+More programs using `CLIBase` in anger:
+[`at_lorawan`](https://github.com/atsign-foundation/at_lorawan) and the
+examples under [`../at_client/example/`](../at_client/example/README.md).
+
+## Injecting an AtOnboardingPreference
+
+If you need to pre-configure fields on the `AtOnboardingPreference`
+before `CLIBase` builds its client — custom storage paths, hooks, test
+overrides — pass an instance in. `CLIBase` will fill in the
+CLI-derived fields in place rather than constructing its own preference
+object:
+
+```dart
+final pref = AtOnboardingPreference()
+  ..someCustomField = 'my value';
+
+final atClient = (await CLIBase.fromCommandLineArgs(
+  args,
+  preference: pref,
+)).atClient;
+
+// pref.hiveStoragePath, pref.namespace, etc. are now populated by CLIBase.
+// pref.someCustomField is untouched.
+```
+
+## Where to go next
+
+- [`at_client`](../at_client) — the SDK whose `AtClient` this produces
+- [`at_onboarding_cli`](../at_onboarding_cli) — how to first-time
+  **provision** an atSign (register, CRAM-onboard, APKAM-enroll). Once
+  you have a `.atKeys` file, `CLIBase` takes over.
+- [`at_auth`](../at_auth) — the lifecycle story behind those keys
 
 ## Open source usage and contributions
 
-This is freely licensed open source code, so feel free to use it as is, suggest
-changes or enhancements or create your own version.
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for
-detailed guidance on how to set up tools, tests and make a pull request.
+BSD3-licensed. See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) for
+guidance on setting up tools, running tests, and raising a PR.

--- a/packages/at_cli_commons/lib/src/cli_base.dart
+++ b/packages/at_cli_commons/lib/src/cli_base.dart
@@ -149,6 +149,7 @@ class CLIBase {
     String? namespace,
     Set<String> hide = const {},
     bool addLegacyRootDomainArg = true,
+    AtOnboardingPreference? preference,
   }) async {
     parser ??= createArgsParser(
       namespace: namespace,
@@ -190,7 +191,8 @@ class CLIBase {
         verbose: parsedArgs['verbose'],
         syncDisabled: parsedArgs['never-sync'],
         maxConnectAttempts: int.parse(parsedArgs['max-connect-attempts']),
-        passPhrase: parsedArgs['pass-phrase']);
+        passPhrase: parsedArgs['pass-phrase'],
+        preference: preference);
 
     await cliBase.init();
 
@@ -208,6 +210,8 @@ class CLIBase {
   final String? passPhrase;
   final bool syncDisabled;
   final int maxConnectAttempts;
+
+  final AtOnboardingPreference? preference;
 
   late final String atKeysFilePathToUse;
   late final String localStoragePathToUse;
@@ -249,7 +253,8 @@ class CLIBase {
       this.downloadDir,
       this.syncDisabled = false,
       this.maxConnectAttempts = defaultMaxConnectAttempts,
-      this.passPhrase}) {
+      this.passPhrase,
+      this.preference}) {
     this.atSign = AtUtils.fixAtSign(atSign);
     if (homeDir == null) {
       if (atKeysFilePath == null) {
@@ -311,11 +316,12 @@ class CLIBase {
       atServiceFactory = ServiceFactoryWithNoOpSyncService();
     }
 
-    AtOnboardingPreference atOnboardingConfig = AtOnboardingPreference()
+    final AtOnboardingPreference atOnboardingConfig =
+        preference ?? AtOnboardingPreference();
+    atOnboardingConfig
       ..hiveStoragePath = localStoragePathToUse
       ..namespace = nameSpace
       ..downloadPath = downloadPathToUse
-      ..isLocalStoreRequired = true
       ..commitLogPath = '$localStoragePathToUse/commitLog'
           .replaceAll('/', Platform.pathSeparator)
       ..rootDomain = atRootDomain.rootDomain

--- a/packages/at_cli_commons/pubspec.yaml
+++ b/packages/at_cli_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_cli_commons
 description: Library of useful stuff when building cli programs which use the AtClient SDK
-version: 3.0.1
+version: 3.1.0
 
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_cli_commons
 homepage: https://atsign.com

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 5.10.0
+
+- feat: add `AtKey.fullKey` getter — key name including its namespace
+- feat: add `AtKey.fullKeyAndOwner` getter — `fullKey` combined with the owning atSign
+
 ## 5.9.0
 - feat: add equals method for `AtBytes`
 

--- a/packages/at_commons/README.md
+++ b/packages/at_commons/README.md
@@ -4,4 +4,128 @@
 
 # at_commons
 
-**at_commons** library will be used for commonly used components in implementation of the atProtocol.
+Foundational types used across every package in the Atsign Protocol SDK:
+key representations, metadata, atSign validation, root-domain parsing,
+verb builders (Atsign Protocol wire format), and the exception hierarchy.
+
+`at_commons` is a pure-Dart library with no dependency on any specific
+client implementation. Most application developers consume these types
+transitively via [`at_client`](../at_client); you'll reach for
+`at_commons` directly when you need to construct an `AtKey` by hand,
+interpret exceptions, or build Atsign Protocol verbs at a lower level.
+
+## AtKey
+
+`AtKey` represents a key in the atServer keystore. Prefer the static
+factory methods over the field-builder form — they encode the key
+*shape* (self / shared / public / local / cached) at the type level:
+
+```dart
+// Shared with another atSign
+AtKey shared = (AtKey.shared('phone', namespace: 'myapp', sharedBy: '@alice')
+      ..sharedWith('@bob'))
+    .build();
+
+// Public (readable by anyone)
+AtKey pub = AtKey.public('avatar', namespace: 'myapp', sharedBy: '@alice').build();
+
+// Self (only readable by the owner)
+AtKey self = AtKey.self('prefs', namespace: 'myapp', sharedBy: '@alice').build();
+
+// Local (never synced to the cloud)
+AtKey local = AtKey.local('cache', '@alice', namespace: 'myapp').build();
+
+// Parse from a wire-format string
+AtKey parsed = AtKey.fromString('@bob:phone.myapp@alice');
+```
+
+Useful getters:
+
+| Getter            | Example output           |
+|-------------------|--------------------------|
+| `fullKey`         | `phone.myapp`            |
+| `fullKeyAndOwner` | `phone.myapp@alice`      |
+| `toString()`      | `@bob:phone.myapp@alice` |
+
+## Metadata
+
+`Metadata` carries per-key settings. The fields most app code actually
+touches:
+
+| Field            | Type        | Description                                                                |
+|------------------|-------------|----------------------------------------------------------------------------|
+| `ttl`            | `int?`      | Time-to-live in ms (key self-expires)                                      |
+| `ttb`            | `int?`      | Time-to-birth in ms (key becomes visible after this delay)                 |
+| `ttr`            | `int?`      | Recipient cache refresh interval in seconds; `-1` means cache indefinitely |
+| `ccd`            | `bool?`     | Cascade-delete cached copies when the original is deleted                  |
+| `isPublic`       | `bool?`     | Key is publicly readable                                                   |
+| `isEncrypted`    | `bool?`     | Value is encrypted                                                         |
+| `isBinary`       | `bool?`     | Value is binary data                                                       |
+| `namespaceAware` | `bool`      | Whether the namespace is appended to the key on the wire                   |
+| `immutable`      | `bool?`     | Key may not be updated once set                                            |
+| `expiresAt`      | `DateTime?` | Derived expiry timestamp (from `ttl`)                                      |
+| `availableAt`    | `DateTime?` | Derived availability timestamp (from `ttb`)                                |
+
+## Atsign / AtRootDomain
+
+```dart
+Atsign alice = '@alice'.toAtsign();          // validated, fully qualified
+AtsignWithoutAt a = alice.withoutAt;         // no leading '@'
+
+AtRootDomain root = AtRootDomain.parse('root.atsign.org:64');
+AtRootDomain prod = AtRootDomain.atsignDomain; // production default
+```
+
+## Exceptions
+
+All exceptions extend `AtException`. The main sub-hierarchies are:
+
+- **`AtConnectException`** — connection / auth failures
+  (`SecondaryServerConnectivityException`, `UnAuthorizedException`,
+  `HandShakeException`, …)
+- **`AtServerException`** — server-side errors
+  (`InboundConnectionLimitException`, `LookupException`,
+  `InternalServerException`, …)
+- **`AtEnrollmentException`** — APKAM enrollment failures
+  (`AtInvalidEnrollmentException`, `AtEnrollmentRevokeException`,
+  `AtThrottleLimitExceeded`)
+- Standalone: `InvalidAtKeyException`, `KeyNotFoundException`,
+  `AtTimeoutException`, `InvalidAtSignException`, `AtSigningException`,
+  `AtIOException`, and others.
+
+## Verb builders
+
+Each builder constructs an Atsign Protocol wire command via `buildCommand()`.
+Application code normally doesn't touch these directly — the client
+packages use them internally — but they're exposed for lower-level
+tooling (see the test suite in [`test/`](test) for concrete usage).
+
+| Builder              | Protocol verb |
+|----------------------|---------------|
+| `UpdateVerbBuilder`  | `update:`     |
+| `DeleteVerbBuilder`  | `delete:`     |
+| `LookupVerbBuilder`  | `lookup:`     |
+| `LLookupVerbBuilder` | `llookup:`    |
+| `PLookupVerbBuilder` | `plookup:`    |
+| `ScanVerbBuilder`    | `scan`        |
+| `NotifyVerbBuilder`  | `notify:`     |
+| `MonitorVerbBuilder` | `monitor`     |
+| `SyncVerbBuilder`    | `sync:`       |
+| `EnrollVerbBuilder`  | `enroll:`     |
+| `StatsVerbBuilder`   | `stats:`      |
+
+## Other types
+
+- **`AtBytes`** — wrapper for base64-encoded binary payloads
+- **`KeyType`** — `selfKey`, `sharedKey`, `publicKey`, `localKey`,
+  `cachedSharedKey`, …
+- **`EnrollmentStatus`** — `pending`, `approved`, `denied`, `revoked`,
+  `expired`
+- **`PublicKeyHash`** — hash + algorithm of a public encryption key
+- **`SecureSocketConfig`** — TLS configuration for atServer connections
+
+## Where to go next
+
+- [`at_client`](../at_client) — the client that uses these types
+- [`at_auth`](../at_auth) — onboarding / authentication that produces
+  the keys embedded in `AtKey`

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -110,6 +110,10 @@ class AtKey {
     }
   }
 
+  String get fullKey => '$key${_dotNamespaceIfPresent()}';
+
+  String get fullKeyAndOwner => '$fullKey$sharedBy';
+
   @override
   String toString() {
     if (key.isNullOrEmpty) {

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.9.0
+version: 5.10.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
## Summary

Chunk A of 7 carving up the monolithic `gkc-enhance-api` branch (PR #1888).

- `at_cli_commons` → 3.1.0: CLIBase accepts AtOnboardingPreference injection.
- `at_commons` → 5.10.0: AtKey helpers.

## Chain

- **A (this)** → B → C → D → E → F → G. Each subsequent PR targets the previous one's branch.

## Test plan

- [ ] `dart analyze packages/at_commons packages/at_cli_commons`
- [ ] `dart test -d packages/at_commons`
- [ ] `dart test -d packages/at_cli_commons`