### PR TITLE
docs: orphan README / EXAMPLE refreshes + CI / e2e cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ These libraries were previously located at
 [at_libraries](https://github.com/atsign-foundation/at_libraries)
 
 - [at_commons](https://pub.dev/packages/at_commons) Commonly used components
-in implementation of the atProtocol.
+in implementation of the Atsign Protocol.
 
 - [at_utils](https://pub.dev/packages/at_utils) This is the Utility library
-for atProtocol projects. It contains utility classes for atSign, atMetadata,
+for Atsign Protocol projects. It contains utility classes for atSign, atMetadata,
 configuration and logger.
 
 - [at_contact](https://pub.dev/packages/at_contact): A contacts library that
@@ -55,7 +55,7 @@ in action by cloning the at_chat_flutter project from the
 [at_widgets repository](https://github.com/atsign-foundation/at_widgets).
 
 - [at_lookup](https://pub.dev/packages/at_lookup): A low-level library that
-directly implements the atProtocol verbs. You can find this dependency in
+directly implements the Atsign Protocol verbs. You can find this dependency in
 several other packages such as at_client and at_client_mobile.
 
 - [at_onboarding_cli](https://pub.dev/packages/at_onboarding_cli): A command
@@ -84,18 +84,18 @@ These libraries were previously located at
 
 - [at_backupkey_flutter](https://pub.dev/packages/at_backupkey_flutter)- A
 flutter plugin project for saving the backup key of any atSign that is being
-onboarded with atProtocol apps. Backup key can be used to authenticate in any
-atProtocol apps.
+onboarded with Atsign Protocol apps. Backup key can be used to authenticate in any
+Atsign Protocol apps.
 
 - [at_chat_flutter](https://pub.dev/packages/at_chat_flutter)- A flutter plugin
-project to provide a chat feature using atSigns and atProtocol.
+project to provide a chat feature using atSigns and Atsign Protocol.
 
 - [at_common_flutter](https://pub.dev/packages/at_common_flutter)- A flutter
 package to provide common widgets used by other Atsign flutter packages.
 
 - [at_contacts_flutter](https://pub.dev/packages/at_contacts_flutter)- A
 flutter plugin project to provide ease of managing contacts for an atSign
-using atProtocol.
+using Atsign Protocol.
 
 - [at_contacts_group_flutter](https://pub.dev/packages/at_contacts_group_flutter)-
 A flutter plugin to provide group functionality for atSign contacts.
@@ -108,7 +108,7 @@ plugin project to share location between two atSigns and track them on Open
 Street Map ([OSM](https://www.openstreetmap.org/)).
 
 - [at_onboarding_flutter](https://pub.dev/packages/at_onboarding_flutter)- A
-flutter plugin project for onboarding any atSign in atProtocol apps with ease.
+flutter plugin project for onboarding any atSign in Atsign Protocol apps with ease.
 Provides QRscanner and upload key file options to authenticate.
 
 - [atsign_authentication_helper](https://pub.dev/packages/atsign_authentication_helper)-

--- a/packages/at_auth/README.md
+++ b/packages/at_auth/README.md
@@ -1,35 +1,128 @@
-Package for onboarding and authentication to an atsign's secondary server  
+# at_auth
 
-## Features
+Platform-neutral core of **onboarding**, **authentication**, and **APKAM
+enrollment** for the Atsign Protocol. Used by both
+[`at_onboarding_cli`](../at_onboarding_cli) (CLI / server apps) and
+[`at_client_flutter`](../at_client_flutter) (Flutter apps) — most
+application developers will pick up one of those higher-level packages
+rather than consuming `at_auth` directly.
 
-- onboard logic - cram authentication,pkam/encryption/apkam key pair generation, initial pkam authentication
-- authentication - read keys from .atKeys file, pkam authentication
+## What `at_auth` does
 
-## Getting started
+| Capability                      | Entry point                                            |
+| ------------------------------- | ------------------------------------------------------ |
+| CRAM-based initial onboarding   | `AtAuth.onboard(AtOnboardingRequest, cramSecret)`      |
+| PKAM authentication             | `AtAuth.authenticate(AtAuthRequest)`                   |
+| APKAM enrollment (request side) | `AtEnrollment.submit(...)`                             |
+| APKAM enrollment (approve side) | `AtEnrollment.approve(...)` / `AtEnrollment.deny(...)` |
+| Free atSign registration        | `RegistrarService` (fetches CRAM key by email)         |
 
-- Developers should have a free/paid atsign from https://atsign.com/ 
+See [`example/onboard.dart`](example/onboard.dart),
+[`example/authenticate.dart`](example/authenticate.dart), and
+[`example/enrollment_request.dart`](example/enrollment_request.dart) for
+end-to-end usage.
 
-## Usage
+## The atSign lifecycle
 
-Onboard an atsign
-```dart
-final atAuth = AtAuth.create();
-final atOnboardingRequest = AtOnboardingRequest('@alice')
-  ..rootDomain = AtRootDomain('vip.ve.atsign.zone', 64)
-  ..appName = 'wavi'
-  ..deviceName = 'iphone';
-final atOnboardingResponse = await atAuth.onboard(atOnboardingRequest, <cram_secret>);
-```
+The full journey from "I don't own an atSign yet" to "my app is talking
+to the atServer" breaks into three phases. Understanding all three is
+important because each produces credentials that need to be handled
+correctly.
 
-Authenticate an atsign
-```dart
-final atAuth = AtAuth.create();
-final atAuthRequest = AtAuthRequest('@alice')
-    ..rootDomain = AtRootDomain('vip.ve.atsign.zone', 64)
-    ..atKeysFilePath = args[1];
-final atAuthResponse = await atAuth.authenticate(atAuthRequest);
-```
+### Phase 1 — Provision an atSign (get a CRAM key)
 
-## Example
+An atSign is a namespaced identity (e.g. `@alice`) with a matching
+personal server (the **atServer**). Before any cryptographic keys exist,
+you need to claim the atSign itself.
 
-For examples please refer to [examples](https://pub.dev/packages/at_auth/example)
+- Free atSigns: [my.noports.com/no-ports-plans](https://my.noports.com/no-ports-plans)
+- Paid / custom atSigns: [my.atsign.com](https://my.atsign.com)
+
+Registration produces a **CRAM key** — a high-entropy secret, delivered
+to the registered email address, that proves first-time ownership.
+Programmatic registration is available via `RegistrarService` (see
+[`lib/src/registrar/`](lib/src/registrar)).
+
+At this point the atSign exists on the root directory but its atServer
+has no authenticated user and no encryption keys. The CRAM key is the
+one-time bootstrap credential.
+
+### Phase 2 — Onboard the atSign (generate the master AtKeys)
+
+Onboarding happens **exactly once per atSign** and consists of:
+
+1. Authenticating to the atServer with the CRAM key.
+2. Generating the atSign's cryptographic keypairs (PKAM signing,
+   encryption, self-encryption).
+3. Publishing the public halves and registering the PKAM public key on
+   the atServer.
+4. Writing the private halves to a local `.atKeys` file (for CLI apps)
+   or to the device **keychain** (for Flutter apps).
+
+The result is a **master AtKeys** set. These keys:
+
+- Are the **root of trust** for the atSign — losing them is
+  approximately as bad as forgetting the password to a cryptocurrency
+  wallet; there is no recovery path that doesn't involve reclaiming the
+  atSign from scratch.
+- **MUST be backed up by the end user.** Any app that uses `at_auth` to
+  onboard an atSign should tell the user to back up the `.atKeys`
+  file / keychain entry. `at_client_flutter` surfaces an "export keys"
+  flow; CLI apps typically just write the file and leave it to the user.
+- Are the only keys allowed to **approve or deny APKAM enrollment
+  requests** — see Phase 3.
+
+After Phase 2, the CRAM key is no longer usable (onboarding is
+single-shot). Use [`example/onboard.dart`](example/onboard.dart) to walk
+through it end-to-end.
+
+### Phase 3 — Authenticate apps via APKAM (per-app scoped AtKeys)
+
+The master AtKeys are powerful — they can read anything on the atServer
+and approve new devices. You don't want every app on every device
+holding them. APKAM (App-level Pkam Key Authentication Mechanism)
+solves this.
+
+How APKAM works:
+
+1. A new app / device submits an **enrollment request** specifying the
+   namespaces it needs and the access level it needs on each
+   (e.g. `{'todos': 'rw', 'profile': 'r'}`). Each request gets a
+   short-lived **OTP** to bind the request to a human-approved session.
+2. An already-authenticated session holding the master AtKeys (or any
+   session whose keys include the `__manage` namespace) **approves or
+   denies** the request.
+3. On approval, the atServer issues a **new, scoped AtKeys set** — it
+   can only read/write within the granted namespaces.
+4. The enrolling app stores those scoped keys (disk or keychain) and
+   uses them for normal PKAM authentication thereafter.
+
+Why this matters:
+
+- **Scope limits blast radius.** An "evil" or simply buggy app with
+  scoped keys can only damage data in its own namespace. A todos app
+  with `{'todos': 'rw'}` can never read your `charts.acme` data even if
+  it's fully compromised.
+- **Scoped keys are revocable.** The master-keys holder can revoke any
+  previously-approved enrollment; the atServer rejects future
+  authentications from those keys immediately.
+- **Audit trail.** Every active enrollment is listed with its `appName`,
+  `deviceName`, namespace permissions, and status (`pending`,
+  `approved`, `denied`, `revoked`, `expired`).
+
+See [`example/enrollment_request.dart`](example/enrollment_request.dart)
+for the submitting side; the approve/deny side is demonstrated in
+[`at_onboarding_cli/example/apkam_examples/enroll_app_listen.dart`](../at_onboarding_cli/example/apkam_examples/enroll_app_listen.dart).
+
+## Where to go next
+
+| If you're building…            | Use                                                                                   |
+| ------------------------------ | ------------------------------------------------------------------------------------- |
+| A CLI or server app            | [`at_onboarding_cli`](../at_onboarding_cli) + [`at_cli_commons`](../at_cli_commons)   |
+| A Flutter app                  | [`at_client_flutter`](../at_client_flutter) — includes pre-built onboarding widgets   |
+| Anything that reads/writes data after auth | [`at_client`](../at_client)                                               |
+
+## Open source usage and contributions
+
+BSD3-licensed. See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) for
+guidance on setting up tools, running tests, and raising a PR.

--- a/packages/at_backupkey_flutter/README.md
+++ b/packages/at_backupkey_flutter/README.md
@@ -32,7 +32,7 @@ Instructions on how to manually add this package to you project can be found on 
 
 ## How it works
 
-Secret keys are generated for an atSign during onboarding flow of atProtocol. This package helps to add those keys in '.atKeys' file. This file can then be saved in the local filesystem or iCloud/Gdrive.
+Secret keys are generated for an atSign during onboarding flow of Atsign Protocol. This package helps to add those keys in '.atKeys' file. This file can then be saved in the local filesystem or iCloud/Gdrive.
 
 ## Setup
 The following platform specific setups are required:

--- a/packages/at_follows_flutter/README.md
+++ b/packages/at_follows_flutter/README.md
@@ -20,7 +20,7 @@ following.
 
 ## Get Started
 
-To get a basic overview of the atProtocol and it's packages. Please visit
+To get a basic overview of the Atsign Protocol and it's packages. Please visit
 the [atsign docs](https://atsign.dev/docs/overview/).
 
 > To use this package you must be have a basic setup of the atPlatform/at_app.

--- a/packages/at_invitation_flutter/example/README.md
+++ b/packages/at_invitation_flutter/example/README.md
@@ -2,7 +2,7 @@
 
 ## at_invitation_flutter example
 
-The at_invitation_flutter package is designed to make it easy to invite people through email or SMS into apps that use atProtocol.
+The at_invitation_flutter package is designed to make it easy to invite people through email or SMS into apps that use Atsign Protocol.
 
 ### Give it a try
 This package includes a working sample application in the [example](https://github.com/atsign-foundation/at_widgets/tree/trunk/at_invitation_flutter/example) directory that demonstrates the key features of the package. To create a personalized copy, use ```at_app create``` as shown below or check it out on GitHub.

--- a/packages/at_invitation_flutter/example/example.md
+++ b/packages/at_invitation_flutter/example/example.md
@@ -2,7 +2,7 @@
 
 ## at_invitation_flutter example
 
-The at_invitation_flutter package is designed to make it easy to invite people through email or SMS into apps that use atProtocol.
+The at_invitation_flutter package is designed to make it easy to invite people through email or SMS into apps that use Atsign Protocol.
 
 ### Give it a try
 This package includes a working sample application in the [example](https://github.com/atsign-foundation/at_widgets/tree/trunk/at_invitation_flutter/example) directory that demonstrates the key features of the package. To create a personalized copy, use ```at_app create``` as shown below or check it out on GitHub.

--- a/packages/at_login_flutter/README.md
+++ b/packages/at_login_flutter/README.md
@@ -2,7 +2,7 @@
 
 # at_login_flutter
 
-A flutter plugin project for adding zero trust logins using the atProtocol.
+A flutter plugin project for adding zero trust logins using the Atsign Protocol.
 
 ## Getting Started
 

--- a/packages/at_lookup/README.md
+++ b/packages/at_lookup/README.md
@@ -6,7 +6,7 @@
 
 ## Overview:
 
-The AtLookup Library is the low-level direct implementation of the atProtocol verbs. The AtLookup package is an interface
+The AtLookup Library is the low-level direct implementation of the Atsign Protocol verbs. The AtLookup package is an interface
 to interact with the secondary server to execute commands(scan, update, lookup, llookup, plookup, etc).
 
 ## Get started:

--- a/packages/at_notify_flutter/README.md
+++ b/packages/at_notify_flutter/README.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-The at_notify_flutter package is for Flutter developers who want to handle notifications in atProtocol apps.
+The at_notify_flutter package is for Flutter developers who want to handle notifications in Atsign Protocol apps.
 
 This open source package is written in Dart, supports Flutter and follows the atPlatform's decentralized, edge computing model with the following features: 
 - Cryptographic control of data access through personal data stores

--- a/packages/at_notify_flutter/example/EXAMPLE.md
+++ b/packages/at_notify_flutter/example/EXAMPLE.md
@@ -1,7 +1,7 @@
 <a href="https://atsign.com#gh-light-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only" alt="The Atsign Foundation"></a><a href="https://atsign.com#gh-dark-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2023/08/atsign-logo-horizontal-reverse2022-Color.svg#gh-dark-mode-only" alt="The Atsign Foundation"></a>
 
 ## at_notify_flutter example
-The at_notify_flutter package is designed to make it easy to add notifications in atProtocol apps.
+The at_notify_flutter package is designed to make it easy to add notifications in Atsign Protocol apps.
 
 ### Give it a try
 This package includes a working sample application in the [example](https://github.com/atsign-foundation/at_widgets/tree/trunk/packages/at_notify_flutter/example) directory that demonstrates the key features of the package. To create a personalized copy, use ```at_app create``` as shown below or check it out on GitHub.

--- a/packages/at_notify_flutter/example/README.md
+++ b/packages/at_notify_flutter/example/README.md
@@ -1,7 +1,7 @@
 <a href="https://atsign.com#gh-light-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only" alt="The Atsign Foundation"></a><a href="https://atsign.com#gh-dark-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2023/08/atsign-logo-horizontal-reverse2022-Color.svg#gh-dark-mode-only" alt="The Atsign Foundation"></a>
 
 ## at_notify_flutter example
-The at_notify_flutter package is designed to make it easy to add notifications in atProtocol apps.
+The at_notify_flutter package is designed to make it easy to add notifications in Atsign Protocol apps.
 
 ### Give it a try
 This package includes a working sample application in the [example](https://github.com/atsign-foundation/at_widgets/tree/trunk/packages/at_notify_flutter/example) directory that demonstrates the key features of the package. To create a personalized copy, use ```at_app create``` as shown below or check it out on GitHub.

--- a/packages/at_onboarding_cli/README.md
+++ b/packages/at_onboarding_cli/README.md
@@ -4,152 +4,113 @@
 
 # at_onboarding_cli
 
-## Introduction
-at_onboarding_cli is a library to authenticate and onboard atSigns.
+CLI-side wrapper around [`at_auth`](../at_auth) that provides the
+command-line tooling end users and CLI apps need to **register**,
+**onboard**, and **enroll** atSigns — plus a library surface for
+building your own onboarding tooling.
 
-## Get Started
+If you're new to the Atsign Protocol lifecycle (register → onboard → APKAM
+enroll), read
+[`at_auth`'s README](../at_auth/README.md#the-atsign-lifecycle) first —
+this package is the CLI concretisation of that model. [`at_client_flutter`](../at_client_flutter)
+is the Flutter-UI equivalent.
 
-To add this package as the dependency in your pubspec.yaml
+## Turnkey CLI tools
 
-```yaml 
-dependencies:
-  at_onboarding_cli: ^1.3.0
-```
-Getting Dependencies
+Both ship as executables when this package is globally activated:
 
 ```sh
-dart pub get 
+dart pub global activate at_onboarding_cli
 ```
 
-To import the library in your application code
+### `at_register` — get a free atSign
+
+```sh
+at_register -e your_email@example.com
+```
+
+Fetches a free atSign, emails you a verification code, then runs
+`at_activate` automatically once you paste the code back. The generated
+`.atKeys` file lands in `~/.atsign/keys/`.
+
+### `at_activate` — onboard an atSign (Phase 2 of the lifecycle)
+
+```sh
+# Using a CRAM secret from email / registrar
+at_activate -a @alice -c <cram_secret>
+
+# OR using an email-delivered verification code
+at_activate -a @alice
+```
+
+Either form produces the **master `.atKeys`** in `~/.atsign/keys/`.
+**These are the root of trust for `@alice` — back them up.**
+
+## APKAM enrollment
+
+A new device / app authenticating as an existing atSign should go
+through APKAM rather than asking the user for their master keys. The
+worked example lives under [`example/apkam_examples/`](example/apkam_examples):
+
+- [`apkam_enroll.dart`](example/apkam_examples/apkam_enroll.dart) —
+  the **new** device submits an enrollment request scoped to specific
+  namespaces
+- [`enroll_app_listen.dart`](example/apkam_examples/enroll_app_listen.dart)
+  — a device holding the master keys listens for and approves /
+  denies incoming requests
+- [`apkam_authenticate.dart`](example/apkam_examples/apkam_authenticate.dart)
+  — the new device authenticates with its newly-issued scoped keys
+
+Full step-by-step walkthrough:
+[`example/README.md`](example/README.md).
+
+## Library usage
+
+If you're building your own onboarding tooling, `AtOnboardingService`
+is the main entry point:
 
 ```dart
 import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+
+final pref = AtOnboardingPreference()
+  ..rootDomain = 'root.atsign.org'
+  ..namespace = 'my_app'
+  ..hiveStoragePath = 'storage/hive'
+  ..commitLogPath = 'storage/commitLog'
+  ..isLocalStoreRequired = true
+  ..atKeysFilePath = 'storage/@alice_key.atKeys';
+
+final svc = AtOnboardingServiceImpl('@alice', pref);
+
+// Onboard (Phase 2): CRAM-authenticate and generate master atKeys.
+// Provide cramSecret via pref.cramSecret; omit to trigger email OTP.
+await svc.onboard();
+
+// Or, for a previously-onboarded atSign, just authenticate (Phase 3).
+await svc.authenticate();
+
+final AtClient? atClient = await svc.atClient;
+final AtLookUp? atLookup = svc.atLookUp;
 ```
 
-## Usage
-Use cases for at_onboarding_cli:\
-    1) Authentication\
-    2) Onboarding (Activation)\
-    3) activate_cli\
-    4) register_cli
-    5) APKAM enrollments
+Worked examples covering each flow:
+[`example/`](example) and
+[`example/legacy_examples/`](example/legacy_examples).
 
-- Set `AtOnboardingPreference` to your preferred settings. These preferences will be used to configure the `AtOnboardingService`. 
-    
- ```
-  AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
-        ..rootDomain = 'root.atsign.org
-        ..qrCodePath = 'storage/qr_code.png'
-        ..hiveStoragePath = 'storage/hive'
-        ..namespace = 'example'
-        ..downloadPath = 'storage/files'
-        ..isLocalStoreRequired = true
-        ..commitLogPath = 'storage/commitLog'
-        ..cramSecret = '<your cram secret>'
-        ..privateKey = '<your private key here>'
-        ..atKeysFilePath = 'storage/alice_key.atKeys';
- ```
+Most **app** developers don't need this library directly — they use
+[`at_cli_commons`](../at_cli_commons)' `CLIBase` which calls
+`AtOnboardingService` internally.
 
-### Authentication:
-Proving that one actually owns the atSign. User needs to authenticate before performing operations on that atSign. Operations include reading, writing, deleting or updating data in the atsign's keystore and sending notifications from that atSign.
+## Where to go next
 
-#### Steps to Authenticate
-   1) Import at_onboarding_cli.
-   2) Set preferences using AtOnboardingPreference. Either of secret key or path to .atKeysFile need to be provided to authenticate.
-   3) Instantiate AtOnboardingServiceImpl using the required atSign and a valid instance of AtOnboardingPreference.
-   4) Call the authenticate method on AtOnboardingService.
-   5) Use getAtLookup/getAtClient to get authenticated instances of AtLookup and AtClient respectively which can be used to perform more complex operations on the atSign.
-```
-AtOnboardingService atOnboardingService = AtOnboardingServiceImpl('@alice', atOnboardingPreference);
-atOnboardingService.authenticate();
-AtClient? atClient = await atOnboardingService.atClient;
-AtLookup? atLookup = atOnboardingService.atLookUp;
-```
-
-### Onboarding: 
-Performing initial one-time authentication using cram secret encoded in the qr_code. This process activates the atSign making it ready to use.
-
-#### Steps to onboard:
-   1) Import at_cli_onboarding.
-   2) Set preferences using AtOnboardingPreference. Provide the cram secret for the atsign if you have one.
-   3) If you do not have a cram secret you can just leave it blank. In this case a verification code will be sent to your registered email which you can provide to activate your already registered atsign.
-   4) Instantiate AtOnboardingServiceImpl using the required atSign and a valid instance of AtOnboardingPreference.
-   5) Call the onboard() in AtOnboardingServiceImpl.
-   6) Use authenticated instances of atClient/atLookup now available in AtOnboardingServiceImpl's instance to perform complex operations on the atSign.
- ```
-AtOnboardingService atOnboardingService = AtOnboardingServiceImpl('@alice', atOnboardingPreference);
-atOnboardingService.onboard();
-> Successfully sent verification code to your registered e-mail
-> [Action Required] Enter your verification code:
-<your 4 charcter code here>
-AtClient? atClient = await atOnboardingService.atClient();
-AtLookup? atLookup = atOnboardingService.atLookUp();
-```
-Please refer to [example](https://pub.dev/packages/at_onboarding_cli/example) to better understand the usage.
-
-### activate_cli:
-A simple tool to onboard(activate) an atSign through command-line arguments
-
-#### Usage 1:
-Run the following commands in your command-line tool (Terminal, CMD, PowerShell, etc)
-
-##### To activate using a verification code
-```
-dart pub global activate at_onboarding_cli
-at_activate -a your_atsign
-> Successfully sent verification code to your registered e-mail
-> [Action Required] Enter your verification code:
-<your 4 charcter code here>
-```
-
-##### To activate using your cram secret
-```
-dart pub global activate at_onboarding_cli
-at_activate -a your_atsign -c your_cram_secret
-```
-
-#### Usage 2:
-   1) Clone code from https://github.com/atsign-foundation/at_libraries
-   2) Change directory to at_libraries/at_onboarding_cli in the cloned repository
-   3) Run `dart pub get`
-   4) Run the following command
-```
-dart run bin/activate_cli.dart -a your_atsign -c your_cram_secret
-
-                             (or)
-
-dart run bin/activate_cli.dart -a your_atsign (to activate using verification code)
-```
-[IMPORTANT] You can find your .atKeysFile in directory ~/.atsign/keys after successful activation
-
-
-### register_cli:
-A command-line tool to get yourself a free atsign. This tool fetches a free atsign and registers it to the email provided as arguments.
-
-#### Usage 1:
-Run the following commands in you command-line tool (Terminal, CMD, PowerShell, etc)
-```
-dart pub global activate at_onboarding_cli
-at_register -e your_email
-```
-
-#### Usage 2:
-   1) Clone code from https://github.com/atsign-foundation/at_libraries
-   2) Change directory to at_libraries/at_onboarding_cli in the cloned repository
-   3) Run `dart pub get`
-   4) Run the following command
-```
-dart run bin/register.dart -e email@email.com
-```
-   5) Enter verification code sent to the provided email when prompted
-   6) register_cli fetches the cramkey and the automatically calls activate_cli to activate the fetched atsign
-   7) You can find your .atKeysFile in directory at_onboarding_cli/keys after successful activation
-
-### APKAM Enrollments
-- Please refer to examples/readme.md in the github repository for at_onboarding_cli
+- [`at_auth`](../at_auth) — the lifecycle model this package exposes
+  via CLI
+- [`at_cli_commons`](../at_cli_commons) — thin layer that gets you from
+  already-onboarded atKeys to an authenticated `AtClient` in one line
+- [`at_client_flutter`](../at_client_flutter) — the Flutter-UI
+  equivalent of this package
 
 ## Open source usage and contributions
 
-This is freely licensed open source code, so feel free to use it as is, suggest changes or enhancements or create your
-own version. See CONTRIBUTING.md for detailed guidance on how to setup tools, tests and make a pull request.
+BSD3-licensed. See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) for
+guidance on setting up tools, running tests, and raising a PR.

--- a/packages/at_policy/README.md
+++ b/packages/at_policy/README.md
@@ -9,7 +9,7 @@
 ## Introduction
 The at_policy library provides generic scaffolding for building policy 
 management services which policy enforcement endpoints communicate with via 
-atProtocol and therefore get all the benefits of using atProtocol - outbound 
+Atsign Protocol and therefore get all the benefits of using Atsign Protocol - outbound 
 communication only, end-to-end encryption, using atSigns rather than IP 
 addresses
 

--- a/packages/at_sync_ui_flutter/example/EXAMPLE.md
+++ b/packages/at_sync_ui_flutter/example/EXAMPLE.md
@@ -1,7 +1,7 @@
 <a href="https://atsign.com#gh-light-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only" alt="The Atsign Foundation"></a><a href="https://atsign.com#gh-dark-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2023/08/atsign-logo-horizontal-reverse2022-Color.svg#gh-dark-mode-only" alt="The Atsign Foundation"></a>
 
 ## at_sync_ui_flutter example
-The [at_sync_ui_flutter] package is designed to make it easy for displaying status of sync process in atProtocol apps.
+The [at_sync_ui_flutter] package is designed to make it easy for displaying status of sync process in Atsign Protocol apps.
 
 ### Give it a try
 This package includes a working sample application in the [example](https://github.com/atsign-foundation/at_widgets/tree/trunk/packages/at_sync_ui_flutter/example) directory that demonstrates the key features of the package. To create a personalized copy, use ```at_app create``` as shown below or check it out on GitHub.

--- a/packages/at_sync_ui_flutter/example/README.md
+++ b/packages/at_sync_ui_flutter/example/README.md
@@ -1,7 +1,7 @@
 <a href="https://atsign.com#gh-light-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2022/05/atsign-logo-horizontal-color2022.svg#gh-light-mode-only" alt="The Atsign Foundation"></a><a href="https://atsign.com#gh-dark-mode-only"><img width=250px src="https://atsign.com/wp-content/uploads/2023/08/atsign-logo-horizontal-reverse2022-Color.svg#gh-dark-mode-only" alt="The Atsign Foundation"></a>
 
 ## at_sync_ui_flutter example
-The [at_sync_ui_flutter] package is designed to make it easy for displaying status of sync process in atProtocol apps.
+The [at_sync_ui_flutter] package is designed to make it easy for displaying status of sync process in Atsign Protocol apps.
 
 ### Give it a try
 This package includes a working sample application in the [example](https://github.com/atsign-foundation/at_widgets/tree/trunk/packages/at_sync_ui_flutter/example) directory that demonstrates the key features of the package. To create a personalized copy, use ```at_app create``` as shown below or check it out on GitHub.

--- a/packages/at_utils/README.md
+++ b/packages/at_utils/README.md
@@ -4,5 +4,5 @@
 
 ## at_utils
 
-**at_utils** is the Utility library for atProtocol projects. It contains
+**at_utils** is the Utility library for Atsign Protocol projects. It contains
 utility classes for atsign, atmetadata, configuration and logger.

--- a/tests/at_end2end_test/lib/src/test_preferences.dart
+++ b/tests/at_end2end_test/lib/src/test_preferences.dart
@@ -22,7 +22,6 @@ class TestPreferences {
     var atClientPreference = AtClientPreference();
     atClientPreference.hiveStoragePath = 'test/hive/client';
     atClientPreference.commitLogPath = 'test/hive/client/commit';
-    atClientPreference.isLocalStoreRequired = true;
     atClientPreference.rootDomain = ConfigUtil.getYaml()['root_server']['url'];
     atClientPreference.syncRegex = TestConstants.namespace;
     atClientPreferencesMap.putIfAbsent(atSign, () => atClientPreference);

--- a/tests/at_end2end_test/lib/utils/test_constants.dart
+++ b/tests/at_end2end_test/lib/utils/test_constants.dart
@@ -1,5 +1,4 @@
 // ignore_for_file: constant_identifier_names
-import 'package:at_client/at_client.dart';
 
 class TestConstants {
   static const String PKAM_PRIVATE_KEY = 'pkamPrivateKey';
@@ -9,6 +8,4 @@ class TestConstants {
   static const String SELF_ENCRYPTION_KEY = 'selfEncryptionKey';
   static const namespace = 'e2e_test';
   static const oneMinuteMillis = 60 * 1000;
-  static final ObjectLifeCycleOptions optionsTtlOneMinute =
-      ObjectLifeCycleOptions(timeToLive: Duration(minutes: 1));
 }

--- a/tests/at_end2end_test/test/notify_with_isolate_test.dart
+++ b/tests/at_end2end_test/test/notify_with_isolate_test.dart
@@ -78,7 +78,6 @@ AtClientPreference getAtClientPreferences(String atSign) {
   var atClientPreference = AtClientPreference();
   atClientPreference.hiveStoragePath = 'test/hive/$atSign';
   atClientPreference.commitLogPath = 'test/hive/$atSign/commit/';
-  atClientPreference.isLocalStoreRequired = true;
   atClientPreference.rootDomain = ConfigUtil.getYaml()['root_server']['url'];
   return atClientPreference;
 }


### PR DESCRIPTION
## Summary

Chunk G of 6 (final). Doc-only refreshes for packages whose code wasn't touched elsewhere in the chain, plus a couple of tiny CI workflow / end-to-end test cleanups that don't logically fit any other chunk.

- Root `README.md` and peripheral package READMEs/EXAMPLEs: at_auth, at_lookup, at_policy, at_backupkey_flutter, at_follows_flutter, at_login_flutter, at_notify_flutter (+ example), at_invitation_flutter/example, at_sync_ui_flutter/example, at_utils, at_onboarding_cli.
- `.github/workflows/codeql.yml`, `.github/workflows/dependency-review.yml` — dependabot changes which will vanish once this branch is rebased on trunk
- `tests/at_end2end_test/lib/src/test_preferences.dart`, `lib/utils/test_constants.dart`, `test/notify_with_isolate_test.dart` — tiny cleanups (5 line removals across the three).

## Chain

A → B → CD → E → F → **G (this)**.

> ⚠️ Review against the chain base (`gkc-chunkF-flutter-todos`), not trunk.

## Verification

After this lands, the chain tip is identical to the original PR 1888 (`gkc-enhance-api`) — `git diff gkc-chunkG-orphan-readmes..gkc-enhance-api` is empty.

## Test plan

- [ ] Spot-check rendered READMEs on GitHub.