### PR TITLE
feat: PQ HPKE seal in at_chops

### DIFF
--- a/packages/at_chops/CHANGELOG.md
+++ b/packages/at_chops/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.0
+- feat: Add `pqSeal`/`pqOpen` — HPKE-style PQ encryption over X-Wing KEM with AES-256-GCM and forward-compatible versioning
+
 ## 3.2.1
 - docs: update README to document PQC algorithms (ML-DSA-65, ML-KEM-768, X-Wing, X25519), FFI vs pure-Dart backends, and usage examples
 

--- a/packages/at_chops/lib/at_chops.dart
+++ b/packages/at_chops/lib/at_chops.dart
@@ -14,6 +14,7 @@ export 'src/algorithm/ml_dsa_65_pure_dart_algo.dart';
 export 'src/algorithm/ml_kem_768_ffi_algo.dart';
 export 'src/algorithm/ml_kem_768_pure_dart_algo.dart';
 export 'src/algorithm/pkam_signing_algo.dart';
+export 'src/algorithm/pq_hpke.dart';
 export 'src/algorithm/rsa_encryption_algo.dart';
 export 'src/algorithm/x25519_ffi_algo.dart';
 export 'src/algorithm/x25519_pure_dart_algo.dart';

--- a/packages/at_chops/lib/src/algorithm/aes_gcm_encryption_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/aes_gcm_encryption_algo.dart
@@ -18,6 +18,11 @@ import 'package:cryptography/cryptography.dart' as crypto;
 /// callers convey it alongside (e.g. in metadata), exactly as with the
 /// existing CTR IVs. Generate one per encryption with
 /// `AtChopsUtil.generateRandomIV(12)` — never reuse a (key, nonce) pair.
+///
+/// An optional [aad] (associated data) may be supplied: it is authenticated
+/// but NOT encrypted, and must be byte-identical at [encrypt] and [decrypt]
+/// or authentication fails. It defaults to empty, so callers that don't use
+/// AAD are unaffected.
 final class AesGcm256EncryptionAlgo
     implements SymmetricEncryptionAlgorithm<Uint8List, Uint8List> {
   static const int nonceLength = 12;
@@ -31,18 +36,19 @@ final class AesGcm256EncryptionAlgo
 
   @override
   Future<Uint8List> encrypt(Uint8List plainData,
-      {InitialisationVector? iv}) async {
+      {InitialisationVector? iv, List<int> aad = const []}) async {
     final crypto.SecretBox box = await _aesGcm.encrypt(
       plainData,
       secretKey: crypto.SecretKey(_keyBytes()),
       nonce: _nonceBytes(iv),
+      aad: aad,
     );
     return Uint8List.fromList(box.cipherText + box.mac.bytes);
   }
 
   @override
   Future<Uint8List> decrypt(Uint8List encryptedData,
-      {InitialisationVector? iv}) async {
+      {InitialisationVector? iv, List<int> aad = const []}) async {
     if (encryptedData.length < tagLength) {
       throw AtDecryptionException(
           'AES-256-GCM input shorter than the $tagLength-byte tag');
@@ -56,6 +62,7 @@ final class AesGcm256EncryptionAlgo
         crypto.SecretBox(cipherText,
             nonce: _nonceBytes(iv), mac: crypto.Mac(tag)),
         secretKey: crypto.SecretKey(_keyBytes()),
+        aad: aad,
       );
       return Uint8List.fromList(plain);
     } on crypto.SecretBoxAuthenticationError {

--- a/packages/at_chops/lib/src/algorithm/pq_hpke.dart
+++ b/packages/at_chops/lib/src/algorithm/pq_hpke.dart
@@ -1,32 +1,36 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:at_chops/src/algorithm/aes_gcm_encryption_algo.dart';
 import 'package:at_chops/src/algorithm/at_algorithm.dart';
-import 'package:cryptography/cryptography.dart';
+import 'package:at_chops/src/algorithm/at_iv.dart';
+import 'package:at_chops/src/algorithm/hkdf_algo.dart';
+import 'package:at_chops/src/key/impl/aes_key.dart';
+import 'package:at_commons/at_commons.dart';
 
-/// HPKE-base-style authenticated public-key encryption over an X-Wing KEM.
+/// HPKE-*style* authenticated public-key encryption over an X-Wing KEM.
 ///
-/// Mirrors RFC 9180 HPKE SealBase/OpenBase with:
+/// Reuses the RFC 9180 HPKE construction shape:
 ///   - KEM      = caller-supplied [AtKemAlgorithm] (intended: X-Wing)
-///   - KDF      = HKDF-SHA256
-///   - AEAD     = AES-256-GCM
+///   - KDF      = HKDF-SHA256 ([HkdfSha256])
+///   - AEAD     = AES-256-GCM ([AesGcm256EncryptionAlgo])
+///
+/// NOT wire-compatible with RFC 9180 HPKE. This uses a custom, internal
+/// envelope (`ver || ctLen || kemCt || ct || tag`) and a custom key schedule,
+/// so do NOT expect interop with off-the-shelf HPKE implementations — it is an
+/// at_protocol-internal envelope only.
 ///
 /// The KEM's 32-byte shared secret is already uniformly random, so the HKDF
-/// step provides HPKE-style context binding ([info]) and AEAD key/nonce
-/// derivation — not randomness extraction.
+/// step provides context binding ([info]) and AEAD key/nonce derivation —
+/// not randomness extraction.
 
 /// Envelope format version. `v1` = single-shot seal with a derived nonce.
 const int _envelopeVersion = 0x01;
 
-const int _gcmNonceLen = 12;
-const int _gcmTagLen = 16;
+const int _gcmNonceLen = AesGcm256EncryptionAlgo.nonceLength;
+const int _gcmTagLen = AesGcm256EncryptionAlgo.tagLength;
 
 final Uint8List _suiteLabel = Uint8List.fromList('atPQv1-base'.codeUnits);
-final Uint8List _polConfirmLabel =
-    Uint8List.fromList('atPQv1-polconfirm'.codeUnits);
-final Uint8List _sessionLabel =
-    Uint8List.fromList('atPQv1-session'.codeUnits);
-
-final AesGcm _aesGcm = AesGcm.with256bits();
 
 /// Why a [pqOpen] call failed.
 ///
@@ -54,8 +58,8 @@ class PqOpenException implements Exception {
 
 /// Seal [plaintext] to the holder of [recipientPublicKey].
 ///
-/// [xwing] is the KEM instance to use (e.g. [XWingFfiAlgo] or
-/// [XWingPureDartAlgo]). [info] binds the key schedule to a usage context;
+/// [xwing] is the KEM instance to use (e.g. `XWingFfiAlgo` or
+/// `XWingPureDartAlgo`). [info] binds the key schedule to a usage context;
 /// [aad] is authenticated-but-not-encrypted associated data. Both must be
 /// supplied identically to [pqOpen] or opening fails.
 ///
@@ -68,12 +72,12 @@ Future<Uint8List> pqSeal(
   Uint8List? aad,
 }) async {
   final enc = await xwing.encapsulate(recipientPublicKey);
-  final _DerivedKey dk = await _deriveKeyAndNonce(enc.sharedSecret, info);
+  final _DerivedKey dk = _deriveKeyAndNonce(enc.sharedSecret, info);
 
-  final SecretBox box = await _aesGcm.encrypt(
+  // body = gcmCipherText || tag(16), per AesGcm256EncryptionAlgo's wire format.
+  final Uint8List body = await AesGcm256EncryptionAlgo(_aesKey(dk.key)).encrypt(
     plaintext,
-    secretKey: SecretKey(dk.key),
-    nonce: dk.nonce,
+    iv: InitialisationVector(dk.nonce),
     aad: aad ?? const <int>[],
   );
 
@@ -83,8 +87,7 @@ Future<Uint8List> pqSeal(
   out.addByte((enc.ciphertext.length >> 8) & 0xff);
   out.addByte(enc.ciphertext.length & 0xff);
   out.add(enc.ciphertext);
-  out.add(box.cipherText);
-  out.add(box.mac.bytes);
+  out.add(body);
   return out.toBytes();
 }
 
@@ -115,47 +118,22 @@ Future<Uint8List> pqOpen(
         'declared ciphertext length overruns envelope');
   }
   final Uint8List kemCt = Uint8List.sublistView(envelope, 3, 3 + ctLen);
+  // gcmBody = gcmCipherText || tag(16); AesGcm256EncryptionAlgo splits the tag.
   final Uint8List gcmBody = Uint8List.sublistView(envelope, 3 + ctLen);
-  final Uint8List cipherText =
-      Uint8List.sublistView(gcmBody, 0, gcmBody.length - _gcmTagLen);
-  final Uint8List tag =
-      Uint8List.sublistView(gcmBody, gcmBody.length - _gcmTagLen);
 
   final Uint8List ss = await xwing.decapsulate(recipientSecretKey, kemCt);
-  final _DerivedKey dk = await _deriveKeyAndNonce(ss, info);
+  final _DerivedKey dk = _deriveKeyAndNonce(ss, info);
 
   try {
-    final List<int> clear = await _aesGcm.decrypt(
-      SecretBox(cipherText, nonce: dk.nonce, mac: Mac(tag)),
-      secretKey: SecretKey(dk.key),
+    return await AesGcm256EncryptionAlgo(_aesKey(dk.key)).decrypt(
+      gcmBody,
+      iv: InitialisationVector(dk.nonce),
       aad: aad ?? const <int>[],
     );
-    return Uint8List.fromList(clear);
-  } on SecretBoxAuthenticationError {
+  } on AtDecryptionException {
     throw PqOpenException(
         PqOpenFailure.authFailure, 'AEAD authentication failed');
   }
-}
-
-/// Derive a 32-byte key-confirmation tag from [sharedSecret].
-///
-/// Used by the inter-server from/pol handshake so the raw shared secret never
-/// traverses the wire. [info] should bind the tag to its context (e.g.
-/// sessionID || fromAtSign).
-Future<Uint8List> pqDeriveConfirmationTag(
-    Uint8List sharedSecret, Uint8List info) {
-  return _hkdf(sharedSecret, _concat([_polConfirmLabel, info]), 32);
-}
-
-/// Derive a 32-byte session key from [sharedSecret].
-///
-/// Called on both sides after a successful from/pol PQ handshake. [info]
-/// should bind the key to its context (e.g. sessionID || fromAtSign). Uses
-/// a distinct HKDF label so the session key is independent from the
-/// confirmation tag.
-Future<Uint8List> pqDeriveSessionKey(
-    Uint8List sharedSecret, Uint8List info) {
-  return _hkdf(sharedSecret, _concat([_sessionLabel, info]), 32);
 }
 
 // ── internals ───────────────────────────────────────────────────────────────
@@ -166,23 +144,21 @@ class _DerivedKey {
   _DerivedKey(this.key, this.nonce);
 }
 
-Future<_DerivedKey> _deriveKeyAndNonce(Uint8List ss, Uint8List? info) async {
+/// Derives the AEAD key and nonce from the KEM [ss], bound to the suite label
+/// and the caller's [info]. Two HKDF labels (`0x01`/`0x02`) keep key and nonce
+/// independent.
+_DerivedKey _deriveKeyAndNonce(Uint8List ss, Uint8List? info) {
   final Uint8List suiteInfo = _concat([_suiteLabel, info ?? Uint8List(0)]);
-  final Uint8List key = await _hkdf(ss, _concat([suiteInfo, _u8(0x01)]), 32);
-  final Uint8List nonce =
-      await _hkdf(ss, _concat([suiteInfo, _u8(0x02)]), _gcmNonceLen);
+  final Uint8List key =
+      HkdfSha256.deriveKey(ss, info: _concat([suiteInfo, _u8(0x01)]), length: 32);
+  final Uint8List nonce = HkdfSha256.deriveKey(ss,
+      info: _concat([suiteInfo, _u8(0x02)]), length: _gcmNonceLen);
   return _DerivedKey(key, nonce);
 }
 
-Future<Uint8List> _hkdf(Uint8List ikm, Uint8List info, int length) async {
-  final hkdf = Hkdf(hmac: Hmac.sha256(), outputLength: length);
-  final SecretKey derived = await hkdf.deriveKey(
-    secretKey: SecretKey(ikm),
-    nonce: const <int>[],
-    info: info,
-  );
-  return Uint8List.fromList(await derived.extractBytes());
-}
+/// Wraps a raw 32-byte key as an [AESKey] (which carries it base64-encoded,
+/// per the at_chops contract).
+AESKey _aesKey(Uint8List rawKey) => AESKey(base64Encode(rawKey));
 
 Uint8List _u8(int b) => Uint8List.fromList([b]);
 

--- a/packages/at_chops/lib/src/algorithm/pq_hpke.dart
+++ b/packages/at_chops/lib/src/algorithm/pq_hpke.dart
@@ -24,13 +24,23 @@ import 'package:at_commons/at_commons.dart';
 /// step provides context binding ([info]) and AEAD key/nonce derivation —
 /// not randomness extraction.
 
-/// Envelope format version. `v1` = single-shot seal with a derived nonce.
+/// Version emitted by [pqSeal]. Bump this when introducing a new construction.
 const int _envelopeVersion = 0x01;
+
+/// All versions [pqOpen] can decrypt. Add new versions here alongside their
+/// suite label in [_suiteLabelFor]; do not remove old ones until all peers
+/// have upgraded past them.
+const Set<int> _supportedVersions = {0x01};
 
 const int _gcmNonceLen = AesGcm256EncryptionAlgo.nonceLength;
 const int _gcmTagLen = AesGcm256EncryptionAlgo.tagLength;
 
-final Uint8List _suiteLabel = Uint8List.fromList('atPQv1-base'.codeUnits);
+/// Returns the suite label for [version]. Each version must have a distinct
+/// label so its HKDF-derived keys are domain-separated from every other version.
+Uint8List _suiteLabelFor(int version) => switch (version) {
+      0x01 => Uint8List.fromList('atPQv1-base'.codeUnits),
+      _ => throw ArgumentError('no suite label for version 0x${version.toRadixString(16)}'),
+    };
 
 /// Why a [pqOpen] call failed.
 ///
@@ -56,7 +66,8 @@ class PqOpenException implements Exception {
   String toString() => 'PqOpenException($reason): $message';
 }
 
-/// Seal [plaintext] to the holder of [recipientPublicKey].
+/// Seal [plaintext] so only the holder of the secret key paired with
+/// [recipientPublicKey] can open it.
 ///
 /// [xwing] is the KEM instance to use (e.g. `XWingFfiAlgo` or
 /// `XWingPureDartAlgo`). [info] binds the key schedule to a usage context;
@@ -72,7 +83,7 @@ Future<Uint8List> pqSeal(
   Uint8List? aad,
 }) async {
   final enc = await xwing.encapsulate(recipientPublicKey);
-  final _DerivedKey dk = _deriveKeyAndNonce(enc.sharedSecret, info);
+  final _DerivedKey dk = _deriveKeyAndNonce(enc.sharedSecret, _envelopeVersion, info);
 
   // body = gcmCipherText || tag(16), per AesGcm256EncryptionAlgo's wire format.
   final Uint8List body = await AesGcm256EncryptionAlgo(_aesKey(dk.key)).encrypt(
@@ -108,9 +119,10 @@ Future<Uint8List> pqOpen(
     throw PqOpenException(
         PqOpenFailure.malformedEnvelope, 'envelope shorter than header');
   }
-  if (envelope[0] != _envelopeVersion) {
+  final int ver = envelope[0];
+  if (!_supportedVersions.contains(ver)) {
     throw PqOpenException(PqOpenFailure.versionMismatch,
-        'unsupported envelope version 0x${envelope[0].toRadixString(16)}');
+        'unsupported envelope version 0x${ver.toRadixString(16)}');
   }
   final int ctLen = (envelope[1] << 8) | envelope[2];
   if (envelope.length < 3 + ctLen + _gcmTagLen) {
@@ -122,7 +134,7 @@ Future<Uint8List> pqOpen(
   final Uint8List gcmBody = Uint8List.sublistView(envelope, 3 + ctLen);
 
   final Uint8List ss = await xwing.decapsulate(recipientSecretKey, kemCt);
-  final _DerivedKey dk = _deriveKeyAndNonce(ss, info);
+  final _DerivedKey dk = _deriveKeyAndNonce(ss, ver, info);
 
   try {
     return await AesGcm256EncryptionAlgo(_aesKey(dk.key)).decrypt(
@@ -145,10 +157,10 @@ class _DerivedKey {
 }
 
 /// Derives the AEAD key and nonce from the KEM [ss], bound to the suite label
-/// and the caller's [info]. Two HKDF labels (`0x01`/`0x02`) keep key and nonce
-/// independent.
-_DerivedKey _deriveKeyAndNonce(Uint8List ss, Uint8List? info) {
-  final Uint8List suiteInfo = _concat([_suiteLabel, info ?? Uint8List(0)]);
+/// for [version] and the caller's [info]. Two HKDF labels (`0x01`/`0x02`) keep
+/// key and nonce independent.
+_DerivedKey _deriveKeyAndNonce(Uint8List ss, int version, Uint8List? info) {
+  final Uint8List suiteInfo = _concat([_suiteLabelFor(version), info ?? Uint8List(0)]);
   final Uint8List key =
       HkdfSha256.deriveKey(ss, info: _concat([suiteInfo, _u8(0x01)]), length: 32);
   final Uint8List nonce = HkdfSha256.deriveKey(ss,

--- a/packages/at_chops/lib/src/algorithm/pq_hpke.dart
+++ b/packages/at_chops/lib/src/algorithm/pq_hpke.dart
@@ -1,0 +1,195 @@
+import 'dart:typed_data';
+
+import 'package:at_chops/src/algorithm/at_algorithm.dart';
+import 'package:cryptography/cryptography.dart';
+
+/// HPKE-base-style authenticated public-key encryption over an X-Wing KEM.
+///
+/// Mirrors RFC 9180 HPKE SealBase/OpenBase with:
+///   - KEM      = caller-supplied [AtKemAlgorithm] (intended: X-Wing)
+///   - KDF      = HKDF-SHA256
+///   - AEAD     = AES-256-GCM
+///
+/// The KEM's 32-byte shared secret is already uniformly random, so the HKDF
+/// step provides HPKE-style context binding ([info]) and AEAD key/nonce
+/// derivation — not randomness extraction.
+
+/// Envelope format version. `v1` = single-shot seal with a derived nonce.
+const int _envelopeVersion = 0x01;
+
+const int _gcmNonceLen = 12;
+const int _gcmTagLen = 16;
+
+final Uint8List _suiteLabel = Uint8List.fromList('atPQv1-base'.codeUnits);
+final Uint8List _polConfirmLabel =
+    Uint8List.fromList('atPQv1-polconfirm'.codeUnits);
+final Uint8List _sessionLabel =
+    Uint8List.fromList('atPQv1-session'.codeUnits);
+
+final AesGcm _aesGcm = AesGcm.with256bits();
+
+/// Why a [pqOpen] call failed.
+///
+/// All AEAD-level failures (wrong key, tampered ciphertext, mismatched
+/// [info]/[aad]) collapse to [authFailure] by design — X-Wing is an
+/// implicit-rejection KEM, so there is no distinct "wrong key" oracle.
+enum PqOpenFailure { versionMismatch, malformedEnvelope, authFailure }
+
+/// Thrown by [pqSeal] on caller misuse (e.g. a wrong-length public key).
+class PqSealException implements Exception {
+  final String message;
+  PqSealException(this.message);
+  @override
+  String toString() => 'PqSealException: $message';
+}
+
+/// Thrown by [pqOpen] for any failure. Inspect [reason].
+class PqOpenException implements Exception {
+  final PqOpenFailure reason;
+  final String message;
+  PqOpenException(this.reason, this.message);
+  @override
+  String toString() => 'PqOpenException($reason): $message';
+}
+
+/// Seal [plaintext] to the holder of [recipientPublicKey].
+///
+/// [xwing] is the KEM instance to use (e.g. [XWingFfiAlgo] or
+/// [XWingPureDartAlgo]). [info] binds the key schedule to a usage context;
+/// [aad] is authenticated-but-not-encrypted associated data. Both must be
+/// supplied identically to [pqOpen] or opening fails.
+///
+/// Returns the serialized wire envelope (raw bytes).
+Future<Uint8List> pqSeal(
+  AtKemAlgorithm xwing,
+  Uint8List recipientPublicKey,
+  Uint8List plaintext, {
+  Uint8List? info,
+  Uint8List? aad,
+}) async {
+  final enc = await xwing.encapsulate(recipientPublicKey);
+  final _DerivedKey dk = await _deriveKeyAndNonce(enc.sharedSecret, info);
+
+  final SecretBox box = await _aesGcm.encrypt(
+    plaintext,
+    secretKey: SecretKey(dk.key),
+    nonce: dk.nonce,
+    aad: aad ?? const <int>[],
+  );
+
+  // envelope: ver(1) || ctLen(2,BE) || kemCt || gcmCipherText || tag(16)
+  final out = BytesBuilder(copy: false);
+  out.addByte(_envelopeVersion);
+  out.addByte((enc.ciphertext.length >> 8) & 0xff);
+  out.addByte(enc.ciphertext.length & 0xff);
+  out.add(enc.ciphertext);
+  out.add(box.cipherText);
+  out.add(box.mac.bytes);
+  return out.toBytes();
+}
+
+/// Open an envelope produced by [pqSeal] using [recipientSecretKey].
+///
+/// [xwing] must be the same KEM type used by the sender. [info]/[aad] must
+/// match what the sender supplied.
+///
+/// Throws [PqOpenException] on any failure (see [PqOpenFailure]).
+Future<Uint8List> pqOpen(
+  AtKemAlgorithm xwing,
+  Uint8List recipientSecretKey,
+  Uint8List envelope, {
+  Uint8List? info,
+  Uint8List? aad,
+}) async {
+  if (envelope.length < 3) {
+    throw PqOpenException(
+        PqOpenFailure.malformedEnvelope, 'envelope shorter than header');
+  }
+  if (envelope[0] != _envelopeVersion) {
+    throw PqOpenException(PqOpenFailure.versionMismatch,
+        'unsupported envelope version 0x${envelope[0].toRadixString(16)}');
+  }
+  final int ctLen = (envelope[1] << 8) | envelope[2];
+  if (envelope.length < 3 + ctLen + _gcmTagLen) {
+    throw PqOpenException(PqOpenFailure.malformedEnvelope,
+        'declared ciphertext length overruns envelope');
+  }
+  final Uint8List kemCt = Uint8List.sublistView(envelope, 3, 3 + ctLen);
+  final Uint8List gcmBody = Uint8List.sublistView(envelope, 3 + ctLen);
+  final Uint8List cipherText =
+      Uint8List.sublistView(gcmBody, 0, gcmBody.length - _gcmTagLen);
+  final Uint8List tag =
+      Uint8List.sublistView(gcmBody, gcmBody.length - _gcmTagLen);
+
+  final Uint8List ss = await xwing.decapsulate(recipientSecretKey, kemCt);
+  final _DerivedKey dk = await _deriveKeyAndNonce(ss, info);
+
+  try {
+    final List<int> clear = await _aesGcm.decrypt(
+      SecretBox(cipherText, nonce: dk.nonce, mac: Mac(tag)),
+      secretKey: SecretKey(dk.key),
+      aad: aad ?? const <int>[],
+    );
+    return Uint8List.fromList(clear);
+  } on SecretBoxAuthenticationError {
+    throw PqOpenException(
+        PqOpenFailure.authFailure, 'AEAD authentication failed');
+  }
+}
+
+/// Derive a 32-byte key-confirmation tag from [sharedSecret].
+///
+/// Used by the inter-server from/pol handshake so the raw shared secret never
+/// traverses the wire. [info] should bind the tag to its context (e.g.
+/// sessionID || fromAtSign).
+Future<Uint8List> pqDeriveConfirmationTag(
+    Uint8List sharedSecret, Uint8List info) {
+  return _hkdf(sharedSecret, _concat([_polConfirmLabel, info]), 32);
+}
+
+/// Derive a 32-byte session key from [sharedSecret].
+///
+/// Called on both sides after a successful from/pol PQ handshake. [info]
+/// should bind the key to its context (e.g. sessionID || fromAtSign). Uses
+/// a distinct HKDF label so the session key is independent from the
+/// confirmation tag.
+Future<Uint8List> pqDeriveSessionKey(
+    Uint8List sharedSecret, Uint8List info) {
+  return _hkdf(sharedSecret, _concat([_sessionLabel, info]), 32);
+}
+
+// ── internals ───────────────────────────────────────────────────────────────
+
+class _DerivedKey {
+  final Uint8List key;
+  final Uint8List nonce;
+  _DerivedKey(this.key, this.nonce);
+}
+
+Future<_DerivedKey> _deriveKeyAndNonce(Uint8List ss, Uint8List? info) async {
+  final Uint8List suiteInfo = _concat([_suiteLabel, info ?? Uint8List(0)]);
+  final Uint8List key = await _hkdf(ss, _concat([suiteInfo, _u8(0x01)]), 32);
+  final Uint8List nonce =
+      await _hkdf(ss, _concat([suiteInfo, _u8(0x02)]), _gcmNonceLen);
+  return _DerivedKey(key, nonce);
+}
+
+Future<Uint8List> _hkdf(Uint8List ikm, Uint8List info, int length) async {
+  final hkdf = Hkdf(hmac: Hmac.sha256(), outputLength: length);
+  final SecretKey derived = await hkdf.deriveKey(
+    secretKey: SecretKey(ikm),
+    nonce: const <int>[],
+    info: info,
+  );
+  return Uint8List.fromList(await derived.extractBytes());
+}
+
+Uint8List _u8(int b) => Uint8List.fromList([b]);
+
+Uint8List _concat(List<Uint8List> parts) {
+  final out = BytesBuilder(copy: false);
+  for (final p in parts) {
+    out.add(p);
+  }
+  return out.toBytes();
+}

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_chops
 description: Package for at_protocol cryptographic and hashing operations
-version: 3.2.1
+version: 3.3.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_chops
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_chops/test/aes_gcm_encryption_algo_test.dart
+++ b/packages/at_chops/test/aes_gcm_encryption_algo_test.dart
@@ -67,6 +67,50 @@ void main() {
     });
   });
 
+  group('AES-256-GCM with AAD', () {
+    final algo = AesGcm256EncryptionAlgo(AESKey.generate(32));
+
+    test('round-trips when AAD matches', () async {
+      final iv = AtChopsUtil.generateRandomIV(12);
+      final plain = Uint8List.fromList(utf8.encode('secret body'));
+      final aad = utf8.encode('authenticated header');
+
+      final encrypted = await algo.encrypt(plain, iv: iv, aad: aad);
+      final decrypted = await algo.decrypt(encrypted, iv: iv, aad: aad);
+      expect(utf8.decode(decrypted), 'secret body');
+    });
+
+    test('mismatched AAD throws AtDecryptionException', () async {
+      final iv = AtChopsUtil.generateRandomIV(12);
+      final plain = Uint8List.fromList(utf8.encode('secret body'));
+
+      final encrypted =
+          await algo.encrypt(plain, iv: iv, aad: utf8.encode('header-A'));
+      expect(() => algo.decrypt(encrypted, iv: iv, aad: utf8.encode('header-B')),
+          throwsA(isA<AtDecryptionException>()));
+    });
+
+    test('AAD present at encrypt but absent at decrypt throws', () async {
+      final iv = AtChopsUtil.generateRandomIV(12);
+      final plain = Uint8List.fromList(utf8.encode('secret body'));
+
+      final encrypted =
+          await algo.encrypt(plain, iv: iv, aad: utf8.encode('header'));
+      // default decrypt (empty AAD) must not authenticate.
+      expect(() => algo.decrypt(encrypted, iv: iv),
+          throwsA(isA<AtDecryptionException>()));
+    });
+
+    test('empty AAD equals omitting it (backward compatible)', () async {
+      final iv = AtChopsUtil.generateRandomIV(12);
+      final plain = Uint8List.fromList(utf8.encode('xyz'));
+
+      final withEmptyAad = await algo.encrypt(plain, iv: iv, aad: const []);
+      final withoutAad = await algo.encrypt(plain, iv: iv);
+      expect(withEmptyAad, equals(withoutAad));
+    });
+  });
+
   group('NIST GCM vectors (McGrew & Viega, 256-bit, no AAD)', () {
     // Test case 13: empty plaintext
     test('case 13: zero key/nonce, empty plaintext', () async {

--- a/packages/at_chops/test/pq_hpke_test.dart
+++ b/packages/at_chops/test/pq_hpke_test.dart
@@ -24,7 +24,7 @@ final class _FixedKem implements AtKemAlgorithm {
       _ss;
 }
 
-Uint8List _b(String s) => Uint8List.fromList(utf8.encode(s));
+Uint8List _utf8(String s) => Uint8List.fromList(utf8.encode(s));
 
 Matcher _opensWith(PqOpenFailure reason) => throwsA(isA<PqOpenException>()
     .having((e) => e.reason, 'reason', reason));
@@ -35,72 +35,73 @@ void main() {
   group('pqSeal/pqOpen round-trip', () {
     test('random keypair, with info + aad', () async {
       final kp = await xwing.generateKeyPair();
-      final pt = _b('the quick brown fox 🦊');
-      final info = _b('context-A');
-      final aad = _b('header-bytes');
+      final pt = _utf8('the quick brown fox 🦊');
+      final info = _utf8('context-A');
+      final aad = _utf8('header-bytes');
 
-      final env =
+      final envelope =
           await pqSeal(xwing, kp.publicKey, pt, info: info, aad: aad);
       final opened =
-          await pqOpen(xwing, kp.secretKey, env, info: info, aad: aad);
+          await pqOpen(xwing, kp.secretKey, envelope, info: info, aad: aad);
 
       expect(opened, equals(pt));
     });
 
     test('random keypair, no info/aad', () async {
       final kp = await xwing.generateKeyPair();
-      final pt = _b('no-context payload');
+      final pt = _utf8('no-context payload');
 
-      final env = await pqSeal(xwing, kp.publicKey, pt);
-      final opened = await pqOpen(xwing, kp.secretKey, env);
+      final envelope = await pqSeal(xwing, kp.publicKey, pt);
+      final opened = await pqOpen(xwing, kp.secretKey, envelope);
 
       expect(opened, equals(pt));
     });
 
-    test('deterministic (vector-seeded) keypair', () async {
+    test('vector-seeded keypair round-trips', () async {
       final kp = await xwing.generateKeyPair(XWingVector1.seed);
-      final pt = _b('sealed to a fixed keypair');
+      final pt = _utf8('sealed to a spec-vector keypair');
+      final info = _utf8('context-A');
 
-      final env = await pqSeal(xwing, kp.publicKey, pt, info: _b('i'));
-      final opened = await pqOpen(xwing, kp.secretKey, env, info: _b('i'));
+      final envelope = await pqSeal(xwing, kp.publicKey, pt, info: info);
+      final opened = await pqOpen(xwing, kp.secretKey, envelope, info: info);
 
       expect(opened, equals(pt));
     });
 
     test('empty plaintext round-trips', () async {
       final kp = await xwing.generateKeyPair();
-      final env = await pqSeal(xwing, kp.publicKey, Uint8List(0));
-      expect(await pqOpen(xwing, kp.secretKey, env), isEmpty);
+      final envelope = await pqSeal(xwing, kp.publicKey, Uint8List(0));
+      expect(await pqOpen(xwing, kp.secretKey, envelope), isEmpty);
     });
   });
 
   group('pqOpen rejects tampering', () {
-    late Uint8List goodEnv;
+    late Uint8List goodEnvelope;
     late ({Uint8List publicKey, Uint8List secretKey}) kp;
-    final pt = _b('tamper target');
+    final pt = _utf8('tamper target');
 
     setUp(() async {
       kp = await xwing.generateKeyPair();
-      goodEnv = await pqSeal(xwing, kp.publicKey, pt);
+      goodEnvelope = await pqSeal(xwing, kp.publicKey, pt);
     });
 
     test('flipped AEAD ciphertext byte → authFailure', () async {
-      final ctLen = (goodEnv[1] << 8) | goodEnv[2];
-      final bad = Uint8List.fromList(goodEnv);
-      bad[3 + ctLen] ^= 0x01; // first byte of the GCM ciphertext
+      final bad = Uint8List.fromList(goodEnvelope);
+      // 3 = header (ver + ctLen), then skip KEM ciphertext to reach the GCM body.
+      bad[3 + XWingPureDartAlgo.ciphertextLength] ^= 0x01;
       expect(() => pqOpen(xwing, kp.secretKey, bad),
           _opensWith(PqOpenFailure.authFailure));
     });
 
     test('flipped tag byte → authFailure', () async {
-      final bad = Uint8List.fromList(goodEnv);
+      final bad = Uint8List.fromList(goodEnvelope);
       bad[bad.length - 1] ^= 0x01; // last byte of the 16-byte tag
       expect(() => pqOpen(xwing, kp.secretKey, bad),
           _opensWith(PqOpenFailure.authFailure));
     });
 
     test('flipped KEM ciphertext byte → authFailure', () async {
-      final bad = Uint8List.fromList(goodEnv);
+      final bad = Uint8List.fromList(goodEnvelope);
       bad[3] ^= 0x01; // implicit-rejection KEM → different ss → AEAD fails
       expect(() => pqOpen(xwing, kp.secretKey, bad),
           _opensWith(PqOpenFailure.authFailure));
@@ -110,15 +111,17 @@ void main() {
   group('pqOpen rejects context mismatch', () {
     test('info mismatch → authFailure', () async {
       final kp = await xwing.generateKeyPair();
-      final env = await pqSeal(xwing, kp.publicKey, _b('x'), info: _b('A'));
-      expect(() => pqOpen(xwing, kp.secretKey, env, info: _b('B')),
+      final envelope = await pqSeal(xwing, kp.publicKey, _utf8('payload'),
+          info: _utf8('context-seal'));
+      expect(() => pqOpen(xwing, kp.secretKey, envelope, info: _utf8('context-open')),
           _opensWith(PqOpenFailure.authFailure));
     });
 
     test('aad mismatch → authFailure', () async {
       final kp = await xwing.generateKeyPair();
-      final env = await pqSeal(xwing, kp.publicKey, _b('x'), aad: _b('A'));
-      expect(() => pqOpen(xwing, kp.secretKey, env, aad: _b('B')),
+      final envelope = await pqSeal(xwing, kp.publicKey, _utf8('payload'),
+          aad: _utf8('aad-seal'));
+      expect(() => pqOpen(xwing, kp.secretKey, envelope, aad: _utf8('aad-open')),
           _opensWith(PqOpenFailure.authFailure));
     });
   });
@@ -126,8 +129,8 @@ void main() {
   group('pqOpen rejects malformed envelopes', () {
     test('unsupported version → versionMismatch', () async {
       final kp = await xwing.generateKeyPair();
-      final env = await pqSeal(xwing, kp.publicKey, _b('x'));
-      final bad = Uint8List.fromList(env)..[0] = 0x02;
+      final envelope = await pqSeal(xwing, kp.publicKey, _utf8('payload'));
+      final bad = Uint8List.fromList(envelope)..[0] = 0x02;
       expect(() => pqOpen(xwing, kp.secretKey, bad),
           _opensWith(PqOpenFailure.versionMismatch));
     });
@@ -153,21 +156,22 @@ void main() {
     // construction ever changes intentionally.
 
     test('fixed-KEM construction KAT: seal is deterministic + opens', () async {
-      final ss = Uint8List.fromList(List<int>.generate(32, (i) => i));
+      final ss = Uint8List.fromList(List<int>.generate(32, (i) => i)); // [0x00..0x1f]
       final ct = fromHex('aabbccddeeff0011');
-      final pt = _b('hpke-style seal KAT v1');
-      final info = _b('kat-info');
-      final aad = _b('kat-aad');
+      final pt = _utf8('hpke-style seal KAT v1');
+      final info = _utf8('kat-info');
+      final aad = _utf8('kat-aad');
 
       const goldenHex =
           '010008aabbccddeeff0011bc05df489e9772f4f4afd413e0a05318e3b5b989d2'
           '29f909f3607bf9731afb4988c8bd5608bc';
 
-      final env = await pqSeal(_FixedKem(ss, ct), _b('pk'), pt,
+      // _FixedKem ignores both keys — any value is valid here.
+      final envelope = await pqSeal(_FixedKem(ss, ct), Uint8List(0), pt,
           info: info, aad: aad);
-      expect(toHex(env), equals(goldenHex));
+      expect(toHex(envelope), equals(goldenHex));
 
-      final opened = await pqOpen(_FixedKem(ss, ct), _b('sk'), env,
+      final opened = await pqOpen(_FixedKem(ss, ct), Uint8List(0), envelope,
           info: info, aad: aad);
       expect(opened, equals(pt));
     });
@@ -215,14 +219,14 @@ void main() {
           'e98b9f949b3fd7ac46409929b534041096d59e43504fcccebc3648f104308a21'
           '283ef973b7';
 
-      final env = fromHex(goldenHex);
+      final envelope = fromHex(goldenHex);
       // sanity: kemCt slice equals the published X-Wing vector ciphertext.
-      expect(toHex(Uint8List.sublistView(env, 3, 3 + XWingVector1.ct.length)),
+      expect(toHex(Uint8List.sublistView(envelope, 3, 3 + XWingVector1.ct.length)),
           equals(toHex(XWingVector1.ct)));
 
-      final opened = await pqOpen(xwing, XWingVector1.seed, env,
-          info: _b('xwing-kat-info'), aad: _b('xwing-kat-aad'));
-      expect(opened, equals(_b('x-wing end-to-end KAT')));
+      final opened = await pqOpen(xwing, XWingVector1.seed, envelope,
+          info: _utf8('xwing-kat-info'), aad: _utf8('xwing-kat-aad'));
+      expect(opened, equals(_utf8('x-wing end-to-end KAT')));
     });
   });
 }

--- a/packages/at_chops/test/pq_hpke_test.dart
+++ b/packages/at_chops/test/pq_hpke_test.dart
@@ -152,8 +152,8 @@ void main() {
     // Golden envelopes are pinned, computed once by composing the
     // already-vector-verified HkdfSha256 + AesGcm256EncryptionAlgo. They lock
     // the seal construction (HKDF key schedule + AES-256-GCM body) against
-    // accidental drift. Regenerate via tool_kat_bootstrap.dart if the
-    // construction ever changes intentionally.
+    // accidental drift. To regenerate after an intentional construction change,
+    // seal with a _FixedKem double (see below) and print the envelope hex.
 
     test('fixed-KEM construction KAT: seal is deterministic + opens', () async {
       final ss = Uint8List.fromList(List<int>.generate(32, (i) => i)); // [0x00..0x1f]

--- a/packages/at_chops/test/pq_hpke_test.dart
+++ b/packages/at_chops/test/pq_hpke_test.dart
@@ -1,0 +1,228 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_chops/src/algorithm/at_algorithm.dart';
+import 'package:test/test.dart';
+
+import 'x_wing_test_vectors.dart';
+
+/// Fixed-output KEM double — makes [pqSeal] deterministic so the seal
+/// construction can be pinned byte-exact, independent of the (randomised) real
+/// X-Wing KEM.
+final class _FixedKem implements AtKemAlgorithm {
+  final Uint8List _ss;
+  final Uint8List _ct;
+  _FixedKem(this._ss, this._ct);
+  @override
+  Future<({Uint8List ciphertext, Uint8List sharedSecret})> encapsulate(
+          Uint8List publicKey) async =>
+      (ciphertext: _ct, sharedSecret: _ss);
+  @override
+  Future<Uint8List> decapsulate(
+          Uint8List secretKey, Uint8List ciphertext) async =>
+      _ss;
+}
+
+Uint8List _b(String s) => Uint8List.fromList(utf8.encode(s));
+
+Matcher _opensWith(PqOpenFailure reason) => throwsA(isA<PqOpenException>()
+    .having((e) => e.reason, 'reason', reason));
+
+void main() {
+  final xwing = XWingPureDartAlgo.instance;
+
+  group('pqSeal/pqOpen round-trip', () {
+    test('random keypair, with info + aad', () async {
+      final kp = await xwing.generateKeyPair();
+      final pt = _b('the quick brown fox 🦊');
+      final info = _b('context-A');
+      final aad = _b('header-bytes');
+
+      final env =
+          await pqSeal(xwing, kp.publicKey, pt, info: info, aad: aad);
+      final opened =
+          await pqOpen(xwing, kp.secretKey, env, info: info, aad: aad);
+
+      expect(opened, equals(pt));
+    });
+
+    test('random keypair, no info/aad', () async {
+      final kp = await xwing.generateKeyPair();
+      final pt = _b('no-context payload');
+
+      final env = await pqSeal(xwing, kp.publicKey, pt);
+      final opened = await pqOpen(xwing, kp.secretKey, env);
+
+      expect(opened, equals(pt));
+    });
+
+    test('deterministic (vector-seeded) keypair', () async {
+      final kp = await xwing.generateKeyPair(XWingVector1.seed);
+      final pt = _b('sealed to a fixed keypair');
+
+      final env = await pqSeal(xwing, kp.publicKey, pt, info: _b('i'));
+      final opened = await pqOpen(xwing, kp.secretKey, env, info: _b('i'));
+
+      expect(opened, equals(pt));
+    });
+
+    test('empty plaintext round-trips', () async {
+      final kp = await xwing.generateKeyPair();
+      final env = await pqSeal(xwing, kp.publicKey, Uint8List(0));
+      expect(await pqOpen(xwing, kp.secretKey, env), isEmpty);
+    });
+  });
+
+  group('pqOpen rejects tampering', () {
+    late Uint8List goodEnv;
+    late ({Uint8List publicKey, Uint8List secretKey}) kp;
+    final pt = _b('tamper target');
+
+    setUp(() async {
+      kp = await xwing.generateKeyPair();
+      goodEnv = await pqSeal(xwing, kp.publicKey, pt);
+    });
+
+    test('flipped AEAD ciphertext byte → authFailure', () async {
+      final ctLen = (goodEnv[1] << 8) | goodEnv[2];
+      final bad = Uint8List.fromList(goodEnv);
+      bad[3 + ctLen] ^= 0x01; // first byte of the GCM ciphertext
+      expect(() => pqOpen(xwing, kp.secretKey, bad),
+          _opensWith(PqOpenFailure.authFailure));
+    });
+
+    test('flipped tag byte → authFailure', () async {
+      final bad = Uint8List.fromList(goodEnv);
+      bad[bad.length - 1] ^= 0x01; // last byte of the 16-byte tag
+      expect(() => pqOpen(xwing, kp.secretKey, bad),
+          _opensWith(PqOpenFailure.authFailure));
+    });
+
+    test('flipped KEM ciphertext byte → authFailure', () async {
+      final bad = Uint8List.fromList(goodEnv);
+      bad[3] ^= 0x01; // implicit-rejection KEM → different ss → AEAD fails
+      expect(() => pqOpen(xwing, kp.secretKey, bad),
+          _opensWith(PqOpenFailure.authFailure));
+    });
+  });
+
+  group('pqOpen rejects context mismatch', () {
+    test('info mismatch → authFailure', () async {
+      final kp = await xwing.generateKeyPair();
+      final env = await pqSeal(xwing, kp.publicKey, _b('x'), info: _b('A'));
+      expect(() => pqOpen(xwing, kp.secretKey, env, info: _b('B')),
+          _opensWith(PqOpenFailure.authFailure));
+    });
+
+    test('aad mismatch → authFailure', () async {
+      final kp = await xwing.generateKeyPair();
+      final env = await pqSeal(xwing, kp.publicKey, _b('x'), aad: _b('A'));
+      expect(() => pqOpen(xwing, kp.secretKey, env, aad: _b('B')),
+          _opensWith(PqOpenFailure.authFailure));
+    });
+  });
+
+  group('pqOpen rejects malformed envelopes', () {
+    test('unsupported version → versionMismatch', () async {
+      final kp = await xwing.generateKeyPair();
+      final env = await pqSeal(xwing, kp.publicKey, _b('x'));
+      final bad = Uint8List.fromList(env)..[0] = 0x02;
+      expect(() => pqOpen(xwing, kp.secretKey, bad),
+          _opensWith(PqOpenFailure.versionMismatch));
+    });
+
+    test('shorter than header → malformedEnvelope', () async {
+      expect(() => pqOpen(xwing, XWingVector1.seed, Uint8List(2)),
+          _opensWith(PqOpenFailure.malformedEnvelope));
+    });
+
+    test('declared ctLen overruns envelope → malformedEnvelope', () async {
+      // ver=0x01, ctLen=0xffff, but only a few bytes follow.
+      final bad = Uint8List.fromList([0x01, 0xff, 0xff, 1, 2, 3, 4, 5, 6, 7]);
+      expect(() => pqOpen(xwing, XWingVector1.seed, bad),
+          _opensWith(PqOpenFailure.malformedEnvelope));
+    });
+  });
+
+  group('known-answer vectors (byte-exact)', () {
+    // Golden envelopes are pinned, computed once by composing the
+    // already-vector-verified HkdfSha256 + AesGcm256EncryptionAlgo. They lock
+    // the seal construction (HKDF key schedule + AES-256-GCM body) against
+    // accidental drift. Regenerate via tool_kat_bootstrap.dart if the
+    // construction ever changes intentionally.
+
+    test('fixed-KEM construction KAT: seal is deterministic + opens', () async {
+      final ss = Uint8List.fromList(List<int>.generate(32, (i) => i));
+      final ct = fromHex('aabbccddeeff0011');
+      final pt = _b('hpke-style seal KAT v1');
+      final info = _b('kat-info');
+      final aad = _b('kat-aad');
+
+      const goldenHex =
+          '010008aabbccddeeff0011bc05df489e9772f4f4afd413e0a05318e3b5b989d2'
+          '29f909f3607bf9731afb4988c8bd5608bc';
+
+      final env = await pqSeal(_FixedKem(ss, ct), _b('pk'), pt,
+          info: info, aad: aad);
+      expect(toHex(env), equals(goldenHex));
+
+      final opened = await pqOpen(_FixedKem(ss, ct), _b('sk'), env,
+          info: info, aad: aad);
+      expect(opened, equals(pt));
+    });
+
+    test('X-Wing end-to-end KAT: open spec-vector envelope', () async {
+      // Envelope = ver || ctLen || XWingVector1.ct || AEAD(body), where the
+      // AEAD key/nonce derive from the vector's expected shared secret. Opening
+      // it drives real XWingPureDartAlgo.decapsulate(seed, ct) → expectedSs.
+      const goldenHex = '010460'
+          'b83aa828d4d62b9a83ceffe1d3d3bb1ef31264643c070c5798927e41fb07914a'
+          '273f8f96e7826cd5375a283d7da885304c5de0516a0f0654243dc5b97f8bfeb8'
+          '31f68251219aabdd723bc6512041acbaef8af44265524942b902e68ffd23221c'
+          'da70b1b55d776a92d1143ea3a0c475f63ee6890157c7116dae3f62bf72f60acd'
+          '2bb8cc31ce2ba0de364f52b8ed38c79d719715963a5dd3842d8e8b43ab704e47'
+          '59b5327bf027c63c8fa857c4908d5a8a7b88ac7f2be394d93c3706ddd4e698cc'
+          '6ce370101f4d0213254238b4a2e8821b6e414a1cf20f6c1244b699046f5a01ca'
+          'a0a1a55516300b40d2048c77cc73afba79afeea9d2c0118bdf2adb8870dc328c'
+          '5516cc45b1a2058141039e2c90a110a9e16b318dfb53bd49a126d6b73f215787'
+          '517b8917cc01cabd107d06859854ee8b4f9861c226d3764c87339ab16c3667d2'
+          'f49384e55456dd40414b70a6af841585f4c90c68725d57704ee8ee7ce6e2f9be'
+          '582dbee985e038ffc346ebfb4e22158b6c84374a9ab4a44e1f91de5aac5197f8'
+          '9bc5e5442f51f9a5937b102ba3beaebf6e1c58380a4a5fedce4a4e5026f88f52'
+          '8f59ffd2db41752b3a3d90efabe463899b7d40870c530c8841e8712b733668ed'
+          '033adbfafb2d49d37a44d4064e5863eb0af0a08d47b3cc888373bc05f7a33b84'
+          '1bc2587c57eb69554e8a3767b7506917b6b70498727f16eac1a36ec8d8cfaf75'
+          '1549f2277db277e8a55a9a5106b23a0206b4721fa9b3048552c5bd5b594d6e24'
+          '7f38c18c591aea7f56249c72ce7b117afcc3a8621582f9cf71787e183dee0936'
+          '7976e98409ad9217a497df888042384d7707a6b78f5f7fb8409e3b5351753734'
+          '61b776002d799cbad62860be70573ecbe13b246e0da7e93a52168e0fb6a9756b'
+          '895ef7f0147a0dc81bfa644b088a9228160c0f9acf1379a2941cd28c06ebc80e'
+          '44e17aa2f8177010afd78a97ce0868d1629ebb294c5151812c583daeb8868522'
+          '0f4da9118112e07041fcc24d5564a99fdbde28869fe0722387d7a9a4d16e1cc8'
+          '555917e09944aa5ebaaaec2cf62693afad42a3f518fce67d273cc6c9fb5472b3'
+          '80e8573ec7de06a3ba2fd5f931d725b493026cb0acbd3fe62d00e4c790d965d7'
+          'a03a3c0b4222ba8c2a9a16e2ac658f572ae0e746eafc4feba023576f08942278'
+          'a041fb82a70a595d5bacbf297ce2029898a71e5c3b0d1c6228b485b1ade509b3'
+          '5fbca7eca97b2132e7cb6bc465375146b7dceac969308ac0c2ac89e7863eb894'
+          '3015b24314cafb9c7c0e85fe543d56658c213632599efabfc1ec49dd8c88547b'
+          'b2cc40c9d38cbd3099b4547840560531d0188cd1e9c23a0ebee0a03d5577d66b'
+          '1d2bcb4baaf21cc7fef1e03806ca96299df0dfbc56e1b2b43e4fc20c37f834c4'
+          'af62127e7dae86c3c25a2f696ac8b589dec71d595bfbe94b5ed4bc07d800b330'
+          '796fda89edb77be0294136139354eb8cd37591578f9c600dd9be8ec6219fdd50'
+          '7adf3397ed4d68707b8d13b24ce4cd8fb22851bfe9d632407f31ed6f7cb1600d'
+          'e56f17576740ce2a32fc5145030145cfb97e63e0e41d354274a079d3e6fb2e15'
+          'e98b9f949b3fd7ac46409929b534041096d59e43504fcccebc3648f104308a21'
+          '283ef973b7';
+
+      final env = fromHex(goldenHex);
+      // sanity: kemCt slice equals the published X-Wing vector ciphertext.
+      expect(toHex(Uint8List.sublistView(env, 3, 3 + XWingVector1.ct.length)),
+          equals(toHex(XWingVector1.ct)));
+
+      final opened = await pqOpen(xwing, XWingVector1.seed, env,
+          info: _b('xwing-kat-info'), aad: _b('xwing-kat-aad'));
+      expect(opened, equals(_b('x-wing end-to-end KAT')));
+    });
+  });
+}


### PR DESCRIPTION
## What

  - Adds post-quantum authenticated encryption to at_chops via pqSeal / pqOpen
  - Construction follows the HPKE shape (RFC 9180 inspired) but uses a custom at_protocol-internal wire envelope — not RFC 9180 wire-compatible
  - Bumps at_chops to 3.3.0
  - Lays the groundwork for PQ-secured shared-key exchange in the atProtocol

## How

  - KEM → X-Wing (AtKemAlgorithm, caller-supplied); KDF → HkdfSha256 (new hkdf_algo.dart); AEAD → AES-256-GCM (AesGcm256EncryptionAlgo)
  - Envelope format: ver(1) || ctLen(2, BE) || kemCt || gcmCipherText || tag(16) — version byte is checked on open for forwards-compat; mismatches throw PqOpenException(PqOpenFailure.versionMismatch, ...)
  - _deriveKeyAndNonce runs HKDF over the 32-byte X-Wing shared secret + optional info binding to produce the AES key + deterministic nonce — no separate randomness needed post-KEM
  - pqOpen validates envelope length before parsing, extracts kemCt via the 2-byte BE length field, decapsulates, re-derives the key, and maps AtDecryptionException → PqOpenException(authFailure) for typed
  error handling
  - HKDF step provides context binding and key/nonce derivation (not extraction — X-Wing shared secret is already uniformly random)
  - Future-proofing: the version byte allows new envelope schemas without breaking readers of old ciphertext

## How to verify

- Tests pass here

## Skills impact

If this PR changes a public API in `at_client`, `at_client_flutter`, or `at_auth`,
consider whether `packages/at_client_skills/` needs a follow-up release.

- [x] No public API change — skill unaffected
- [ ] Public API changed — I have opened or will open an `at_client_skills` PR to reflect this
