### PR TITLE
feat(at_commons): add :cl/:nc/:dAt flags and ISO timestamp metadata fields

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 5.10.0
+
+- feat: add `:cl` flag to the `scan` verb syntax, plus
+  `ScanVerbBuilder.commitLog`
+- feat: add `:nc` (no-commit) flag to the `update`, `update:meta`, `update:json`
+  and `delete` verb syntaxes, plus `UpdateVerbBuilder.noCommit` and
+  `DeleteVerbBuilder.noCommit`
+- feat: add `:dAt` (deletedAt) timestamp to the `delete` verb syntax, plus
+  `DeleteVerbBuilder.deletedAt`
+- feat: emit `Metadata.createdAt` / `updatedAt` / `expiresAt` / `availableAt` on
+  the wire as `:cAt:` / `:uAt:` / `:eAt:` / `:aAt:` (used by `update`,
+  `update:meta` and `notify`)
+- feat: timestamp wire format is ISO 8601 UTC with 6 fractional-second digits,
+  e.g. `2026-05-05T11:59:44.123456Z`; helper at `VerbUtil.formatIso8601Micros`
+
 ## 5.9.0
 
 - feat: add `AtKey.fullKey` getter — key name including its namespace

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -4,6 +4,7 @@ import 'package:at_commons/src/keystore/at_key_builder_impl.dart';
 import 'package:at_commons/src/keystore/public_key_hash.dart';
 import 'package:at_commons/src/utils/at_key_regex_utils.dart';
 import 'package:at_commons/src/utils/string_utils.dart';
+import 'package:at_commons/src/verb/verb_util.dart';
 
 import '../at_constants.dart';
 import '../exception/at_exceptions.dart';
@@ -548,6 +549,18 @@ class Metadata {
     }
     if (ccd != null) {
       sb.write(':ccd:$ccd');
+    }
+    if (createdAt != null) {
+      sb.write(':cAt:${VerbUtil.formatIso8601Micros(createdAt!)}');
+    }
+    if (updatedAt != null) {
+      sb.write(':uAt:${VerbUtil.formatIso8601Micros(updatedAt!)}');
+    }
+    if (expiresAt != null) {
+      sb.write(':eAt:${VerbUtil.formatIso8601Micros(expiresAt!)}');
+    }
+    if (availableAt != null) {
+      sb.write(':aAt:${VerbUtil.formatIso8601Micros(availableAt!)}');
     }
     if (dataSignature.isNotNullOrEmpty) {
       sb.write(':${AtConstants.publicDataSignature}:$dataSignature');

--- a/packages/at_commons/lib/src/verb/delete_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/delete_verb_builder.dart
@@ -15,9 +15,24 @@ import 'package:at_commons/src/verb/verb_util.dart';
 class DeleteVerbBuilder extends AbstractVerbBuilder {
   bool force = false;
 
+  /// When true, the server is asked not to write a commit-log entry for this
+  /// delete. Emitted on the wire as the `:nc` flag.
+  bool noCommit = false;
+
+  /// When set, the timestamp at which the deletion is asserted to have
+  /// occurred. Emitted on the wire as `:dAt:<millisecondsSinceEpoch>`.
+  DateTime? deletedAt;
+
   @override
   String buildCommand() {
     StringBuffer serverCommandBuffer = StringBuffer('delete:');
+    if (deletedAt != null) {
+      serverCommandBuffer
+          .write('dAt:${VerbUtil.formatIso8601Micros(deletedAt!)}:');
+    }
+    if (noCommit) {
+      serverCommandBuffer.write('nc:');
+    }
     if (force) {
       serverCommandBuffer.write('force:');
     }
@@ -33,6 +48,10 @@ class DeleteVerbBuilder extends AbstractVerbBuilder {
     builder.atKey.metadata.isPublic =
         verbParams[AtConstants.publicScopeParam] == 'public';
     builder.force = verbParams[AtConstants.force] == AtConstants.force;
+    builder.noCommit = verbParams['noCommit'] != null;
+    if (verbParams['deletedAt'] != null) {
+      builder.deletedAt = DateTime.parse(verbParams['deletedAt']!);
+    }
     builder.atKey.sharedWith =
         VerbUtil.formatAtSign(verbParams[AtConstants.forAtSign]);
     builder.atKey.sharedBy =

--- a/packages/at_commons/lib/src/verb/scan_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/scan_verb_builder.dart
@@ -39,10 +39,17 @@ class ScanVerbBuilder implements VerbBuilder {
   /// Defaulted to false.
   bool showHiddenKeys = false;
 
+  /// If set to true, the server is asked to scan the commit log rather than
+  /// the keystore. Emitted on the wire as the `:cl` flag.
+  bool commitLog = false;
+
   @override
   String buildCommand() {
     StringBuffer serverCommandBuffer = StringBuffer('scan');
 
+    if (commitLog) {
+      serverCommandBuffer.write(':cl');
+    }
     if (showHiddenKeys) {
       serverCommandBuffer.write(':${AtConstants.showHidden}:true');
     }

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -18,8 +18,12 @@ class VerbSyntax {
       r'^plookup:(bypassCache:(?<bypassCache>true|false):)?((?<operation>meta|all):)?(?<atKey>[^@\s]+)@(?<atSign>[^:@\s]+)$';
   static const lookup =
       r'^lookup:(bypassCache:(?<bypassCache>true|false):)?((?<operation>meta|all):)?(?<atKey>(?:[^:]).+)@(?<atSign>[^:@\s]+)$';
-  static const scan =
-      r'^scan$|scan(:showhidden:(?<showhidden>true|false))?(:(?<forAtSign>@[^:@\s]+))?(:page:(?<page>\d+))?( (?<regex>\S+))?$';
+  static const scan = r'^scan$|scan'
+      r'(:cl(?<commitLog>))?'
+      r'(:showhidden:(?<showhidden>true|false))?'
+      r'(:(?<forAtSign>@[^:@\s]+))?'
+      r'(:page:(?<page>\d+))?'
+      r'( (?<regex>\S+))?$';
   static const config =
       r'^config:(?:(?<=config:)block:(?<operation>add|remove|show)(?:(?<=show)\s?$|(?:(?<=add|remove):(?<atSign>(?:@[^:@\s]+)( (?:@[^\s@]+))*$))))|(?:(?<=config:)(?<setOperation>set|reset|print):(?<configNew>.+)$)';
   static const stats =
@@ -34,6 +38,10 @@ class VerbSyntax {
       r'(:ttb:(?<ttb>(-?)\d+))?'
       r'(:ttr:(?<ttr>(-?)\d+))?'
       r'(:ccd:(?<ccd>true|false))?'
+      r'(:cAt:(?<createdAt>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z))?'
+      r'(:uAt:(?<updatedAt>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z))?'
+      r'(:eAt:(?<expiresAt>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z))?'
+      r'(:aAt:(?<availableAt>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z))?'
       r'(:dataSignature:(?<dataSignature>[^:@\s]+))?'
       r'(:sharedKeyStatus:(?<sharedKeyStatus>[^:@\s]+))?'
       r'(:isBinary:(?<isBinary>true|false))?'
@@ -50,24 +58,30 @@ class VerbSyntax {
       r'(:skeEncAlgo:(?<skeEncAlgo>[^:@\s]+))?'
       r'(:immutable:(?<immutable>true|false))?';
 
-  static const update = r'^update:json:(?<json>.+)$'
+  static const update = r'^update'
+      r'(:nc(?<noCommit>))?'
+      r'('
+      r':json:(?<json>.+)'
       r'|'
-      r'^update'
       '$metadataFragment'
       r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'
       r':(?<atKey>(([^:@\s]+)|(privatekey:at_pkam_publickey)))'
       r'(@(?<atSign>[^:@\s]+))?'
       r' (?<value>.+)'
+      r')'
       r'$';
 
   // ignore: constant_identifier_names
   static const update_meta = r'^update:meta'
+      r'(:nc(?<noCommit>))?'
       r'(:((?<publicScope>public)|(@(?<forAtSign>[^:@\s]+))))?'
       r':(?<atKey>[^:@]((?!:{2})[^:@])+)'
       r'@(?<atSign>[^:@\s]+)'
       '$metadataFragment'
       r'$';
   static const delete = r'^delete'
+      r'(:dAt:(?<deletedAt>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z))?'
+      r'(:nc(?<noCommit>))?'
       r'(:(?<force>force))?'
       r'(:priority:(?<priority>low|medium|high))?'
       r'(:cached)?'

--- a/packages/at_commons/lib/src/verb/update_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/update_verb_builder.dart
@@ -48,9 +48,15 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
 
   bool isJson = false;
 
+  /// When true, the server is asked not to write a commit-log entry for this
+  /// update. Emitted on the wire as the `:nc` flag, valid for both the
+  /// metadata-fragment and the `update:json:...` forms.
+  bool noCommit = false;
+
   @override
   String buildCommand() {
     String atKeyName = buildKey();
+    var noCommitFragment = noCommit ? ':nc' : '';
     if (isJson) {
       var updateParams = UpdateParams()
         ..atKey = atKeyName
@@ -59,11 +65,12 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
         ..sharedWith = atKey.sharedWith
         ..metadata = atKey.metadata;
       var json = updateParams.toJson();
-      var command = 'update:json:${jsonEncode(json)}\n';
+      var command = 'update$noCommitFragment:json:${jsonEncode(json)}\n';
       return command;
     } else {
       var metadataFragment = atKey.metadata.toAtProtocolFragment();
-      var command = 'update$metadataFragment:$atKeyName $value\n';
+      var command =
+          'update$noCommitFragment$metadataFragment:$atKeyName $value\n';
       return command;
     }
   }
@@ -81,7 +88,8 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
   String buildCommandForMeta() {
     String atKeyName = buildKey();
     var metadataFragment = atKey.metadata.toAtProtocolFragment();
-    var command = 'update:meta:$atKeyName$metadataFragment\n';
+    var noCommitFragment = noCommit ? ':nc' : '';
+    var command = 'update:meta$noCommitFragment:$atKeyName$metadataFragment\n';
     return command;
   }
 
@@ -124,6 +132,23 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
     if (verbParams[AtConstants.ccd] != null) {
       builder.atKey.metadata.ccd =
           _getBoolVerbParams(verbParams[AtConstants.ccd]!);
+    }
+    builder.noCommit = verbParams['noCommit'] != null;
+    if (verbParams[AtConstants.createdAt] != null) {
+      builder.atKey.metadata.createdAt =
+          DateTime.parse(verbParams[AtConstants.createdAt]!);
+    }
+    if (verbParams[AtConstants.updatedAt] != null) {
+      builder.atKey.metadata.updatedAt =
+          DateTime.parse(verbParams[AtConstants.updatedAt]!);
+    }
+    if (verbParams['expiresAt'] != null) {
+      builder.atKey.metadata.expiresAt =
+          DateTime.parse(verbParams['expiresAt']!);
+    }
+    if (verbParams['availableAt'] != null) {
+      builder.atKey.metadata.availableAt =
+          DateTime.parse(verbParams['availableAt']!);
     }
 
     builder.atKey.metadata.dataSignature =
@@ -207,6 +232,11 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
           atKey.metadata.ttb == other.atKey.metadata.ttb &&
           atKey.metadata.ttr == other.atKey.metadata.ttr &&
           atKey.metadata.ccd == other.atKey.metadata.ccd &&
+          atKey.metadata.createdAt == other.atKey.metadata.createdAt &&
+          atKey.metadata.updatedAt == other.atKey.metadata.updatedAt &&
+          atKey.metadata.expiresAt == other.atKey.metadata.expiresAt &&
+          atKey.metadata.availableAt == other.atKey.metadata.availableAt &&
+          noCommit == other.noCommit &&
           atKey.metadata.dataSignature == other.atKey.metadata.dataSignature &&
           atKey.metadata.sharedKeyStatus ==
               other.atKey.metadata.sharedKeyStatus &&
@@ -236,6 +266,11 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
       atKey.metadata.ttb.hashCode ^
       atKey.metadata.ttr.hashCode ^
       atKey.metadata.ccd.hashCode ^
+      atKey.metadata.createdAt.hashCode ^
+      atKey.metadata.updatedAt.hashCode ^
+      atKey.metadata.expiresAt.hashCode ^
+      atKey.metadata.availableAt.hashCode ^
+      noCommit.hashCode ^
       atKey.metadata.dataSignature.hashCode ^
       atKey.metadata.sharedKeyStatus.hashCode ^
       atKey.metadata.sharedKeyEnc.hashCode ^

--- a/packages/at_commons/lib/src/verb/verb_util.dart
+++ b/packages/at_commons/lib/src/verb/verb_util.dart
@@ -46,4 +46,23 @@ class VerbUtil {
   static String getFormattedValue(String value) {
     return value.replaceAll(newLineReplacePattern, '\n');
   }
+
+  /// Formats [dt] as an ISO 8601 UTC string with exactly six fractional-second
+  /// digits, e.g. `2026-05-05T11:59:44.123456Z`. The wire grammar for
+  /// timestamp metadata fields (cAt/uAt/eAt/aAt/dAt) accepts this shape;
+  /// `DateTime.toIso8601String()` is not used directly because it emits a
+  /// variable number of fractional digits depending on whether the source
+  /// value carries microseconds.
+  static String formatIso8601Micros(DateTime dt) {
+    final utc = dt.toUtc();
+    final y = utc.year.toString().padLeft(4, '0');
+    final mo = utc.month.toString().padLeft(2, '0');
+    final d = utc.day.toString().padLeft(2, '0');
+    final h = utc.hour.toString().padLeft(2, '0');
+    final mi = utc.minute.toString().padLeft(2, '0');
+    final s = utc.second.toString().padLeft(2, '0');
+    final us =
+        (utc.millisecond * 1000 + utc.microsecond).toString().padLeft(6, '0');
+    return '$y-$mo-${d}T$h:$mi:$s.${us}Z';
+  }
 }

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.9.0
+version: 5.10.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_commons/test/delete_verb_test.dart
+++ b/packages/at_commons/test/delete_verb_test.dart
@@ -89,6 +89,86 @@ void main() {
     });
   });
 
+  group('A group of tests for DeleteVerbBuilder noCommit and deletedAt', () {
+    final when = DateTime.utc(2026, 5, 5, 11, 59, 44, 123, 456);
+    const whenIso = '2026-05-05T11:59:44.123456Z';
+
+    test('deletedAt and noCommit are unset by default', () {
+      var builder = DeleteVerbBuilder()
+        ..atKey.key = 'phone'
+        ..atKey.sharedBy = '@bob';
+      expect(builder.noCommit, false);
+      expect(builder.deletedAt, null);
+      expect(builder.buildCommand(), 'delete:phone@bob\n');
+    });
+
+    test('noCommit=true emits :nc:', () {
+      var builder = DeleteVerbBuilder()
+        ..noCommit = true
+        ..atKey.key = 'phone'
+        ..atKey.sharedBy = '@bob';
+      expect(builder.buildCommand(), 'delete:nc:phone@bob\n');
+    });
+
+    test('deletedAt emits :dAt:<iso8601-utc-microseconds>:', () {
+      var builder = DeleteVerbBuilder()
+        ..deletedAt = when
+        ..atKey.key = 'phone'
+        ..atKey.sharedBy = '@bob';
+      expect(builder.buildCommand(), 'delete:dAt:$whenIso:phone@bob\n');
+    });
+
+    test('deletedAt and noCommit emit in regex order: dAt before nc', () {
+      var builder = DeleteVerbBuilder()
+        ..deletedAt = when
+        ..noCommit = true
+        ..atKey.key = 'phone'
+        ..atKey.sharedBy = '@bob';
+      expect(builder.buildCommand(), 'delete:dAt:$whenIso:nc:phone@bob\n');
+    });
+
+    test('deletedAt + noCommit + force on a public shared key', () {
+      var builder = DeleteVerbBuilder()
+        ..deletedAt = when
+        ..noCommit = true
+        ..force = true
+        ..atKey.metadata.isPublic = true
+        ..atKey.key = 'phone'
+        ..atKey.sharedBy = '@bob';
+      expect(builder.buildCommand(),
+          'delete:dAt:$whenIso:nc:force:public:phone@bob\n');
+    });
+
+    test('deletedAt converts a non-UTC source DateTime to UTC on emit', () {
+      var localWhen = DateTime(2026, 5, 5, 11, 59, 44, 123, 456);
+      var builder = DeleteVerbBuilder()
+        ..deletedAt = localWhen
+        ..atKey.key = 'phone'
+        ..atKey.sharedBy = '@bob';
+      var command = builder.buildCommand();
+      expect(command, contains('Z:phone@bob'));
+      var rebuilt = DeleteVerbBuilder.getBuilder(command.trim());
+      expect(rebuilt.deletedAt!.isUtc, true);
+      expect(rebuilt.deletedAt!.microsecondsSinceEpoch,
+          localWhen.microsecondsSinceEpoch);
+    });
+
+    test('getBuilder round-trips noCommit and deletedAt', () {
+      String command = 'delete:dAt:$whenIso:nc:@alice:phone.wavi@bob\n';
+      var builder = DeleteVerbBuilder.getBuilder(command.trim());
+      expect(builder.noCommit, true);
+      expect(builder.deletedAt, when);
+      expect(builder.buildCommand(), command);
+    });
+
+    test('getBuilder leaves noCommit=false and deletedAt=null when absent', () {
+      String command = 'delete:@alice:phone.wavi@bob\n';
+      var builder = DeleteVerbBuilder.getBuilder(command.trim());
+      expect(builder.noCommit, false);
+      expect(builder.deletedAt, null);
+    });
+  });
+
   group('A group of tests to validate the exceptions', () {
     test('test to verify cached local key throws invalid atkey exception', () {
       expect(

--- a/packages/at_commons/test/scan_verb_test.dart
+++ b/packages/at_commons/test/scan_verb_test.dart
@@ -71,4 +71,36 @@ void main() {
       expect(verbParams[AtConstants.regex], '.wavi');
     });
   });
+
+  group('A group of tests for ScanVerbBuilder commitLog flag', () {
+    test('commitLog is false by default and :cl is not emitted', () {
+      var builder = ScanVerbBuilder();
+      expect(builder.commitLog, false);
+      expect(builder.buildCommand(), 'scan\n');
+    });
+
+    test('commitLog=true emits :cl immediately after scan', () {
+      var builder = ScanVerbBuilder()..commitLog = true;
+      expect(builder.buildCommand(), 'scan:cl\n');
+    });
+
+    test('commitLog=true combines with showHidden, sharedBy and regex', () {
+      var builder = ScanVerbBuilder()
+        ..commitLog = true
+        ..showHiddenKeys = true
+        ..sharedBy = '@alice'
+        ..regex = '.wavi';
+      expect(builder.buildCommand(), 'scan:cl:showhidden:true:@alice .wavi\n');
+    });
+
+    test('commitLog command parses back through the regex', () {
+      var builder = ScanVerbBuilder()
+        ..commitLog = true
+        ..sharedBy = '@alice';
+      var verbParams =
+          getVerbParams(VerbSyntax.scan, builder.buildCommand().trim());
+      expect(verbParams['commitLog'], '');
+      expect(verbParams[AtConstants.forAtSign], '@alice');
+    });
+  });
 }

--- a/packages/at_commons/test/syntax_test.dart
+++ b/packages/at_commons/test/syntax_test.dart
@@ -354,6 +354,260 @@ void main() {
       expect(enrollVerbParams['operation'], 'get');
     });
   });
+
+  group('A group of tests for the scan verb commitLog flag', () {
+    test('scan with :cl flag sets commitLog group', () {
+      var command = 'scan:cl';
+      var verbParams = getVerbParams(VerbSyntax.scan, command);
+      expect(verbParams['commitLog'], '');
+    });
+
+    test('scan without :cl flag leaves commitLog group null', () {
+      var command = 'scan';
+      var verbParams = getVerbParams(VerbSyntax.scan, command);
+      expect(verbParams['commitLog'], null);
+    });
+
+    test('scan with :cl combined with showhidden, forAtSign, page, regex', () {
+      var command = 'scan:cl:showhidden:true:@alice:page:2 .wavi';
+      var verbParams = getVerbParams(VerbSyntax.scan, command);
+      expect(verbParams['commitLog'], '');
+      expect(verbParams[AtConstants.showHidden], 'true');
+      expect(verbParams[AtConstants.forAtSign], '@alice');
+      expect(verbParams[AtConstants.page], '2');
+      expect(verbParams[AtConstants.regex], '.wavi');
+    });
+
+    test('scan: :cl must precede showhidden — wrong order does not match', () {
+      var command = 'scan:showhidden:true:cl';
+      expect(
+          () => getVerbParams(VerbSyntax.scan, command),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidSyntaxException &&
+              e.message == 'command does not match the regex')));
+    });
+  });
+
+  group('A group of tests for the update verb noCommit flag', () {
+    test('update with :nc flag sets noCommit group', () {
+      var command = 'update:nc:@alice:phone@bob 12345';
+      var verbParams = getVerbParams(VerbSyntax.update, command);
+      expect(verbParams['noCommit'], '');
+      expect(verbParams[AtConstants.atKey], 'phone');
+      expect(verbParams[AtConstants.forAtSign], 'alice');
+      expect(verbParams[AtConstants.atSign], 'bob');
+      expect(verbParams[AtConstants.value], '12345');
+    });
+
+    test('update without :nc flag leaves noCommit group null', () {
+      var command = 'update:@alice:phone@bob 12345';
+      var verbParams = getVerbParams(VerbSyntax.update, command);
+      expect(verbParams['noCommit'], null);
+    });
+
+    test('update with :nc and metadata fields', () {
+      var command = 'update:nc:ttl:1000:ttr:-1:@alice:phone@bob 12345';
+      var verbParams = getVerbParams(VerbSyntax.update, command);
+      expect(verbParams['noCommit'], '');
+      expect(verbParams[AtConstants.ttl], '1000');
+      expect(verbParams[AtConstants.ttr], '-1');
+    });
+  });
+
+  group('A group of tests for the update:meta verb noCommit flag', () {
+    test('update:meta with :nc flag sets noCommit group', () {
+      var command = 'update:meta:nc:@alice:phone@bob:ttl:5000';
+      var verbParams = getVerbParams(VerbSyntax.update_meta, command);
+      expect(verbParams['noCommit'], '');
+      expect(verbParams[AtConstants.atKey], 'phone');
+      expect(verbParams[AtConstants.forAtSign], 'alice');
+      expect(verbParams[AtConstants.atSign], 'bob');
+      expect(verbParams[AtConstants.ttl], '5000');
+    });
+
+    test('update:meta without :nc flag leaves noCommit group null', () {
+      var command = 'update:meta:@alice:phone@bob:ttl:5000';
+      var verbParams = getVerbParams(VerbSyntax.update_meta, command);
+      expect(verbParams['noCommit'], null);
+    });
+  });
+
+  group('A group of tests for metadata timestamp fields', () {
+    const cAt = '2026-05-05T11:59:44.123456Z';
+    const uAt = '2026-05-05T11:59:45.000000Z';
+    const eAt = '2026-05-05T11:59:46.999000Z';
+    const aAt = '2026-05-05T11:59:47.500000Z';
+
+    test('update with all timestamp fields captures ISO values', () {
+      var command = 'update'
+          ':cAt:$cAt'
+          ':uAt:$uAt'
+          ':eAt:$eAt'
+          ':aAt:$aAt'
+          ':@alice:phone@bob 12345';
+      var verbParams = getVerbParams(VerbSyntax.update, command);
+      expect(verbParams[AtConstants.createdAt], cAt);
+      expect(verbParams[AtConstants.updatedAt], uAt);
+      expect(verbParams['expiresAt'], eAt);
+      expect(verbParams['availableAt'], aAt);
+    });
+
+    test('update with only createdAt captures the ISO value', () {
+      var command = 'update:cAt:$cAt:@alice:phone@bob 12345';
+      var verbParams = getVerbParams(VerbSyntax.update, command);
+      expect(verbParams[AtConstants.createdAt], cAt);
+      expect(verbParams[AtConstants.updatedAt], null);
+      expect(verbParams['expiresAt'], null);
+      expect(verbParams['availableAt'], null);
+    });
+
+    test('update without any timestamp fields leaves them null', () {
+      var command = 'update:@alice:phone@bob 12345';
+      var verbParams = getVerbParams(VerbSyntax.update, command);
+      expect(verbParams[AtConstants.createdAt], null);
+      expect(verbParams[AtConstants.updatedAt], null);
+      expect(verbParams['expiresAt'], null);
+      expect(verbParams['availableAt'], null);
+    });
+
+    test('update:meta with all timestamp fields captures ISO values', () {
+      var command = 'update:meta:@alice:phone@bob'
+          ':cAt:$cAt'
+          ':uAt:$uAt'
+          ':eAt:$eAt'
+          ':aAt:$aAt';
+      var verbParams = getVerbParams(VerbSyntax.update_meta, command);
+      expect(verbParams[AtConstants.createdAt], cAt);
+      expect(verbParams[AtConstants.updatedAt], uAt);
+      expect(verbParams['expiresAt'], eAt);
+      expect(verbParams['availableAt'], aAt);
+    });
+
+    test('update with timestamps alongside ttl/ttr and dataSignature', () {
+      var command = 'update'
+          ':ttl:1000'
+          ':ttr:-1'
+          ':cAt:$cAt'
+          ':uAt:$uAt'
+          ':dataSignature:abc'
+          ':@alice:phone@bob 12345';
+      var verbParams = getVerbParams(VerbSyntax.update, command);
+      expect(verbParams[AtConstants.ttl], '1000');
+      expect(verbParams[AtConstants.ttr], '-1');
+      expect(verbParams[AtConstants.createdAt], cAt);
+      expect(verbParams[AtConstants.updatedAt], uAt);
+      expect(verbParams[AtConstants.publicDataSignature], 'abc');
+    });
+
+    test('timestamps with millisecond-precision fractional seconds match', () {
+      var command = 'update:cAt:2026-05-05T11:59:44.123Z'
+          ':@alice:phone@bob 12345';
+      var verbParams = getVerbParams(VerbSyntax.update, command);
+      expect(verbParams[AtConstants.createdAt], '2026-05-05T11:59:44.123Z');
+    });
+
+    test('timestamps with no fractional-second component match', () {
+      var command = 'update:cAt:2026-05-05T11:59:44Z'
+          ':@alice:phone@bob 12345';
+      var verbParams = getVerbParams(VerbSyntax.update, command);
+      expect(verbParams[AtConstants.createdAt], '2026-05-05T11:59:44Z');
+    });
+
+    test('non-UTC ISO (no Z suffix) is rejected', () {
+      var command = 'update:cAt:2026-05-05T11:59:44.123456'
+          ':@alice:phone@bob 12345';
+      expect(
+          () => getVerbParams(VerbSyntax.update, command),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidSyntaxException &&
+              e.message == 'command does not match the regex')));
+    });
+
+    test('numeric ms-since-epoch is not accepted', () {
+      var command = 'update:cAt:1730000000000:@alice:phone@bob 12345';
+      expect(
+          () => getVerbParams(VerbSyntax.update, command),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidSyntaxException &&
+              e.message == 'command does not match the regex')));
+    });
+  });
+
+  group('A group of tests for the delete verb deletedAt and noCommit', () {
+    const dAt = '2026-05-05T11:59:44.123456Z';
+
+    test('delete with :dAt captures the deletedAt ISO value', () {
+      var command = 'delete:dAt:$dAt:@alice:phone@bob';
+      var verbParams = getVerbParams(VerbSyntax.delete, command);
+      expect(verbParams['deletedAt'], dAt);
+      expect(verbParams[AtConstants.forAtSign], 'alice');
+      expect(verbParams[AtConstants.atKey], 'phone');
+      expect(verbParams[AtConstants.atSign], 'bob');
+    });
+
+    test('delete with :nc flag sets noCommit group', () {
+      var command = 'delete:nc:@alice:phone@bob';
+      var verbParams = getVerbParams(VerbSyntax.delete, command);
+      expect(verbParams['noCommit'], '');
+      expect(verbParams['deletedAt'], null);
+    });
+
+    test('delete with :dAt and :nc together', () {
+      var command = 'delete:dAt:$dAt:nc:@alice:phone@bob';
+      var verbParams = getVerbParams(VerbSyntax.delete, command);
+      expect(verbParams['deletedAt'], dAt);
+      expect(verbParams['noCommit'], '');
+    });
+
+    test('delete with :dAt, :nc, :force, :priority, public scope', () {
+      var command = 'delete:dAt:$dAt:nc:force:priority:high:public:phone@bob';
+      var verbParams = getVerbParams(VerbSyntax.delete, command);
+      expect(verbParams['deletedAt'], dAt);
+      expect(verbParams['noCommit'], '');
+      expect(verbParams[AtConstants.force], 'force');
+      expect(verbParams[AtConstants.priority], 'high');
+      expect(verbParams[AtConstants.publicScopeParam], 'public');
+      expect(verbParams[AtConstants.atKey], 'phone');
+      expect(verbParams[AtConstants.atSign], 'bob');
+    });
+
+    test('delete without :dAt or :nc still parses (regression)', () {
+      var command = 'delete:@alice:phone@bob';
+      var verbParams = getVerbParams(VerbSyntax.delete, command);
+      expect(verbParams['deletedAt'], null);
+      expect(verbParams['noCommit'], null);
+      expect(verbParams[AtConstants.forAtSign], 'alice');
+      expect(verbParams[AtConstants.atKey], 'phone');
+      expect(verbParams[AtConstants.atSign], 'bob');
+    });
+
+    test('delete: order is fixed — :nc before :dAt does not match', () {
+      var command = 'delete:nc:dAt:$dAt:@alice:phone@bob';
+      expect(
+          () => getVerbParams(VerbSyntax.delete, command),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidSyntaxException &&
+              e.message == 'command does not match the regex')));
+    });
+
+    test('delete: :dAt rejects non-UTC ISO (no Z suffix)', () {
+      var command = 'delete:dAt:2026-05-05T11:59:44.123456:@alice:phone@bob';
+      expect(
+          () => getVerbParams(VerbSyntax.delete, command),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidSyntaxException &&
+              e.message == 'command does not match the regex')));
+    });
+
+    test('delete: numeric ms-since-epoch is not accepted', () {
+      var command = 'delete:dAt:1730000000000:@alice:phone@bob';
+      expect(
+          () => getVerbParams(VerbSyntax.delete, command),
+          throwsA(predicate((dynamic e) =>
+              e is InvalidSyntaxException &&
+              e.message == 'command does not match the regex')));
+    });
+  });
 }
 
 Map getVerbParams(String regex, String command) {

--- a/packages/at_commons/test/update_verb_builder_test.dart
+++ b/packages/at_commons/test/update_verb_builder_test.dart
@@ -634,7 +634,6 @@ void main() {
       var updateBuilder = UpdateVerbBuilder()
         ..value = 'sampleEncryptedValue'
         ..atKey.metadata.ttl = 5000
-        ..atKey.metadata.isEncrypted = false
         ..atKey.key = 'email'
         ..atKey.sharedBy = '@alice'
         ..atKey.sharedWith = '@bob';
@@ -646,6 +645,171 @@ void main() {
           getVerbParams(VerbSyntax.update, updateCommand.trim());
       print(updateVerbParams);
       expect(updateVerbParams['isEncrypted'], 'false');
+    });
+  });
+
+  group('A group of tests for UpdateVerbBuilder noCommit flag', () {
+    test('noCommit is false by default and :nc is not emitted', () {
+      var builder = UpdateVerbBuilder()
+        ..value = 'v'
+        ..atKey.key = 'phone'
+        ..atKey.sharedBy = '@alice';
+      expect(builder.noCommit, false);
+      expect(
+          builder.buildCommand(), 'update:isEncrypted:false:phone@alice v\n');
+    });
+
+    test('noCommit=true emits :nc immediately after update', () {
+      var builder = UpdateVerbBuilder()
+        ..noCommit = true
+        ..value = 'v'
+        ..atKey.key = 'phone'
+        ..atKey.sharedBy = '@alice';
+      expect(builder.buildCommand(),
+          'update:nc:isEncrypted:false:phone@alice v\n');
+    });
+
+    test('noCommit=true also emits :nc on the update:meta form', () {
+      var builder = UpdateVerbBuilder()
+        ..noCommit = true
+        ..atKey.key = 'phone'
+        ..atKey.sharedBy = '@alice';
+      expect(builder.buildCommandForMeta(),
+          'update:meta:nc:phone@alice:isEncrypted:false\n');
+    });
+
+    test('noCommit=true emits :nc on the json form', () {
+      var builder = UpdateVerbBuilder()
+        ..noCommit = true
+        ..isJson = true
+        ..value = 'alice@gmail.com'
+        ..atKey.key = 'email'
+        ..atKey.sharedBy = '@alice';
+      var command = builder.buildCommand();
+      expect(command, startsWith('update:nc:json:'));
+      var verbParams = getVerbParams(VerbSyntax.update, command.trim());
+      expect(verbParams['noCommit'], '');
+      expect(verbParams['json'], isNotNull);
+    });
+
+    test('json form without noCommit does not emit :nc', () {
+      var builder = UpdateVerbBuilder()
+        ..isJson = true
+        ..value = 'alice@gmail.com'
+        ..atKey.key = 'email'
+        ..atKey.sharedBy = '@alice';
+      var command = builder.buildCommand();
+      expect(command, startsWith('update:json:'));
+      var verbParams = getVerbParams(VerbSyntax.update, command.trim());
+      expect(verbParams['noCommit'], null);
+    });
+
+    test('getBuilder round-trips noCommit on the metadata-fragment form', () {
+      String command = 'update:nc:ttl:5000:@bob:phone@alice 1234\n';
+      var builder = UpdateVerbBuilder.getBuilder(command.trim())!;
+      expect(builder.noCommit, true);
+      expect(builder.atKey.metadata.ttl, 5000);
+    });
+
+    test('getBuilder round-trips noCommit on the update:meta form', () {
+      String command = 'update:meta:nc:@bob:phone@alice:ttl:5000\n';
+      var builder = UpdateVerbBuilder.getBuilder(command.trim())!;
+      expect(builder.noCommit, true);
+      expect(builder.operation, AtConstants.updateMeta);
+      expect(builder.atKey.metadata.ttl, 5000);
+    });
+  });
+
+  group('A group of tests for UpdateVerbBuilder metadata timestamps', () {
+    final cAt = DateTime.utc(2026, 5, 5, 11, 59, 44, 123, 456);
+    final uAt = DateTime.utc(2026, 5, 5, 11, 59, 45, 0, 0);
+    final eAt = DateTime.utc(2026, 5, 5, 11, 59, 46, 999, 0);
+    final aAt = DateTime.utc(2026, 5, 5, 11, 59, 47, 500, 0);
+    const cAtIso = '2026-05-05T11:59:44.123456Z';
+    const uAtIso = '2026-05-05T11:59:45.000000Z';
+    const eAtIso = '2026-05-05T11:59:46.999000Z';
+    const aAtIso = '2026-05-05T11:59:47.500000Z';
+
+    test(
+        'toAtProtocolFragment emits cAt/uAt/eAt/aAt as ISO 8601 UTC microseconds',
+        () {
+      var metadata = Metadata()
+        ..createdAt = cAt
+        ..updatedAt = uAt
+        ..expiresAt = eAt
+        ..availableAt = aAt;
+      var fragment = metadata.toAtProtocolFragment();
+      expect(fragment, contains(':cAt:$cAtIso'));
+      expect(fragment, contains(':uAt:$uAtIso'));
+      expect(fragment, contains(':eAt:$eAtIso'));
+      expect(fragment, contains(':aAt:$aAtIso'));
+    });
+
+    test('toAtProtocolFragment emits timestamps in regex order (after ccd)',
+        () {
+      var metadata = Metadata()
+        ..ttl = 1000
+        ..ccd = true
+        ..createdAt = cAt
+        ..updatedAt = uAt
+        ..expiresAt = eAt
+        ..availableAt = aAt;
+      var fragment = metadata.toAtProtocolFragment();
+      expect(
+          fragment,
+          startsWith(':ttl:1000:ccd:true'
+              ':cAt:$cAtIso'
+              ':uAt:$uAtIso'
+              ':eAt:$eAtIso'
+              ':aAt:$aAtIso'));
+    });
+
+    test('toAtProtocolFragment omits unset timestamps', () {
+      var metadata = Metadata()..ttl = 1000;
+      expect(metadata.toAtProtocolFragment(), isNot(contains(':cAt:')));
+      expect(metadata.toAtProtocolFragment(), isNot(contains(':uAt:')));
+      expect(metadata.toAtProtocolFragment(), isNot(contains(':eAt:')));
+      expect(metadata.toAtProtocolFragment(), isNot(contains(':aAt:')));
+    });
+
+    test('toAtProtocolFragment always emits 6 fractional-second digits', () {
+      var metadata = Metadata()
+        ..createdAt = DateTime.utc(2026, 1, 1, 0, 0, 0); // zero fractional
+      var fragment = metadata.toAtProtocolFragment();
+      expect(fragment, contains(':cAt:2026-01-01T00:00:00.000000Z'));
+    });
+
+    test('UpdateVerbBuilder full round-trip preserves all four timestamps', () {
+      var builder = UpdateVerbBuilder()
+        ..value = 'v'
+        ..atKey.key = 'phone'
+        ..atKey.sharedBy = '@alice'
+        ..atKey.sharedWith = '@bob'
+        ..atKey.metadata.createdAt = cAt
+        ..atKey.metadata.updatedAt = uAt
+        ..atKey.metadata.expiresAt = eAt
+        ..atKey.metadata.availableAt = aAt;
+      var command = builder.buildCommand();
+      var rebuilt = UpdateVerbBuilder.getBuilder(command.trim())!;
+      expect(rebuilt.atKey.metadata.createdAt, cAt);
+      expect(rebuilt.atKey.metadata.updatedAt, uAt);
+      expect(rebuilt.atKey.metadata.expiresAt, eAt);
+      expect(rebuilt.atKey.metadata.availableAt, aAt);
+    });
+
+    test('UpdateVerbBuilder converts a non-UTC source DateTime to UTC on emit',
+        () {
+      var localCAt = DateTime(2026, 5, 5, 11, 59, 44, 123, 456);
+      var builder = UpdateVerbBuilder()
+        ..value = 'v'
+        ..atKey.key = 'phone'
+        ..atKey.sharedBy = '@alice'
+        ..atKey.metadata.createdAt = localCAt;
+      var command = builder.buildCommand();
+      var rebuilt = UpdateVerbBuilder.getBuilder(command.trim())!;
+      expect(rebuilt.atKey.metadata.createdAt!.isUtc, true);
+      expect(rebuilt.atKey.metadata.createdAt!.microsecondsSinceEpoch,
+          localCAt.microsecondsSinceEpoch);
     });
   });
 }


### PR DESCRIPTION
## Summary

Wire-protocol additions in `at_commons`, plus matching builder support, regex tightening, and tests.

## Purpose
- `createdAt`, `updatedAt`, `expiresAt` and `availableAt` timestamps need to be transmitted faithfully between clients and atServers, and between atServers rather than the current situation which is rederiving those values. We need to extend the atsign protocol syntax to include those timestamps.
- We also need the ability for `delete` to specify a `deletedAt` value, which will be used by the fsync (fast streaming sync) algorithm as well as the `updatedAt` value
- commit logs sometimes accumulate cruft which affects atServer performance and client sync performance, but currently we have no way to enable clients to deal with that.
  - We add the ability for update and delete to specify "no commit" meaning
    - (i) do the actual command as usual but
    - (ii) do not create a commit log entry for this command, and not only that, but also
    - (iii) delete any existing commit log entry for the record key.
  - We add the `:cl` flag to the scan syntax
  - In combination this means that a client can issue a `scan:cl:...` command for commit log entries and then issue `delete:nc:...` commands for commit log entries we don't like
  - Note that we will also be adding an automatic commitlog pruning to atServer which will automatically prune commitlog entries for keys which no longer exist and were deleted more than 90 days ago. All of this together will allows clients to properly manage their atServer commit log. (Aside: as with all other commands, these operations are access-controlled by the APKAM namespaces of the connected client.)

Once this version has been published, we will bump the atServer dependency, verify, then do a canary rollout followed by a full prod rollout a day or so later. This will add the syntax to the atServers although no capability as yet. We can then proceed to implement and rollout the actual feature functionality behind all of these changes, in the atServer and atClients.

### Verb syntax additions
- `scan` gains a `:cl` flag (commitLog) — `ScanVerbBuilder.commitLog`
- `update` / `update:meta` / `update:json` / `delete` gain a `:nc` flag (no-commit) — `UpdateVerbBuilder.noCommit`, `DeleteVerbBuilder.noCommit`
- `delete` gains a `:dAt` timestamp — `DeleteVerbBuilder.deletedAt`
- `metadataFragment` gains `:cAt:` / `:uAt:` / `:eAt:` / `:aAt:` emissions, used by `update`, `update:meta` and `notify` — sourced from existing `Metadata.createdAt` / `updatedAt` / `expiresAt` / `availableAt` fields

### Timestamp wire format
ISO 8601 UTC with exactly six fractional-second digits, e.g. `2026-05-05T11:59:44.123456Z`. New helper `VerbUtil.formatIso8601Micros` emits this shape; `DateTime.toIso8601String()` is not used directly because its fractional precision varies with the input.

### Notable internal detail
The `update` regex shares a single `(:nc(?<noCommit>))?` prefix between the `:json:` and metadata-fragment alternatives, since Dart's `RegExp` engine forbids duplicate named groups across alternation.

### Version
Bumps `at_commons` to **5.10.0** (5.9.0 is published on pub.dev).

## How to verify it
- Tests pass