### PR TITLE
feat(at_commons): add Metadata.appMetadata wire field (5.11.0)

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 5.11.0
+
+- feat: add `Metadata.appMetadata` (`AppMetadata{providerId, additional}`),
+  emitted on the wire as `:appMetadata:` (base64-encoded JSON) on the
+  `update`, `update:meta` and `notify` verbs and parsed back by the verb
+  builders. `providerId` routes pluggable-crypto decryption; `additional`
+  is provider-owned opaque metadata. `providerId` must be a non-empty
+  string (a `FormatException` is thrown otherwise).
+
 ## 5.10.0
 
 - feat: add `:cl` flag to the `scan` verb syntax, plus

--- a/packages/at_commons/lib/src/at_constants.dart
+++ b/packages/at_commons/lib/src/at_constants.dart
@@ -69,6 +69,7 @@ class AtConstants {
   static const String sharedWithPublicKeyHashingAlgo = 'hashingAlgo';
   static const String sharedKeyEncryptedEncryptingKeyName = 'skeEncKeyName';
   static const String sharedKeyEncryptedEncryptingAlgo = 'skeEncAlgo';
+  static const String appMetadata = 'appMetadata';
   static const String immutable = 'immutable';
   static const String force = 'force';
   static const String firstByte = '#';

--- a/packages/at_commons/lib/src/exception/at_client_exceptions.dart
+++ b/packages/at_commons/lib/src/exception/at_client_exceptions.dart
@@ -82,3 +82,10 @@ class InvalidPinException extends AtClientException {
 
   InvalidPinException.message(String message) : super.message(message);
 }
+
+class CryptoProviderNotRegistered extends AtClientException {
+  CryptoProviderNotRegistered(String message,
+      {Intent? intent, ExceptionScenario? exceptionScenario})
+      : super.message(message,
+            intent: intent, exceptionScenario: exceptionScenario);
+}

--- a/packages/at_commons/lib/src/exception/at_exceptions.dart
+++ b/packages/at_commons/lib/src/exception/at_exceptions.dart
@@ -225,5 +225,6 @@ enum Intent {
   fetchEncryptionPublicKey,
   fetchEncryptionPrivateKey,
   fetchEncryptionSharedKey,
-  fetchSelfEncryptionKey
+  fetchSelfEncryptionKey,
+  fetchCryptoProvider
 }

--- a/packages/at_commons/lib/src/keystore/at_key.dart
+++ b/packages/at_commons/lib/src/keystore/at_key.dart
@@ -526,6 +526,14 @@ class Metadata {
   /// when executing the `delete` verb.
   bool immutable = false;
 
+  /// Provider-owned crypto metadata serialized on the wire as `appMetadata`.
+  ///
+  /// The SDK owns [AppMetadata.providerId] only for routing to the
+  /// provider that can decrypt the value. [AppMetadata.additional] is opaque to
+  /// the SDK and belongs to that provider. It is plaintext metadata, so
+  /// providers must not store record plaintext or other sensitive values here.
+  AppMetadata? appMetadata;
+
   @override
   String toString() {
     return 'Metadata{${jsonEncode(toJson())}}';
@@ -609,6 +617,10 @@ class Metadata {
     if (immutable) {
       sb.write(':${AtConstants.immutable}:$immutable');
     }
+    if (appMetadata != null) {
+      sb.write(
+          ':${AtConstants.appMetadata}:${Metadata.encodeAppMetadata(appMetadata!)}');
+    }
     return sb.toString();
   }
 
@@ -639,6 +651,7 @@ class Metadata {
     map[AtConstants.sharedKeyEncryptedEncryptingKeyName] = skeEncKeyName;
     map[AtConstants.sharedKeyEncryptedEncryptingAlgo] = skeEncAlgo;
     map[AtConstants.immutable] = immutable;
+    map[AtConstants.appMetadata] = appMetadata?.toJson();
     map['namespaceAware'] = namespaceAware;
     map['isCached'] = isCached;
 
@@ -703,8 +716,34 @@ class Metadata {
     metaData.skeEncAlgo = json[AtConstants.sharedKeyEncryptedEncryptingAlgo];
     metaData.namespaceAware = json['namespaceAware'] ?? false;
     metaData.immutable = json[AtConstants.immutable] ?? false;
+    metaData.appMetadata =
+        Metadata.decodeAppMetadata(json[AtConstants.appMetadata]);
 
     return metaData;
+  }
+
+  static String encodeAppMetadata(AppMetadata appMetadata) {
+    return base64Encode(utf8.encode(jsonEncode(appMetadata.toJson())));
+  }
+
+  static AppMetadata? decodeAppMetadata(dynamic value) {
+    if (value == null || value == 'null') {
+      return null;
+    }
+    if (value is AppMetadata) {
+      return value;
+    }
+    if (value is Map) {
+      return AppMetadata.fromJson(value);
+    }
+    if (value is String && value.isNotEmpty) {
+      final decoded = utf8.decode(base64Decode(value));
+      final decodedJson = jsonDecode(decoded);
+      if (decodedJson is Map) {
+        return AppMetadata.fromJson(decodedJson);
+      }
+    }
+    throw FormatException('Invalid appMetadata: $value');
   }
 
   @override
@@ -739,7 +778,8 @@ class Metadata {
           ivNonce == other.ivNonce &&
           skeEncKeyName == other.skeEncKeyName &&
           skeEncAlgo == other.skeEncAlgo &&
-          immutable == other.immutable;
+          immutable == other.immutable &&
+          appMetadata == other.appMetadata;
 
   @override
   int get hashCode =>
@@ -770,7 +810,8 @@ class Metadata {
       ivNonce.hashCode ^
       skeEncKeyName.hashCode ^
       skeEncAlgo.hashCode ^
-      immutable.hashCode;
+      immutable.hashCode ^
+      appMetadata.hashCode;
 }
 
 class AtValue {
@@ -792,4 +833,91 @@ class AtValue {
 
   @override
   int get hashCode => value.hashCode ^ metadata.hashCode;
+}
+
+class AppMetadata {
+  /// SDK-owned routing field for the crypto provider which can decrypt the
+  /// associated value.
+  String providerId;
+
+  /// Provider-owned opaque plaintext metadata.
+  ///
+  /// Serialized flat in the appMetadata JSON object.
+  /// The SDK preserves these values but does not interpret them.
+  Map<String, dynamic>? additional;
+
+  AppMetadata({required String providerId, this.additional})
+      : providerId = _validateProviderId(providerId);
+
+  Map<String, dynamic> toJson() {
+    final map = <String, dynamic>{
+      'providerId': providerId,
+    };
+    if (additional != null) {
+      map.addAll(additional!);
+    }
+    return map;
+  }
+
+  static AppMetadata fromJson(Map json) {
+    final providerId = json['providerId'];
+    if (providerId is! String) {
+      throw FormatException('Invalid appMetadata.providerId: $providerId');
+    }
+    final additional = <String, dynamic>{};
+    json.forEach((key, value) {
+      if (key != 'providerId') {
+        additional[key.toString()] = value;
+      }
+    });
+
+    return AppMetadata(
+      providerId: providerId,
+      additional: additional.isEmpty ? null : additional,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AppMetadata &&
+          runtimeType == other.runtimeType &&
+          providerId == other.providerId &&
+          _mapEquals(additional, other.additional);
+
+  @override
+  int get hashCode => providerId.hashCode ^ _mapHash(additional);
+
+  static bool _mapEquals(Map<String, dynamic>? a, Map<String, dynamic>? b) {
+    if (a == null || a.isEmpty) {
+      return b == null || b.isEmpty;
+    }
+    if (b == null || a.length != b.length) {
+      return false;
+    }
+    for (final entry in a.entries) {
+      if (!b.containsKey(entry.key) || b[entry.key] != entry.value) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  static int _mapHash(Map<String, dynamic>? map) {
+    if (map == null || map.isEmpty) {
+      return 0;
+    }
+    var hash = 0;
+    for (final key in map.keys.toList()..sort()) {
+      hash = hash ^ key.hashCode ^ map[key].hashCode;
+    }
+    return hash;
+  }
+
+  static String _validateProviderId(String providerId) {
+    if (providerId.trim().isEmpty) {
+      throw FormatException('Invalid appMetadata.providerId: $providerId');
+    }
+    return providerId;
+  }
 }

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -56,7 +56,8 @@ class VerbSyntax {
       r'(:ivNonce:(?<ivNonce>[^:@\s]+))?'
       r'(:skeEncKeyName:(?<skeEncKeyName>[^:@\s]+))?'
       r'(:skeEncAlgo:(?<skeEncAlgo>[^:@\s]+))?'
-      r'(:immutable:(?<immutable>true|false))?';
+      r'(:immutable:(?<immutable>true|false))?'
+      r'(:appMetadata:(?<appMetadata>[^:@\s]+))?';
 
   static const update = r'^update'
       r'(:nc(?<noCommit>))?'

--- a/packages/at_commons/lib/src/verb/update_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/update_verb_builder.dart
@@ -191,6 +191,8 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
       builder.atKey.metadata.immutable =
           _getBoolVerbParams(verbParams[AtConstants.immutable]!);
     }
+    builder.atKey.metadata.appMetadata =
+        Metadata.decodeAppMetadata(verbParams[AtConstants.appMetadata]);
     builder.value = verbParams[AtConstants.value];
 
     return builder;
@@ -248,7 +250,8 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
           atKey.metadata.encAlgo == other.atKey.metadata.encAlgo &&
           atKey.metadata.ivNonce == other.atKey.metadata.ivNonce &&
           atKey.metadata.skeEncKeyName == other.atKey.metadata.skeEncKeyName &&
-          atKey.metadata.skeEncAlgo == other.atKey.metadata.skeEncAlgo;
+          atKey.metadata.skeEncAlgo == other.atKey.metadata.skeEncAlgo &&
+          atKey.metadata.appMetadata == other.atKey.metadata.appMetadata;
 
   @override
   int get hashCode =>
@@ -281,5 +284,6 @@ class UpdateVerbBuilder extends AbstractVerbBuilder {
       atKey.metadata.encAlgo.hashCode ^
       atKey.metadata.ivNonce.hashCode ^
       atKey.metadata.skeEncKeyName.hashCode ^
-      atKey.metadata.skeEncAlgo.hashCode;
+      atKey.metadata.skeEncAlgo.hashCode ^
+      atKey.metadata.appMetadata.hashCode;
 }

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.10.0
+version: 5.11.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_commons/test/at_key_test.dart
+++ b/packages/at_commons/test/at_key_test.dart
@@ -1001,6 +1001,7 @@ void main() {
       expect(metadataMap['skeEncAlgo'], null);
       expect(metadataMap['immutable'], false);
       expect(metadataMap['pubKeyHash'], null);
+      expect(metadataMap['appMetadata'], null);
     });
 
     Metadata createMetadata({
@@ -1032,6 +1033,10 @@ void main() {
         ..ivNonce = '16'
         ..skeEncKeyName = 'dummy_enc_key_name'
         ..skeEncAlgo = 'RSA'
+        ..appMetadata = AppMetadata(providerId: 'test_provider', additional: {
+          'encKeyName': 'key_12345.__shared_keys.wavi',
+          'encAlgo': 'test_algo',
+        })
         ..immutable = immutable;
     }
 
@@ -1067,6 +1072,11 @@ void main() {
       expect(metadataMap['ivNonce'], '16');
       expect(metadataMap['skeEncKeyName'], 'dummy_enc_key_name');
       expect(metadataMap['skeEncAlgo'], 'RSA');
+      expect(metadataMap['appMetadata'], {
+        'providerId': 'test_provider',
+        'encKeyName': 'key_12345.__shared_keys.wavi',
+        'encAlgo': 'test_algo',
+      });
       expect(metadataMap['immutable'], immutable);
     }
 
@@ -1108,6 +1118,24 @@ void main() {
       );
       Metadata roundTripped = Metadata.fromJson(metadata.toJson());
       expect(metadata.toJson(), roundTripped.toJson());
+    });
+
+    test('throws FormatException for empty appMetadata providerId', () {
+      expect(
+        () => AppMetadata(providerId: ''),
+        throwsA(isA<FormatException>()),
+      );
+      expect(
+        () => Metadata.decodeAppMetadata({'providerId': '  '}),
+        throwsA(isA<FormatException>()),
+      );
+    });
+
+    test('throws FormatException for non-string appMetadata providerId', () {
+      expect(
+        () => Metadata.decodeAppMetadata({'providerId': 1}),
+        throwsA(isA<FormatException>()),
+      );
     });
   });
   group('A group of tests to verify key length validation', () {

--- a/packages/at_commons/test/notify_verb_builder_test.dart
+++ b/packages/at_commons/test/notify_verb_builder_test.dart
@@ -190,6 +190,30 @@ void main() {
           params[AtConstants.sharedKeyEncryptedEncryptingKeyName], 'ske_ekn');
       expect(params[AtConstants.sharedKeyEncryptedEncryptingAlgo], 'ske_ea');
     });
+
+    test('notify command with app metadata', () {
+      final appMetadata = AppMetadata(providerId: 'test_provider', additional: {
+        'encKeyName': 'key_12345.__shared_keys.wavi',
+        'encAlgo': 'test_algo',
+      });
+      final encodedAppMetadata = Metadata.encodeAppMetadata(appMetadata);
+
+      var notifyVerbBuilder = NotifyVerbBuilder()
+        ..id = '123'
+        ..value = 'alice@atsign.com'
+        ..atKey.key = 'email.wavi'
+        ..atKey.sharedBy = '@alice'
+        ..atKey.sharedWith = '@bob'
+        ..atKey.metadata.appMetadata = appMetadata;
+
+      var command = notifyVerbBuilder.buildCommand();
+      expect(command, contains(':appMetadata:$encodedAppMetadata'));
+
+      var params = VerbUtil.getVerbParam(VerbSyntax.notify, command.trim())!;
+      expect(params[AtConstants.appMetadata], encodedAppMetadata);
+      expect(Metadata.decodeAppMetadata(params[AtConstants.appMetadata]),
+          appMetadata);
+    });
   });
 
   try {

--- a/packages/at_commons/test/update_verb_builder_test.dart
+++ b/packages/at_commons/test/update_verb_builder_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:at_commons/at_builders.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:test/test.dart';
@@ -66,6 +68,30 @@ void main() {
           skeEncKeyName);
       expect(updateVerbParams[AtConstants.sharedKeyEncryptedEncryptingAlgo],
           skeEncAlgo);
+    });
+
+    test('verify update command with app metadata', () {
+      final appMetadata = AppMetadata(providerId: 'test_provider', additional: {
+        'encKeyName': 'key_12345.__shared_keys.wavi',
+        'encAlgo': 'test_algo',
+      });
+      final encodedAppMetadata = Metadata.encodeAppMetadata(appMetadata);
+      var updateBuilder = UpdateVerbBuilder()
+        ..value = 'alice@atsign.com'
+        ..atKey.key = 'email.wavi'
+        ..atKey.sharedBy = '@alice'
+        ..atKey.sharedWith = '@bob'
+        ..atKey.metadata.appMetadata = appMetadata;
+      var updateCommand = updateBuilder.buildCommand();
+      expect(
+          updateCommand,
+          'update:isEncrypted:false'
+          ':appMetadata:$encodedAppMetadata'
+          ':@bob:email.wavi@alice alice@atsign.com'
+          '\n');
+      var roundTrippedBuilder =
+          UpdateVerbBuilder.getBuilder(updateCommand.trim())!;
+      expect(roundTrippedBuilder.atKey.metadata.appMetadata, appMetadata);
     });
 
     test('verify local key command', () {
@@ -159,6 +185,25 @@ void main() {
           skeEncKeyName);
       expect(updateMetaVerbParams[AtConstants.sharedKeyEncryptedEncryptingAlgo],
           skeEncAlgo);
+    });
+
+    test('verify update:meta command with app metadata', () {
+      final appMetadata = AppMetadata(providerId: 'test_provider');
+      final encodedAppMetadata = Metadata.encodeAppMetadata(appMetadata);
+      var updateBuilder = UpdateVerbBuilder()
+        ..atKey.key = 'email.wavi'
+        ..atKey.sharedBy = '@alice'
+        ..atKey.sharedWith = '@bob'
+        ..atKey.metadata.appMetadata = appMetadata;
+      var updateMetaCommand = updateBuilder.buildCommandForMeta();
+      expect(
+          updateMetaCommand,
+          'update:meta:@bob:email.wavi@alice:isEncrypted:false'
+          ':appMetadata:$encodedAppMetadata'
+          '\n');
+      var roundTrippedBuilder =
+          UpdateVerbBuilder.getBuilder(updateMetaCommand.trim())!;
+      expect(roundTrippedBuilder.atKey.metadata.appMetadata, appMetadata);
     });
   });
 
@@ -702,6 +747,29 @@ void main() {
       expect(command, startsWith('update:json:'));
       var verbParams = getVerbParams(VerbSyntax.update, command.trim());
       expect(verbParams['noCommit'], null);
+    });
+
+    test('json form round-trips app metadata through UpdateParams', () {
+      final appMetadata = AppMetadata(providerId: 'test_provider', additional: {
+        'encKeyName': 'key_12345.__shared_keys.wavi',
+        'encAlgo': 'test_algo',
+      });
+      var builder = UpdateVerbBuilder()
+        ..isJson = true
+        ..value = 'alice@atsign.com'
+        ..atKey.key = 'email.wavi'
+        ..atKey.sharedBy = '@alice'
+        ..atKey.sharedWith = '@bob'
+        ..atKey.metadata.appMetadata = appMetadata;
+
+      var command = builder.buildCommand();
+      expect(command, startsWith('update:json:'));
+
+      var verbParams = getVerbParams(VerbSyntax.update, command.trim());
+      var json = jsonDecode(verbParams['json']!);
+      var updateParams = UpdateParams.fromJson(json);
+
+      expect(updateParams.metadata!.appMetadata, appMetadata);
     });
 
     test('getBuilder round-trips noCommit on the metadata-fragment form', () {


### PR DESCRIPTION
**- What I did**

Added `Metadata.appMetadata` — an `AppMetadata{providerId, additional}` value carried on the wire as `:appMetadata:` (base64-encoded JSON) on the `update`, `update:meta`, and `notify` verbs, and parsed back by the verb builders. Also added the supporting `CryptoProviderNotRegistered` exception and the `fetchCryptoProvider` `Intent`, and bumped at_commons to 5.11.0.

This is the foundational, dependency-free first step of a series that lands pluggable, post-quantum-ready encryption in the SDK. It adds **only** the at_commons wire field and shared vocabulary — the consuming logic ships in later, dependent PRs (at_chops, at_persistence_secondary_server, at_client). `CryptoProviderNotRegistered`/`fetchCryptoProvider` are not yet referenced in-tree; they live here because at_commons owns the `AtClientException`/`Intent` vocabulary and at_client 3.13.0 will consume them from the published at_commons.

**- How I did it**

- `AppMetadata.providerId` — SDK-owned routing field naming the crypto provider able to decrypt the value; validated as a non-empty string (`FormatException` otherwise).
- `AppMetadata.additional` — provider-owned opaque plaintext metadata the SDK preserves but does not interpret (plaintext on the wire, so no secrets).
- Serialized via `Metadata.encodeAppMetadata` (base64-JSON) only when present; decoded in `Metadata.fromJson` and the verb builders. `==`/`hashCode` on `Metadata` and `UpdateVerbBuilder` extended to include it.
- No behavioural change for existing callers: `appMetadata` is `null` unless set.

**- How to verify it**

New coverage in `at_key_test.dart`, `update_verb_builder_test.dart`, and `notify_verb_builder_test.dart` (encode/decode round trip, verb serialization/parsing, `providerId` validation). Full suite: **486 tests pass**; `dart analyze --fatal-warnings` clean; `dart format` clean.

**- Description for the changelog**

Add `Metadata.appMetadata` wire field (and `CryptoProviderNotRegistered`/`fetchCryptoProvider`) for pluggable-crypto provider routing.