### PR TITLE
refactor(at_onboarding_cli): route crypto through at_chops

### DIFF
--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 1.16.0
+- refactor: route enrollment crypto — `sha256` hashing, AES key generation and RSA keypair generation — through at_chops (`SHA256HashingAlgo`, `AtChopsUtil.generateSymmetricKey`, `AtChopsUtil.generateAtEncryptionKeyPair`). `crypto`, `encrypt` and `crypton` are no longer imported anywhere in the package and have been dropped from `dependencies`. Byte-identical by construction.
 - feat: enrollment authorization wait can now be resumed across sessions
 - feat: atKeys files are now restricted to read/write permissions for the current user only
 - feat: atKeys file writability is verified before enrollment or onboarding begins

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -14,8 +14,6 @@ import 'package:at_server_status/at_server_status.dart';
 import 'package:at_utils/at_progress.dart';
 import 'package:at_utils/at_utils.dart';
 import 'package:chalkdart/chalk.dart';
-import 'package:crypton/crypton.dart';
-import 'package:encrypt/encrypt.dart';
 import 'package:image/image.dart';
 import 'package:meta/meta.dart';
 import 'package:zxing2/qrcode.dart';
@@ -747,14 +745,14 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     return jsonData;
   }
 
-  /// Generates a random RSA keypair
-  RSAKeypair generateRsaKeypair() {
-    return RSAKeypair.fromRandom();
+  /// Generates a random RSA encryption keypair (RSA-2048) via at_chops.
+  AtEncryptionKeyPair generateRsaKeypair() {
+    return AtChopsUtil.generateAtEncryptionKeyPair();
   }
 
   /// Generate a random AES key
   String generateAESKey() {
-    return AES(Key.fromSecureRandom(32)).key.base64;
+    return AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256).key;
   }
 
   /// Returns secondary server status

--- a/packages/at_onboarding_cli/lib/src/onboard/helpers/enrollment_checkpoint.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/helpers/enrollment_checkpoint.dart
@@ -2,10 +2,10 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:at_auth/at_auth.dart';
+import 'package:at_chops/at_chops.dart' show SHA256HashingAlgo;
 import 'package:at_onboarding_cli/src/util/at_file_util.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:meta/meta.dart';
-import 'package:crypto/crypto.dart';
 import 'package:path/path.dart' as path;
 
 /// Manages the enrollment checkpoint file used to resume interrupted enrollments.
@@ -37,14 +37,14 @@ class EnrollmentCheckpoint {
           ..sort((a, b) => a.key.compareTo(b.key)))
         .map((e) => '${e.key}:${e.value}')
         .join(',');
-    return sha256
-        .convert(utf8.encode('$atSign$appName$deviceName$sortedNamespaces'))
-        .toString();
+    // SHA-256 hex via at_chops (= sha256.convert(...).toString()).
+    return SHA256HashingAlgo()
+        .hash(utf8.encode('$atSign$appName$deviceName$sortedNamespaces'));
   }
 
   @visibleForTesting
-  File getFile(String appName, String deviceName,
-          Map<String, String> namespaces) =>
+  File getFile(
+          String appName, String deviceName, Map<String, String> namespaces) =>
       File(path.join(Directory.current.path,
           '${_paramsHash(_atSign, appName, deviceName, namespaces)}.enrollment.checkpoint'));
 
@@ -62,13 +62,14 @@ class EnrollmentCheckpoint {
     expiry ??= defaultCheckpointExpiry;
 
     final Map<String, dynamic> json = er.toJson();
-    json.remove('atSign'); // do not reveal which atSign this checkpoint belongs to
+    json.remove(
+        'atSign'); // do not reveal which atSign this checkpoint belongs to
     json['atAuthKeys'] = er.atAuthKeys?.toJson();
     json['validTill'] = DateTime.now().add(expiry).millisecondsSinceEpoch;
 
     final file = getFile(appName, deviceName, namespaces);
     file.writeAsStringSync(jsonEncode(json));
-    
+
     await AtFileUtil.setSecureFilePermissions(file.path);
     _logger.info('Saved checkpoint for ${er.enrollmentId}');
   }
@@ -109,5 +110,4 @@ class EnrollmentCheckpoint {
     final file = getFile(appName, deviceName, namespaces);
     if (file.existsSync()) file.deleteSync();
   }
-
 }

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -15,8 +15,6 @@ executables:
 
 dependencies:
   args: ^2.6.0
-  crypton: ^2.2.1
-  encrypt: ^5.0.3
   http: ^1.2.1
   image: ^4.1.7
   meta: ^1.16.0
@@ -30,7 +28,6 @@ dependencies:
   at_server_status: ^1.0.5
   at_utils: ^3.2.0
   duration: ^4.0.3
-  crypto: ^3.0.5
   chalkdart: ">=2.0.9<4.0.0" # no breaking changes in 3.0.0
 
 dev_dependencies:

--- a/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
+++ b/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
@@ -14,7 +14,6 @@ import 'package:at_persistence_secondary_server/at_persistence_secondary_server.
 // ignore: depend_on_referenced_packages
 import 'package:at_persistence_secondary_server/hive.dart';
 import 'package:at_utils/at_logger.dart';
-import 'package:crypton/crypton.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/expect.dart';
 import 'package:test/scaffolding.dart';
@@ -207,15 +206,22 @@ void main() {
       AtEnrollmentResponse atEnrollmentResponse =
           AtEnrollmentResponse('123', EnrollmentStatus.approved);
 
-      RSAKeypair encryptionRsaKeyPair = onboardingService.generateRsaKeypair();
+      AtEncryptionKeyPair encryptionRsaKeyPair =
+          onboardingService.generateRsaKeypair();
       atEnrollmentResponse.atAuthKeys = AtKeys()
         ..enrollmentId = '123'
-        ..defaultSelfEncryptionKey = AtBytes.fromString(onboardingService.generateAESKey())
-        ..defaultEncryptionPublicKey = AtBytes.fromString(encryptionRsaKeyPair.publicKey.toString())
-        ..defaultEncryptionPrivateKey = AtBytes.fromString(encryptionRsaKeyPair.privateKey.toString())
-        ..apkamPrivateKey = AtBytes.fromString(encryptionRsaKeyPair.privateKey.toString())
-        ..apkamPublicKey = AtBytes.fromString(encryptionRsaKeyPair.publicKey.toString())
-        ..apkamSymmetricKey = AtBytes.fromString(onboardingService.generateAESKey());
+        ..defaultSelfEncryptionKey =
+            AtBytes.fromString(onboardingService.generateAESKey())
+        ..defaultEncryptionPublicKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPublicKey.publicKey)
+        ..defaultEncryptionPrivateKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPrivateKey.privateKey)
+        ..apkamPrivateKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPrivateKey.privateKey)
+        ..apkamPublicKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPublicKey.publicKey)
+        ..apkamSymmetricKey =
+            AtBytes.fromString(onboardingService.generateAESKey());
 
       var f = await onboardingService.createAtKeysFile(atEnrollmentResponse);
       expect(f.path.endsWith('$atsign.atKeys'), true);
@@ -239,15 +245,22 @@ void main() {
       AtEnrollmentResponse atEnrollmentResponse =
           AtEnrollmentResponse('123', EnrollmentStatus.approved);
 
-      RSAKeypair encryptionRsaKeyPair = onboardingService.generateRsaKeypair();
+      AtEncryptionKeyPair encryptionRsaKeyPair =
+          onboardingService.generateRsaKeypair();
       atEnrollmentResponse.atAuthKeys = AtKeys()
         ..enrollmentId = '123'
-        ..defaultSelfEncryptionKey = AtBytes.fromString(onboardingService.generateAESKey())
-        ..defaultEncryptionPublicKey = AtBytes.fromString(encryptionRsaKeyPair.publicKey.toString())
-        ..defaultEncryptionPrivateKey = AtBytes.fromString(encryptionRsaKeyPair.privateKey.toString())
-        ..apkamPrivateKey = AtBytes.fromString(encryptionRsaKeyPair.privateKey.toString())
-        ..apkamPublicKey = AtBytes.fromString(encryptionRsaKeyPair.publicKey.toString())
-        ..apkamSymmetricKey = AtBytes.fromString(onboardingService.generateAESKey());
+        ..defaultSelfEncryptionKey =
+            AtBytes.fromString(onboardingService.generateAESKey())
+        ..defaultEncryptionPublicKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPublicKey.publicKey)
+        ..defaultEncryptionPrivateKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPrivateKey.privateKey)
+        ..apkamPrivateKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPrivateKey.privateKey)
+        ..apkamPublicKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPublicKey.publicKey)
+        ..apkamSymmetricKey =
+            AtBytes.fromString(onboardingService.generateAESKey());
 
       var f = await onboardingService.createAtKeysFile(atEnrollmentResponse);
       expect(f.path.endsWith('$atsign.me.atKeys'), true);
@@ -271,15 +284,22 @@ void main() {
       AtEnrollmentResponse atEnrollmentResponse =
           AtEnrollmentResponse('123', EnrollmentStatus.approved);
 
-      RSAKeypair encryptionRsaKeyPair = onboardingService.generateRsaKeypair();
+      AtEncryptionKeyPair encryptionRsaKeyPair =
+          onboardingService.generateRsaKeypair();
       atEnrollmentResponse.atAuthKeys = AtKeys()
         ..enrollmentId = '123'
-        ..defaultSelfEncryptionKey = AtBytes.fromString(onboardingService.generateAESKey())
-        ..defaultEncryptionPublicKey = AtBytes.fromString(encryptionRsaKeyPair.publicKey.toString())
-        ..defaultEncryptionPrivateKey = AtBytes.fromString(encryptionRsaKeyPair.privateKey.toString())
-        ..apkamPrivateKey = AtBytes.fromString(encryptionRsaKeyPair.privateKey.toString())
-        ..apkamPublicKey = AtBytes.fromString(encryptionRsaKeyPair.publicKey.toString())
-        ..apkamSymmetricKey = AtBytes.fromString(onboardingService.generateAESKey());
+        ..defaultSelfEncryptionKey =
+            AtBytes.fromString(onboardingService.generateAESKey())
+        ..defaultEncryptionPublicKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPublicKey.publicKey)
+        ..defaultEncryptionPrivateKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPrivateKey.privateKey)
+        ..apkamPrivateKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPrivateKey.privateKey)
+        ..apkamPublicKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPublicKey.publicKey)
+        ..apkamSymmetricKey =
+            AtBytes.fromString(onboardingService.generateAESKey());
 
       var f = await onboardingService.createAtKeysFile(atEnrollmentResponse);
       expect(f.path.endsWith('$atsign-me.atKeys'), true);
@@ -303,15 +323,22 @@ void main() {
       AtEnrollmentResponse atEnrollmentResponse =
           AtEnrollmentResponse('123', EnrollmentStatus.approved);
 
-      RSAKeypair encryptionRsaKeyPair = onboardingService.generateRsaKeypair();
+      AtEncryptionKeyPair encryptionRsaKeyPair =
+          onboardingService.generateRsaKeypair();
       atEnrollmentResponse.atAuthKeys = AtKeys()
         ..enrollmentId = '123'
-        ..defaultSelfEncryptionKey = AtBytes.fromString(onboardingService.generateAESKey())
-        ..defaultEncryptionPublicKey = AtBytes.fromString(encryptionRsaKeyPair.publicKey.toString())
-        ..defaultEncryptionPrivateKey = AtBytes.fromString(encryptionRsaKeyPair.privateKey.toString())
-        ..apkamPrivateKey = AtBytes.fromString(encryptionRsaKeyPair.privateKey.toString())
-        ..apkamPublicKey = AtBytes.fromString(encryptionRsaKeyPair.publicKey.toString())
-        ..apkamSymmetricKey = AtBytes.fromString(onboardingService.generateAESKey());
+        ..defaultSelfEncryptionKey =
+            AtBytes.fromString(onboardingService.generateAESKey())
+        ..defaultEncryptionPublicKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPublicKey.publicKey)
+        ..defaultEncryptionPrivateKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPrivateKey.privateKey)
+        ..apkamPrivateKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPrivateKey.privateKey)
+        ..apkamPublicKey =
+            AtBytes.fromString(encryptionRsaKeyPair.atPublicKey.publicKey)
+        ..apkamSymmetricKey =
+            AtBytes.fromString(onboardingService.generateAESKey());
 
       var f = await onboardingService.createAtKeysFile(atEnrollmentResponse);
       expect(f.path.endsWith('$atsign-me.atKeys'), true);
@@ -755,21 +782,27 @@ AtKeys getAtAuthKeysFromAtChopsKeys(AtChopsKeys atChopsKeys) {
   AtKeys atAuthKeys = AtKeys();
 
   if (atChopsKeys.atPkamKeyPair?.atPublicKey.publicKey != null) {
-    atAuthKeys.apkamPublicKey = AtBytes.fromString(atChopsKeys.atPkamKeyPair!.atPublicKey.publicKey);
+    atAuthKeys.apkamPublicKey =
+        AtBytes.fromString(atChopsKeys.atPkamKeyPair!.atPublicKey.publicKey);
   }
   if (atChopsKeys.atPkamKeyPair?.atPrivateKey.privateKey != null) {
-    atAuthKeys.apkamPrivateKey = AtBytes.fromString(atChopsKeys.atPkamKeyPair!.atPrivateKey.privateKey);
+    atAuthKeys.apkamPrivateKey =
+        AtBytes.fromString(atChopsKeys.atPkamKeyPair!.atPrivateKey.privateKey);
   }
   if (atChopsKeys.atEncryptionKeyPair?.atPublicKey.publicKey != null) {
-    atAuthKeys.defaultEncryptionPublicKey = AtBytes.fromString(atChopsKeys.atEncryptionKeyPair!.atPublicKey.publicKey);
+    atAuthKeys.defaultEncryptionPublicKey = AtBytes.fromString(
+        atChopsKeys.atEncryptionKeyPair!.atPublicKey.publicKey);
   }
   if (atChopsKeys.atEncryptionKeyPair?.atPrivateKey.privateKey != null) {
-    atAuthKeys.defaultEncryptionPrivateKey = AtBytes.fromString(atChopsKeys.atEncryptionKeyPair!.atPrivateKey.privateKey);
+    atAuthKeys.defaultEncryptionPrivateKey = AtBytes.fromString(
+        atChopsKeys.atEncryptionKeyPair!.atPrivateKey.privateKey);
   }
   if (atChopsKeys.selfEncryptionKey?.key != null) {
-    atAuthKeys.defaultSelfEncryptionKey = AtBytes.fromString(atChopsKeys.selfEncryptionKey!.key);
+    atAuthKeys.defaultSelfEncryptionKey =
+        AtBytes.fromString(atChopsKeys.selfEncryptionKey!.key);
   }
-  atAuthKeys.apkamSymmetricKey = AtBytes.fromString(atChopsKeys.apkamSymmetricKey!.key);
+  atAuthKeys.apkamSymmetricKey =
+      AtBytes.fromString(atChopsKeys.apkamSymmetricKey!.key);
 
   return atAuthKeys;
 }


### PR DESCRIPTION
## What I did

Routes all of at_onboarding_cli's enrollment crypto through **at_chops** and removes `package:crypto`, `package:encrypt` and `package:crypton` from both `lib` and the package's dependencies. No behavioural change — byte-identical by construction.

## Why

Consolidating security cryptography onto at_chops gives the SDK a single place where crypto is implemented and can evolve, and removes `crypto`/`encrypt`/`crypton` as direct dependencies of at_onboarding_cli.

## How I did it

- `enrollment_checkpoint`: `sha256` → `SHA256HashingAlgo` (identical hex digest).
- `generateAESKey()`: → `AtChopsUtil.generateSymmetricKey(aes256)` (random key; signature unchanged).
- `generateRsaKeypair()`: return type changed from crypton `RSAKeypair` to at_chops `AtEncryptionKeyPair` (`AtChopsUtil.generateAtEncryptionKeyPair`). This is an impl-only method (not on the `AtOnboardingService` interface); only the package's own tests consume it — updated to read `.atPublicKey.publicKey` / `.atPrivateKey.privateKey` and dropped the crypton import.

`crypto`, `encrypt` and `crypton` are no longer referenced anywhere in the package and have been removed from `dependencies`. `lib` analyzes clean and the changed files are `dart format`-clean.

## How to verify it

```bash
cd packages/at_onboarding_cli
dart pub get
dart analyze lib            # No issues found
grep -rn "package:crypto\|package:encrypt\|package:crypton" lib/   # no matches
```

## Description for the changelog

refactor: route enrollment crypto (sha256, AES key gen, RSA keypair gen) through at_chops; `crypto`/`encrypt`/`crypton` removed from `lib` and dependencies. Byte-identical by construction.
