### PR TITLE
build(at_client_flutter): release 1.1.2

### DIFF
--- a/packages/at_client_flutter/CHANGELOG.md
+++ b/packages/at_client_flutter/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 1.1.2
 
+- fix: prevent blank dialog box flashing during login
 - docs(examples): improved READMEs, added dockerstats flutter app
 
 ## 1.1.1

--- a/packages/at_client_flutter/CHANGELOG.md
+++ b/packages/at_client_flutter/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.1.2
 
 - fix: prevent blank dialog box flashing during login
+- fix: remove phosphor_flutter dependency which fails to build on Flutter 3.44+, now using a built-in icon
 - docs(examples): improved READMEs, added dockerstats flutter app
 
 ## 1.1.1

--- a/packages/at_client_flutter/pubspec.yaml
+++ b/packages/at_client_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client_flutter
 description: A Flutter extension to the at_client library which adds support for mobile, desktop and IoT devices.
-version: 1.1.2-rc.1
+version: 1.1.2
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
## Release `at_client_flutter` 1.1.2

Prepares the `at_client_flutter` 1.1.2 release for publishing to pub.dev (current latest published: 1.1.1).

### Changes
- Bump `version` to `1.1.2` in `pubspec.yaml` (was `1.1.2-rc.1`).
- Add changelog entry for the blank dialog box fix.

### What's in this release
- **fix: prevent blank dialog box flashing during login** (#1957) — `CramDialog` and `PkamDialog` `StreamBuilder`s returned an empty `Container()` when a progress event arrived but no custom `progressBuilder` was provided, causing a blank dialog box to flash on screen during login. They now keep showing the `LoadingDialog` until onboarding/auth completes and the dialog is popped.
- docs(examples): improved READMEs, added dockerstats flutter app

### Notes
- `flutter pub publish --dry-run` passes (only pre-existing warnings remain).