### PR TITLE
refactor(at_auth): route enrollment RSA through at_chops

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 3.1.1
+- refactor: route enrollment RSA (encrypt/decrypt `apkamSymmetricKey` under the default encryption keypair) through at_chops (`RsaEncryptionAlgo`) — `crypton` no longer imported in `lib` and moved to `dev_dependencies` (only the enrollment test still uses it for RSA keypair fixtures). Same framing, byte-identical by construction.
 - fix: `decodeAtKeys()` now reliably throws `AtDecryptionException` on an incorrect passphrase. The `jsonDecode` of the decrypted bytes now runs inside the decrypt try/catch, so wrong-passphrase garbage no longer escapes as an uncaught `FormatException` (an intermittent failure in `at_keys_io_test`).
 
 ## 3.1.0

--- a/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
+++ b/packages/at_auth/lib/src/enroll/at_enrollment_impl.dart
@@ -14,7 +14,6 @@ import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:at_utils/at_progress.dart';
-import 'package:crypton/crypton.dart';
 
 /// A concrete implementation of [AtEnrollment] for managing enrollments.
 ///
@@ -96,9 +95,11 @@ class AtEnrollmentImpl implements AtEnrollment {
 
     // encrypting the following APKAM keys:
     // apkamSymmetricKey for the enroll verb
-    String encryptedAPKAMSymmetricKey =
-        RSAPublicKey.fromString(defaultEncryptionPublicKey)
-            .encrypt(apkamSymmetricKey.key);
+    // RSA encrypt via at_chops (wraps crypton's RSAPublicKey.encrypt:
+    // base64(encryptData(utf8(msg)))).
+    String encryptedAPKAMSymmetricKey = base64Encode((RsaEncryptionAlgo()
+          ..atPublicKey = AtPublicKey.fromString(defaultEncryptionPublicKey))
+        .encrypt(utf8.encode(apkamSymmetricKey.key)));
 
     EnrollVerbBuilder enrollVerbBuilder = EnrollVerbBuilder()
       ..appName = atEnrollmentRequest.appName
@@ -138,14 +139,14 @@ class AtEnrollmentImpl implements AtEnrollment {
       throw AtAuthenticationException(
           'The authentication keys are not initialized');
     }
-    // Fetch the encryptionPrivateKey from atChops instance.
-    RSAPrivateKey defaultEncryptionPrivateKey = RSAPrivateKey.fromString(
-        atLookUp
-            .atChops!.atChopsKeys.atEncryptionKeyPair!.atPrivateKey.privateKey);
-
-    // Decrypt the encrypted APKAM Symmetric key to get the original APKAM symmetric key
-    String apkamSymmetricKey = defaultEncryptionPrivateKey
-        .decrypt(enrollmentRequestDecision.encryptedAPKAMSymmetricKey);
+    // Decrypt the encrypted APKAM symmetric key with the encryption private key
+    // from the atChops instance, via at_chops (wraps crypton's
+    // RSAPrivateKey.decrypt: utf8.decode(decryptData(base64(msg)))).
+    String apkamSymmetricKey = utf8.decode((RsaEncryptionAlgo()
+          ..atPrivateKey = AtPrivateKey.fromString(atLookUp.atChops!.atChopsKeys
+              .atEncryptionKeyPair!.atPrivateKey.privateKey))
+        .decrypt(base64Decode(
+            enrollmentRequestDecision.encryptedAPKAMSymmetricKey)));
 
     // Set the APKAM Symmetric key to the AtChops Instance.
     atLookUp.atChops?.atChopsKeys.apkamSymmetricKey = AESKey(apkamSymmetricKey);

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -15,13 +15,13 @@ dependencies:
   at_lookup: ^3.4.2
   at_chops: ^3.0.0
   at_utils: ^3.0.19
-  crypton: ^2.2.1
   http: ^1.2.1
   meta: ^1.16.0
 
 dev_dependencies:
   args: ^2.6.0 # used in example
   at_demo_data: ^1.2.0
+  crypton: ^2.2.1 # test-only: RSA keypair fixtures in enrollment_test
   lints: ^6.0.0
   test: ^1.25.0
   mocktail: ^1.0.4


### PR DESCRIPTION
**What I did**

Routes at_auth's enrollment RSA (encrypt `apkamSymmetricKey` under the default encryption public key; decrypt it on approve) through **at_chops** (`RsaEncryptionAlgo`) instead of importing `crypton` directly. No public API change; same RSA framing, byte-identical by construction.

**Why**

Consolidating security cryptography onto at_chops gives the SDK a single place where crypto is implemented and can evolve, and removes `crypton` as a runtime dependency of at_auth.

**How I did it**

The two enrollment sites in `enroll/at_enrollment_impl.dart` use at_chops's `RsaEncryptionAlgo` with the same `base64(encryptData(utf8))` / `utf8.decode(decryptData(base64))` framing used elsewhere. `crypton` is no longer imported in `lib`; it stays only as a `dev_dependency` for the enrollment test's RSA keypair fixtures. CHANGELOG folded under the in-progress `3.1.1` heading (pub.dev latest is 3.1.0 — no pubspec bump).

**How to verify it**

1. `dart analyze packages/at_auth` — clean.
2. `grep -rn "package:crypton" packages/at_auth/lib` — no hits.
3. at_auth unit tests green; the enrollment path is exercised by the functional suite.

**Description for the changelog**

refactor: route at_auth enrollment RSA through at_chops; `crypton` removed from `lib` (now dev-only). Byte-identical by construction.
