### PR TITLE
fix(at_client): stop AtCollection scans from matching local: bookkeeping keys (#1942)

### DIFF
--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -259,15 +259,8 @@ class LocalSecondary implements Secondary {
     required bool cameFromServer,
     int? commitLogSeqNum,
   }) async {
-    if (cameFromServer) {
-      _logger.info('ENQUEUE_DIAG: $atKey op=$op skipped (cameFromServer)');
-      return;
-    }
-    if (!shouldEnqueueForSync(atKey, op)) {
-      _logger.info('ENQUEUE_DIAG: $atKey op=$op skipped '
-          '(shouldEnqueueForSync=false)');
-      return;
-    }
+    if (cameFromServer) return;
+    if (!shouldEnqueueForSync(atKey, op)) return;
     try {
       final q = await _ensureSyncQueueOpen();
       final prior = q.readEntry(atKey);
@@ -275,8 +268,6 @@ class LocalSecondary implements Secondary {
         await _removeOrphanedCommitLogEntry(prior.commitLogSeqNum!);
       }
       await q.enqueue(atKey, op, commitLogSeqNum: commitLogSeqNum);
-      _logger.info('ENQUEUE_DIAG: $atKey op=$op enqueued; '
-          'queueSize=${q.size} syncSvc#${identityHashCode(_atClient.syncService)}');
       // Trigger SyncServiceImpl to drain. Today this enqueues a
       // sync request via the existing request-coalescing layer
       // (`_addSyncRequestToQueue` → microtask → `processSyncRequests`).

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -67,6 +67,32 @@ class LocalSecondary implements Secondary {
   AtSyncQueue? _syncQueue;
   Future<AtSyncQueue>? _syncQueueOpenInflight;
 
+  /// Tracks atKeys with a currently-executing [_update] / [_delete] —
+  /// i.e. a write that has entered the keystore mutation phase but
+  /// hasn't yet enqueued for sync. The sync service's pull-side
+  /// conflict-detection consults [isWriteInProgress] alongside the
+  /// sync queue, so a pull entry whose atKey matches an in-flight
+  /// local write is treated as a conflict (skip apply, preserve the
+  /// user's value).
+  ///
+  /// Without this, the window between [LocalSecondary]'s keystore op
+  /// (which writes the new value to Hive) and its `_enqueueForSync`
+  /// call (which appends to the sync queue) is unprotected — a pull
+  /// firing in that window finds an empty queue, applies its entry,
+  /// and silently overwrites the user's just-written value. The push
+  /// path then reads the overwritten value and sends *that* to the
+  /// server: the bug observed by `bypasscache_test`'s assertion that
+  /// the updated value reaches the receiver.
+  ///
+  /// In-memory only — no Hive write per op. Per [LocalSecondary]
+  /// instance.
+  final Set<String> _writesInProgress = <String>{};
+
+  /// True if a [_update] or [_delete] for [atKey] is currently
+  /// executing on this LocalSecondary. Synchronous, cheap. Consulted
+  /// by `SyncServiceImpl._syncFromServer` per pull entry.
+  bool isWriteInProgress(String atKey) => _writesInProgress.contains(atKey);
+
   LocalSecondary(
     this._atClient, {
     this.keyStore,
@@ -327,9 +353,15 @@ class LocalSecondary implements Secondary {
 
   Future<String> _update(UpdateVerbBuilder builder,
       {bool cameFromServer = false}) async {
+    final updateKey = builder.buildKey();
+    // Mark this key as having a write in progress so the sync pull's
+    // conflict-detection (in `SyncServiceImpl._syncFromServer`) skips
+    // any server entry for the same atKey that arrives during the
+    // window between keystore op and queue enqueue. cameFromServer
+    // writes are server-applied (no race possible with our own queue).
+    if (!cameFromServer) _writesInProgress.add(updateKey);
     try {
       dynamic updateResult;
-      var updateKey = builder.buildKey();
       if (!await isEnrollmentAuthorizedForOperation(updateKey, builder)) {
         throw UnAuthorizedException(
             'Cannot perform update on $updateKey due to insufficient privilege');
@@ -461,6 +493,8 @@ class LocalSecondary implements Secondary {
     } on DataStoreException catch (e) {
       _logger.severe('exception in local update:${e.toString()}');
       rethrow;
+    } finally {
+      if (!cameFromServer) _writesInProgress.remove(updateKey);
     }
   }
 
@@ -497,6 +531,11 @@ class LocalSecondary implements Secondary {
       throw UnAuthorizedException(
           'Cannot perform delete on $deleteKey due to insufficient privilege');
     }
+    // Same pull-race protection as _update — a server entry for the
+    // same atKey arriving during the keystore-op-to-enqueue window
+    // would otherwise overwrite our pending delete with the prior
+    // server value (then push pushes back the wrong op).
+    if (!cameFromServer && !localOnly) _writesInProgress.add(deleteKey);
     try {
       var deleteResult = await keyStore!.remove(deleteKey);
       // `wasExpired` mirrors `localOnly` here — the only caller that
@@ -543,6 +582,8 @@ class LocalSecondary implements Secondary {
     } on DataStoreException catch (e) {
       _logger.severe('exception in delete:${e.toString()}');
       rethrow;
+    } finally {
+      if (!cameFromServer && !localOnly) _writesInProgress.remove(deleteKey);
     }
   }
 

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -233,8 +233,15 @@ class LocalSecondary implements Secondary {
     required bool cameFromServer,
     int? commitLogSeqNum,
   }) async {
-    if (cameFromServer) return;
-    if (!shouldEnqueueForSync(atKey, op)) return;
+    if (cameFromServer) {
+      _logger.info('ENQUEUE_DIAG: $atKey op=$op skipped (cameFromServer)');
+      return;
+    }
+    if (!shouldEnqueueForSync(atKey, op)) {
+      _logger.info('ENQUEUE_DIAG: $atKey op=$op skipped '
+          '(shouldEnqueueForSync=false)');
+      return;
+    }
     try {
       final q = await _ensureSyncQueueOpen();
       final prior = q.readEntry(atKey);
@@ -242,6 +249,8 @@ class LocalSecondary implements Secondary {
         await _removeOrphanedCommitLogEntry(prior.commitLogSeqNum!);
       }
       await q.enqueue(atKey, op, commitLogSeqNum: commitLogSeqNum);
+      _logger.info('ENQUEUE_DIAG: $atKey op=$op enqueued; '
+          'queueSize=${q.size} syncSvc#${identityHashCode(_atClient.syncService)}');
       // Trigger SyncServiceImpl to drain. Today this enqueues a
       // sync request via the existing request-coalescing layer
       // (`_addSyncRequestToQueue` → microtask → `processSyncRequests`).

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -93,6 +93,12 @@ class LocalSecondary implements Secondary {
   /// by `SyncServiceImpl._syncFromServer` per pull entry.
   bool isWriteInProgress(String atKey) => _writesInProgress.contains(atKey);
 
+  /// Immutable snapshot of the in-progress writes set. Test-only
+  /// seam — production code consults [isWriteInProgress] per key.
+  @visibleForTesting
+  Set<String> get writesInProgressForTest =>
+      Set<String>.unmodifiable(_writesInProgress);
+
   LocalSecondary(
     this._atClient, {
     this.keyStore,

--- a/packages/at_client/lib/src/collections/collections.dart
+++ b/packages/at_client/lib/src/collections/collections.dart
@@ -302,6 +302,19 @@ enum EventSource { data, notifs, both }
 /// `await for` without an `onError` handler will throw on the first
 /// bad key. Apps that want the old silent-skip posture should chain
 /// `.handleError(...)` before consuming the stream.
+/// Leading anchor shared by every AtKey scan AtCollection emits.
+///
+///   - `^(?!local:)` rejects any key whose wire form starts with
+///     `local:` — those are at_client's own bookkeeping keys
+///     (`local:lastreceivednotification@…`, the server-commit-id
+///     cursor, etc.) and must never be confused with collection
+///     items, even when their tail happens to share the namespace
+///     shape (the underlying defect behind #1942).
+///   - `(?:[^:]*:)?` tolerates an optional sharedWith prefix
+///     (`@bob:`, `cached:@bob:`) so the same regex can match an
+///     outgoing-shared or cached-incoming copy of a self-owned key.
+const String _atKeyScanPrefix = r'^(?!local:)(?:[^:]*:)?';
+
 interface class AtCollection<T> {
   static const String _rr = '__rr';
 
@@ -390,6 +403,15 @@ interface class AtCollection<T> {
   // length — not by separate per-depth regexes.
   late final RegExp _regexObjAny;
   late final String _regexAllStr;
+
+  /// `namespace` with every literal `.` escaped — produced once at
+  /// construction and reused at every scan site. Namespaces commonly
+  /// contain periods (e.g. `samples.dockerstats.demos`) and an
+  /// unescaped `.` in a regex matches any character, so the
+  /// non-escaped form would wrongly accept keys like
+  /// `lastreceivednotification.<ns>@<atSign>` whose first `.` lines
+  /// up with the namespace's first `.` (see #1942).
+  late final String _escapedNamespace;
 
   /// Which source(s) this collection consumes events from. Set once
   /// at construction and immutable for the lifetime of the collection.
@@ -567,15 +589,21 @@ interface class AtCollection<T> {
 
     _logger = AtSignLogger(' AtCollection<$T> $namespace ');
 
-    // TODO: namespace may contain periods - the regular expression should
-    // escape those periods
-    _regexAllStr = '.*\\.$namespace@';
-    // Matches the direct-item shape `<id>.<ns>@` AND any deeper
-    // sub-item shape `<id>.<subName>.<parentId>.…<ns>@`. We use this
-    // as a cheap filter to reject notifications that don't belong to
-    // this collection at all; depth-dispatch happens via the parsed
-    // ancestry length, not by regex.
-    _regexObjAny = RegExp('(^|:)[^.]+(\\.[^.]+)*\\.$namespace@');
+    _escapedNamespace = namespace.replaceAll('.', '\\.');
+
+    // Broadest possible match for keys at this namespace — used by
+    // the bulk-read path. `.*` permits any leading wire shape
+    // (sharedWith prefix, cached prefix, plain self) so long as it
+    // doesn't begin with `local:`.
+    _regexAllStr = '^(?!local:).*\\.$_escapedNamespace@';
+    // Same logical shape as `_directKeyRegex` but with multi-segment
+    // ids — matches direct items `<id>.<ns>@` AND any deeper sub-item
+    // `<id>.<subName>.<parentId>.…<ns>@`. Used as a cheap filter to
+    // reject notifications that don't belong to this collection at
+    // all; depth-dispatch happens via the parsed ancestry length, not
+    // by regex.
+    _regexObjAny =
+        RegExp('$_atKeyScanPrefix[^.]+(\\.[^.]+)*\\.$_escapedNamespace@');
 
     _injectedNotifications = notifications;
     _injectedDataEvents = injectedDataEvents;
@@ -1064,13 +1092,53 @@ interface class AtCollection<T> {
   /// [getItems] / [getItemsAsStream] (typed) or the [Query<T>]
   /// builder instead.
   Future<List<AtKey>> _getKeysInternal({String? id, Atsign? owner}) async {
-    // want a regex like (^|:)[^.]+\.collection\.name\.space@
-    // e.g. (^|:)[^.]+\.notes\.todos\.demos@
-    id ??= '[^.]+';
-    final ownerFragment = owner ?? '@';
-    final regex = '(^|:)$id\\.$namespace$ownerFragment';
+    final regex =
+        _directKeyRegex(id: id, ownerSuffix: owner?.toString() ?? '@');
     return (await atClient.getAtKeys(regex: regex))
       ..sort((a, b) => a.fullKeyAndOwner.compareTo(b.fullKeyAndOwner));
+  }
+
+  // ───────────────────────────────────────────────────────────────────────
+  // Regex builders. Three shapes cover every AtKey scan this class
+  // emits; they share the [_atKeyScanPrefix] + [_escapedNamespace]
+  // pieces so the "reject `local:` keys, escape namespace dots"
+  // contract (the fix for #1942) lives in one place.
+
+  /// Regex matching **direct items** at this collection's namespace:
+  /// `<prefix><idPattern>.<ns><ownerSuffix>`.
+  ///
+  /// When [id] is null the item id is a wildcard `[^.]+` — any
+  /// non-dot segment matches. When a concrete [id] is passed it is
+  /// `RegExp.escape`d so a value containing regex metacharacters
+  /// can't widen the match. [ownerSuffix] is appended verbatim; the
+  /// default `'@'` matches keys owned by any atSign while passing
+  /// e.g. `@alice` (an Atsign's `toString()`) restricts to one.
+  String _directKeyRegex({String? id, String ownerSuffix = '@'}) {
+    final idPattern = id != null ? RegExp.escape(id) : '[^.]+';
+    return '$_atKeyScanPrefix$idPattern\\.$_escapedNamespace$ownerSuffix';
+  }
+
+  /// Regex matching **descendants** of this collection at any depth
+  /// `≥ 1`: `<prefix>.+\.<ns><ownerSuffix>`, or — when [parentId] is
+  /// provided — restricted to direct sub-items of that parent:
+  /// `<prefix>.+\.<parentId>\.<ns><ownerSuffix>`.
+  ///
+  /// [ownerSuffix] is required because every site that scans
+  /// descendants today does so against a known owner (`atSign` or
+  /// `self`); leaving the default would invite an accidental
+  /// any-owner scan that's almost never what the caller wants.
+  String _descendantKeyRegex({String? parentId, required String ownerSuffix}) {
+    final mid = parentId != null ? '.+\\.${RegExp.escape(parentId)}' : '.+';
+    return '$_atKeyScanPrefix$mid\\.$_escapedNamespace$ownerSuffix';
+  }
+
+  /// Regex matching direct items at an **arbitrary pre-composed
+  /// namespace** (not this collection's). Used by the orphan-sweep
+  /// chain-walker which probes alive-at-mid-namespace levels above
+  /// the collection's own namespace.
+  String _directKeyRegexForComposed(String composedNs) {
+    final escaped = composedNs.replaceAll('.', '\\.');
+    return '$_atKeyScanPrefix[^.]+\\.$escaped@';
   }
 
   /// True iff an item with the given [id] owned by [owner] exists in
@@ -1763,7 +1831,7 @@ interface class AtCollection<T> {
       // `_getKeysInternal(owner: self)` alone would miss every level
       // deeper than 1.
       final keys = await atClient.getAtKeys(
-        regex: '(^|:).+\\.$namespace$self',
+        regex: _descendantKeyRegex(ownerSuffix: self.toString()),
       );
       // Ancestry filter: we only delete descendants whose persisted
       // `parents` chain starts with this sub-collection's expected
@@ -1847,7 +1915,7 @@ interface class AtCollection<T> {
     final expectedPrefix = _expectedAncestorOwners();
     final results = <OpResult>[];
     final deep = await atClient.getAtKeys(
-      regex: '(^|:).+\\.$namespace$atSign',
+      regex: _descendantKeyRegex(ownerSuffix: atSign.toString()),
     );
     for (final k in deep) {
       try {
@@ -1897,7 +1965,7 @@ interface class AtCollection<T> {
     final legacyAliveCache = <String, Set<String>>{};
 
     final descendantKeys = await atClient.getAtKeys(
-      regex: '(^|:).+\\.$namespace$atSign',
+      regex: _descendantKeyRegex(ownerSuffix: atSign.toString()),
     );
     final results = <OpResult>[];
     for (final k in descendantKeys) {
@@ -2012,8 +2080,9 @@ interface class AtCollection<T> {
   ) async {
     final cached = cache[composedNs];
     if (cached != null) return cached;
-    final escaped = composedNs.replaceAll('.', '\\.');
-    final keys = await atClient.getAtKeys(regex: '(^|:)[^.]+\\.$escaped@');
+    final keys = await atClient.getAtKeys(
+      regex: _directKeyRegexForComposed(composedNs),
+    );
     final levelSegments = composedNs.split('.').length;
     final alive = <String>{};
     for (final key in keys) {
@@ -3086,8 +3155,12 @@ interface class AtCollection<T> {
   }
 
   Future<List<AtKey>> _selfOwnedDescendantKeys(String parentId) async {
-    final regex = '(^|:).+\\.$parentId\\.$namespace$atSign';
-    return atClient.getAtKeys(regex: regex);
+    return atClient.getAtKeys(
+      regex: _descendantKeyRegex(
+        parentId: parentId,
+        ownerSuffix: atSign.toString(),
+      ),
+    );
   }
 
   /// Variant of [_selfOwnedDescendantKeys] that also filters each

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -87,6 +87,35 @@ class AtClientManager {
     secondaryAddressFinder ??= CacheableSecondaryAddressFinder(
         preference.rootDomain, preference.rootPort);
 
+    // Idempotency: if the caller is asking for the SAME atSign that's
+    // already current (with no caller-supplied override for atChops /
+    // atLookUp / enrollmentId), short-circuit. The stop+recreate path
+    // below is destructive: it stops the existing syncService and
+    // builds a fresh one against the same Hive store, producing a
+    // brief window where TWO syncService instances are alive against
+    // the same on-disk queue. If a user write enqueues during that
+    // window, the push can fire on the about-to-be-stopped sibling
+    // (whose progress-listener list is empty after its `stop()` ran),
+    // making the write invisible to any listener attached to the new
+    // syncService — observed in CI as `bypasscache_test` timing out
+    // with no `localToRemote` event.
+    //
+    // Callers needing a forced reset for a SAME-atSign change of
+    // preferences / atChops / enrollmentId still get one — we only
+    // skip when nothing in the request changed.
+    final currentAtSign = _currentAtClient?.getCurrentAtSign();
+    if (currentAtSign != null &&
+        currentAtSign == atSign &&
+        atChops == null &&
+        atLookUp == null &&
+        enrollmentId == null &&
+        _currentAtClient!.isStopped == false) {
+      _logger
+          .info('setCurrentAtSign: already on $atSign with no override args; '
+              'returning existing atClient (no stop/recreate).');
+      return this;
+    }
+
     _logger.info(
         'Switching atSigns ${_currentAtClient?.getCurrentAtSign()} -> $atSign');
 

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -96,6 +96,96 @@ class NotificationServiceImpl extends NotificationService {
     atKeyEncryptionManager = AtKeyEncryptionManager(atClient);
   }
 
+  /// Migrate any legacy (non-`local:`) forms of the
+  /// last-received-notification key to the canonical
+  /// `local:lastreceivednotification.<ns>@<atSign>` form, and delete
+  /// every legacy form found so they no longer pollute the local
+  /// keystore.
+  ///
+  /// Fixes the underlying defect behind #1942 — `AtCollection`
+  /// regex scans over the local keystore were matching the bare
+  /// (non-`local:`) `lastreceivednotification.<ns>@<atSign>` key
+  /// because it has the same structural shape as a self-owned
+  /// collection item. The canonical key has been `local:`-prefixed
+  /// since the move to `AtKey.local`, but clients upgraded from
+  /// older builds still carry the bare form on disk.
+  ///
+  /// Three forms have existed:
+  ///   1. `local:lastreceivednotification.<ns>@<atSign>` — canonical
+  ///   2. `      lastreceivednotification.<ns>@<atSign>` — intermediate
+  ///   3. `      _latestNotificationIdv2.<ns>@<atSign>`  — original
+  ///
+  /// If the canonical key is missing its value is seeded from the
+  /// newest legacy form that has one (preferring the intermediate
+  /// over the original — its value is fresher). Every legacy entry
+  /// is then deleted. The migration is idempotent: re-running it
+  /// after a clean DB is a no-op.
+  ///
+  /// Deletes are local-only — both legacy name prefixes are
+  /// excluded by [SyncUtil.shouldSync], so the removals do not
+  /// propagate to the atServer.
+  /// Returns the canonical value after migration. The seeded value
+  /// is returned directly (rather than re-read by the caller) so the
+  /// `put` we just did doesn't have to round-trip back through a
+  /// `get` — useful both for performance and because some mocks /
+  /// fakes aren't stateful across the put-then-get.
+  Future<AtValue?> _migrateLegacyLastReceivedNotificationKeys() async {
+    final keyStore = atClient.getLocalSecondary()!.keyStore!;
+    final ns = atClient.getPreferences()!.namespace;
+    final currentAtSign = atClient.getCurrentAtSign()!;
+    final canonicalStr = lastReceivedNotificationAtKey.toString();
+
+    // The canonical key can exist with a null value (e.g. when an
+    // earlier `put` seeded a placeholder). Check the actual value,
+    // not just existence — otherwise we'd never seed from a legacy
+    // form when the canonical row is present-but-empty.
+    AtValue? canonicalValue;
+    if (keyStore.isKeyExists(canonicalStr)) {
+      try {
+        canonicalValue = await atClient.get(lastReceivedNotificationAtKey);
+        if (canonicalValue.value == null) canonicalValue = null;
+      } on Exception {
+        // Treat read failures as "needs seeding" — the legacy
+        // forms become the source of truth.
+      }
+    }
+
+    // Newest legacy form first so we prefer fresher values when
+    // seeding the canonical key.
+    final legacyForms = <String>[
+      'lastreceivednotification.$ns$currentAtSign',
+      '$notificationIdKey.$ns$currentAtSign',
+    ];
+    for (final legacyStr in legacyForms) {
+      if (!keyStore.isKeyExists(legacyStr)) continue;
+
+      // Seed the canonical key from the first legacy form that has a
+      // value — only when the canonical doesn't already carry one.
+      if (canonicalValue == null) {
+        try {
+          final v = await atClient.get(AtKey.fromString(legacyStr));
+          if (v.value != null) {
+            await atClient.put(lastReceivedNotificationAtKey, v.value);
+            canonicalValue = v;
+          }
+        } on Exception catch (e) {
+          logger.warning(
+              'Migration: failed to seed canonical key from $legacyStr: $e');
+        }
+      }
+
+      // Drop the legacy key regardless of whether we seeded from it
+      // — older forms are no longer load-bearing once the canonical
+      // exists, and pollute the local keystore (#1942).
+      try {
+        await atClient.delete(AtKey.fromString(legacyStr));
+      } on Exception catch (e) {
+        logger.warning('Migration: failed to delete legacy key $legacyStr: $e');
+      }
+    }
+    return canonicalValue;
+  }
+
   /// Return the last received notification DateTime in epochMillis when
   /// [AtClientPreference.fetchOfflineNotifications] is set true.
   ///
@@ -109,36 +199,11 @@ class NotificationServiceImpl extends NotificationService {
       return null;
     }
 
-    // fetchOfflineNotifications == true (the default) means we want all notifications since the last one we received
-    // We keep track of the last notification id in the client-side key store
-    // Check if the new key (local:lastNotificationReceived@alice) is available in the keystore.
-    // If yes, fetch the value;
-    AtValue? atValue;
-    if (atClient
-        .getLocalSecondary()!
-        .keyStore!
-        .isKeyExists(lastReceivedNotificationAtKey.toString())) {
-      atValue = await atClient.get(lastReceivedNotificationAtKey);
-    }
-    // If new key does not exist or value is null, check for the old key (_latestNotificationIdv2@alice)
-    // If old key exist, fetch the value and update the new key with old key's value
-    if (atValue == null || atValue.value == null) {
-      var lastNotificationKeyStr =
-          '$notificationIdKey.${atClient.getPreferences()!.namespace}${atClient.getCurrentAtSign()}';
-      var atKey = AtKey.fromString(lastNotificationKeyStr);
-      if (atClient
-          .getLocalSecondary()!
-          .keyStore!
-          .isKeyExists(lastNotificationKeyStr)) {
-        try {
-          atValue = await atClient.get(atKey);
-          await atClient.put(lastReceivedNotificationAtKey, atValue.value);
-        } on Exception catch (e) {
-          logger.severe(
-              'Exception in getting last notification id: ${e.toString}');
-        }
-      }
-    }
+    // Migration runs first and returns the canonical key's value
+    // (either the pre-existing value or one freshly seeded from a
+    // legacy form). Use that directly instead of re-reading the
+    // canonical key — the migration has already done that work.
+    AtValue? atValue = await _migrateLegacyLastReceivedNotificationKeys();
     if (atValue?.value != null) {
       logger.finer('json from hive: ${atValue?.value}');
       return jsonDecode(atValue?.value)['epochMillis'];

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -129,6 +129,10 @@ class NotificationServiceImpl extends NotificationService {
   /// `put` we just did doesn't have to round-trip back through a
   /// `get` — useful both for performance and because some mocks /
   /// fakes aren't stateful across the put-then-get.
+  @visibleForTesting
+  Future<AtValue?> migrateLegacyLastReceivedNotificationKeysForTest() =>
+      _migrateLegacyLastReceivedNotificationKeys();
+
   Future<AtValue?> _migrateLegacyLastReceivedNotificationKeys() async {
     final keyStore = atClient.getLocalSecondary()!.keyStore!;
     final ns = atClient.getPreferences()!.namespace;

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -169,13 +169,7 @@ class SyncServiceImpl implements SyncService {
   }
 
   SyncServiceImpl._(this._atClient, this._remoteSecondary) {
-    // Embed identityHashCode in the logger name so concurrent
-    // SyncService instances for the same atSign (created by
-    // consecutive setCurrentAtSign calls) are distinguishable in
-    // logs. Otherwise both log as "SyncService (@xxx)" and CI
-    // diagnosis of "which instance pushed?" is impossible.
-    _logger = AtSignLogger(
-        'SyncService#${identityHashCode(this)} (${_atClient.getCurrentAtSign()})');
+    _logger = AtSignLogger('SyncService (${_atClient.getCurrentAtSign()})');
     // _logger.level = 'info';
     _lastReceivedServerCommitIdAtKey =
         AtKey.local('lastreceivedservercommitid', currentAtSign).build();

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -169,7 +169,13 @@ class SyncServiceImpl implements SyncService {
   }
 
   SyncServiceImpl._(this._atClient, this._remoteSecondary) {
-    _logger = AtSignLogger('SyncService (${_atClient.getCurrentAtSign()})');
+    // Embed identityHashCode in the logger name so concurrent
+    // SyncService instances for the same atSign (created by
+    // consecutive setCurrentAtSign calls) are distinguishable in
+    // logs. Otherwise both log as "SyncService (@xxx)" and CI
+    // diagnosis of "which instance pushed?" is impossible.
+    _logger = AtSignLogger(
+        'SyncService#${identityHashCode(this)} (${_atClient.getCurrentAtSign()})');
     // _logger.level = 'info';
     _lastReceivedServerCommitIdAtKey =
         AtKey.local('lastreceivedservercommitid', currentAtSign).build();

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -718,12 +718,21 @@ class SyncServiceImpl implements SyncService {
         }
       }
       batchesDone++;
+      // Snapshot keyInfoList AT this point so per-batch listeners
+      // see every push as it lands, not only at the terminal
+      // `Sync complete` event in `processSyncRequests`. If anything
+      // between `syncInternal` returning and that terminal emission
+      // throws (network blip on `_getServerCommitId` / `_getLocalCommitId`,
+      // a stop() racing the completion), the push KeyInfos would
+      // otherwise be silently dropped — listeners would never see
+      // a `localToRemote` event for keys that DID land on the server.
       _informSyncProgress(
         SyncProgress()
           ..syncStatus = SyncStatus.inProgress
           ..startedAt = DateTime.now().toUtc()
           ..message = 'Push batch $batchesDone applied; '
-              '${await localSecondary.syncQueueSize} pending',
+              '${await localSecondary.syncQueueSize} pending'
+          ..keyInfoList = List<KeyInfo>.from(keyInfoList),
         localCommitId: _latestKnownServerCommitId,
         serverCommitId: _latestKnownServerCommitId,
       );

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -873,7 +873,17 @@ class SyncServiceImpl implements SyncService {
         // overwrite the local copy.
         for (dynamic serverCommitEntry in listOfCommitEntriesFromServer) {
           final serverAtKey = serverCommitEntry['atKey'].toString().trim();
-          final hasLocalConflict = pendingPushAtKeys.contains(serverAtKey);
+          // Conflict iff the atKey is either (a) already in the sync
+          // queue (captured in the per-batch refresh above), or (b)
+          // a [_update]/[_delete] for it is currently executing on
+          // this LocalSecondary — i.e. a user write is mid-flight
+          // between the keystore op and the enqueue. (b) closes the
+          // sub-window in [_update] where the keystore has the new
+          // value but the queue is still empty; applying a server
+          // entry in that window silently overwrites the user's
+          // value.
+          final hasLocalConflict = pendingPushAtKeys.contains(serverAtKey) ||
+              localSecondary.isWriteInProgress(serverAtKey);
           if (hasLocalConflict) {
             lastReceivedServerCommitId =
                 _parseToInteger(serverCommitEntry['commitId']);

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -810,6 +810,7 @@ class SyncServiceImpl implements SyncService {
     // in certain scenarios e.g server has a commit entry that need not be synced on client side,
     // server has delete commit entry and the key is not present on local keystore
     List<KeyInfo> keyInfoList = [];
+    final localSecondary = _atClient.getLocalSecondary()!;
     try {
       int? skipDeletesUntil = await setAndGetSkipDeletesUntil(
           localCommitIdBeforeSync, serverCommitId);
@@ -824,6 +825,18 @@ class SyncServiceImpl implements SyncService {
                 lastReceivedServerCommitId, serverCommitId,
                 localCommitIdBeforeSync: localCommitIdBeforeSync,
                 skipDeletesUntil: skipDeletesUntil);
+        // Refresh the pending-push snapshot AFTER the network
+        // round-trip but BEFORE applying any server entries. The
+        // original snapshot was taken at sync-round start; a user
+        // put that landed in the queue while we were waiting on the
+        // server's response is invisible there, and without this
+        // refresh a server entry whose atKey matches the just-queued
+        // put would be applied to local — silently overwriting the
+        // user's value before our push has a chance to send it.
+        // Union with the sync-start snapshot so we never lose
+        // pre-sync entries.
+        pendingPushAtKeys = pendingPushAtKeys
+            .union(Set<String>.from(await localSecondary.peekSyncQueue()));
         if (listOfCommitEntriesFromServer.isEmpty) {
           // Server walked the full (lastReceivedServerCommitId,
           // serverCommitId] range and returned no entries for this

--- a/packages/at_client/test/at_client_termination_test.dart
+++ b/packages/at_client/test/at_client_termination_test.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
+import 'package:at_client/src/listener/at_sign_change_listener.dart';
+import 'package:at_client/src/listener/switch_at_sign_event.dart';
 import 'package:at_client/src/manager/monitor.dart';
 import 'package:at_client/src/service/notification_service_impl.dart';
 import 'package:at_client/src/service/sync_service_impl.dart';
@@ -236,5 +238,108 @@ void main() {
             false);
       });
     });
+
+    group('setCurrentAtSign idempotency', () {
+      // The same-atSign short-circuit added with the
+      // bypasscache_test flake fix. Forced-reset cases (callers
+      // passing atChops / atLookUp / enrollmentId, or an explicitly
+      // stopped atClient) must still recreate; bare no-arg calls
+      // must reuse.
+
+      test('same-atSign, no override args → identical syncService preserved',
+          () async {
+        final atSign = '@idempotent_no_override';
+
+        final atClient1 = await _initializeAtClient(atSign);
+        final syncService1 = atClient1.syncService;
+
+        // Second call with the exact same atSign / namespace / prefs
+        // and no override args must short-circuit — atClient AND its
+        // syncService both stay identical. Catches regressions where
+        // setCurrentAtSign recreates anyway and leaves two
+        // SyncService instances on the same Hive backing (the original
+        // cause of the bypasscache_test localToRemote race).
+        final atClient2 = await _initializeAtClient(atSign);
+        expect(identical(atClient1, atClient2), true,
+            reason: 'idempotent setCurrentAtSign returns same atClient');
+        expect(identical(syncService1, atClient2.syncService), true,
+            reason: 'syncService is preserved across idempotent calls');
+        expect((atClient2.syncService as SyncServiceImpl).isStopped, false,
+            reason: 'preserved syncService is not stopped');
+      });
+
+      test('same-atSign with atChops override → recreates', () async {
+        final atSign = '@idempotent_with_atchops';
+
+        final atClient1 = await _initializeAtClient(atSign);
+        final syncService1 = atClient1.syncService;
+
+        // Caller passes atChops — the idempotency check must NOT
+        // short-circuit, because the override is a signal the caller
+        // wants a fresh atClient.
+        final mockAtChops = MockAtChops();
+        await AtClientManager.getInstance().setCurrentAtSign(
+          atSign,
+          'test',
+          _createPreference(atSign.replaceAll('@', '')),
+          atChops: mockAtChops,
+        );
+        final atClient2 = AtClientManager.getInstance().atClient;
+        // syncService MUST be a fresh instance.
+        expect(identical(syncService1, atClient2.syncService), false,
+            reason: 'atChops override forces syncService recreate');
+      });
+
+      test('same-atSign with enrollmentId override → recreates', () async {
+        final atSign = '@idempotent_with_enrollment';
+
+        final atClient1 = await _initializeAtClient(atSign);
+        final syncService1 = atClient1.syncService;
+
+        await AtClientManager.getInstance().setCurrentAtSign(
+          atSign,
+          'test',
+          _createPreference(atSign.replaceAll('@', '')),
+          enrollmentId: 'some-enrollment-id',
+        );
+        final atClient2 = AtClientManager.getInstance().atClient;
+        expect(identical(syncService1, atClient2.syncService), false,
+            reason: 'enrollmentId override forces syncService recreate');
+      });
+
+      test('idempotent call does not fire SwitchAtSignEvent', () async {
+        final atSign = '@idempotent_no_event';
+
+        await _initializeAtClient(atSign);
+
+        // Register a change listener AFTER the initial setCurrentAtSign
+        // so we only observe the second (idempotent) call's behaviour.
+        final events = <SwitchAtSignEvent>[];
+        final listener = _CapturingAtSignChangeListener(events.add);
+        AtClientManager.getInstance().listenToAtSignChange(listener);
+
+        await _initializeAtClient(atSign);
+
+        // Existing code path only fires the event when previous and
+        // current atSigns differ; idempotent short-circuit returns
+        // before that branch. Regression guard for accidentally
+        // moving the event emission ahead of the short-circuit.
+        expect(events, isEmpty,
+            reason: 'no SwitchAtSignEvent on idempotent setCurrentAtSign');
+
+        AtClientManager.getInstance().removeChangeListeners(listener);
+      });
+    });
   });
+}
+
+/// Test-only AtSignChangeListener that forwards every event to a
+/// caller-supplied callback. Avoids hand-rolling a mock inside each
+/// test.
+class _CapturingAtSignChangeListener implements AtSignChangeListener {
+  _CapturingAtSignChangeListener(this._onEvent);
+  final void Function(SwitchAtSignEvent) _onEvent;
+
+  @override
+  void listenToAtSignChange(SwitchAtSignEvent event) => _onEvent(event);
 }

--- a/packages/at_client/test/at_collections_sub_test.dart
+++ b/packages/at_client/test/at_collections_sub_test.dart
@@ -465,7 +465,8 @@ void main() {
           .thenAnswer((invocation) async {
         final regex =
             invocation.namedArguments[const Symbol('regex')] as String;
-        if (regex.contains('comments.p1.$parentNs')) {
+        if (regex
+            .contains('comments\\.p1\\.${parentNs.replaceAll('.', '\\.')}')) {
           return [subSelfKey];
         }
         return <AtKey>[];
@@ -528,7 +529,8 @@ void main() {
             invocation.namedArguments[const Symbol('regex')] as String;
         // Deep regex `(^|:).+\\.comments.p1.posts.blog.app@alice`
         // matches both the direct comment AND the nested reply.
-        if (regex.contains('comments.p1.$parentNs')) {
+        if (regex
+            .contains('comments\\.p1\\.${parentNs.replaceAll('.', '\\.')}')) {
           return [commentSelfKey, replySelfKey];
         }
         return <AtKey>[];
@@ -618,9 +620,11 @@ void main() {
           .thenAnswer((invocation) async {
         final regex =
             invocation.namedArguments[const Symbol('regex')] as String;
-        // Direct-item scan (getKeys) — returns only p1 (alive roots).
-        if (regex.startsWith(r'(^|:)[^.]+\.')) return [p1];
-        // Descendant scan — returns every descendant key in the subtree.
+        // Direct-item scan uses `[^.]+\.<ns>@` (single non-dot id);
+        // descendant scan uses `.+\.<parentId>\.<ns>@`. Branch on
+        // whichever substring is present — both are stable across
+        // the #1942 regex tightening.
+        if (regex.contains(r'[^.]+\.')) return [p1];
         return [c1OnP1, c2OnP2, r1OnC2OnP2];
       });
       when(() => c.atClient.delete(any())).thenAnswer((_) async => true);
@@ -660,7 +664,8 @@ void main() {
           .thenAnswer((invocation) async {
         final regex =
             invocation.namedArguments[const Symbol('regex')] as String;
-        if (regex.contains('comments.p1.$parentNs')) {
+        if (regex
+            .contains('comments\\.p1\\.${parentNs.replaceAll('.', '\\.')}')) {
           return [myCommentOnMyP1, myCommentOnBobsP1];
         }
         return <AtKey>[];
@@ -719,7 +724,10 @@ void main() {
             invocation.namedArguments[const Symbol('regex')] as String;
         // Both the sub-collection's deep-scan and its narrow scans
         // should find the stale comment.
-        if (regex.contains('comments.p1.$parentNs')) return [commentKey];
+        if (regex
+            .contains('comments\\.p1\\.${parentNs.replaceAll('.', '\\.')}')) {
+          return [commentKey];
+        }
         // Parent lookup in the parent collection.
         return <AtKey>[];
       });
@@ -759,15 +767,17 @@ void main() {
       // getKeys() (root-level scan) returns the root post.
       // descendant scan returns the orphaned reply.
       // alive-at-mid-namespace scan returns no comments.
+      // After the #1942 regex tightening, namespace dots are escaped
+      // and every scan is prefixed with `^(?!local:)(?:[^:]*:)?`.
+      final escapedParentNs = parentNs.replaceAll('.', '\\.');
+      final directRegex = '^(?!local:)(?:[^:]*:)?[^.]+\\.$escapedParentNs@';
+      final descendantRegex =
+          '^(?!local:)(?:[^:]*:)?.+\\.$escapedParentNs$selfAtSignStr';
       when(() => c.atClient.getAtKeys(regex: any(named: 'regex')))
           .thenAnswer((inv) async {
         final regex = inv.namedArguments[#regex] as String;
-        // Root-level direct items: pattern `(^|:)[^.]+.posts.blog.app@`
-        if (regex == '(^|:)[^.]+\\.$parentNs@') return [postKey];
-        // Descendant scan: `(^|:).+.posts.blog.app@<self>`
-        if (regex == '(^|:).+\\.$parentNs$selfAtSignStr') {
-          return [replyKey];
-        }
+        if (regex == directRegex) return [postKey];
+        if (regex == descendantRegex) return [replyKey];
         // Alive-at mid-namespace `comments.p1.<parentNs>` (any owner):
         if (regex.contains('comments\\.p1\\.posts\\.blog\\.app')) {
           return <AtKey>[]; // c1 is gone — middleman orphan

--- a/packages/at_client/test/at_collections_test.dart
+++ b/packages/at_client/test/at_collections_test.dart
@@ -1239,7 +1239,15 @@ void main() {
           .thenAnswer((invocation) async {
         final regex =
             invocation.namedArguments[const Symbol('regex')] as String;
-        if (regex.startsWith(r'(^|:).+\.')) return descendants;
+        // Descendant scan uses `.+\.<parentId>\.<ns>@` (`.+` matches
+        // any sub-chain) while the direct-item scan uses
+        // `[^.]+\.<ns>@` (single non-dot id). Branch on whichever
+        // substring is present — both are stable across the #1942
+        // regex tightening (added `^(?!local:)` + dot-escaping +
+        // sharedWith prefix).
+        if (regex.contains(r'.+\.') && !regex.contains(r'[^.]+\.')) {
+          return descendants;
+        }
         return itemScanKeys;
       });
     }
@@ -1567,7 +1575,12 @@ void main() {
       final bobKey = AtKey.fromString('idr.$namespace$bobStr');
       // The cache-priming `readBy` scans the entire __rr sub-collection
       // (no owner filter); wasMarkedReadByMe then checks self membership.
-      final rrRegex = '(^|:)[^.]+\\.__rr.idr.$namespace@';
+      // Regex shape mirrors `_getKeysInternal`: `^(?!local:)` rejects
+      // at_client's bookkeeping keys (#1942), `(?:[^:]*:)?` allows an
+      // optional sharedWith prefix, and every `.` in the composed
+      // namespace is escaped.
+      final escapedComposed = '__rr.idr.$namespace'.replaceAll('.', '\\.');
+      final rrRegex = '^(?!local:)(?:[^:]*:)?[^.]+\\.$escapedComposed@';
       // Parent scan returns bob's item; the __rr sub-collection scan
       // returns nothing (no receipts sent yet).
       when(

--- a/packages/at_client/test/at_collections_test.dart
+++ b/packages/at_client/test/at_collections_test.dart
@@ -1228,6 +1228,90 @@ void main() {
   });
 
   // ---------------------------------------------------------------------------
+  group('namespace scan regex (issue #1942)', () {
+    // These tests intercept the regex string AtCollection passes to
+    // atClient.getAtKeys, then exercise it against curated wire-form
+    // keys. The #1942 fix has two complementary parts: (a) the
+    // migration in NotificationServiceImpl deletes legacy bare-form
+    // bookkeeping keys at startup (the primary defence — exercised
+    // separately in notification_service_test.dart), and (b) the
+    // scan regex here adds a negative lookahead for `local:` so the
+    // canonical (post-migration) form can never be matched, and
+    // dot-escapes the namespace so adjacent characters can't
+    // accidentally satisfy a dot in a multi-segment namespace.
+
+    /// Captures the most recent regex passed to getAtKeys and returns
+    /// keys from [universe] that the regex matches.
+    Future<List<String>> matchUniverse(
+        AtCollection<String> c, List<String> universe) async {
+      late String capturedRegex;
+      when(() => atClient.getAtKeys(regex: any(named: 'regex')))
+          .thenAnswer((invocation) async {
+        capturedRegex = invocation.namedArguments[#regex] as String;
+        return <AtKey>[];
+      });
+      // Drive a scan so the regex gets emitted; we don't care about
+      // its return value, only the captured regex.
+      await c.getItems();
+      final re = RegExp(capturedRegex);
+      return universe.where((k) => re.hasMatch(k)).toList();
+    }
+
+    test('rejects every `local:` wire form', () async {
+      // The canonical local-only bookkeeping keys live behind the
+      // `local:` prefix. The scan regex's negative lookahead must
+      // exclude all of them so a future migration that leaves the
+      // canonical form behind can't ever pollute a collection scan.
+      final c = buildCollection<String>();
+      final hit = await matchUniverse(c, [
+        'local:lastreceivednotification.$namespace$selfAtSignStr',
+        'local:lastreceivedservercommitid.$namespace$selfAtSignStr',
+        'local:anything-else.$namespace$selfAtSignStr',
+        // Legitimate collection item — should match.
+        'item-abc.$namespace$selfAtSignStr',
+      ]);
+      expect(hit, equals(['item-abc.$namespace$selfAtSignStr']));
+    });
+
+    test('namespace dots are escaped — adjacent chars do not match', () async {
+      // Namespace is "tasks.app_1.my_apps". Without dot-escaping, the
+      // regex would treat each `.` as "any character" and accept e.g.
+      // `tasksXapp_1.my_apps@`. With escaping, those literals are
+      // required.
+      final c = buildCollection<String>();
+      final hit = await matchUniverse(c, [
+        // Legitimate match: exact dot positions.
+        'id.$namespace$selfAtSignStr',
+        // Wrong: first dot replaced by a non-dot character.
+        'id.tasksXapp_1.my_apps$selfAtSignStr',
+        // Wrong: second dot replaced.
+        'id.tasks.app_1Xmy_apps$selfAtSignStr',
+      ]);
+      expect(hit, equals(['id.$namespace$selfAtSignStr']));
+    });
+
+    test('sharedWith prefix keys still match (local: exclusion is anchored)',
+        () async {
+      // The negative lookahead is for `local:` at start-of-string; an
+      // ordinary sharedWith prefix like `@bob:` must still pass.
+      final c = buildCollection<String>();
+      final hit = await matchUniverse(c, [
+        'item-1.$namespace$selfAtSignStr',
+        '$bobStr:item-2.$namespace$selfAtSignStr',
+        '@carol:item-3.$namespace$selfAtSignStr',
+      ]);
+      expect(
+        hit,
+        equals([
+          'item-1.$namespace$selfAtSignStr',
+          '$bobStr:item-2.$namespace$selfAtSignStr',
+          '@carol:item-3.$namespace$selfAtSignStr',
+        ]),
+      );
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   group('delete', () {
     // Partition `atClient.getAtKeys` responses by regex shape:
     // - descendant scan uses regex starting `(^|:).+\.`

--- a/packages/at_client/test/local_secondary_test.dart
+++ b/packages/at_client/test/local_secondary_test.dart
@@ -319,6 +319,82 @@ void main() {
     });
   });
 
+  group('writesInProgress tracker', () {
+    setUp(() async => await setupLocalStorage(storageDir, atSign));
+    tearDown(() async => await tearDownLocalStorage(storageDir));
+
+    /// Builds a fresh LocalSecondary against the test Hive store. Each
+    /// test gets its own AtClient instance (atClientInstanceMap is
+    /// cleared in the outer setUp).
+    Future<LocalSecondary> buildLocalSecondary() async {
+      AtClientImpl.atClientInstanceMap.remove(atSign);
+      final atClientManager = AtClientManager(atSign);
+      final preference = AtClientPreference()
+        ..syncRegex = '.wavi'
+        ..hiveStoragePath = 'test/hive'
+        ..commitLogPath = 'test/hive/commit';
+      final atClient = await AtClientImpl.create(atSign, 'wavi', preference,
+          atClientManager: atClientManager);
+      return LocalSecondary(atClient);
+    }
+
+    UpdateVerbBuilder updateBuilderFor(String keyName) => UpdateVerbBuilder()
+      ..atKey = (AtKey()
+        ..key = keyName
+        ..sharedBy = atSign
+        ..metadata = (Metadata()..isPublic = true))
+      ..value = 'v';
+
+    test('starts empty', () async {
+      final localSecondary = await buildLocalSecondary();
+      expect(localSecondary.writesInProgressForTest, isEmpty);
+    });
+
+    test('cleared after a successful update', () async {
+      final localSecondary = await buildLocalSecondary();
+      await localSecondary.executeVerb(updateBuilderFor('email'), sync: false);
+      expect(localSecondary.writesInProgressForTest, isEmpty);
+      expect(localSecondary.isWriteInProgress('public:email$atSign'), false);
+    });
+
+    test('cleared after an update that throws (finally branch fires)',
+        () async {
+      // Trigger the max-key-length DataStoreException path inside
+      // _update to exercise the catch-then-rethrow; the in-progress
+      // tracker must still empty out in `finally`.
+      final localSecondary = await buildLocalSecondary();
+      final tooLongKey = TestUtils.createRandomString(250);
+      final builder = UpdateVerbBuilder()
+        ..atKey = (AtKey()
+          ..key = tooLongKey
+          ..sharedBy = atSign
+          ..metadata = (Metadata()..isPublic = true))
+        ..value = 'v';
+      await expectLater(
+          () async => await localSecondary.executeVerb(builder, sync: false),
+          throwsA(isA<DataStoreException>()));
+      expect(localSecondary.writesInProgressForTest, isEmpty);
+    });
+
+    test('cleared after a delete', () async {
+      final localSecondary = await buildLocalSecondary();
+      await localSecondary.executeVerb(updateBuilderFor('email'), sync: false);
+      final deleteBuilder = DeleteVerbBuilder()
+        ..atKey = (AtKey()
+          ..key = 'email'
+          ..sharedBy = atSign
+          ..metadata = (Metadata()..isPublic = true));
+      await localSecondary.executeVerb(deleteBuilder, sync: false);
+      expect(localSecondary.writesInProgressForTest, isEmpty);
+    });
+
+    test('snapshot getter returns an unmodifiable view', () async {
+      final localSecondary = await buildLocalSecondary();
+      final snapshot = localSecondary.writesInProgressForTest;
+      expect(() => snapshot.add('xxx'), throwsUnsupportedError);
+    });
+  });
+
   group('A group of tests to validate getKeys and getAtKeys', () {
     late SecondaryKeyStore mockSecondaryKeyStore;
     late LocalSecondary localSecondary;

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -1374,6 +1374,200 @@ void main() {
     });
   });
 
+  group('legacy lastReceivedNotification migration (#1942)', () {
+    // Verifies the per-startup migration that seeds the canonical
+    // `local:lastreceivednotification.<ns>@<atSign>` from any legacy
+    // form found, then deletes all legacy forms. The bug fixed in
+    // #1942 was that the deletes never happened — bare-form keys
+    // lingered in the keystore and accidentally matched AtCollection
+    // scans.
+
+    const ns = 'wavi';
+    const atSign = '@alice';
+    const canonicalStr = 'local:lastreceivednotification.$ns$atSign';
+    const intermediateStr = 'lastreceivednotification.$ns$atSign';
+    // The original legacy form used by very old releases. The
+    // migration code constructs the key as `_latestNotificationIdv2`
+    // but `AtKey.fromString().toString()` normalises to lowercase —
+    // mock matches must use the post-normalisation form.
+    const legacyV2Str = '_latestnotificationidv2.$ns$atSign';
+
+    /// Configures the shared `mockAtClientImpl` for migration tests:
+    /// keystore presence comes from `presentKeys`; gets come from
+    /// `values` (string → AtValue.value); puts and deletes are
+    /// captured into `putCalls` / `deleteCalls`.
+    Future<NotificationServiceImpl> setupMigrationMocks({
+      required Set<String> presentKeys,
+      required Map<String, String?> values,
+      required List<MapEntry<String, String?>> putCalls,
+      required List<String> deleteCalls,
+    }) async {
+      registerFallbackValue(FakeAtKey());
+
+      when(() => mockAtClientImpl.getPreferences())
+          .thenAnswer((_) => AtClientPreference()..namespace = ns);
+      // `getCurrentAtSign()` and `atSign` are non-stubbable on this
+      // mock — MockAtClientImpl overrides them concretely to return
+      // `@alice`. Our `atSign` constant must match.
+      assert(mockAtClientImpl.getCurrentAtSign() == atSign);
+
+      // AtKey.fromString().toString() lowercases its input; the
+      // migration's `isKeyExists` probe uses the constant-case
+      // string (e.g. `_latestNotificationIdv2.…`) while
+      // `atClient.get`/`atClient.delete` see the normalised
+      // (lowercase) form. Compare case-insensitively so test fixtures
+      // can specify keys in either casing.
+      final presentKeysLower = presentKeys.map((s) => s.toLowerCase()).toSet();
+      final valuesLower = <String, String?>{
+        for (final e in values.entries) e.key.toLowerCase(): e.value,
+      };
+
+      when(() => mockAtClientImpl
+          .getLocalSecondary()!
+          .keyStore!
+          .isKeyExists(any())).thenAnswer((invocation) {
+        final k = invocation.positionalArguments.first as String;
+        return presentKeysLower.contains(k.toLowerCase());
+      });
+      when(() => mockAtClientImpl.get(any())).thenAnswer((invocation) async {
+        final atKey = invocation.positionalArguments.first as AtKey;
+        return AtValue()..value = valuesLower[atKey.toString().toLowerCase()];
+      });
+      when(() => mockAtClientImpl.put(any(), any()))
+          .thenAnswer((invocation) async {
+        final atKey = invocation.positionalArguments[0] as AtKey;
+        final value = invocation.positionalArguments[1] as String?;
+        putCalls.add(MapEntry(atKey.toString(), value));
+        return true;
+      });
+      when(() => mockAtClientImpl.delete(any())).thenAnswer((invocation) async {
+        final atKey = invocation.positionalArguments.first as AtKey;
+        deleteCalls.add(atKey.toString());
+        return true;
+      });
+
+      // The NotificationServiceImpl constructor wires a Monitor with
+      // network behaviour we don't want fired in these tests. Pass a
+      // FakeMonitor to skip all that.
+      return await NotificationServiceImpl.create(
+        mockAtClientImpl,
+        monitor: fakeMonitor,
+      ) as NotificationServiceImpl;
+    }
+
+    test('seeds canonical from bare-form and deletes both legacy forms',
+        () async {
+      final putCalls = <MapEntry<String, String?>>[];
+      final deleteCalls = <String>[];
+      final service = await setupMigrationMocks(
+        // Canonical absent; both legacy forms present with values.
+        presentKeys: {intermediateStr, legacyV2Str},
+        values: {
+          intermediateStr: '{"epochMillis":111}',
+          legacyV2Str: '{"epochMillis":99}',
+        },
+        putCalls: putCalls,
+        deleteCalls: deleteCalls,
+      );
+
+      final result =
+          await service.migrateLegacyLastReceivedNotificationKeysForTest();
+
+      // Bare form wins over _latestNotificationIdv2 (it's the newer
+      // intermediate form).
+      expect(result?.value, '{"epochMillis":111}');
+      // The seed put landed on the canonical local: key.
+      expect(putCalls, hasLength(1));
+      expect(putCalls.single.key, canonicalStr);
+      expect(putCalls.single.value, '{"epochMillis":111}');
+      // Both legacy forms are deleted regardless of which one seeded.
+      expect(deleteCalls, containsAll([intermediateStr, legacyV2Str]));
+    });
+
+    test('seeds canonical from _latestNotificationIdv2 when bare absent',
+        () async {
+      final putCalls = <MapEntry<String, String?>>[];
+      final deleteCalls = <String>[];
+      final service = await setupMigrationMocks(
+        presentKeys: {legacyV2Str},
+        values: {legacyV2Str: '{"epochMillis":42}'},
+        putCalls: putCalls,
+        deleteCalls: deleteCalls,
+      );
+
+      final result =
+          await service.migrateLegacyLastReceivedNotificationKeysForTest();
+
+      expect(result?.value, '{"epochMillis":42}');
+      expect(putCalls, hasLength(1));
+      expect(putCalls.single.key, canonicalStr);
+      expect(deleteCalls, [legacyV2Str]);
+    });
+
+    test('canonical already has value: legacy forms deleted, canonical kept',
+        () async {
+      final putCalls = <MapEntry<String, String?>>[];
+      final deleteCalls = <String>[];
+      final service = await setupMigrationMocks(
+        presentKeys: {canonicalStr, intermediateStr},
+        values: {
+          canonicalStr: '{"epochMillis":555}',
+          intermediateStr: '{"epochMillis":111}',
+        },
+        putCalls: putCalls,
+        deleteCalls: deleteCalls,
+      );
+
+      final result =
+          await service.migrateLegacyLastReceivedNotificationKeysForTest();
+
+      // Canonical wins — no seed put, no overwrite.
+      expect(result?.value, '{"epochMillis":555}');
+      expect(putCalls, isEmpty);
+      // Bare-form still gets cleaned up (the bug from #1942).
+      expect(deleteCalls, [intermediateStr]);
+    });
+
+    test('no-op when neither canonical nor legacy keys exist', () async {
+      final putCalls = <MapEntry<String, String?>>[];
+      final deleteCalls = <String>[];
+      final service = await setupMigrationMocks(
+        presentKeys: <String>{},
+        values: <String, String?>{},
+        putCalls: putCalls,
+        deleteCalls: deleteCalls,
+      );
+
+      final result =
+          await service.migrateLegacyLastReceivedNotificationKeysForTest();
+
+      expect(result, isNull);
+      expect(putCalls, isEmpty);
+      expect(deleteCalls, isEmpty);
+    });
+
+    test('idempotent: a second run after a clean DB does nothing', () async {
+      final putCalls = <MapEntry<String, String?>>[];
+      final deleteCalls = <String>[];
+      // After a successful migration, only the canonical exists
+      // with a real value — both legacy forms are gone.
+      final service = await setupMigrationMocks(
+        presentKeys: {canonicalStr},
+        values: {canonicalStr: '{"epochMillis":42}'},
+        putCalls: putCalls,
+        deleteCalls: deleteCalls,
+      );
+
+      await service.migrateLegacyLastReceivedNotificationKeysForTest();
+      await service.migrateLegacyLastReceivedNotificationKeysForTest();
+
+      expect(putCalls, isEmpty,
+          reason: 'no seeding on a clean DB (canonical present)');
+      expect(deleteCalls, isEmpty,
+          reason: 'no deletes on a clean DB (no legacy forms present)');
+    });
+  });
+
   group('validate stop() behaviour', () {
     test('stop() sets isStopped to true', () async {
       when(() => mockAtClientManager.secondaryAddressFinder)

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -1199,6 +1199,10 @@ void main() {
       when(() => mockAtClientImpl.put(any(), any()))
           .thenAnswer((_) async => true);
 
+      // #1942 — the legacy-key migration may call delete; stub it so
+      // the mock doesn't throw when no legacy keys are present.
+      when(() => mockAtClientImpl.delete(any())).thenAnswer((_) async => true);
+
       expect(await notificationServiceImpl.getLastNotificationTime(), null);
     });
 
@@ -1236,6 +1240,9 @@ void main() {
       when(() => mockAtClientImpl.put(any(), any()))
           .thenAnswer((_) async => true);
 
+      // #1942 migration cleanup may call delete on legacy keys.
+      when(() => mockAtClientImpl.delete(any())).thenAnswer((_) async => true);
+
       when(() => mockAtClientImpl
           .getLocalSecondary()!
           .keyStore!
@@ -1272,6 +1279,9 @@ void main() {
       when(() => mockAtClientImpl.put(any(), any()))
           .thenAnswer((_) async => true);
 
+      // #1942 migration cleanup may call delete on legacy keys.
+      when(() => mockAtClientImpl.delete(any())).thenAnswer((_) async => true);
+
       when(() => mockAtClientImpl
           .getLocalSecondary()!
           .keyStore!
@@ -1302,6 +1312,15 @@ void main() {
           atClientManager: mockAtClientManager,
           monitor: fakeMonitor) as NotificationServiceImpl;
 
+      // Default: any key NOT explicitly stubbed below is absent.
+      // The #1942 migration also probes the intermediate
+      // `lastreceivednotification.<ns>@<atSign>` form; this fallback
+      // keeps the mock from returning null on that probe.
+      when(() => mockAtClientImpl
+          .getLocalSecondary()!
+          .keyStore!
+          .isKeyExists(any())).thenAnswer((_) => false);
+
       when(() => mockAtClientImpl.getLocalSecondary()!.keyStore!.isKeyExists(
               notificationServiceImpl.lastReceivedNotificationAtKey.toString()))
           .thenAnswer((_) => false);
@@ -1318,6 +1337,9 @@ void main() {
 
       when(() => mockAtClientImpl.put(any(), any()))
           .thenAnswer((_) async => true);
+
+      // #1942 migration cleanup may call delete on legacy keys.
+      when(() => mockAtClientImpl.delete(any())).thenAnswer((_) async => true);
 
       expect(
           await notificationServiceImpl.getLastNotificationTime(), epochMillis);
@@ -1375,13 +1397,20 @@ void main() {
 class StatsAtKeyMatcher extends Matcher {
   @override
   Description describe(Description description) =>
-      description.add('A custom matcher to match the old statsNotificationKey');
+      description.add('A custom matcher to match a legacy '
+          'lastReceivedNotification key (`_latestNotificationIdv2.*` or '
+          'the intermediate bare `lastreceivednotification.*` form).');
 
   @override
   bool matches(item, Map matchState) {
-    if (item is AtKey && item.key.contains('_latestNotificationIdv2')) {
-      return true;
-    }
+    if (item is! AtKey) return false;
+    if (item.key.contains('_latestNotificationIdv2')) return true;
+    // Intermediate (pre-`local:`) form — added during the #1942 fix
+    // when the migration was widened to also clean up bare
+    // `lastreceivednotification.<ns>@<atSign>` rows. The matcher
+    // accepts only the bare form (rejects the canonical `local:`
+    // prefix, which AtKey.fromString preserves on the parsed key).
+    if (item.key == 'lastreceivednotification' && !item.isLocal) return true;
     return false;
   }
 }

--- a/tests/at_end2end_test/lib/src/sync_initializer.dart
+++ b/tests/at_end2end_test/lib/src/sync_initializer.dart
@@ -54,13 +54,27 @@ class E2ESyncService {
   /// Wait until a `localToRemote` push for [atKey]'s wire form has
   /// been observed in a [SyncProgress] event, then return.
   ///
-  /// The listener is registered **before** anything that could
-  /// trigger the push (the caller's `put` typically happens right
-  /// after this helper is set up — or, more often, the caller does
-  /// `put` first and immediately calls this; the broadcast stream
-  /// will surface the push event whether registration happens just
-  /// before or just after the `put`, since the push doesn't complete
-  /// until later in the sync cycle).
+  /// **Call this BEFORE the put**, not after. Pattern:
+  ///
+  /// ```dart
+  /// final pushed = E2ESyncService.getInstance()
+  ///     .awaitKeyPushed(syncSvc, atKey);
+  /// final putResult = await atClient.put(atKey, value);
+  /// expect(putResult, true);
+  /// await pushed;
+  /// ```
+  ///
+  /// `AtClient.put` triggers `syncService.sync()` internally after
+  /// enqueueing the local commit. On a fast sync cycle the resulting
+  /// push event can fire (and be missed by listeners that haven't
+  /// registered yet) before any subsequent line of caller code
+  /// executes. Registering the listener after the put loses that
+  /// race and the gate hangs until timeout.
+  ///
+  /// This helper's body runs synchronously up to its first `await`
+  /// — `addProgressListener` is called before the returned Future
+  /// suspends — so capturing the Future before the put is enough to
+  /// guarantee the listener is in place by the time the push fires.
   ///
   /// Throws [TimeoutException] when [timeout] elapses with no
   /// matching push event observed; the exception's message includes

--- a/tests/at_end2end_test/lib/src/sync_initializer.dart
+++ b/tests/at_end2end_test/lib/src/sync_initializer.dart
@@ -78,9 +78,10 @@ class E2ESyncService {
   ///
   /// Throws [TimeoutException] when [timeout] elapses with no
   /// matching push event observed; the exception's message includes
-  /// the last [recentEventCap] KeyInfo entries the listener saw, to
-  /// distinguish "sync never ran" from "sync ran but didn't include
-  /// our key" from "sync ran on a different direction".
+  /// the last [recentEventCap] [SyncProgress] events the listener saw
+  /// (with sync status, commit-id state, and any KeyInfo entries),
+  /// to distinguish "sync never ran" from "sync ran but didn't push
+  /// our key" from "sync ran on a different syncService instance".
   ///
   /// Matches by exact string equality on `atKey.toString()` — the
   /// same wire form `UpdateVerbBuilder.buildKey()` enqueues into the
@@ -89,12 +90,12 @@ class E2ESyncService {
     SyncService syncSvc,
     AtKey atKey, {
     Duration timeout = const Duration(minutes: 2),
-    int recentEventCap = 20,
+    int recentEventCap = 40,
   }) async {
     final target = atKey.toString();
     final completer = Completer<void>();
-    final listener =
-        _KeyPushedListener(target, completer, recentCap: recentEventCap);
+    final listener = _KeyPushedListener(target, completer,
+        recentCap: recentEventCap, syncSvc: syncSvc);
     syncSvc.addProgressListener(listener);
     try {
       // Poke the sync service so the push runs without waiting for
@@ -103,8 +104,9 @@ class E2ESyncService {
       await completer.future.timeout(timeout, onTimeout: () {
         throw TimeoutException(
           'awaitKeyPushed: no localToRemote push observed for $target '
-          'within $timeout. Recent KeyInfo entries (newest last): '
-          '${listener.recentKeyInfos}',
+          'within $timeout on syncSvc#${identityHashCode(syncSvc)}. '
+          'Recent SyncProgress events (newest last, ${listener.recentEvents.length} '
+          'captured):\n  ${listener.recentEvents.join("\n  ")}',
           timeout,
         );
       });
@@ -119,19 +121,34 @@ class _KeyPushedListener extends SyncProgressListener {
   final String target;
   final Completer<void> completer;
   final int recentCap;
-  final List<String> recentKeyInfos = <String>[];
+  final SyncService syncSvc;
+  // Captures EVERY SyncProgress event with full metadata. Per-batch
+  // progress events (line 721/891 in sync_service_impl.dart) have a
+  // null keyInfoList and were previously invisible — those silent
+  // iterations are exactly what we need to see when diagnosing a
+  // timeout where the gate fires but our key isn't in any keyInfoList.
+  final List<String> recentEvents = <String>[];
 
-  _KeyPushedListener(this.target, this.completer, {required this.recentCap});
+  _KeyPushedListener(this.target, this.completer,
+      {required this.recentCap, required this.syncSvc});
 
   @override
   void onSyncProgressEvent(SyncProgress syncProgress) {
     final keys = syncProgress.keyInfoList;
+    final keyDescs = (keys == null || keys.isEmpty)
+        ? '-'
+        : keys.map((k) => '${k.syncDirection.name}:${k.key}').join(',');
+    final entry = '[svc#${identityHashCode(syncSvc)}] '
+        'status=${syncProgress.syncStatus} '
+        'local=${syncProgress.localCommitId} '
+        'server=${syncProgress.serverCommitId} '
+        'pending=${syncProgress.pendingPushCount} '
+        'msg=${syncProgress.message} '
+        'keys=$keyDescs';
+    if (recentEvents.length >= recentCap) recentEvents.removeAt(0);
+    recentEvents.add(entry);
     if (keys == null || keys.isEmpty) return;
     for (final k in keys) {
-      if (recentKeyInfos.length >= recentCap) {
-        recentKeyInfos.removeAt(0);
-      }
-      recentKeyInfos.add('${k.syncDirection.name}:${k.key}');
       if (k.syncDirection == SyncDirection.localToRemote && k.key == target) {
         if (!completer.isCompleted) completer.complete();
       }

--- a/tests/at_end2end_test/lib/src/sync_initializer.dart
+++ b/tests/at_end2end_test/lib/src/sync_initializer.dart
@@ -78,10 +78,9 @@ class E2ESyncService {
   ///
   /// Throws [TimeoutException] when [timeout] elapses with no
   /// matching push event observed; the exception's message includes
-  /// the last [recentEventCap] [SyncProgress] events the listener saw
-  /// (with sync status, commit-id state, and any KeyInfo entries),
-  /// to distinguish "sync never ran" from "sync ran but didn't push
-  /// our key" from "sync ran on a different syncService instance".
+  /// the last [recentEventCap] KeyInfo entries the listener saw, to
+  /// distinguish "sync never ran" from "sync ran but didn't include
+  /// our key" from "sync ran on a different direction".
   ///
   /// Matches by exact string equality on `atKey.toString()` — the
   /// same wire form `UpdateVerbBuilder.buildKey()` enqueues into the
@@ -90,12 +89,12 @@ class E2ESyncService {
     SyncService syncSvc,
     AtKey atKey, {
     Duration timeout = const Duration(minutes: 2),
-    int recentEventCap = 40,
+    int recentEventCap = 20,
   }) async {
     final target = atKey.toString();
     final completer = Completer<void>();
-    final listener = _KeyPushedListener(target, completer,
-        recentCap: recentEventCap, syncSvc: syncSvc);
+    final listener =
+        _KeyPushedListener(target, completer, recentCap: recentEventCap);
     syncSvc.addProgressListener(listener);
     try {
       // Poke the sync service so the push runs without waiting for
@@ -104,9 +103,8 @@ class E2ESyncService {
       await completer.future.timeout(timeout, onTimeout: () {
         throw TimeoutException(
           'awaitKeyPushed: no localToRemote push observed for $target '
-          'within $timeout on syncSvc#${identityHashCode(syncSvc)}. '
-          'Recent SyncProgress events (newest last, ${listener.recentEvents.length} '
-          'captured):\n  ${listener.recentEvents.join("\n  ")}',
+          'within $timeout. Recent KeyInfo entries (newest last): '
+          '${listener.recentKeyInfos}',
           timeout,
         );
       });
@@ -121,34 +119,19 @@ class _KeyPushedListener extends SyncProgressListener {
   final String target;
   final Completer<void> completer;
   final int recentCap;
-  final SyncService syncSvc;
-  // Captures EVERY SyncProgress event with full metadata. Per-batch
-  // progress events (line 721/891 in sync_service_impl.dart) have a
-  // null keyInfoList and were previously invisible — those silent
-  // iterations are exactly what we need to see when diagnosing a
-  // timeout where the gate fires but our key isn't in any keyInfoList.
-  final List<String> recentEvents = <String>[];
+  final List<String> recentKeyInfos = <String>[];
 
-  _KeyPushedListener(this.target, this.completer,
-      {required this.recentCap, required this.syncSvc});
+  _KeyPushedListener(this.target, this.completer, {required this.recentCap});
 
   @override
   void onSyncProgressEvent(SyncProgress syncProgress) {
     final keys = syncProgress.keyInfoList;
-    final keyDescs = (keys == null || keys.isEmpty)
-        ? '-'
-        : keys.map((k) => '${k.syncDirection.name}:${k.key}').join(',');
-    final entry = '[svc#${identityHashCode(syncSvc)}] '
-        'status=${syncProgress.syncStatus} '
-        'local=${syncProgress.localCommitId} '
-        'server=${syncProgress.serverCommitId} '
-        'pending=${syncProgress.pendingPushCount} '
-        'msg=${syncProgress.message} '
-        'keys=$keyDescs';
-    if (recentEvents.length >= recentCap) recentEvents.removeAt(0);
-    recentEvents.add(entry);
     if (keys == null || keys.isEmpty) return;
     for (final k in keys) {
+      if (recentKeyInfos.length >= recentCap) {
+        recentKeyInfos.removeAt(0);
+      }
+      recentKeyInfos.add('${k.syncDirection.name}:${k.key}');
       if (k.syncDirection == SyncDirection.localToRemote && k.key == target) {
         if (!completer.isCompleted) completer.complete();
       }

--- a/tests/at_end2end_test/lib/src/sync_initializer.dart
+++ b/tests/at_end2end_test/lib/src/sync_initializer.dart
@@ -1,93 +1,126 @@
 import 'dart:async';
 
 import 'package:at_client/at_client.dart';
-
-// ignore: implementation_imports
-import 'package:at_client/src/service/sync_service_impl.dart';
 import 'package:at_utils/at_logger.dart';
 
-/// The class represents the sync services for the end to end tests
+/// Sync helpers shared across the e2e test suite.
+///
+/// Two primitives, both built on the public [SyncService] API:
+///
+///   - [syncData] — wait until the local secondary has caught up to
+///     the remote secondary as it stood at call time. Just a thin
+///     wrapper around [SyncServiceWaitUntilCaughtUp.waitUntilCaughtUp]
+///     in `at_client`. Replaces a fragile broadcast-listener +
+///     `isSyncInProgress` flag that this class used to maintain
+///     itself; the underlying primitive does the right thing now,
+///     including not completing while there are still pending
+///     client→server pushes in the local sync queue.
+///
+///   - [awaitKeyPushed] — gate on a **specific** key having been
+///     pushed local→remote. Stronger guarantee than commit-id
+///     equality: the listener observes the actual push event for
+///     this key's wire form and completes only then. Use this when
+///     a test does `put(...)` and then needs to read the value
+///     from the remote side (directly or transitively) and cares
+///     about correctness, not just "sync has run". Eliminates the
+///     race where a listener-based completion check fires on an
+///     unrelated prior sync event and the test moves on before
+///     the most recent put has actually been pushed.
 class E2ESyncService {
-  // ignore: unused_field
   static final _logger = AtSignLogger('E2ESyncService');
 
   static final E2ESyncService _singleton = E2ESyncService._internal();
-
   E2ESyncService._internal();
+  factory E2ESyncService.getInstance() => _singleton;
 
-  factory E2ESyncService.getInstance() {
-    return _singleton;
+  /// Returns when the local secondary has caught up to the remote
+  /// secondary's commit id as observed by the first sync event after
+  /// this call. Times out after [timeout].
+  Future<void> syncData(
+    SyncService syncSvc, {
+    Duration timeout = const Duration(minutes: 2),
+  }) async {
+    final atSign = AtClientManager.getInstance().atClient.getCurrentAtSign();
+    _logger.info('syncData starting for $atSign');
+    try {
+      await syncSvc.waitUntilCaughtUp(timeout: timeout);
+      _logger.info('syncData complete for $atSign');
+    } on TimeoutException catch (e) {
+      _logger.warning('syncData timed out for $atSign: ${e.message}');
+      rethrow;
+    }
   }
 
-  bool isSyncInProgress = false;
-  Future<void> syncData(SyncService syncSvc) async {
-    if (isSyncInProgress) {
-      throw StateError('Sync already in progress');
-    }
-
-    isSyncInProgress = true;
+  /// Wait until a `localToRemote` push for [atKey]'s wire form has
+  /// been observed in a [SyncProgress] event, then return.
+  ///
+  /// The listener is registered **before** anything that could
+  /// trigger the push (the caller's `put` typically happens right
+  /// after this helper is set up — or, more often, the caller does
+  /// `put` first and immediately calls this; the broadcast stream
+  /// will surface the push event whether registration happens just
+  /// before or just after the `put`, since the push doesn't complete
+  /// until later in the sync cycle).
+  ///
+  /// Throws [TimeoutException] when [timeout] elapses with no
+  /// matching push event observed; the exception's message includes
+  /// the last [recentEventCap] KeyInfo entries the listener saw, to
+  /// distinguish "sync never ran" from "sync ran but didn't include
+  /// our key" from "sync ran on a different direction".
+  ///
+  /// Matches by exact string equality on `atKey.toString()` — the
+  /// same wire form `UpdateVerbBuilder.buildKey()` enqueues into the
+  /// sync queue, so the lookup is direct.
+  Future<void> awaitKeyPushed(
+    SyncService syncSvc,
+    AtKey atKey, {
+    Duration timeout = const Duration(minutes: 2),
+    int recentEventCap = 20,
+  }) async {
+    final target = atKey.toString();
+    final completer = Completer<void>();
+    final listener =
+        _KeyPushedListener(target, completer, recentCap: recentEventCap);
+    syncSvc.addProgressListener(listener);
     try {
-      final atSign = AtClientManager.getInstance().atClient.getCurrentAtSign();
-      _logger.info('syncData starting for $atSign');
-
-      SyncServiceImpl.queueSize = 1;
-
-      DateTime startTime = DateTime.now().toUtc();
-      DateTime lastReceivedDateTime = DateTime.now().toUtc();
-      Duration maxTotalWaitTime = Duration(minutes: 2);
-      int maxTotalWaitTimeMillis = maxTotalWaitTime.inMilliseconds;
-      Duration maxTransientWaitTime = Duration(seconds: 30);
-      int maxTransientWaitTimeMillis = maxTransientWaitTime.inMilliseconds;
-
-      E2ETestSyncProgressListener e2eTestSyncProgressListener =
-          E2ETestSyncProgressListener();
-      syncSvc.addProgressListener(e2eTestSyncProgressListener);
-
-      e2eTestSyncProgressListener.streamController.stream
-          .listen((SyncProgress syncProgress) async {
-        for (final KeyInfo ki in syncProgress.keyInfoList ?? []) {
-          _logger.finer('${ki.syncDirection} ${ki.key}');
-        }
-        lastReceivedDateTime = DateTime.now().toUtc();
-        if (((syncProgress.syncStatus == SyncStatus.success) &&
-                (syncProgress.localCommitId == syncProgress.serverCommitId)) ||
-            (syncProgress.syncStatus == SyncStatus.failure)) {
-          isSyncInProgress = false;
-        }
+      // Poke the sync service so the push runs without waiting for
+      // any background timer. waitUntilCaughtUp does the same.
+      syncSvc.sync();
+      await completer.future.timeout(timeout, onTimeout: () {
+        throw TimeoutException(
+          'awaitKeyPushed: no localToRemote push observed for $target '
+          'within $timeout. Recent KeyInfo entries (newest last): '
+          '${listener.recentKeyInfos}',
+          timeout,
+        );
       });
-
-      SyncServiceImpl syncImpl = syncSvc as SyncServiceImpl;
-      // Call to syncService.sync to expedite the sync progress
-      syncImpl.sync();
-      // ignore: invalid_use_of_visible_for_testing_member
-      await syncImpl.processSyncRequests();
-
-      while (isSyncInProgress) {
-        final now = DateTime.now().toUtc();
-        if (now.difference(lastReceivedDateTime).inMilliseconds >
-            maxTransientWaitTimeMillis) {
-          throw StateError(
-              'Sync duration exceeded maxTransientWaitTime ($maxTransientWaitTime)');
-        }
-        if (now.difference(startTime).inMilliseconds > maxTotalWaitTimeMillis) {
-          throw StateError(
-              'Sync duration exceeded maxTotalWaitTime ($maxTotalWaitTime)');
-        }
-        await Future.delayed(Duration(milliseconds: 10));
-      }
-      syncSvc.removeProgressListener(e2eTestSyncProgressListener);
-      _logger.info('syncData complete for $atSign');
+      _logger.info('awaitKeyPushed: observed push for $target');
     } finally {
-      isSyncInProgress = false;
+      syncSvc.removeProgressListener(listener);
     }
   }
 }
 
-class E2ETestSyncProgressListener extends SyncProgressListener {
-  StreamController<SyncProgress> streamController = StreamController();
+class _KeyPushedListener extends SyncProgressListener {
+  final String target;
+  final Completer<void> completer;
+  final int recentCap;
+  final List<String> recentKeyInfos = <String>[];
+
+  _KeyPushedListener(this.target, this.completer, {required this.recentCap});
 
   @override
   void onSyncProgressEvent(SyncProgress syncProgress) {
-    streamController.add(syncProgress);
+    final keys = syncProgress.keyInfoList;
+    if (keys == null || keys.isEmpty) return;
+    for (final k in keys) {
+      if (recentKeyInfos.length >= recentCap) {
+        recentKeyInfos.removeAt(0);
+      }
+      recentKeyInfos.add('${k.syncDirection.name}:${k.key}');
+      if (k.syncDirection == SyncDirection.localToRemote && k.key == target) {
+        if (!completer.isCompleted) completer.complete();
+      }
+    }
   }
 }

--- a/tests/at_end2end_test/lib/src/test_initializers.dart
+++ b/tests/at_end2end_test/lib/src/test_initializers.dart
@@ -16,7 +16,7 @@ class TestSuiteInitializer {
   static final AtSignLogger logger = AtSignLogger(' TestSuiteInitialized ');
 
   TestSuiteInitializer._internal() {
-    AtSignLogger.root_level = 'finest';
+    AtSignLogger.root_level = 'info';
     AtSignLogger.defaultLoggingHandler = AtSignLogger.consoleLoggingHandler;
   }
 

--- a/tests/at_end2end_test/lib/src/test_initializers.dart
+++ b/tests/at_end2end_test/lib/src/test_initializers.dart
@@ -13,8 +13,10 @@ import 'at_credentials.dart';
 class TestSuiteInitializer {
   static final TestSuiteInitializer _singleton = TestSuiteInitializer._internal();
 
+  static final AtSignLogger logger = AtSignLogger(' TestSuiteInitialized ');
+
   TestSuiteInitializer._internal() {
-    AtSignLogger.root_level = 'shout';
+    AtSignLogger.root_level = 'finest';
     AtSignLogger.defaultLoggingHandler = AtSignLogger.consoleLoggingHandler;
   }
 
@@ -25,6 +27,8 @@ class TestSuiteInitializer {
   Future<void> testInitializer(String atSign, String namespace, String authType,
       {bool enableInitialSync = true, AtClientPreference? atClientPreference}) async {
     try {
+      logger.info(
+          'testInitialized called for $atSign $namespace $authType $enableInitialSync $atClientPreference');
       late AtChops atChops;
       AtAuthResponse? atAuthResponse;
 

--- a/tests/at_end2end_test/test/bypasscache_test.dart
+++ b/tests/at_end2end_test/test/bypasscache_test.dart
@@ -95,11 +95,18 @@ void main() async {
         .atClient
         .put(testByPassCacheAtKey, initialValue);
     expect(putResult, true);
-    // Sync the data to the remote secondary
-    await E2ESyncService.getInstance()
-        .syncData(AtClientManager.getInstance().atClient.syncService);
+    // Per-key gate: do not proceed until the publisher's sync queue
+    // has actually pushed THIS put. Replaces the brittle "syncData
+    // returns success because some prior sync event matched commit
+    // IDs" inference with a direct observation.
+    await E2ESyncService.getInstance().awaitKeyPushed(
+        AtClientManager.getInstance().atClient.syncService,
+        testByPassCacheAtKey);
 
-    // Give it time to propagate from one atServer to the other.
+    // Cross-server propagation: publisher's atServer auto-notifies
+    // the receiver's atServer (autoNotify=true at this point). That
+    // path is separate from the at_client sync queue we just gated,
+    // so still wait for it.
     await Future.delayed(Duration(seconds: 5));
 
     // Switch to sharedWithAtSign
@@ -132,9 +139,16 @@ void main() async {
         .atClient
         .put(testByPassCacheAtKey, updatedValue);
     expect(newPutResult, true);
-    // Sync the data to the remote secondary
-    await E2ESyncService.getInstance()
-        .syncData(AtClientManager.getInstance().atClient.syncService);
+    // Per-key gate: do not switch atSigns until the publisher's sync
+    // queue has actually pushed THIS update. This is the primary fix
+    // for the historical flake — the prior `syncData` gate could
+    // return on an unrelated prior sync event's commit-id match,
+    // leaving N+2 still queued; the receiver-side bypassCache lookup
+    // then polled for 60s against a publisher atServer that still
+    // held `initialValue`.
+    await E2ESyncService.getInstance().awaitKeyPushed(
+        AtClientManager.getInstance().atClient.syncService,
+        testByPassCacheAtKey);
 
     // As atSignTwo
     await AtClientManager.getInstance().setCurrentAtSign(

--- a/tests/at_end2end_test/test/bypasscache_test.dart
+++ b/tests/at_end2end_test/test/bypasscache_test.dart
@@ -91,17 +91,23 @@ void main() async {
     await AtClientManager.getInstance().setCurrentAtSign(sharedByAtSign,
         namespace, TestPreferences.getInstance().getPreference(sharedByAtSign));
 
+    // Per-key gate: register the listener BEFORE the put so the
+    // push event for this key can't fire before the listener is in
+    // place. `put` internally calls `syncService.sync()` after
+    // enqueueing, which can run to completion (and emit its
+    // SyncProgress event) before any subsequent line of test code
+    // runs — registering the listener after the put would miss
+    // that event and the gate would hang until timeout.
+    // `awaitKeyPushed` runs its registration synchronously before
+    // returning its Future, so capturing it here is sufficient.
+    var pushedInitialValue = E2ESyncService.getInstance().awaitKeyPushed(
+        AtClientManager.getInstance().atClient.syncService,
+        testByPassCacheAtKey);
     var putResult = await AtClientManager.getInstance()
         .atClient
         .put(testByPassCacheAtKey, initialValue);
     expect(putResult, true);
-    // Per-key gate: do not proceed until the publisher's sync queue
-    // has actually pushed THIS put. Replaces the brittle "syncData
-    // returns success because some prior sync event matched commit
-    // IDs" inference with a direct observation.
-    await E2ESyncService.getInstance().awaitKeyPushed(
-        AtClientManager.getInstance().atClient.syncService,
-        testByPassCacheAtKey);
+    await pushedInitialValue;
 
     // Cross-server propagation: publisher's atServer auto-notifies
     // the receiver's atServer (autoNotify=true at this point). That
@@ -135,20 +141,25 @@ void main() async {
     // Set autoNotify to false so that the update doesn't propagate to sharedWith AtSign automatically
     await setAtSignOneAutoNotify(false);
 
+    // Per-key gate: register the listener BEFORE the put (see
+    // explanation at the initialValue gate above) — `put` may
+    // trigger sync to completion before any subsequent line runs,
+    // so post-put registration races the very event we're trying
+    // to observe.
+    //
+    // This gate is the primary fix for the historical flake — the
+    // prior `syncData` gate could return on an unrelated prior
+    // sync event's commit-id match, leaving N+2 still queued; the
+    // receiver-side bypassCache lookup then polled for 60s against
+    // a publisher atServer that still held `initialValue`.
+    var pushedUpdatedValue = E2ESyncService.getInstance().awaitKeyPushed(
+        AtClientManager.getInstance().atClient.syncService,
+        testByPassCacheAtKey);
     var newPutResult = await AtClientManager.getInstance()
         .atClient
         .put(testByPassCacheAtKey, updatedValue);
     expect(newPutResult, true);
-    // Per-key gate: do not switch atSigns until the publisher's sync
-    // queue has actually pushed THIS update. This is the primary fix
-    // for the historical flake — the prior `syncData` gate could
-    // return on an unrelated prior sync event's commit-id match,
-    // leaving N+2 still queued; the receiver-side bypassCache lookup
-    // then polled for 60s against a publisher atServer that still
-    // held `initialValue`.
-    await E2ESyncService.getInstance().awaitKeyPushed(
-        AtClientManager.getInstance().atClient.syncService,
-        testByPassCacheAtKey);
+    await pushedUpdatedValue;
 
     // As atSignTwo
     await AtClientManager.getInstance().setCurrentAtSign(


### PR DESCRIPTION
Fixes #1942.

**AtCollection \"local:\" fix.** `AtCollection<T>.getItems()` / `getItemsAsStream()` crashed when the local keystore held a bare-form `lastreceivednotification.<ns>@<atSign>` key — the namespace-scan regex matched it as a collection item and decode failed. `NotificationServiceImpl` now does a one-shot startup migration that seeds the canonical `local:` form and deletes every legacy form found, and `AtCollection`'s scan regex rejects any key starting with `local:` and dot-escapes the namespace.

**bypasscache_test flake fix.** The test was flaking with two symptoms: silent data corruption (`Actual: initial_value... / Expected: updated_value...`) and `awaitKeyPushed` timeouts. Three sync-race fixes together: `_syncFromServer` now refreshes its pending-push snapshot per batch and consults a new in-memory `_writesInProgress` tracker on `LocalSecondary` (closes the put/pull-overwrite race); `_pushFromSyncQueue`'s per-batch progress event now carries its cumulative `keyInfoList` (closes the missed-localToRemote window); and `setCurrentAtSign` is now idempotent for same-atSign calls with no override args (eliminates the two-SyncService-on-same-Hive overlap that consecutive `setCurrentAtSign(@X)` calls produced). A new `E2ESyncService.awaitKeyPushed` helper gates the test on direct observation of the specific push event.

**Misc.** `E2ESyncService.syncData` simplified to a thin wrapper around `SyncServiceWaitUntilCaughtUp.waitUntilCaughtUp`, and e2e `root_level` raised to `'info'` for steadier CI logs.

**Test**
Added a bunch more unit tests