### PR TITLE
fix(at_auth): reliably throw AtDecryptionException on incorrect passphrase

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.1
+- fix: `decodeAtKeys()` now reliably throws `AtDecryptionException` on an incorrect passphrase. The `jsonDecode` of the decrypted bytes now runs inside the decrypt try/catch, so wrong-passphrase garbage no longer escapes as an uncaught `FormatException` (an intermittent failure in `at_keys_io_test`).
+
 ## 3.1.0
 - feat: `validateAtServer()` now emits progress events and probes atSign connectivity before returning
 - fix: `decodeAtKeys()` now throws when an invalid passphrase is provided

--- a/packages/at_auth/lib/src/keys/at_keys_io.dart
+++ b/packages/at_auth/lib/src/keys/at_keys_io.dart
@@ -195,16 +195,23 @@ mixin KeyIOMixin on AtKeysIo {
             'Hashing algo type is required for decryption of password protected atKeys file');
       }
 
-      String decryptedAtKeysData;
       try {
-        decryptedAtKeysData = await AtKeysCrypto.fromHashingAlgorithm(
+        final decryptedAtKeysData = await AtKeysCrypto.fromHashingAlgorithm(
                 atEncrypted.hashingAlgoType!)
             .decrypt(atEncrypted, passPhrase!);
+        // jsonDecode must stay inside the try: the cipher is unauthenticated,
+        // so an incorrect passphrase does not fail decrypt() -- it yields
+        // arbitrary bytes. Whether those bytes parse as a JSON object is
+        // effectively random per file (the IV varies per write), so a wrong
+        // passphrase otherwise escapes as an uncaught FormatException (invalid
+        // JSON) or a cast error (valid non-object JSON) instead of the
+        // documented AtDecryptionException.
+        decodedAtKeysData =
+            jsonDecode(decryptedAtKeysData) as Map<String, dynamic>;
       } catch (e) {
         throw AtDecryptionException(
             'Failed to decrypt atKeys file - passphrase may be incorrect: $e');
       }
-      decodedAtKeysData = jsonDecode(decryptedAtKeysData);
     }
 
     return decodedAtKeysData;

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 3.1.0
+version: 3.1.1
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
## What I did

Fixed an intermittently-failing at_auth unit test, `at_keys_io_test.dart › Test read() -> throws with incorrect passphrase`, by making `decodeAtKeys()` reliably throw `AtDecryptionException` when the passphrase is wrong.

The test was observed failing on an unrelated PR's CI ([#1984](https://github.com/atsign-foundation/at_client_sdk/pull/1984)) and passing on a re-run — a flake.

## How I did it

`decodeAtKeys()` wrapped only the `decrypt()` call in its try/catch; the subsequent `jsonDecode()` of the decrypted bytes ran *outside* it. The atKeys cipher is unauthenticated, so an incorrect passphrase does not make `decrypt()` throw — it returns arbitrary bytes. Whether those bytes happen to parse as a JSON object is effectively random per file (the IV varies on each `write()`), so a wrong passphrase intermittently escaped as an uncaught `FormatException` (invalid JSON) or a cast error (valid non-object JSON) instead of the documented `AtDecryptionException`.

Moving `jsonDecode(...)` inside the existing decrypt try/catch means any wrong-passphrase outcome — invalid JSON, valid-but-non-object JSON, or a decrypt error — is consistently surfaced as `AtDecryptionException`. This also makes the existing 3.1.0 CHANGELOG promise ("`decodeAtKeys()` now throws when an invalid passphrase is provided") actually hold.

Bumps at_auth 3.1.0 → 3.1.1.

## How to verify it

```
cd packages/at_auth
dart analyze --fatal-warnings lib
dart test --concurrency=1 test/at_keys_io_test.dart   # run a few times
```

The "throws with incorrect passphrase" test now passes deterministically (verified across repeated runs); before this change it passed only when the wrong-passphrase decryption happened to produce non-JSON bytes. Full at_auth unit suite (61 tests) is green.

## Description for the changelog

fix: `decodeAtKeys()` now reliably throws `AtDecryptionException` on an incorrect passphrase (jsonDecode of the decrypted bytes runs inside the decrypt try/catch, so wrong-passphrase garbage no longer escapes as an uncaught `FormatException`).