### PR TITLE
refactor(at_lookup): route PKAM/CRAM crypto through at_chops

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 3.5.0 (unreleased tech-debt-removal branch changes)
+## 3.6.0
+
+- refactor: route PKAM/CRAM signing + hashing through at_chops
+  (`PkamSigningAlgo` / `SHA512HashingAlgo`); `crypton` and `crypto` are no
+  longer imported anywhere in the package and have been dropped from
+  `dependencies`. Byte-identical by construction.
+
+## 3.5.0
 
 - chore(deps): at_chops ^3.0.0
 

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -10,8 +10,6 @@ import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_lookup/src/connection/outbound_message_listener.dart';
 import 'package:at_utils/at_logger.dart';
-import 'package:crypto/crypto.dart';
-import 'package:crypton/crypton.dart';
 import 'package:mutex/mutex.dart';
 import 'package:at_chops/at_chops.dart';
 
@@ -175,15 +173,15 @@ class AtLookupImpl implements AtLookUp {
       publicKeyResult = publicKeyResult.replaceFirst(RegExp(r'^data:'), '');
       logger.finer('public key of $sharedBy :$publicKeyResult');
 
-      var publicKey = RSAPublicKey.fromString(publicKeyResult);
       var dataSignature = resultJson['metaData']['dataSignature'];
       var value = resultJson['data'];
       value = VerbUtil.getFormattedValue(value);
       logger.finer('value: $value dataSignature:$dataSignature');
-      var isDataValid = publicKey.verifySHA256Signature(
-          // ignore: unnecessary_cast
-          utf8.encode(value) as Uint8List,
-          base64Decode(dataSignature));
+      // RSA SHA-256 verify via at_chops (wraps the same crypton
+      // RSAPublicKey.verifySHA256Signature).
+      var isDataValid = PkamSigningAlgo(null, HashingAlgoType.sha256).verify(
+          Uint8List.fromList(utf8.encode(value)), base64Decode(dataSignature),
+          publicKey: publicKeyResult);
       logger.finer('data verify result: $isDataValid');
       return 'data:$value';
     } on Exception catch (e) {
@@ -451,10 +449,11 @@ class AtLookupImpl implements AtLookUp {
         }
         fromResponse = fromResponse.trim().replaceFirst(RegExp(r'^data:'), '');
         logger.finer('fromResponse $fromResponse');
-        var key = RSAPrivateKey.fromString(privateKey);
-        var sha256signature =
-            // ignore: unnecessary_cast
-            key.createSHA256Signature(utf8.encode(fromResponse) as Uint8List);
+        // RSA SHA-256 sign via at_chops (wraps the same crypton
+        // RSAPrivateKey.createSHA256Signature; only the private key is used).
+        var sha256signature = PkamSigningAlgo(
+                AtPkamKeyPair.create('', privateKey), HashingAlgoType.sha256)
+            .sign(Uint8List.fromList(utf8.encode(fromResponse)));
         var signature = base64Encode(sha256signature);
         logger.finer('Sending command pkam:$signature');
         await _sendCommand('pkam:$signature\n');
@@ -541,7 +540,8 @@ class AtLookupImpl implements AtLookUp {
         fromResponse = fromResponse.trim().replaceFirst(RegExp(r'^data:'), '');
         var digestInput = '$secret$fromResponse';
         var bytes = utf8.encode(digestInput);
-        var digest = sha512.convert(bytes);
+        // SHA-512 hex digest via at_chops (= sha512.convert(bytes).toString()).
+        var digest = SHA512HashingAlgo().hash(bytes);
         await _sendCommand('cram:$digest\n');
         var cramResponse = await messageListener.read(
             transientWaitTimeMillis: 4000, maxWaitMilliSeconds: 10000);

--- a/packages/at_lookup/lib/src/monitor_client.dart
+++ b/packages/at_lookup/lib/src/monitor_client.dart
@@ -4,10 +4,10 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:at_chops/at_chops.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_utils/at_logger.dart';
-import 'package:crypton/crypton.dart';
 
 /// Utility class to execute monitor verb.
 class MonitorClient {
@@ -73,10 +73,11 @@ class MonitorClient {
     logger.info('from result:$fromResponse');
     fromResponse = fromResponse.trim().replaceFirst(RegExp(r'^data:'), '');
     logger.info('fromResponse $fromResponse');
-    var key = RSAPrivateKey.fromString(_privateKey);
-    var sha256signature =
-        // ignore: unnecessary_cast
-        key.createSHA256Signature(utf8.encode(fromResponse) as Uint8List);
+    // RSA SHA-256 sign via at_chops (wraps the same crypton
+    // RSAPrivateKey.createSHA256Signature; only the private key is used).
+    var sha256signature = PkamSigningAlgo(
+            AtPkamKeyPair.create('', _privateKey), HashingAlgoType.sha256)
+        .sign(Uint8List.fromList(utf8.encode(fromResponse)));
     var signature = base64Encode(sha256signature);
     logger.info('Sending command pkam:$signature');
     await monitorConnection.write('pkam:$signature\n');

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.5.0
+version: 3.6.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_lookup
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -10,8 +10,6 @@ environment:
 resolution: workspace
 
 dependencies:
-  crypton: ^2.2.1
-  crypto: ^3.0.5
   at_utils: ^3.0.19
   at_commons: ^5.7.0
   mutex: ^3.0.0


### PR DESCRIPTION
**What I did**

Routes at_lookup's PKAM/CRAM signing + hashing through **at_chops** (`PkamSigningAlgo` / `SHA512HashingAlgo`) instead of importing `crypton`/`crypto` directly, and drops both packages from at_lookup's dependencies. No public API change; byte-identical by construction.

**Why**

Consolidating security cryptography onto at_chops gives the SDK a single place where crypto is implemented and can evolve, and removes `crypton`/`crypto` as direct dependencies of at_lookup.

**How I did it**

The four call sites (`at_lookup_impl` verify/sign/cram + `monitor_client` sign) now wrap the same operations via at_chops's algorithm classes. `crypton` and `crypto` are no longer referenced anywhere in the package and have been removed from `dependencies`. Released as `3.6.0` (`3.5.0` is already published on pub.dev).

**How to verify it**

1. `dart analyze packages/at_lookup` — clean.
2. `grep -rn "package:crypton\|package:crypto/" packages/at_lookup` — no hits.
3. at_lookup unit tests green; the auth path is exercised by the functional suite.

**Description for the changelog**

refactor: route at_lookup PKAM/CRAM signing + hashing through at_chops; `crypton`/`crypto` removed from dependencies. Byte-identical by construction.
