### PR TITLE
test(at_functional_test): CRAM-onboard → enroll → approve round trip

### DIFF
--- a/tests/at_functional_test/.gitignore
+++ b/tests/at_functional_test/.gitignore
@@ -10,3 +10,4 @@ build/
 pubspec.lock
 
 test/testData/@srie.atKeys
+test/testData/@sachin.atKeys

--- a/tests/at_functional_test/test/enrollment_test.dart
+++ b/tests/at_functional_test/test/enrollment_test.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:at_auth/at_auth.dart';
 import 'package:at_chops/at_chops.dart';
@@ -668,6 +669,157 @@ void main() {
     });
     //To prevent failure due to latency, adding timeout for client to receive notifications sent from the server.
   }, timeout: Timeout(Duration(minutes: 1)));
+
+  group('Full enrollment round trip on a freshly CRAM-onboarded atSign', () {
+    test(
+        'CRAM onboard, generate OTP, enroll a second app, approve it, and '
+        'verify the enrolled client can act only within its granted namespace',
+        () async {
+      final cramAtSign = ConfigUtil.getYaml()['atSign']['apkamSecondAtSign'];
+      final cramSecret = cramKeyMap[cramAtSign]!;
+      String keysFilePath(String a) => 'test/testData/$a.atKeys';
+      final rootDomain = AtRootDomain('vip.ve.atsign.zone', 64);
+
+      // Onboarding refuses to run if a keys file already exists, so clear any
+      // left over from a prior run — this test mints @sachin's keys fresh
+      // against the (recycled) atServer.
+      final existingKeys = File(keysFilePath(cramAtSign));
+      if (existingKeys.existsSync()) {
+        existingKeys.deleteSync();
+      }
+
+      // (a) Initial onboarding with the CRAM secret. Mints the first
+      // (manage-capable) enrollment plus the atSign's key set, writes the
+      // .atKeys file; authenticate to load those keys into AtChops.
+      final ownerAuth = AtAuth.create();
+      final onboardResponse = await ownerAuth.onboard(
+        AtOnboardingRequest(cramAtSign)
+          ..appName = 'wavi'
+          ..deviceName = 'pixel-onboard'
+          ..rootDomain = rootDomain
+          ..atKeysIo = FileAtKeysIo(filePath: keysFilePath),
+        cramSecret,
+      );
+      expect(onboardResponse.isSuccessful, true);
+      expect(onboardResponse.enrollmentId, isNotEmpty);
+
+      final ownerAuthResponse = await ownerAuth.authenticate(
+        AtAuthRequest(cramAtSign,
+            atKeysIo: FileAtKeysIo(filePath: keysFilePath))
+          ..rootDomain = rootDomain,
+      );
+      expect(ownerAuthResponse.isSuccessful, true);
+
+      final ownerManager = await AtClientManager.getInstance().setCurrentAtSign(
+          cramAtSign, namespace, TestUtils.getPreference(cramAtSign),
+          atChops: ownerAuth.atChops,
+          enrollmentId: onboardResponse.enrollmentId);
+      final ownerClient = ownerManager.atClient;
+
+      // The atSign's default encryption keypair and self-encryption key are
+      // atSign-wide (shared across enrollments). Read them from the owner's
+      // AtChops to hand to the enrollee for authentication later.
+      final encryptionKeyPair =
+          ownerAuth.atChops!.atChopsKeys.atEncryptionKeyPair!;
+      final selfEncryptionKey =
+          ownerAuth.atChops!.atChopsKeys.selfEncryptionKey!.key;
+
+      // The enrollee fetches publickey<atSign> to wrap its apkamSymmetricKey,
+      // so ensure it is published.
+      await ownerClient.getRemoteSecondary()!.executeCommand(
+          'update:public:publickey$cramAtSign ${encryptionKeyPair.atPublicKey.publicKey}\n',
+          auth: true);
+
+      // (b) Generate an OTP from the onboarded (manage-capable) client.
+      final otp = (await ownerClient.getOTP()).response;
+      expect(otp.length, 6);
+
+      // (c) A second app submits an enrollment request with the OTP. submit
+      // generates a fresh APKAM keypair and wraps its apkamSymmetricKey with
+      // the atSign's default encryption public key.
+      final random = Uuid().v4().hashCode;
+      final enrolleeLookup = AtLookupImpl(cramAtSign, 'vip.ve.atsign.zone', 64);
+      final enrollResponse = await AtEnrollment.create().submit(
+        AtEnrollmentRequest(
+          atSign: cramAtSign,
+          appName: 'buzz-$random',
+          deviceName: 'pixel-enrollee',
+          otp: otp,
+          namespaces: {'buzz': 'rw'},
+        ),
+        enrolleeLookup,
+      );
+      expect(enrollResponse.enrollmentId, isNotEmpty);
+      expect(enrollResponse.enrollStatus, EnrollmentStatus.pending);
+
+      // (d) The owner approves the request. enroll:fetch returns the
+      // encryptedAPKAMSymmetricKey, which approve decrypts with the atSign's
+      // encryption private key and re-wraps for the new enrollment.
+      var fetchResponse = await ownerClient.getRemoteSecondary()!.executeCommand(
+          'enroll:fetch:{"enrollmentId":"${enrollResponse.enrollmentId}"}\n',
+          auth: true);
+      final fetched = Enrollment.fromJSON(
+          jsonDecode(fetchResponse!.replaceAll('data:', '')));
+      final approveResponse = await ownerClient.enrollmentService?.approve(
+          EnrollmentRequestDecision.approved(
+              enrollmentId: enrollResponse.enrollmentId,
+              atSign: cramAtSign,
+              apkamSymmetricKey:
+                  AtBytes.fromString(fetched.encryptedAPKAMSymmetricKey!)));
+      expect(approveResponse?.enrollStatus, EnrollmentStatus.approved);
+
+      // (e) Verify outcomes: the enrollee authenticates with its own APKAM
+      // keypair plus the atSign's default encryption/self keys, then can act in
+      // its granted namespace (buzz) but not in an ungranted one (wavi).
+      AtClientManager.getInstance().reset();
+      AtClientImpl.atClientInstanceMap.clear();
+
+      final enrolleeChopsKeys = AtChopsKeys.create(
+          AtEncryptionKeyPair.create(encryptionKeyPair.atPublicKey.publicKey,
+              encryptionKeyPair.atPrivateKey.privateKey),
+          AtPkamKeyPair.create(
+              enrollResponse.atAuthKeys!.apkamPublicKey!.toString(),
+              enrollResponse.atAuthKeys!.apkamPrivateKey!.toString()))
+        ..selfEncryptionKey = AESKey(selfEncryptionKey);
+      final enrolleeChops = AtChopsImpl(enrolleeChopsKeys);
+
+      final enrolleeAuth = AtAuth.create(atChops: enrolleeChops);
+      final enrolleeAuthRequest = AtAuthRequest(cramAtSign,
+          atKeysIo: FileAtKeysIo(filePath: keysFilePath))
+        ..enrollmentId = enrollResponse.enrollmentId
+        ..atAuthKeys = enrollResponse.atAuthKeys
+        ..rootDomain = rootDomain;
+      enrolleeAuthRequest.atAuthKeys?.defaultEncryptionPrivateKey =
+          AtBytes.fromString(encryptionKeyPair.atPrivateKey.privateKey);
+      enrolleeAuthRequest.atAuthKeys?.defaultSelfEncryptionKey =
+          AtBytes.fromString(selfEncryptionKey);
+      final enrolleeAuthResponse =
+          await enrolleeAuth.authenticate(enrolleeAuthRequest);
+      expect(enrolleeAuthResponse.isSuccessful, true);
+
+      await AtClientManager.getInstance().setCurrentAtSign(
+          cramAtSign, 'buzz', TestUtils.getPreference(cramAtSign),
+          atChops: enrolleeChops, enrollmentId: enrollResponse.enrollmentId);
+      final enrolleeClient = AtClientManager.getInstance().atClient;
+
+      // Granted namespace (buzz): write then read back.
+      final buzzKey =
+          AtKey.self('mobile', namespace: 'buzz', sharedBy: cramAtSign).build();
+      final putResponse = await enrolleeClient.putText(buzzKey, '99899');
+      expect(putResponse.response, isNotEmpty);
+      final getValue = await enrolleeClient.get(buzzKey);
+      expect(getValue.value, '99899');
+
+      // Ungranted namespace (wavi): the server rejects the write.
+      final waviKey =
+          AtKey.self('phone', namespace: 'wavi', sharedBy: cramAtSign).build();
+      expect(
+          () async => await enrolleeClient.putText(waviKey, '123'),
+          throwsA(predicate((dynamic e) =>
+              e is AtClientException &&
+              e.message.contains('insufficient privilege'))));
+    }, timeout: Timeout(Duration(minutes: 2)));
+  });
 }
 
 AtClientPreference getClient2Preferences() {


### PR DESCRIPTION
## What I did

Added a functional round-trip test that exercises the full enrollment flow against a live atServer on a freshly CRAM-onboarded atSign (`@sachin`). No production-code change — test-only.

## How I did it

The test walks the complete flow:
- (a) CRAM onboarding — mints the first manage-capable enrollment + key set;
- (b) `getOTP` from the onboarded client;
- (c) a second app submits an enrollment request with the OTP;
- (d) the owner approves it (`enroll:fetch` + `enrollmentService.approve`);
- (e) the enrollee authenticates with its new APKAM keys and is correctly restricted to its granted namespace (`buzz`) — and rejected on `wavi`.

This covers the at_auth enrollment RSA in both directions: the `apkamSymmetricKey` is RSA-encrypted under the atSign's default encryption public key on submit and RSA-decrypted on approve.

Onboarding refuses to run when a local `.atKeys` file exists, so the test clears its own `@sachin.atKeys` first (the runner only clears `@srie`'s) rather than depending on the runner — keeping it self-contained and re-runnable. The generated `@sachin.atKeys` is gitignored alongside the existing `@srie.atKeys` entry.

## How to verify it

```bash
cd tests/at_functional_test
./runLocal.sh            # recycles the virtualenv container, then runs the suite
```

Full functional suite green (82/82) against the live atServer.

## Description for the changelog

test(at_functional_test): add CRAM-onboard → OTP → enroll → approve enrollment round trip on a freshly onboarded atSign.
