### PR TITLE
chore: move tombstones

### DIFF
--- a/deprecated/at_client_mobile/README.md
+++ b/deprecated/at_client_mobile/README.md
@@ -2,4 +2,4 @@
 
 Package being phased out. See the [root README](../../README.md) for
 the currently-supported package list. New mobile work should use
-[`at_client_flutter`](../at_client_flutter) instead.
+[`at_client_flutter`](../../packages/at_client_flutter) instead.

--- a/deprecated/at_client_mobile/README.md
+++ b/deprecated/at_client_mobile/README.md
@@ -1,5 +1,0 @@
-# at_client_mobile
-
-Package being phased out. See the [root README](../../README.md) for
-the currently-supported package list. New mobile work should use
-[`at_client_flutter`](../../packages/at_client_flutter) instead.

--- a/deprecated/at_onboarding_flutter/README.md
+++ b/deprecated/at_onboarding_flutter/README.md
@@ -2,4 +2,4 @@
 
 Package being phased out. See the [root README](../../README.md) for
 the currently-supported package list. The onboarding surface for new
-Flutter apps lives in [`at_client_flutter`](../at_client_flutter).
+Flutter apps lives in [`at_client_flutter`](../../packages/at_client_flutter).

--- a/deprecated/at_onboarding_flutter/README.md
+++ b/deprecated/at_onboarding_flutter/README.md
@@ -1,5 +1,0 @@
-# at_onboarding_flutter
-
-Package being phased out. See the [root README](../../README.md) for
-the currently-supported package list. The onboarding surface for new
-Flutter apps lives in [`at_client_flutter`](../../packages/at_client_flutter).

--- a/deprecated/flutter/at_client_mobile/README.md
+++ b/deprecated/flutter/at_client_mobile/README.md
@@ -1,0 +1,5 @@
+# at_client_mobile
+
+Package being phased out. See the [root README](../../../README.md) for
+the currently-supported package list. New mobile work should use
+[`at_client_flutter`](../../../packages/at_client_flutter) instead.

--- a/deprecated/flutter/at_onboarding_flutter/README.md
+++ b/deprecated/flutter/at_onboarding_flutter/README.md
@@ -1,0 +1,5 @@
+# at_onboarding_flutter
+
+Package being phased out. See the [root README](../../../README.md) for
+the currently-supported package list. The onboarding surface for new
+Flutter apps lives in [`at_client_flutter`](../../../packages/at_client_flutter).


### PR DESCRIPTION
**- What I did**
 - move at_client_mobile and at_onboarding_flutter tombstones into the deprecated folder in our root
 
**- How I did it**

**- How to verify it**
 - test links in rich diff

**- Description for the changelog**
chore: move tombstones