### PR TITLE
fix: remove phosphor_flutter dependency

### DIFF
--- a/packages/at_client_flutter/lib/src/widgets/shared/typable_dropdown.dart
+++ b/packages/at_client_flutter/lib/src/widgets/shared/typable_dropdown.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:phosphor_flutter/phosphor_flutter.dart';
 
 class TypableDropdown extends StatelessWidget {
   final List<String> items;
@@ -91,7 +90,7 @@ class TypableDropdown extends StatelessWidget {
                     controller.clear();
                     focusNode.requestFocus();
                   },
-                  child: PhosphorIcon(PhosphorIcons.caretDown()),
+                  child: Icon(Icons.keyboard_arrow_down),
                 ),
               ),
           onChanged: (value) {

--- a/packages/at_client_flutter/pubspec.yaml
+++ b/packages/at_client_flutter/pubspec.yaml
@@ -22,7 +22,6 @@ dependencies:
   at_auth: ^3.0.1
   at_client: ^3.11.0
   encrypt: ^5.0.3
-  phosphor_flutter: ^2.1.0
   intl: ^0.20.2
   file_picker: ^11.0.02
   path: ^1.9.1


### PR DESCRIPTION
phosphor_flutter no longer builds on Flutter 3.44+ because IconData is now a final class and can't be extended. It was only used for one dropdown icon, so this replaces it with the built-in Icons.keyboard_arrow_down and removes the dependency.

Verified with flutter build ios.

Fixes #1961