### PR TITLE
refactor(at_client): minor core housekeeping

### DIFF
--- a/packages/at_client/analysis_options.yaml
+++ b/packages/at_client/analysis_options.yaml
@@ -2,6 +2,7 @@
 # projects at Google. For details and rationale,
 # see https://pub.dev/packages/lints.
 include: package:lints/recommended.yaml
+# include: package:very_good_analysis/analysis_options.yaml
 
 # For lint rules and documentation, see http://dart-lang.github.io/linter/lints.
 # Uncomment to specify additional rules.
@@ -11,7 +12,7 @@ linter:
     unnecessary_string_interpolations : true
     await_only_futures : true
     unawaited_futures: true
-    depend_on_referenced_packages : false
+#    depend_on_referenced_packages : false
 
 #analyzer:
 #   exclude:

--- a/packages/at_client/analysis_options.yaml
+++ b/packages/at_client/analysis_options.yaml
@@ -12,7 +12,7 @@ linter:
     unnecessary_string_interpolations : true
     await_only_futures : true
     unawaited_futures: true
-#    depend_on_referenced_packages : false
+#     depend_on_referenced_packages : false
 
 #analyzer:
 #   exclude:

--- a/packages/at_client/lib/src/at_collection/at_collection_model.dart
+++ b/packages/at_client/lib/src/at_collection/at_collection_model.dart
@@ -9,6 +9,7 @@ import 'impl/at_collection_operations_impl.dart';
 import 'impl/at_collection_query_operations_impl.dart';
 import 'impl/at_collection_stream_operations_impl.dart';
 
+@Deprecated("Use AtClient.collection for collection-style operations")
 abstract class AtCollectionModel<T> implements AtCollectionModelOperations {
   static final _logger = AtSignLogger('AtCollectionModel');
 

--- a/packages/at_client/lib/src/at_collection/at_collection_model_factory.dart
+++ b/packages/at_client/lib/src/at_collection/at_collection_model_factory.dart
@@ -1,5 +1,6 @@
 import 'package:at_client/src/at_collection/at_collection_model.dart';
 
+@Deprecated("Use AtClient.collection for collection-style operations")
 abstract class AtCollectionModelFactory<T extends AtCollectionModel> {
   /// Expected to return an instance of T
   T create();
@@ -15,6 +16,7 @@ abstract class AtCollectionModelFactory<T extends AtCollectionModel> {
   }
 }
 
+@Deprecated("Use AtClient.collection for collection-style operations")
 class AtCollectionModelFactoryManager {
   static final AtCollectionModelFactoryManager _singleton =
       AtCollectionModelFactoryManager._internal();

--- a/packages/at_client/lib/src/at_collection/at_json_collection_model.dart
+++ b/packages/at_client/lib/src/at_collection/at_json_collection_model.dart
@@ -2,6 +2,7 @@ import 'at_collection_model.dart';
 import 'at_collection_model_factory.dart';
 
 // Represents a generic JSON model of a atCollection model
+@Deprecated("Use AtClient.collection for collection-style operations")
 class AtJsonCollectionModel extends AtCollectionModel {
   late Map<String, dynamic> jsonModel;
 
@@ -18,6 +19,7 @@ class AtJsonCollectionModel extends AtCollectionModel {
 
 // Factory for creating instance of AtJsonCollectionModel
 // Factory accepts ay collection name
+@Deprecated("Use AtClient.collection for collection-style operations")
 class AtJsonCollectionModelFactory extends AtCollectionModelFactory {
   @override
   AtCollectionModel create() {

--- a/packages/at_client/lib/src/at_collection/collection_util.dart
+++ b/packages/at_client/lib/src/at_collection/collection_util.dart
@@ -1,3 +1,4 @@
+@Deprecated("Use AtClient.collection for collection-style operations")
 class CollectionUtil {
   /// replaces character with '-' if it's not alphanumeric.
   static String format(String id) {

--- a/packages/at_client/lib/src/at_collection/collections.dart
+++ b/packages/at_client/lib/src/at_collection/collections.dart
@@ -1,6 +1,7 @@
 import 'package:at_client/at_client.dart';
 
 /// Contains CRUD operations that can be performed on [AtCollectionModel]
+@Deprecated("Use AtClient.collection for collection-style operations")
 abstract interface class AtCollectionModelOperations<T> {
   /// Saves the json representation of [AtCollectionModel] to the secondary server of a atSign.
   /// [save] calls [toJson] method to get the json representation of a [AtCollectionModel].
@@ -122,6 +123,7 @@ abstract interface class AtCollectionModelOperations<T> {
 }
 
 /// Contains query methods on [AtCollectionModel]
+@Deprecated("Use AtClient.collection for collection-style operations")
 abstract interface class AtCollectionQueryOperations {
   /// Returns list of AtCollectionModels that are shared by the given [atSign]
   /// Returns an empty list when nothing has been shared
@@ -178,6 +180,7 @@ abstract interface class AtCollectionQueryOperations {
 /// class MyModel extends AtCollectionModel {}
 /// ```
 ///
+@Deprecated("Use AtClient.collection for collection-style operations")
 abstract class AtCollectionModelStreamOperations {
   /// Saves the json representation of the object to the secondary server of the @sign.
   /// [save] calls [toJson] method to get the json representation.
@@ -272,6 +275,7 @@ abstract class AtCollectionModelStreamOperations {
   Stream<AtOperationItemStatus> delete();
 }
 
+@Deprecated("Use AtClient.collection for collection-style operations")
 class AtOperationItemStatus {
   late String atSign;
   late String key;
@@ -288,8 +292,10 @@ class AtOperationItemStatus {
   });
 }
 
+@Deprecated("Use AtClient.collection for collection-style operations")
 enum Operation { save, share, unshare, delete }
 
+@Deprecated("Use AtClient.collection for collection-style operations")
 abstract class KeyMaker {
   AtKey createSelfKey(
       {required String keyId,
@@ -305,6 +311,7 @@ abstract class KeyMaker {
       ObjectLifeCycleOptions? objectLifeCycleOptions});
 }
 
+@Deprecated("Use AtClient.collection for collection-style operations")
 class ObjectLifeCycleOptions {
   // How long the object is supposed to live
   Duration? timeToLive;

--- a/packages/at_client/lib/src/at_collection/impl/at_collection_operations_impl.dart
+++ b/packages/at_client/lib/src/at_collection/impl/at_collection_operations_impl.dart
@@ -6,6 +6,7 @@ import 'package:at_client/src/at_collection/collection_util.dart';
 import 'package:at_utils/at_logger.dart';
 import 'collection_methods_impl.dart';
 
+@Deprecated("Use AtClient.collection for collection-style operations")
 class AtCollectionModelOperationsImpl implements AtCollectionModelOperations {
   final _logger = AtSignLogger('AtCollectionModelOperationsImpl');
   late AtCollectionModel atCollectionModel;

--- a/packages/at_client/lib/src/at_collection/impl/at_collection_query_operations_impl.dart
+++ b/packages/at_client/lib/src/at_collection/impl/at_collection_query_operations_impl.dart
@@ -5,6 +5,7 @@ import 'package:at_client/src/at_collection/collection_util.dart';
 import 'package:at_client/src/at_collection/impl/default_key_maker.dart';
 import 'package:at_utils/at_logger.dart';
 
+@Deprecated("Use AtClient.collection for collection-style operations")
 class AtCollectionQueryOperationsImpl implements AtCollectionQueryOperations {
   final _logger = AtSignLogger('AtCollectionQueryOperationsImpl');
   AtClientManager? atClientManager;

--- a/packages/at_client/lib/src/at_collection/impl/at_collection_stream_operations_impl.dart
+++ b/packages/at_client/lib/src/at_collection/impl/at_collection_stream_operations_impl.dart
@@ -5,6 +5,7 @@ import 'package:at_client/src/at_collection/collection_util.dart';
 import 'package:at_client/src/at_collection/collections.dart';
 import 'collection_methods_impl.dart';
 
+@Deprecated("Use AtClient.collection for collection-style operations")
 class AtCollectionModelStreamOperationsImpl
     extends AtCollectionModelStreamOperations {
   late AtCollectionModel atCollectionModel;

--- a/packages/at_client/lib/src/at_collection/impl/collection_methods_impl.dart
+++ b/packages/at_client/lib/src/at_collection/impl/collection_methods_impl.dart
@@ -11,6 +11,7 @@ import '../collections.dart';
 /// [AtCollectionMethodImpl] have the implementation of all the methods available in collections package.
 /// These methods are wrapped with a stream or future return types for the end consumption.
 
+@Deprecated("Use AtClient.collection for collection-style operations")
 class AtCollectionMethodImpl {
   final _logger = AtSignLogger('AtCollectionModelMethodsImpl');
 

--- a/packages/at_client/lib/src/at_collection/impl/default_key_maker.dart
+++ b/packages/at_client/lib/src/at_collection/impl/default_key_maker.dart
@@ -1,5 +1,6 @@
 import 'package:at_client/at_client.dart';
 
+@Deprecated("Use AtClient.collection for collection-style operations")
 class DefaultKeyMaker implements KeyMaker {
   AtClient _getAtClient() {
     return AtClientManager.getInstance().atClient;

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -28,7 +28,13 @@ class AtClientManager {
   late String _atSign;
   AtClient? _currentAtClient;
 
-  AtClient get atClient => _currentAtClient!;
+  AtClient get atClient {
+    if (_currentAtClient == null) {
+      throw StateError('No atClient yet');
+    } else {
+      return _currentAtClient!;
+    }
+  }
 
   @Deprecated('Use atClientManager.atClient.syncService')
   SyncService get syncService => atClient.syncService;

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,7 +10,7 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.12.0';
+  final String atClientVersion = '3.13.0';
 
   /// Represents the client commit log compaction time interval
   ///

--- a/packages/at_client/lib/src/preference/at_client_preference.dart
+++ b/packages/at_client/lib/src/preference/at_client_preference.dart
@@ -134,9 +134,11 @@ class AtClientPreference {
   /// hashing algorithm to use for pkam authentication
   HashingAlgoType hashingAlgoType = HashingAlgoType.sha256;
 
-  /// Set this to [RemoteLocalPref.remoteFirst] or [RemoteLocalPref.remoteOnly]
+  /// Set this to [RemoteLocalPref.remoteOnly]
   /// if you require all data operations (get / put / delete) to be performed
-  /// on the remote atServer first.
+  /// on the remote atServer rather than on local storage. (When operations are
+  /// performed locally, we depend on sync to get eventual consistency between
+  /// local and remote.
   RemoteLocalPref remoteLocalPref = RemoteLocalPref.localOnly;
 }
 

--- a/packages/at_client/lib/src/rpc/at_rpc.dart
+++ b/packages/at_client/lib/src/rpc/at_rpc.dart
@@ -14,6 +14,11 @@ abstract class AtRpcCallbacks {
   Future<void> handleResponse(AtRpcResp response);
 }
 
+typedef RpcRequestHandler = Future<AtRpcResp> Function(
+  AtRpcReq request,
+  String fromAtSign,
+);
+
 class AtRpcClient implements AtRpcCallbacks {
   static final AtSignLogger logger = AtSignLogger(' AtRpcClient ',
       loggingHandler: AtSignLogger.stdErrLoggingHandler);
@@ -173,6 +178,30 @@ class AtRpc {
   /// When enabled, it prevents multiple [AtRpc] responses from being sent for
   /// the same request.
   final bool enableRequestMutex;
+
+  factory AtRpc.server({
+    required AtClient atClient,
+    required String baseNameSpace,
+    String rpcsNameSpace = '__rpcs',
+    required String domainNameSpace,
+    required RpcRequestHandler requestHandler,
+    Set<Atsign>? allowList,
+    required bool allowAll,
+    required bool enableRequestMutex,
+  }) {
+    return AtRpc(
+      atClient: atClient,
+      baseNameSpace: baseNameSpace,
+      rpcsNameSpace: rpcsNameSpace,
+      domainNameSpace: domainNameSpace,
+      callbacks: _Callbacks(requestHandler),
+      allowList: allowList ?? {},
+      allowAll: allowAll,
+      isClient: false,
+      isServer: true,
+      enableRequestMutex: enableRequestMutex,
+    );
+  }
 
   AtRpc({
     required this.atClient,
@@ -532,5 +561,22 @@ class AtRpc {
         }
       }
     }
+  }
+}
+
+class _Callbacks implements AtRpcCallbacks {
+  final RpcRequestHandler requestHandler;
+
+  _Callbacks(this.requestHandler);
+
+  @override
+  Future<AtRpcResp> handleRequest(AtRpcReq request, String fromAtSign) async {
+    return requestHandler(request, fromAtSign);
+  }
+
+  /// Never called - We are not a client so we don't handle responses
+  @override
+  Future<void> handleResponse(AtRpcResp response) {
+    throw UnimplementedError();
   }
 }


### PR DESCRIPTION
## Summary

Chunk B of 7. Non-feature core housekeeping in at_client that doesn't fit chunks C (sync rewrite) or D (AtCollection feature). Mostly tiny: analyzer rules, manager/preference/rpc internals, deprecation markers on the legacy at_collection directory.

## Chain

A → **B (this)** → C → D → E → F → G.

> ⚠️ Review against the chain base (`gkc-chunkA-commons`), not trunk.

## Test plan

- [ ] `dart analyze packages/at_client/lib packages/at_client/test`
- [ ] `dart test -d packages/at_client --concurrency=1` (the sync-related and AtCollection-related test files arrive in C and D respectively)