### PR TITLE
docs: Restructuring crypto planning docs for readability

### DIFF
--- a/docs/crypto-roadmap.md
+++ b/docs/crypto-roadmap.md
@@ -6,10 +6,37 @@ capability (encrypt/decrypt for other clients of the same atSign,
 encrypt/decrypt for other atSigns), strengthened with two-lever key
 rotation, and giving applications a bootstrap path to pq-mls groups.
 
-> **This document is the design source of truth** — goals, architecture,
-> phasing, and the *why*. The detailed build plan, status, task breakdown, and
-> PR carving live in its companion, the
-> [crypto implementation plan](crypto_impl_plan.md).
+> **This is the design source of truth** — goals, architecture, phasing, and
+> the *why*. It has two companions, and the three docs share one shape (design →
+> build → worked example):
+>
+> - **[crypto_impl_plan.md](crypto_impl_plan.md)** — the build plan: task
+>   breakdown, ordering, dependencies, PR carving, acceptance (the *how* and
+>   *when*).
+> - **[crypto-walkthroughs.md](crypto-walkthroughs.md)** — worked end-to-end
+>   examples (NoPorts, a large group, an `at_talk` chat) that exercise this
+>   design.
+>
+> When a companion disagrees with this document on design intent, this document
+> wins. See the [document map](#document-map) for how the sections pair up.
+
+## Document map
+
+How the three docs line up — **design** (this doc, the source of truth) ↔
+**build** (the plan) ↔ **worked example** (the walkthroughs). Find your row and
+jump.
+
+| Topic | Design (roadmap) | Build (plan) | Worked example |
+|---|---|---|---|
+| The two deliverables (D1 / D2) | [The two major deliverables](crypto-roadmap.md#the-two-major-deliverables) | [Current state (1)](crypto_impl_plan.md#1-current-state-2026-06-22) · [D1 acceptance (2)](crypto_impl_plan.md#2-d1-acceptance--what-done-means) | — |
+| D1 Tier1 — the `nskey` default | [D1 — preserving legacy simplicity](crypto-roadmap.md#d1--preserving-legacy-simplicity-two-tiers) | [D1-B (3)](crypto_impl_plan.md#d1-b--the-nskey-provider-d1-tier1--the-default) | — |
+| Migration, rollout & versioning | [Application migration & rollout](crypto-roadmap.md#application-migration--rollout) | [D1-C / D1-D (3)](crypto_impl_plan.md#d1-c--migration--rollout-machinery) | — |
+| Identity, KeyPackages, self groups | [Phases 2–3](crypto-roadmap.md#phase-2--identity-layer-keypackages-and-per-client-atkeys) | [D1-E (3)](crypto_impl_plan.md#d1-e--d1-tier2-shape-corrections-fold-into-wp-gp) · [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | — |
+| Cross-atSign shared groups | [Phase 4](crypto-roadmap.md#phase-4--cross-atsign-groups-shared-encryption) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [C — `at_talk` chat](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-client-churn-at_talk) |
+| pq-mls engine + Delivery Service | [atServer group Delivery Service](crypto-roadmap.md#atserver-group-delivery-service-target-design) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [B — a large group](crypto-walkthroughs.md#walkthrough-b--a-large-group-end-to-end) |
+| NoPorts adoption | [Upgrading NoPorts](crypto-roadmap.md#upgrading-noports-with-daemon-ping-feature-discovery) | [Cross-repo & NoPorts (5)](crypto_impl_plan.md#5-cross-repo-pr--publish-sequence--noports) | [A — NoPorts](crypto-walkthroughs.md#walkthrough-a--noports-end-to-end) |
+| Structural enablers / WASM split | [Component responsibilities & WASM-readiness](crypto-roadmap.md#component-responsibilities--wasm-readiness) | [D1-S (3)](crypto_impl_plan.md#d1-s--structural-enablers-prerequisite--lands-first) | — |
+| Release order & work packages | [Starting point](crypto-roadmap.md#starting-point) | [Work packages (7)](crypto_impl_plan.md#7-delivery-plan--work-packages) | — |
 
 ## The two major deliverables
 
@@ -366,33 +393,13 @@ rotation, or opt into per-device (D1 Tier2) security.
 
 ## Starting point
 
-`trunk`, incorporating and extending three lines of work:
-
-| Work                 | Contributes                                                         | Status                  |
-|----------------------|---------------------------------------------------------------------|-------------------------|
-| `jt-pq`              | Post-quantum primitives in at_chops (ML-KEM-768, X25519)            | Merged to trunk         |
-| `xl-pluggable`       | Pluggable `CryptoProvider` model + wire routing (`AppMetadata`)     | PR #1930 (open, green)  |
-| `gkc-pqmls-spike`    | Per-client identity, discovery, and same-atSign delivery + the above | Rebuilt on `xl-pluggable` |
-
-### Delivery model
-
-Delivery is **trunk-based**: each work package is a short-lived branch
-**merged to `trunk` when complete** and **published to pub.dev as needed** in
-dependency order — **trunk is the single integration point**. See the
-[delivery plan & work packages](crypto_impl_plan.md#7-delivery-plan--work-packages)
-in the implementation plan. There is **no long-lived shared integration
-branch**; when the full stack needs proving before a batch lands, spin up an
-*ephemeral* integration branch on demand (merge the in-flight WP branches, run
-the e2e rigs, discard) or rely on CI. (`gkc-pqmls-spike` is now just a personal
-working branch + historical context.) The dependency-ordered sequence and its status: `at_commons` (the
-`appMetadata` wire field — **published 5.11.0**) → `at_chops` (X-Wing / AES-GCM
-/ key consolidation — **published 3.2.1**) → `at_persistence_secondary_server`
-(commit-log-free keystore + `appMetadata` — **published 5.0.0 / 5.1.0**) →
-`at_client` (4a migration **merged to trunk**; 4b pluggable crypto = **PR
-#1930**; 4c secret sharing to follow). `at_server` must round-trip
-`appMetadata` before the at_client crypto path verifies end-to-end, so it
-landed ahead (released to the fleet); `sshnoports` consumes the released SDK
-and comes last.
+This design builds on `trunk`. Delivery is **trunk-based** — each work package
+is a short-lived branch merged to `trunk` when complete and published to pub.dev
+as needed in dependency order. The current build status, branch model, and the
+dependency-ordered publish sequence are the build plan's responsibility: see the
+implementation plan's
+[current state (section 1)](crypto_impl_plan.md#1-current-state-2026-06-22) and
+[delivery plan & work packages (section 7)](crypto_impl_plan.md#7-delivery-plan--work-packages).
 
 ## The end state
 
@@ -462,60 +469,39 @@ its own; later ones build on earlier. (Phase numbers cross-reference the
 | **M6 · pq-mls engine** (Phase 5) | Swap the v1 engine for MLS (TreeKEM, RFC 9420 FS/PCS, PQ ciphersuites) behind the same interface + DS | O(log n) commits, standardized + audited group security — the actual end state. |
 | **NoPorts adoption** (finish line) | Session keys via `SecureGroup.export`; daemon-feature-gated tiers 0–2 | The production payoff: PQ-safe NoPorts, derived (not transmitted) session keys, fleet management. |
 
-Status: M0, M1 (X-Wing/GCM/HKDF), M2 (KeyPackage framing), M3 (self) and the
-cross-cutting "at_chops is the sole security-crypto dependency" (Phase 6) are
-done or in flight; **M4, M5, M6 are the substantive build ahead.** In
-deliverable terms (see [The two major deliverables](#the-two-major-deliverables)):
-**M0–M4 are Deliverable 1** (PQ-safe messaging) — largely done, with M4 the main
-remaining piece — and **M5–M6 are Deliverable 2** (pq-mls). The M2–M4 rows below
+In deliverable terms (see
+[The two major deliverables](#the-two-major-deliverables)): **M0–M4 are
+Deliverable 1** (PQ-safe messaging) and **M5–M6 are Deliverable 2** (pq-mls).
+The authoritative build status is the plan's
+[phase status](crypto_impl_plan.md#phase-status); in brief — M1 (X-Wing/GCM/HKDF)
+and Phase 6 (at_chops as the sole security-crypto dependency) are in trunk; the
+M0 seam is in flight (#1930); the per-client KeyPackage framing (M2) and `group`
+provider (M3) are **prototyped on the spike, not yet landed**; M4 is the main
+remaining D1 piece and M5–M6 are the D2 build ahead. The M2–M4 rows above
 describe the **per-client group** capability; per
 [D1 — preserving legacy simplicity](#d1--preserving-legacy-simplicity-two-tiers)
 that is the **opt-in D1 Tier2** and the D2 substrate — D1's *default* path is the
 simpler `nskey` shared-namespace-key tier, with the same milestones reframed.
 
-## How it works — NoPorts (summary)
+## How it works — in brief
 
-A NoPorts session is a *small* group — @client↔@daemon (plus @srvd for relay)
-— so the member-atSign count is 1–2 and there is **no Delivery Service**:
-delivery stays pairwise, as today. Backwards compatibility rides the daemon
-ping's `supportedFeatures`; three feature-gated tiers:
+Two shapes, one `SecureGroup` interface — each with a design section and a
+worked trace:
 
-- **Tier 0 — transport PQ-safe:** daemons advertise `groupCrypto`; the client
-  routes per-destination through the `group` provider (PQ-safe) or falls back
-  to `legacy`. The still-RSA-wrapped session key now travels *inside* a
-  group-encrypted payload, so a recorded exchange can't be peeled open later —
-  harvest-now-decrypt-later closed, no protocol change.
-- **Tier 1 — derive, don't transmit:** gated on `pqSessionKeys`; both sides
-  form the @client↔@daemon pair group and `export()` the session keys
-  independently — no key material in flight; deletes the per-session RSA
-  keypair.
-- **Tier 2 — fleet self-group:** many sshnpd on one device atSign + a policy
-  client are a self group; config secrets are shared once and read by all
-  daemons; revoke → leaf removed + rotate → a stolen daemon reads nothing
-  after.
-
-Full walk-through: [Appendix A](#appendix-a--noports-end-to-end-detailed).
-
-## How it works — a large group (summary)
-
-A large group runs against a dedicated, **ciphertext-only Delivery Service
-atSign** (e.g. `@my_org_groups`) operated as infrastructure. Members are
-leaves (per-client); one or more admins drive membership. The DS atServer
-holds the group object (roster + monotonic `seq` + TTL'd ciphertext log) and
-does the work the pairwise model can't:
-
-- **sequencing** — the atomic per-group `seq` is the MLS commit order;
-- **fan-out** — wake-then-pull, **O(member-atSigns), not O(member-clients)**;
-- **catch-up / retention** — `fetch:since` is the single delivery primitive;
-  app messages may expire (tombstoned), commits are retained until
-  applied-by-all or a straggler rejoins.
-
-The DS never decrypts and cannot forge membership (members validate commits
-cryptographically; reorder/withhold is detectable via the transcript hash).
-The crypto is MLS (v2) — TreeKEM gives O(log n) commits and real FS/PCS —
-behind the same `SecureGroup` interface.
-
-Full walk-through: [Appendix B](#appendix-b--a-large-group-end-to-end-detailed).
+- **Small groups (NoPorts: @client↔@daemon, ±@srvd for relay).** Member-atSign
+  count is 1–2, so there is **no Delivery Service** — delivery stays pairwise, as
+  today. Daemon-ping `supportedFeatures` gates three tiers (transport-PQ-safe →
+  derive-don't-transmit → fleet self-group), each backwards-compatible with old
+  peers. Design:
+  [Upgrading NoPorts](#upgrading-noports-with-daemon-ping-feature-discovery);
+  trace: [Walkthrough A](crypto-walkthroughs.md#walkthrough-a--noports-end-to-end).
+- **Large groups.** Run against a dedicated **ciphertext-only Delivery Service
+  atSign**: it holds the group object (roster + monotonic `seq` + TTL'd
+  ciphertext log), sequences commits as the MLS total order, and fans out
+  **wake-then-pull, O(member-atSigns) not O(member-clients)** — it orders and
+  routes but never decrypts and cannot forge membership. Design:
+  [atServer group Delivery Service](#atserver-group-delivery-service-target-design);
+  trace: [Walkthrough B](crypto-walkthroughs.md#walkthrough-b--a-large-group-end-to-end).
 
 ## Usability — a first-class constraint
 
@@ -542,7 +528,7 @@ exist to keep it true. The promises, each linking to where it's realised:
 - **Old data stays readable forever; migration is lazy.** The `CryptoProvider`
   seam routes per value by `AppMetadata`, so legacy and new schemes coexist,
   re-encryption is on-touch, and there is never a flag-day. →
-  [Foundations](#foundations-what-exists-today)
+  [Foundations](#foundations)
 - **Backwards-compatible, per-destination rollout.** Feature discovery
   (daemon-ping `supportedFeatures`) gates new behaviour per peer; an old peer
   silently keeps the legacy path. →
@@ -567,50 +553,45 @@ revocation and audit). The corresponding builder-facing surface is the
 "LLM-friendly verbs, explicit semantics, no hidden invariants" goal as the
 rest of `AtCollection`.
 
-## Foundations (landed, in flight, and prototyped)
+## Foundations
 
-Status as of 2026-06-22 — only the first two below are at_chops/at_client code
-you can build against; the provider seam is in review; secret sharing and the
-`group` provider are spike prototypes still to be landed (see the build plan's
-[work-package sequence](crypto_impl_plan.md#the-work-package-sequence--single-source-for-ordering)).
+Three building blocks the rest of this design composes. For which are landed, in
+flight, or still prototyped, see the build plan's
+[current state](crypto_impl_plan.md#1-current-state-2026-06-22).
 
-**`xl-pluggable` — the provider seam** *(at_client; PR #1930, in flight).*
-`CryptoProvider { id;
-encrypt(CryptoContext, AtKey, String) → String; decrypt(CryptoContext, AtKey,
-String) → String }` — **stateless**, with the per-operation `CryptoContext`
-(the client) handed in per call. Providers are declared in
-`AtClientPreference.crypto` (`CryptoConfig { defaultProviderId, providers }`);
-`CryptoRuntime` resolves each put/get/notify/sync against the live config by
-`appMetadata.providerId`, falling back to the built-in `LegacyCryptoProvider`.
-The wire carries `Metadata.appMetadata = AppMetadata{providerId, additional}`;
-the SDK stamps `providerId` + `isEncrypted` after a successful encrypt, so a
-provider only contributes `additional`. `PutRequestOptions.cryptoProviderId`
-overrides per operation. This seam is the migration machinery itself: legacy
-and new schemes coexist per-value, old data stays readable forever,
-re-encryption can be lazy. (Slimmed on this branch: the registry,
-`CryptoPolicy`, `CryptoStorage`, `initialize`, and the request/result wrappers
-were removed; resolution reads the live `preference.crypto`.)
+**The provider seam.** `CryptoProvider { id; encrypt(CryptoContext, AtKey,
+String) → String; decrypt(CryptoContext, AtKey, String) → String }` —
+**stateless**, with the per-operation `CryptoContext` (the client) handed in per
+call. Providers are declared in `AtClientPreference.crypto`
+(`CryptoConfig { defaultProviderId, providers }`); `CryptoRuntime` resolves each
+put/get/notify/sync against the live config by `appMetadata.providerId`, falling
+back to the built-in `LegacyCryptoProvider`. The wire carries
+`Metadata.appMetadata = AppMetadata{providerId, additional}`; the SDK stamps
+`providerId` + `isEncrypted` after a successful encrypt, so a provider only
+contributes `additional`. `PutRequestOptions.cryptoProviderId` overrides per
+operation. **This seam is the migration machinery itself**: legacy and new
+schemes coexist per-value, old data stays readable forever, re-encryption can be
+lazy.
 
-**`jt-pq` — PQ primitives** *(at_chops 3.2.1, in trunk).* ML-KEM-768 and X25519
-(pure-Dart and OpenSSL-FFI), the `AtKemAlgorithm` interface, in at_chops.
-HPKE `pqSeal`/`pqOpen` is in flight (PR #1993).
+**PQ primitives.** ML-KEM-768 and X25519 (pure-Dart and OpenSSL-FFI), the
+`AtKemAlgorithm` interface, AES-256-GCM, and HKDF/HMAC — in at_chops. HPKE
+`pqSeal`/`pqOpen` is the one audited public-key-encryption primitive the
+providers seal through.
 
-**Secret sharing — identity + same-atSign delivery** *(prototyped on
-`gkc-pqmls-spike`, NOT yet landed — carve-out WP-SS).* Per-client identity
+**Secret sharing — identity + same-atSign delivery.** Per-client identity
 (clientId + X-Wing keypair) published as an APKAM-signed `ClientKeyPackage`:
 canonical hidden public key in the enrollment's reserved namespace (location
 exclusivity = identity anchor) plus namespace-scoped copies whose *presence*
-proves the enrollment holds `rw` on that namespace (server-enforced, verified
-empirically). Store-and-forward encrypted envelopes scoped by application
-namespace; `SecretStore` with newest-wins merge; enrollment-approval sharing;
-shared per-AtClient instance (`AtClientSecretSharing.forClient`); race-free
+proves the enrollment holds `rw` on that namespace (server-enforced).
+Store-and-forward encrypted envelopes scoped by application namespace;
+`SecretStore` with newest-wins merge; enrollment-approval sharing; race-free
 `waitForSecret`; crypto-agile formats (`{kid, use, alg}` key lists,
 `{keyAlg, kid, encAlg}` envelopes) so algorithms upgrade by id with no schema
-change. PQ-native: `x-wing` key transport + `aes-256-gcm` payloads. API
-`@experimental` (durable surface will be `SecureGroup`).
+change. PQ-native: `x-wing` key transport + `aes-256-gcm` payloads. The durable
+app-facing surface will be `SecureGroup`.
 
-**Get-path invariants** (the secret-sharing and pluggable-crypto work both
-touch the get path; both are satisfied on the integration branch):
+**Get-path invariants** (both the secret-sharing and pluggable-crypto paths
+touch get):
 
 - `get` respects the `isEncrypted` tri-state: explicit `false` skips
   decryption and returns the raw value; absent (legacy data) takes the
@@ -658,7 +639,7 @@ metadata, or public keys:
   `public:__sskb-…@atsign`): a client's X-Wing/encryption/signing *public* key
   plus a signature. The secret is the private half, which stays on the device.
 
-**Two honest edges:**
+**Two exceptions, by design:**
 
 - **`shouldEncrypt=false` is an app-accessible escape hatch.** The SDK uses it
   only for already-sealed envelopes and public KeyPackages, but it is a real
@@ -802,29 +783,23 @@ Only **`at_auth` takes a major** (the breaking WASM barrel split); everyone else
 stays minor — additive features behind the AtChops shim plus the `at_auth`
 constraint bumps. The `at_auth` work is **split into an additive minor then a
 breaking major** so the `WritableAtKeys` API lands and bakes *before* the
-breaking barrel cut, removing the lockstep crunch. Publish in dependency order:
-
-| # | Package | Bump | Why |
-|---|---|---|---|
-| 1 | `at_chops` | minor `3.2.1 → 3.3.0` | stateless functional core + HPKE `pqSeal`/`pqOpen` **added**; stateful `AtChopsImpl` kept as `@Deprecated` shim (additive) |
-| 2 | `at_auth` | minor `3.1.1 → 3.2.0` | **additive API:** `WritableAtKeys` added; `AtKeysIo`/`WrittenAtKeysIo` widened (add/remove/update, default impls); `InMemoryAtKeysIo`. No barrel change yet — downstream can adopt `WritableAtKeys` immediately |
-| 3 | `at_auth` | **major `3.2.0 → 4.0.0`** | **breaking WASM cut:** `FileAtKeysIo` out of the main barrel (→ `at_auth_io.dart`); `FileAtKeysIo()` default removed; registrar → `package:http`; probe extracted; core compiles under `dart2wasm` |
-| 4 | `at_client` | minor `3.13.0 → 3.14.0` | `at_auth ^4.0.0`; `CryptoContext` gains a `WritableAtKeys keys` field (additive; context is `{atClient}` today — nothing to deprecate); `LocalKeystoreAtKeysIo`; `nskey` provider scaffold |
-| 5 | `at_onboarding_cli` | minor `1.16.0 → 1.17.0` | `at_auth ^4.0.0`; imports `FileAtKeysIo` from `at_auth_io.dart`; injects it explicitly (default gone) |
-| 6 | `at_client_flutter` | minor `1.1.3 → 1.2.0` | `at_auth ^4.0.0`; `file_picker` imports `at_auth_io.dart` |
-| 7 | `at_cli_commons` | minor (constraint bump) | consumes the new `at_onboarding_cli` / `at_client` |
+breaking barrel cut, removing the lockstep crunch.
 
 This **`at_auth 4.0`** (structural / WASM) is **independent of the eventual
 `at_client 4.0`** (the `disallowLegacyEncryption` default flip + dead-code
 removal, gated on the ecosystem floor) — different majors, different times.
 
+The per-package bump table and dependency-ordered publish steps are the build
+plan's job: see
+[package versions & release sequencing (section 7)](crypto_impl_plan.md#package-versions--release-sequencing).
+
 ## Phases
 
-### Phase 0 — land the foundations — **done on the integration branch**
+### Phase 0 — land the foundations
 
-`jt-pq` merged to trunk; `xl-pluggable` merged into `gkc-pqmls-spike`; the
-secret-sharing substrate is in place. The get-path invariants above hold
-post-merge (at_client 711 / at_chops 99 / at_commons 486 tests green).
+The pluggable-crypto seam, the PQ primitives, and the secret-sharing substrate —
+see [Foundations](#foundations). Build status is the plan's
+[phase status](crypto_impl_plan.md#phase-status).
 
 ### Phase 1 — complete the PQ primitives (at_chops)
 
@@ -1132,7 +1107,7 @@ that actually encrypts data is epochal and rotates as a matter of course.
 ## Dependencies
 
 ```
-0 (merge 1976 + xl-pluggable + jt-pq)
+0 (foundations: provider seam + PQ primitives + secret-sharing substrate)
 └─► 1 (X-Wing, GCM, HKDF, PQ enrollment pubkey)
     └─► 2 (KeyPackages PQ-native, AtKeys split, cross-atSign publication)
         └─► 3 (SecureGroup v1 + group provider, self)  ─► retire sEK 1–2
@@ -1161,76 +1136,41 @@ an old daemon), and features gate behavior per session — exactly how
 | `pqSessionKeys` | supports deriving session keys from a pair-group `export()` (none in flight)  |
 
 The crucial subtlety: a client must NOT flip its default provider for
-traffic to a daemon that can't decrypt it. `PutRequestOptions.
-cryptoProviderId` (per-operation override, from `xl-pluggable`) is the
-gate: choose the provider per destination based on the ping response.
+traffic to a daemon that can't decrypt it. `PutRequestOptions.cryptoProviderId`
+(per-operation override, from the M0 seam) is the gate: choose the provider per
+destination based on the ping response.
 
-**Tier 0 — transport becomes PQ-safe (no protocol change).** Daemons
-upgrade first (the new SDK decrypts both legacy- and group-encrypted
-values automatically via `AppMetadata` routing) and advertise
-`groupCrypto`. Clients then send per-destination:
+Three feature-gated tiers, each strictly compatible with un-upgraded peers:
 
-```dart
-final features = await pingDaemon(device);            // existing flow
-final provider = features['groupCrypto'] == true ? 'group' : 'legacy';
-await notify(req, ..., putRequestOptions: PutRequestOptions()
-  ..cryptoProviderId = provider);
-```
+- **Tier 0 — transport becomes PQ-safe (no protocol change).** Daemons upgrade
+  first (the new SDK decrypts both legacy- and group-encrypted values via
+  `AppMetadata` routing) and advertise `groupCrypto`; clients then route
+  per-destination through `group` or fall back to `legacy`. The RSA-wrapped
+  session keys travel *inside* these payloads, so tier 0 alone closes the
+  harvest-now hole — a recorded exchange can no longer be peeled open later.
+- **Tier 1 — derive session keys, never transmit them.** Gated on
+  `pqSessionKeys`: both sides resolve the same pair group and `export()` the
+  session keys independently — no key material in flight; deletes the
+  per-session RSA-2048 keypair (a startup win on small devices). The srvd
+  relay-auth key involves a third atSign, so it stays transmitted, protected by
+  tier 0.
+- **Tier 2 — fleet management via the self group.** Many daemons on one device
+  atSign plus the policy service are a self group; config secrets are shared
+  once and read by all daemons (joined automatically at enrollment); revoke →
+  leaf removed + rotate → a stolen daemon reads nothing after.
 
-Old daemon → legacy path, byte-identical to today. New daemon → every
-request/response/heartbeat is group-encrypted and PQ-safe. Note the
-compounding effect: the RSA-wrapped session keys travel *inside* these
-payloads, so tier 0 alone closes the harvest-now hole — a recorded
-exchange can no longer be peeled open later to recover the inner RSA
-ciphertext.
+**Rollout order**: (1) ship dual-stack daemons that advertise the features —
+safe, nothing changes on the wire; (2) ship clients that prefer the features
+when advertised; (3) once the deployed-daemon floor includes `groupCrypto`, flip
+the client default, keeping the legacy fallback for stragglers; (4) the
+`pqSessionKeys` path retires `genBundle`/ephemeral-keypair code when the floor
+allows. Consolidation bonus: NoPorts can replace `validation_utils` signing with
+the SDK's `EnvelopeSigning` (its descendant), moving verification onto the
+per-enrollment `_apsk` trust chain — strictly better for multi-daemon
+deployments.
 
-**Tier 1 — derive session keys, never transmit them.** Gated on
-`pqSessionKeys`:
-
-```dart
-// sshnpd, replacing genBundle():
-final pair = await atClient.groups
-    .withAtSigns([requestingAtsign], namespace: '$device.sshnp');
-final aesKeyC2D = await pair.export('c2d:$sessionId');
-final aesKeyD2C = await pair.export('d2c:$sessionId');
-// response carries only sessionId — no key material in flight
-
-// sshnp: the same two export() calls; both sides derive independently
-```
-
-When the daemon doesn't advertise `pqSessionKeys`, the client falls back
-to today's ephemeral-RSA exchange (which tier 0 already protects in
-flight). Side benefit: deletes the per-session RSA-2048 keypair
-generation — a measurable startup win on small devices. The srvd
-relay-auth key involves a third atSign; a per-session 3-party group is
-overkill, so it stays transmitted, protected by tier 0.
-
-**Tier 2 — fleet management via the self group.** Many daemons on one
-device atSign plus the policy service is the self-group use case:
-
-```dart
-// management client, once:
-await atClient.groups.self('policy_v2.sshnp')
-    .putSecret('webhook-token', token);
-
-// every sshnpd, joined automatically at enrollment:
-final token = await atClient.groups.self('policy_v2.sshnp')
-    .getSecret('webhook-token');
-
-// stolen device: enroll:revoke → leaf removed + group rotates;
-// everything shared after that moment is unreadable by it
-```
-
-**Rollout order**: (1) ship daemons that are dual-stack readers and
-advertise the features — safe immediately, changes nothing on the wire;
-(2) ship clients that prefer the new features when advertised; (3) once
-the deployed-daemon floor includes `groupCrypto`, flip the client default
-and keep the legacy fallback for stragglers; (4) the `pqSessionKeys` path
-retires `genBundle`/ephemeral-keypair code when the floor allows.
-Consolidation bonus at any point: NoPorts can replace `validation_utils`
-signing with the SDK's `EnvelopeSigning` (its descendant), moving
-verification onto the per-enrollment `_apsk` trust chain — strictly better
-for multi-daemon deployments.
+The session trace and the Dart for each tier are in
+[Walkthrough A](crypto-walkthroughs.md#walkthrough-a--noports-end-to-end).
 
 ### Admission UX — a new leaf never blocks on a manual step
 
@@ -1295,7 +1235,7 @@ the desktop app) and many service instances all under one atSign:
   membership); a brand-new leaf may do a one-time epoch-key fetch on first
   access (invisible in practice).
 
-**The load-bearing condition: admission stays per-atSign, not per-leaf.** A
+**The critical condition: admission stays per-atSign, not per-leaf.** A
 daemon admits any *validly-credentialed leaf of an authorised atSign* — the
 allow-list still lists `@client`, and any of its leaves (sshnp/npt/desktop/
 ephemeral forks) is accepted by verifying its KeyPackage chains to `@client`'s
@@ -1308,7 +1248,7 @@ per-device revocation (revoke the lost laptop's `noports-desktop` leaf without
 nuking all of `@client`); finer `@events` audit (attribute activity to a
 leaf/device).
 
-**Residuals (the honest "any difference at all"):** more SDK-managed key files
+**Residuals (the under-the-hood changes):** more SDK-managed key files
 (one persistent leaf keyset per client program + transient, non-persisted
 ephemerals); transient short-TTL KeyPackage churn on `@client`'s atServer
 (self-cleaning); deterministic behaviour on a duplicate same-identity launch
@@ -1330,7 +1270,7 @@ taken after the all-in-MLS decision. The early classical interim
 PQ-native (X-Wing + AES-256-GCM), so the "legacy-plus" secret-sharing
 mechanisms that predated this decision have already been superseded.
 
-The load-bearing decisions hold and carry forward to MLS as an engine
+The primary decisions hold and carry forward to MLS as an engine
 swap: the provider seam, PQ-native KeyPackages, the `SecureGroup`
 `seal/open/rotate/export` interface, `(atSign, namespace)` scoping that
 mirrors server authorization, and lazy `AppMetadata`-routed migration.
@@ -1588,7 +1528,7 @@ deliberate extension noted at the top of this section). It is a
 *catch-up-determinism* convenience, **not a correctness requirement**: the MLS
 transcript hash is the real backstop that prevents a member ever silently
 skipping a missing commit; tombstones merely let a puller classify a gap
-(expired-app → skip vs unexpected → investigate) and keep logs honest.
+(expired-app → skip vs unexpected → investigate) and keep the mls logs accurate.
 
 **Bounded commit retention:** members send `group:ack:{group, seq}` (a seq,
 not content); the DS truncates the log below `min(member high-water marks)` —
@@ -1632,251 +1572,18 @@ policy, tombstones, and ack-truncation.
 possible transitional form, but the target is the group object + wake/pull
 + membership-gated log above.)
 
-## Appendix A — NoPorts, end to end (detailed)
+## Worked walkthroughs
 
-Actors: **@client** (sshnp), **@daemon** (sshnpd; a device may run many),
-**@srvd** (relay; a third atSign). Each client is a leaf with a published
-KeyPackage. Tier/rollout detail lives in
-[Upgrading NoPorts](#upgrading-noports-with-daemon-ping-feature-discovery);
-this is one session's trace.
+The end-to-end traces that exercise this design live in their own companion,
+[crypto-walkthroughs.md](crypto-walkthroughs.md):
 
-1. **Discovery.** sshnp pings @daemon (existing flow); the ping response
-   carries `supportedFeatures`, read null-tolerantly (a missing map = old
-   daemon). The client learns `groupCrypto` and `pqSessionKeys`.
-2. **Session request (Tier 0 — transport).** The client picks a provider per
-   the ping — `provider = features['groupCrypto'] ? 'group' : 'legacy'`, set
-   via `PutRequestOptions.cryptoProviderId`. With `group`, the request
-   notification is a PQ-safe group message of the @client↔@daemon pair group;
-   with `legacy`, byte-identical to today. Because the (still RSA-wrapped)
-   session key rides *inside* this payload, a recorded exchange can no longer
-   be peeled open later — the harvest-now hole is closed even before Tier 1.
-3. **Session keys (Tier 1 — derive, don't transmit).** If `pqSessionKeys`,
-   both sides resolve the same pair group and derive
-   `aesC2D = pair.export('c2d:'+sessionId)` and
-   `aesD2C = pair.export('d2c:'+sessionId)`. Same `(label, epoch)` → identical
-   bytes on both sides; the response carries only `sessionId`, no key material
-   in flight, and the per-session RSA keypair generation is deleted. Without
-   `pqSessionKeys`, fall back to today's ephemeral-RSA exchange (already
-   protected by Tier 0).
-4. **srvd relay.** The relay-auth key involves a third atSign; a per-session
-   3-party group is overkill, so it stays transmitted, protected by Tier 0.
-5. **Delivery.** The group is 2 atSigns (or a self group within one atSign for
-   Tier 2). The member-atSign count is tiny, so there is **no DS host** —
-   pairwise notify + the recipient atServer's sync to its own clients.
-   (Appendix B's Delivery Service is only for large groups.)
-6. **Fleet management (Tier 2 — self group).** Many sshnpd on one device atSign
-   plus a policy/management client are a self `SecureGroup`. Management writes
-   a config secret once; every daemon reads it, joined automatically at
-   enrollment. A stolen device → `enroll:revoke` → the daemon's leaf is
-   removed and the group rotates → everything shared after that instant is
-   unreadable by it.
-7. **Rollout.** (1) ship dual-stack daemons that advertise the features — safe,
-   nothing changes on the wire; (2) ship clients that prefer the features when
-   advertised; (3) once the deployed-daemon floor includes `groupCrypto`, flip
-   the client default; (4) `pqSessionKeys` retires `genBundle`/ephemeral-keypair
-   code when the floor allows.
-
-Net: every request/response/heartbeat becomes PQ-safe (Tier 0), session keys
-stop travelling at all (Tier 1), and fleet secrets get rotating-key
-distribution with instant revocation (Tier 2) — with old peers always
-negotiating cleanly via feature discovery.
-
-## Appendix B — a large group, end to end (detailed)
-
-Actors: a dedicated DS atSign **`@my_org_groups`** running the
-[group Delivery Service](#atserver-group-delivery-service-target-design);
-admins **@alice**, **@bob**; members across many atSigns, each a leaf with a
-published KeyPackage.
-
-1. **Provision the DS.** `@my_org_groups` is operated as infrastructure (HA,
-   monitored, backed up). It is ciphertext-only — never a group member, never
-   holds group keys.
-2. **Create.** `@alice` → `group:create{groupId, ownerAcl:[@alice,@bob]}`. The
-   DS provisions the group object: roster, `seq=0`, empty TTL'd log.
-3. **Add a member (@frank).** An admin: fetches + verifies @frank's published
-   KeyPackage; commits an Add locally (advances the epoch), producing a Commit
-   + a Welcome; sends the **Welcome pairwise** to @frank (1:1); then
-   `group:append{kind:commit, value:<commit ct>, msgId}` + `group:add @frank`
-   to the DS. The DS assigns `seq=N`, logs it, adds @frank to the roster, and
-   fans out `{group, N}` **wakes** to every member atSign. Members
-   `group:fetch:since` the commit, apply it, advance to epoch N; @frank pulls
-   current state and joins.
-4. **Application message (any member → group).** The sender seals once under
-   the epoch key, then one `group:append{kind:app, value:<ct>, expiresAt,...}`
-   to the DS. The DS assigns the next `seq`, logs (with the app TTL), fans out
-   wakes. Each member atServer pulls the delta into local storage; that
-   atSign's many clients then read it via ordinary sync — including the
-   sender's *own* other clients (the DS fans out to the sender's atSign too).
-   Cost: one append + O(member-atSigns) wakes/pulls — never O(member-clients).
-5. **Concurrent admins.** @alice and @bob both commit at epoch N. Both
-   `group:append`; the DS's atomic `seq` orders them — one lands at N, the
-   other gets a conflict, rebases to N+1, resubmits. No fork.
-6. **Catch-up.** A member offline for a while returns and
-   `group:fetch:since:<lastSeq>`. Commits replay in `seq` order; expired app
-   messages appear as tombstones (skippable). If a commit it still needs has
-   aged out (offline past the retention deadline), it is a straggler → an
-   admin **re-adds it at the current epoch** (fresh Welcome), not a
-   full-history replay.
-7. **Remove / revoke (@grace).** An admin commits a Remove + rotates the epoch
-   (`excludeEnrollmentIds`), then `group:append{kind:commit}` +
-   `group:remove @grace`. The DS sequences, fans out, drops @grace from the
-   roster. Everything from the new epoch on is unreadable by @grace.
-8. **Retention & GC.** Members periodically `group:ack{seq}`; the DS truncates
-   the log below the min high-water mark (everyone has those) or a deadline.
-   App messages expire per their `expiresAt`; commits are retained until
-   applied-by-all or the deadline (then straggler-rejoin).
-9. **Trust boundary.** The DS only ever sees ciphertext + the plaintext atSign
-   roster: it orders, routes, and retains, but never decrypts and cannot forge
-   membership — members reject any commit not signed by an authorised owner
-   leaf, and reorder/withhold is detectable via the MLS transcript hash.
-10. **Engine (v2).** The crypto is MLS: TreeKEM makes each commit O(log n)
-    instead of O(n), with RFC 9420 forward secrecy and post-compromise
-    security — all behind the same `SecureGroup` interface and the same DS.
-
-Net: members send/admin once to the DS; the DS sequences and fans out
-ciphertext it can't read; catch-up, retention, ordering, and revocation are
-handled at the group object — and the per-message cost scales with the number
-of member *atSigns*, not member *clients*.
-
-## Appendix C — a two-atSign chat with client churn (`at_talk`, detailed)
-
-A worked example of the Phase 4 `(pair, namespace)` shared group: two atSigns,
-multiple clients each, bidirectional messaging, and late-joining clients. It
-shows exactly how decryption stays scoped to namespace-authorized clients on
-both sides, and how a freshly-created client reads new *and* past messages.
-
-**Setup.** `alice1`, `alice2`, `bob1`, `bob2` exist, each has `rw` on the
-`at_talk` namespace and has published a KeyPackage (X-Wing leaf KEM key +
-APKAM-certified signing key). The group is **`pair:@alice:@bob:at_talk`** —
-canonical atSign ordering so both sides compute the same `groupId`; one
-symmetric group, both directions sealing under the same epoch key. Members =
-`{alice1, alice2, bob1, bob2}`. Epoch key `E1` is the AES-256-GCM key the group
-encrypts under, minted lazily on first use.
-
-**Why scope = `(pair, namespace)`.** The group is *not* `pair:@alice:@bob`
-(would leak alice→bob `banking` to an at_talk-only bob client) and *not*
-`self:@alice:at_talk` (would hand bob alice's private self data). It is the
-unique group whose membership equals "both sides' `at_talk` clients", mirroring
-the atServer's enrollment-authorization topology for the `at_talk` keys it
-carries.
-
-```mermaid
-sequenceDiagram
-    autonumber
-    participant a1 as alice1
-    participant a2 as alice2
-    participant a3 as alice3
-    participant S as atServers
-    participant b1 as bob1
-    participant b2 as bob2
-    participant b3 as bob3
-
-    Note over a1,b2: Step 0 — a1,a2,b1,b2 published KeyPackages, rw on at_talk. Group pair:@alice:@bob:at_talk, members {a1,a2,b1,b2}
-    Note over S: atServers gate every at_talk key (data AND epoch-key envelopes) by enrollment access
-
-    rect rgb(232,242,255)
-    Note over a1: Step 1 — alice1 sends to @bob
-    a1->>a1: lazily create group; mint epoch E1; seal M1 under E1
-    a1->>S: put @bob:msg1.at_talk@alice {group, epoch 1, kid k1}
-    a1->>S: push E1 to a2,b1,b2 — X-Wing per leaf, via __ssenv.at_talk envelopes
-    end
-
-    rect rgb(232,255,236)
-    Note over b1,b2: Step 2 — bob1 and bob2 decrypt M1
-    S-->>b1: @bob:msg1... + E1 envelope (allowed: at_talk)
-    S-->>b2: @bob:msg1... + E1 envelope (allowed: at_talk)
-    b1->>b1: decapsulate E1 with leaf key; open M1
-    b2->>b2: decapsulate E1; open M1
-    Note over b1,b2: a client missed at push-time pulls E1 (requestSecretsFromNamespace at_talk)
-    end
-
-    rect rgb(255,250,232)
-    Note over b2: Step 3 — bob2 replies to @alice (same group, same E1)
-    b2->>b2: seal M2 under E1
-    b2->>S: put @alice:msg2.at_talk@bob {group, epoch 1, kid k1}
-    end
-
-    rect rgb(232,255,236)
-    Note over a1,a2: Step 4 — alice1 and alice2 decrypt M2
-    S-->>a1: @alice:msg2...
-    S-->>a2: @alice:msg2...
-    a1->>a1: open M2 with E1 (already a member)
-    a2->>a2: open M2 with E1
-    end
-
-    rect rgb(255,232,244)
-    Note over b3: Step 5 — bob3 created, publishes KeyPackage (at_talk)
-    b3->>S: publish KeyPackage; register for at_talk
-    b1->>b1: roster-watch sees b3 → Add b3 + Commit → epoch E2 (mandatory rotation)
-    b1->>S: push E2 to {a1,a2,b1,b2,b3} (fans out cross-atSign)
-    Note over b3: NEW: holds E2 → opens every message from epoch 2 on
-    b3->>S: PAST: pull __rk.1 (request in at_talk)
-    S-->>b3: E1 (allowed: b3 is at_talk-authorized)
-    Note over b3: history-ON → opens M1,M2 · history-OFF (strict FS) → M1,M2 stay opaque
-    end
-
-    rect rgb(244,232,255)
-    Note over a3: Step 6 — alice3 created, publishes KeyPackage (at_talk)
-    a3->>S: publish KeyPackage; register for at_talk
-    a1->>a1: roster-watch sees a3 → Add a3 + Commit → epoch E3
-    a1->>S: push E3 to {a1,a2,a3,b1,b2,b3}
-    Note over a3: NEW: holds E3 → opens every message from epoch 3 on
-    a3->>S: PAST: pull __rk.1, __rk.2
-    S-->>a3: E1, E2 (allowed: a3 is at_talk-authorized)
-    Note over a3: history-ON → opens M1,M2 · also joins self:@alice:at_talk for alice's self data
-    end
-```
-
-### How a new client obtains the epoch key
-
-The epoch key is never sent in the clear and never wrapped under a static
-per-atSign key. For each member leaf, the committer **X-Wing-encapsulates** the
-epoch key to *that leaf's* published KEM public key and writes the result as a
-secret-sharing envelope keyed `<msgId>.<clientId>.__ssenv.at_talk@<atsign>`.
-Two independent gates
-therefore protect every copy of the key:
-
-1. **Transport gate (atServer, by namespace).** The envelope key carries the
-   `at_talk` suffix, so the atServer only lets a client *read* the envelope if
-   its enrollment is authorized for `at_talk` — identical to the gate on the
-   message itself. A client without `at_talk` can't even fetch the envelope.
-2. **Crypto gate (the leaf KEM key).** The envelope body is encapsulated to one
-   specific leaf's KEM public key, so only the holder of that leaf's private
-   key can **decapsulate** it. Possessing a different member's envelope is
-   useless.
-
-So for **bob3** (Step 5): bob3 generates its leaf keypair locally and publishes
-the *public* KeyPackage. A current member (bob1, via same-atSign roster watch)
-Adds bob3 and Commits a new epoch `E2`, encapsulating `E2` to bob3's published
-KEM public key and writing the `__ssenv.at_talk` envelope addressed to bob3.
-bob3's atServer delivers it (bob3 is at_talk-authorized → gate 1 passes); bob3
-decapsulates with its leaf KEM **private** key, which never left the device →
-recovers `E2` (gate 2 passes). For past messages, bob3 issues a pull for
-`__rk.1`; a member re-encapsulates `E1` to bob3's leaf and delivers it through
-the same two gates. Nothing about bob3's identity is special — it succeeds iff
-(a) its enrollment authorizes `at_talk` and (b) it holds its own leaf private
-key. That is exactly "all bob clients with `at_talk` access, and only those."
-
-### New clients: new vs. past messages
-
-| Client | New messages | Past messages |
-|--------|--------------|---------------|
-| **bob3** | A same-atSign member Adds+Commits → mandatory rotation to `E2`, pushed to all members; bob3 decapsulates `E2` and reads from epoch 2 on. (If not proactively added, bob3 pulls `__rk.current`.) | Pulls retained `__rk.1`; server allows (at_talk-authorized). **history-ON** → opens M1, M2. **history-OFF** (strict FS) → pre-join epochs stay opaque. |
-| **alice3** | Symmetric: alice1/alice2 Add+Commit → `E3`, fanned out cross-atSign to all six clients; alice3 reads from epoch 3 on. Also joins `self:@alice:at_talk` for alice's self data. | Pulls `__rk.1`, `__rk.2`; server-allowed. Same history-ON/OFF fork. |
-
-### Caveats this example surfaces
-
-- **History is a policy fork, not a mechanism gap.** v1 retains old epoch keys
-  and lets any namespace-authorized client pull them, so chat history works —
-  but that is in tension with forward secrecy. The MLS swap (D2) gives true FS,
-  under which a joiner cannot read pre-join traffic by design; "new member reads
-  history" then needs an explicit history-sharing mechanism (re-encrypt to the
-  new member, or a separate history key). Decide the `at_talk` policy
-  deliberately.
-- **Every join rotates the epoch** (lever A, mandatory). Churny fleets rotate
-  often; fine at pair scale, and a motivation for the Delivery Service (M5) at
-  large scale.
-- **M4, not yet built.** Today shared keys still route to `legacy` (the `group`
-  provider refuses shared keys), so currently *all* bob clients decrypt via
-  bob's shared keypair — the loose superset, not the namespace-scoped flow
-  above. This appendix is the target the Phase 4 design specifies.
+- **[NoPorts, end to end](crypto-walkthroughs.md#walkthrough-a--noports-end-to-end)**
+  — the canonical Deliverable 1 consumer: per-destination feature-gated tiers
+  0–2, one session traced step by step.
+- **[A large group, end to end](crypto-walkthroughs.md#walkthrough-b--a-large-group-end-to-end)**
+  — Deliverable 2 at scale against the
+  [group Delivery Service](#atserver-group-delivery-service-target-design):
+  create, add, append, catch-up, revoke, GC.
+- **[A two-atSign chat with client churn (`at_talk`)](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-client-churn-at_talk)**
+  — the Phase 4 `(pair, namespace)` shared group with late-joining clients
+  reading new *and* past messages.

--- a/docs/crypto-walkthroughs.md
+++ b/docs/crypto-walkthroughs.md
@@ -1,0 +1,342 @@
+# Crypto walkthroughs — worked end-to-end examples
+
+Worked, end-to-end traces of the post-quantum / group-first encryption design
+in action — the "how does it actually play out" companion in a three-doc set
+that shares one shape (design → build → worked example):
+
+> - **[crypto-roadmap.md](crypto-roadmap.md)** — the design source of truth
+>   (goals, architecture, phasing, the *why*).
+> - **[crypto_impl_plan.md](crypto_impl_plan.md)** — the build plan
+>   (task breakdown, ordering, PR carving, the *how* and *when*).
+> - **This doc** — worked scenarios that exercise the design.
+>
+> Nothing here is normative; when a walkthrough and the roadmap disagree, the
+> roadmap wins. See the roadmap's
+> [document map](crypto-roadmap.md#document-map) for how the sections pair up.
+
+The three walkthroughs map onto the design's two deliverables (see
+[the two deliverables](crypto-roadmap.md#the-two-major-deliverables)):
+
+- **[Walkthrough A — NoPorts](#walkthrough-a--noports-end-to-end)** exercises
+  Deliverable 1 (PQ-safe messaging) on small groups — the production payoff.
+- **[Walkthrough B — a large group](#walkthrough-b--a-large-group-end-to-end)**
+  exercises Deliverable 2 (pq-mls) at scale, against the atServer group
+  Delivery Service.
+- **[Walkthrough C — a two-atSign chat](#walkthrough-c--a-two-atsign-chat-with-client-churn-at_talk)**
+  exercises the cross-atSign `(pair, namespace)` shared group with client churn.
+
+## Walkthrough A — NoPorts, end to end
+
+Actors: **@client** (sshnp), **@daemon** (sshnpd; a device may run many),
+**@srvd** (relay; a third atSign). Each client is a leaf with a published
+KeyPackage.
+
+NoPorts is the canonical consumer: it already has the many-clients-per-atSign
+problem (multiple sshnpd daemons per device atSign), already signs envelopes
+(its `validation_utils` is the ancestor of the SDK's `EnvelopeSigning`), and its
+main harvest-now-decrypt-later exposure is the session-key exchange (sshnpd
+RSA-2048-wraps AES session keys to sshnp's per-session ephemeral keypair).
+
+### Feature discovery — the backwards-compatibility lever
+
+Backwards compatibility rides NoPorts' existing **feature discovery**: the
+daemon's ping response carries `supportedFeatures: {name: bool}`
+(`sshnpd_impl.dart`), clients read it null-tolerantly (a missing map means an
+old daemon), and features gate behaviour per session — exactly how `twinKeys`
+rolled out. Two new `DaemonFeature`s:
+
+| Feature         | Daemon advertises that it...                                                  |
+|-----------------|-------------------------------------------------------------------------------|
+| `groupCrypto`   | can decrypt notifications encrypted by the SDK's `group` provider             |
+| `pqSessionKeys` | supports deriving session keys from a pair-group `export()` (none in flight)  |
+
+The crucial subtlety: a client must NOT flip its default provider for traffic to
+a daemon that can't decrypt it. `PutRequestOptions.cryptoProviderId`
+(per-operation override, from the M0 seam) is the gate: choose the provider per
+destination based on the ping response.
+
+### One session, step by step
+
+1. **Discovery.** sshnp pings @daemon (existing flow); the ping response
+   carries `supportedFeatures`, read null-tolerantly (a missing map = old
+   daemon). The client learns `groupCrypto` and `pqSessionKeys`.
+2. **Session request (Tier 0 — transport).** The client picks a provider per
+   the ping — `provider = features['groupCrypto'] ? 'group' : 'legacy'`, set
+   via `PutRequestOptions.cryptoProviderId`. With `group`, the request
+   notification is a PQ-safe group message of the @client↔@daemon pair group;
+   with `legacy`, byte-identical to today. Because the (still RSA-wrapped)
+   session key rides *inside* this payload, a recorded exchange can no longer
+   be peeled open later — the harvest-now hole is closed even before Tier 1.
+
+   ```dart
+   final features = await pingDaemon(device);            // existing flow
+   final provider = features['groupCrypto'] == true ? 'group' : 'legacy';
+   await notify(req, ..., putRequestOptions: PutRequestOptions()
+     ..cryptoProviderId = provider);
+   ```
+
+3. **Session keys (Tier 1 — derive, don't transmit).** If `pqSessionKeys`,
+   both sides resolve the same pair group and derive
+   `aesC2D = pair.export('c2d:'+sessionId)` and
+   `aesD2C = pair.export('d2c:'+sessionId)`. Same `(label, epoch)` → identical
+   bytes on both sides; the response carries only `sessionId`, no key material
+   in flight, and the per-session RSA keypair generation is deleted. Without
+   `pqSessionKeys`, fall back to today's ephemeral-RSA exchange (already
+   protected by Tier 0).
+
+   ```dart
+   // sshnpd, replacing genBundle():
+   final pair = await atClient.groups
+       .withAtSigns([requestingAtsign], namespace: '$device.sshnp');
+   final aesKeyC2D = await pair.export('c2d:$sessionId');
+   final aesKeyD2C = await pair.export('d2c:$sessionId');
+   // response carries only sessionId — no key material in flight
+
+   // sshnp: the same two export() calls; both sides derive independently
+   ```
+
+   Side benefit: deletes the per-session RSA-2048 keypair generation — a
+   measurable startup win on small devices.
+4. **srvd relay.** The relay-auth key involves a third atSign; a per-session
+   3-party group is overkill, so it stays transmitted, protected by Tier 0.
+5. **Delivery.** The group is 2 atSigns (or a self group within one atSign for
+   Tier 2). The member-atSign count is tiny, so there is **no DS host** —
+   pairwise notify + the recipient atServer's sync to its own clients.
+   (Walkthrough B's Delivery Service is only for large groups.)
+6. **Fleet management (Tier 2 — self group).** Many sshnpd on one device atSign
+   plus a policy/management client are a self `SecureGroup`. Management writes
+   a config secret once; every daemon reads it, joined automatically at
+   enrollment. A stolen device → `enroll:revoke` → the daemon's leaf is
+   removed and the group rotates → everything shared after that instant is
+   unreadable by it.
+
+   ```dart
+   // management client, once:
+   await atClient.groups.self('policy_v2.sshnp')
+       .putSecret('webhook-token', token);
+
+   // every sshnpd, joined automatically at enrollment:
+   final token = await atClient.groups.self('policy_v2.sshnp')
+       .getSecret('webhook-token');
+
+   // stolen device: enroll:revoke → leaf removed + group rotates;
+   // everything shared after that moment is unreadable by it
+   ```
+
+7. **Rollout.** (1) ship dual-stack daemons that advertise the features — safe,
+   nothing changes on the wire; (2) ship clients that prefer the features when
+   advertised; (3) once the deployed-daemon floor includes `groupCrypto`, flip
+   the client default; (4) `pqSessionKeys` retires `genBundle`/ephemeral-keypair
+   code when the floor allows. Consolidation bonus at any point: NoPorts can
+   replace `validation_utils` signing with the SDK's `EnvelopeSigning` (its
+   descendant), moving verification onto the per-enrollment `_apsk` trust chain
+   — strictly better for multi-daemon deployments.
+
+Net: every request/response/heartbeat becomes PQ-safe (Tier 0), session keys
+stop travelling at all (Tier 1), and fleet secrets get rotating-key
+distribution with instant revocation (Tier 2) — with old peers always
+negotiating cleanly via feature discovery. The design requirements that keep
+this user-invisible (admission stays per-atSign; identity is derived from
+identifiers the program already has) live in the roadmap's
+[NoPorts adoption](crypto-roadmap.md#upgrading-noports-with-daemon-ping-feature-discovery).
+
+## Walkthrough B — a large group, end to end
+
+Actors: a dedicated DS atSign **`@my_org_groups`** running the
+[group Delivery Service](crypto-roadmap.md#atserver-group-delivery-service-target-design);
+admins **@alice**, **@bob**; members across many atSigns, each a leaf with a
+published KeyPackage.
+
+1. **Provision the DS.** `@my_org_groups` is operated as infrastructure (HA,
+   monitored, backed up). It is ciphertext-only — never a group member, never
+   holds group keys.
+2. **Create.** `@alice` → `group:create{groupId, ownerAcl:[@alice,@bob]}`. The
+   DS provisions the group object: roster, `seq=0`, empty TTL'd log.
+3. **Add a member (@frank).** An admin: fetches + verifies @frank's published
+   KeyPackage; commits an Add locally (advances the epoch), producing a Commit
+   + a Welcome; sends the **Welcome pairwise** to @frank (1:1); then
+   `group:append{kind:commit, value:<commit ct>, msgId}` + `group:add @frank`
+   to the DS. The DS assigns `seq=N`, logs it, adds @frank to the roster, and
+   fans out `{group, N}` **wakes** to every member atSign. Members
+   `group:fetch:since` the commit, apply it, advance to epoch N; @frank pulls
+   current state and joins.
+4. **Application message (any member → group).** The sender seals once under
+   the epoch key, then one `group:append{kind:app, value:<ct>, expiresAt,...}`
+   to the DS. The DS assigns the next `seq`, logs (with the app TTL), fans out
+   wakes. Each member atServer pulls the delta into local storage; that
+   atSign's many clients then read it via ordinary sync — including the
+   sender's *own* other clients (the DS fans out to the sender's atSign too).
+   Cost: one append + O(member-atSigns) wakes/pulls — never O(member-clients).
+5. **Concurrent admins.** @alice and @bob both commit at epoch N. Both
+   `group:append`; the DS's atomic `seq` orders them — one lands at N, the
+   other gets a conflict, rebases to N+1, resubmits. No fork.
+6. **Catch-up.** A member offline for a while returns and
+   `group:fetch:since:<lastSeq>`. Commits replay in `seq` order; expired app
+   messages appear as tombstones (skippable). If a commit it still needs has
+   aged out (offline past the retention deadline), it is a straggler → an
+   admin **re-adds it at the current epoch** (fresh Welcome), not a
+   full-history replay.
+7. **Remove / revoke (@grace).** An admin commits a Remove + rotates the epoch
+   (`excludeEnrollmentIds`), then `group:append{kind:commit}` +
+   `group:remove @grace`. The DS sequences, fans out, drops @grace from the
+   roster. Everything from the new epoch on is unreadable by @grace.
+8. **Retention & GC.** Members periodically `group:ack{seq}`; the DS truncates
+   the log below the min high-water mark (everyone has those) or a deadline.
+   App messages expire per their `expiresAt`; commits are retained until
+   applied-by-all or the deadline (then straggler-rejoin).
+9. **Trust boundary.** The DS only ever sees ciphertext + the plaintext atSign
+   roster: it orders, routes, and retains, but never decrypts and cannot forge
+   membership — members reject any commit not signed by an authorised owner
+   leaf, and reorder/withhold is detectable via the MLS transcript hash.
+10. **Engine (v2).** The crypto is MLS: TreeKEM makes each commit O(log n)
+    instead of O(n), with RFC 9420 forward secrecy and post-compromise
+    security — all behind the same `SecureGroup` interface and the same DS.
+
+Net: members send/admin once to the DS; the DS sequences and fans out
+ciphertext it can't read; catch-up, retention, ordering, and revocation are
+handled at the group object — and the per-message cost scales with the number
+of member *atSigns*, not member *clients*.
+
+## Walkthrough C — a two-atSign chat with client churn (`at_talk`)
+
+A worked example of the Phase 4 `(pair, namespace)` shared group: two atSigns,
+multiple clients each, bidirectional messaging, and late-joining clients. It
+shows exactly how decryption stays scoped to namespace-authorized clients on
+both sides, and how a freshly-created client reads new *and* past messages. The
+design it realises is the roadmap's
+[Phase 4 — cross-atSign groups](crypto-roadmap.md#phase-4--cross-atsign-groups-shared-encryption).
+
+**Setup.** `alice1`, `alice2`, `bob1`, `bob2` exist, each has `rw` on the
+`at_talk` namespace and has published a KeyPackage (X-Wing leaf KEM key +
+APKAM-certified signing key). The group is **`pair:@alice:@bob:at_talk`** —
+canonical atSign ordering so both sides compute the same `groupId`; one
+symmetric group, both directions sealing under the same epoch key. Members =
+`{alice1, alice2, bob1, bob2}`. Epoch key `E1` is the AES-256-GCM key the group
+encrypts under, minted lazily on first use.
+
+**Why scope = `(pair, namespace)`.** The group is *not* `pair:@alice:@bob`
+(would leak alice→bob `banking` to an at_talk-only bob client) and *not*
+`self:@alice:at_talk` (would hand bob alice's private self data). It is the
+unique group whose membership equals "both sides' `at_talk` clients", mirroring
+the atServer's enrollment-authorization topology for the `at_talk` keys it
+carries.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant a1 as alice1
+    participant a2 as alice2
+    participant a3 as alice3
+    participant S as atServers
+    participant b1 as bob1
+    participant b2 as bob2
+    participant b3 as bob3
+
+    Note over a1,b2: Step 0 — a1,a2,b1,b2 published KeyPackages, rw on at_talk. Group pair:@alice:@bob:at_talk, members {a1,a2,b1,b2}
+    Note over S: atServers gate every at_talk key (data AND epoch-key envelopes) by enrollment access
+
+    rect rgb(232,242,255)
+    Note over a1: Step 1 — alice1 sends to @bob
+    a1->>a1: lazily create group; mint epoch E1; seal M1 under E1
+    a1->>S: put @bob:msg1.at_talk@alice {group, epoch 1, kid k1}
+    a1->>S: push E1 to a2,b1,b2 — X-Wing per leaf, via __ssenv.at_talk envelopes
+    end
+
+    rect rgb(232,255,236)
+    Note over b1,b2: Step 2 — bob1 and bob2 decrypt M1
+    S-->>b1: @bob:msg1... + E1 envelope (allowed: at_talk)
+    S-->>b2: @bob:msg1... + E1 envelope (allowed: at_talk)
+    b1->>b1: decapsulate E1 with leaf key; open M1
+    b2->>b2: decapsulate E1; open M1
+    Note over b1,b2: a client missed at push-time pulls E1 (requestSecretsFromNamespace at_talk)
+    end
+
+    rect rgb(255,250,232)
+    Note over b2: Step 3 — bob2 replies to @alice (same group, same E1)
+    b2->>b2: seal M2 under E1
+    b2->>S: put @alice:msg2.at_talk@bob {group, epoch 1, kid k1}
+    end
+
+    rect rgb(232,255,236)
+    Note over a1,a2: Step 4 — alice1 and alice2 decrypt M2
+    S-->>a1: @alice:msg2...
+    S-->>a2: @alice:msg2...
+    a1->>a1: open M2 with E1 (already a member)
+    a2->>a2: open M2 with E1
+    end
+
+    rect rgb(255,232,244)
+    Note over b3: Step 5 — bob3 created, publishes KeyPackage (at_talk)
+    b3->>S: publish KeyPackage; register for at_talk
+    b1->>b1: roster-watch sees b3 → Add b3 + Commit → epoch E2 (mandatory rotation)
+    b1->>S: push E2 to {a1,a2,b1,b2,b3} (fans out cross-atSign)
+    Note over b3: NEW: holds E2 → opens every message from epoch 2 on
+    b3->>S: PAST: pull __rk.1 (request in at_talk)
+    S-->>b3: E1 (allowed: b3 is at_talk-authorized)
+    Note over b3: history-ON → opens M1,M2 · history-OFF (strict FS) → M1,M2 stay opaque
+    end
+
+    rect rgb(244,232,255)
+    Note over a3: Step 6 — alice3 created, publishes KeyPackage (at_talk)
+    a3->>S: publish KeyPackage; register for at_talk
+    a1->>a1: roster-watch sees a3 → Add a3 + Commit → epoch E3
+    a1->>S: push E3 to {a1,a2,a3,b1,b2,b3}
+    Note over a3: NEW: holds E3 → opens every message from epoch 3 on
+    a3->>S: PAST: pull __rk.1, __rk.2
+    S-->>a3: E1, E2 (allowed: a3 is at_talk-authorized)
+    Note over a3: history-ON → opens M1,M2 · also joins self:@alice:at_talk for alice's self data
+    end
+```
+
+### How a new client obtains the epoch key
+
+The epoch key is never sent in the clear and never wrapped under a static
+per-atSign key. For each member leaf, the committer **X-Wing-encapsulates** the
+epoch key to *that leaf's* published KEM public key and writes the result as a
+secret-sharing envelope keyed `<msgId>.<clientId>.__ssenv.at_talk@<atsign>`.
+Two independent gates therefore protect every copy of the key:
+
+1. **Transport gate (atServer, by namespace).** The envelope key carries the
+   `at_talk` suffix, so the atServer only lets a client *read* the envelope if
+   its enrollment is authorized for `at_talk` — identical to the gate on the
+   message itself. A client without `at_talk` can't even fetch the envelope.
+2. **Crypto gate (the leaf KEM key).** The envelope body is encapsulated to one
+   specific leaf's KEM public key, so only the holder of that leaf's private
+   key can **decapsulate** it. Possessing a different member's envelope is
+   useless.
+
+So for **bob3** (Step 5): bob3 generates its leaf keypair locally and publishes
+the *public* KeyPackage. A current member (bob1, via same-atSign roster watch)
+Adds bob3 and Commits a new epoch `E2`, encapsulating `E2` to bob3's published
+KEM public key and writing the `__ssenv.at_talk` envelope addressed to bob3.
+bob3's atServer delivers it (bob3 is at_talk-authorized → gate 1 passes); bob3
+decapsulates with its leaf KEM **private** key, which never left the device →
+recovers `E2` (gate 2 passes). For past messages, bob3 issues a pull for
+`__rk.1`; a member re-encapsulates `E1` to bob3's leaf and delivers it through
+the same two gates. Nothing about bob3's identity is special — it succeeds iff
+(a) its enrollment authorizes `at_talk` and (b) it holds its own leaf private
+key. That is exactly "all bob clients with `at_talk` access, and only those."
+
+### New clients: new vs. past messages
+
+| Client | New messages | Past messages |
+|--------|--------------|---------------|
+| **bob3** | A same-atSign member Adds+Commits → mandatory rotation to `E2`, pushed to all members; bob3 decapsulates `E2` and reads from epoch 2 on. (If not proactively added, bob3 pulls `__rk.current`.) | Pulls retained `__rk.1`; server allows (at_talk-authorized). **history-ON** → opens M1, M2. **history-OFF** (strict FS) → pre-join epochs stay opaque. |
+| **alice3** | Symmetric: alice1/alice2 Add+Commit → `E3`, fanned out cross-atSign to all six clients; alice3 reads from epoch 3 on. Also joins `self:@alice:at_talk` for alice's self data. | Pulls `__rk.1`, `__rk.2`; server-allowed. Same history-ON/OFF fork. |
+
+### Caveats this example surfaces
+
+- **History is a policy fork, not a mechanism gap.** v1 retains old epoch keys
+  and lets any namespace-authorized client pull them, so chat history works —
+  but that is in tension with forward secrecy. The MLS swap (D2) gives true FS,
+  under which a joiner cannot read pre-join traffic by design; "new member reads
+  history" then needs an explicit history-sharing mechanism (re-encrypt to the
+  new member, or a separate history key). Decide the `at_talk` policy
+  deliberately.
+- **Every join rotates the epoch** (lever A, mandatory). Churny fleets rotate
+  often; fine at pair scale, and a motivation for the Delivery Service (M5) at
+  large scale.
+- **M4, not yet built.** Today shared keys still route to `legacy` (the `group`
+  provider refuses shared keys), so currently *all* bob clients decrypt via
+  bob's shared keypair — the loose superset, not the namespace-scoped flow
+  above. This walkthrough is the target the Phase 4 design specifies.

--- a/docs/crypto_impl_plan.md
+++ b/docs/crypto_impl_plan.md
@@ -1,16 +1,42 @@
 # Crypto implementation plan
 
 The detailed, living implementation plan for the post-quantum / group-first
-encryption work. Its companion is [`crypto-roadmap.md`](crypto-roadmap.md) —
-**the roadmap is the design source of truth** (goals, architecture, phasing,
-and the *why*); **this file is the build plan** (task breakdown, ordering,
-dependencies, PR carving, and acceptance — the *how* and *when*).
+encryption work.
+
+> **This is the build plan** — task breakdown, ordering, dependencies, PR
+> carving, and acceptance (the *how* and *when*). It has two companions, and the
+> three docs share one shape (design → build → worked example):
+>
+> - **[crypto-roadmap.md](crypto-roadmap.md)** — the design source of truth
+>   (goals, architecture, phasing, the *why*). On a design question, it wins.
+> - **[crypto-walkthroughs.md](crypto-walkthroughs.md)** — worked end-to-end
+>   examples (NoPorts, a large group, an `at_talk` chat).
+>
+> See the [document map](#document-map) for how the sections pair up.
 
 By intent this plan is **much more detailed for Deliverable 1 (D1 — PQ-safe
 messaging)**, which is the near-term build; **Deliverable 2 (D2 — pq-mls)** is
 left as **sparser placeholders that call out where detailed planning is still
 required**. See the roadmap's
 [two deliverables](crypto-roadmap.md#the-two-major-deliverables).
+
+## Document map
+
+How the three docs line up — **design** (the roadmap, the source of truth) ↔
+**build** (this doc) ↔ **worked example** (the walkthroughs). Find your row and
+jump.
+
+| Topic | Design (roadmap) | Build (plan) | Worked example |
+|---|---|---|---|
+| The two deliverables (D1 / D2) | [The two major deliverables](crypto-roadmap.md#the-two-major-deliverables) | [Current state (1)](crypto_impl_plan.md#1-current-state-2026-06-22) · [D1 acceptance (2)](crypto_impl_plan.md#2-d1-acceptance--what-done-means) | — |
+| D1 Tier1 — the `nskey` default | [D1 — preserving legacy simplicity](crypto-roadmap.md#d1--preserving-legacy-simplicity-two-tiers) | [D1-B (3)](crypto_impl_plan.md#d1-b--the-nskey-provider-d1-tier1--the-default) | — |
+| Migration, rollout & versioning | [Application migration & rollout](crypto-roadmap.md#application-migration--rollout) | [D1-C / D1-D (3)](crypto_impl_plan.md#d1-c--migration--rollout-machinery) | — |
+| Identity, KeyPackages, self groups | [Phases 2–3](crypto-roadmap.md#phase-2--identity-layer-keypackages-and-per-client-atkeys) | [D1-E (3)](crypto_impl_plan.md#d1-e--d1-tier2-shape-corrections-fold-into-wp-gp) · [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | — |
+| Cross-atSign shared groups | [Phase 4](crypto-roadmap.md#phase-4--cross-atsign-groups-shared-encryption) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [C — `at_talk` chat](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-client-churn-at_talk) |
+| pq-mls engine + Delivery Service | [atServer group Delivery Service](crypto-roadmap.md#atserver-group-delivery-service-target-design) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [B — a large group](crypto-walkthroughs.md#walkthrough-b--a-large-group-end-to-end) |
+| NoPorts adoption | [Upgrading NoPorts](crypto-roadmap.md#upgrading-noports-with-daemon-ping-feature-discovery) | [Cross-repo & NoPorts (5)](crypto_impl_plan.md#5-cross-repo-pr--publish-sequence--noports) | [A — NoPorts](crypto-walkthroughs.md#walkthrough-a--noports-end-to-end) |
+| Structural enablers / WASM split | [Component responsibilities & WASM-readiness](crypto-roadmap.md#component-responsibilities--wasm-readiness) | [D1-S (3)](crypto_impl_plan.md#d1-s--structural-enablers-prerequisite--lands-first) | — |
+| Release order & work packages | [Starting point](crypto-roadmap.md#starting-point) | [Work packages (7)](crypto_impl_plan.md#7-delivery-plan--work-packages) | — |
 
 ---
 
@@ -19,7 +45,7 @@ required**. See the roadmap's
 ### Branches & delivery model (trunk-based)
 - **Trunk is the single integration point.** Each work package is a short-lived
   branch **merged to `trunk` when complete**, and **published to pub.dev as
-  needed** in dependency order (§7). No long-lived shared integration branch.
+  needed** in dependency order ([section 7](#7-delivery-plan--work-packages)). No long-lived shared integration branch.
 - **When the full stack needs proving before a batch lands**, spin up an
   *ephemeral* integration branch on demand (merge the in-flight WP branches, run
   the e2e rigs, discard) or rely on CI — not a standing branch.
@@ -47,7 +73,7 @@ required**. See the roadmap's
    - **(4a)** commit-log-free persistence migration — **MERGED to trunk (#1984).**
    - **(4b)** pluggable crypto seam (slim) — **PR #1930, OPEN + green.**
    - **(4c)** the secret-sharing substrate, `nskey` / D1 Tier1, and the `group`
-     provider — **land on trunk as the §7 work packages complete** (WP-SS /
+     provider — **land on trunk as the [section 7](#7-delivery-plan--work-packages) work packages complete** (WP-SS /
      WP6 / WP-GP …); the spike (`gkc-pqmls-spike`) holds working prototypes.
 
 ### What is built vs prototyped — re-baselined: assume only trunk + #1930 + #1993
@@ -59,7 +85,7 @@ required**. See the roadmap's
 - **Phase 6 — at_chops is the sole security-crypto dependency**: at_client /
   at_lookup / at_auth / at_onboarding_cli route all security crypto through
   at_chops; a CI gate enforces it (the four small PRs #1995–1998, **merged**).
-  (Record in §6.)
+  (Record in [section 6](#6-standing-verification--implementation-record).)
 
 **In flight (open PRs — the rest of the foundation):**
 - **M0 pluggable crypto seam** — **PR #1930** (at_client). Stateless
@@ -73,7 +99,7 @@ required**. See the roadmap's
   machinery** the whole rollout rides.
 - **HPKE `pqSeal`/`pqOpen`** — **PR #1993** (at_chops).
 
-**Prototyped on `gkc-pqmls-spike` but NOT landed — first-class WPs (§7), not
+**Prototyped on `gkc-pqmls-spike` but NOT landed — first-class WPs ([section 7](#7-delivery-plan--work-packages)), not
 foundation.** The spike has working code for these; treat re-landing it on trunk
 as real work (carve-out + alignment to the slim seam + `pqSeal`):
 - **Secret-sharing substrate (PQ-native)** → **WP-SS**: per-client X-Wing
@@ -91,16 +117,21 @@ as real work (carve-out + alignment to the slim seam + `pqSeal`):
 / Request-Result wrappers were removed in #1930's slim refactor; the
 `cryptoRegistry` getter is off the `AtClient` spec.)*
 
-### Phase status (cross-ref roadmap [Milestones](crypto-roadmap.md#milestones-and-capabilities))
+### Phase status
+Cross-ref roadmap [Milestones](crypto-roadmap.md#milestones-and-capabilities).
+"Prototyped on spike" means working code on `gkc-pqmls-spike` that is **not in
+trunk** — first-class work to land (a WP), not "done". "In flight" is reserved
+for the open PRs **#1930 / #1993**.
+
 | Phase / Milestone | Status |
 |---|---|
-| 0 — foundations (secret sharing, pluggable crypto, jt-pq) | **Partial**: jt-pq + Phase-6 in trunk; pluggable crypto **in flight** (#1930); secret sharing **not landed** (spike → WP-SS) |
-| 1 — PQ primitives in at_chops (X-Wing, GCM, HKDF, HMAC) | **Done**; remaining: PQ enrollment-conveyance pubkey |
-| 2 — identity layer (KeyPackages + per-client AtKeys) | KeyPackage framing **done**; AtKeys device-local split + identity resolution: not started (mostly D2 / D1 Tier2) |
+| 0 — foundations (secret sharing, pluggable crypto, jt-pq) | **Partial**: jt-pq + Phase-6 in trunk; pluggable crypto **in flight** (#1930); secret sharing **prototyped on spike, not landed** (→ WP-SS) |
+| 1 — PQ primitives in at_chops (X-Wing, GCM, HKDF, HMAC) | **Done** (trunk); remaining: PQ enrollment-conveyance pubkey |
+| 2 — identity layer (KeyPackages + per-client AtKeys) | KeyPackage framing **prototyped on spike, not landed** (→ WP-SS); AtKeys device-local split + identity resolution: not started (mostly D2 / D1 Tier2) |
 | 2.5 — at_persistence 5.x migration | **Done & verified** |
-| 3 — `SecureGroup` v1 + `group` provider (self) | **Prototyped on spike, not landed** (→ WP-GP); D1 Tier1 `nskey` self is **new D1 work** (§3) |
-| 4 — cross-atSign shared | D1 Tier1 `nskey` shared is **new D1 work** (§3); per-client pair group is D1 Tier2 / D2 |
-| 5 — pq-mls engine | **D2 placeholder** (§4) |
+| 3 — `SecureGroup` v1 + `group` provider (self) | **Prototyped on spike, not landed** (→ WP-GP); D1 Tier1 `nskey` self is **new D1 work** ([section 3](#3-d1--detailed-implementation-plan)) |
+| 4 — cross-atSign shared | D1 Tier1 `nskey` shared is **new D1 work** ([section 3](#3-d1--detailed-implementation-plan)); per-client pair group is D1 Tier2 / D2 |
+| 5 — pq-mls engine | **D2 placeholder** ([section 4](#4-d2--pq-mls-placeholders-detailed-planning-deferred)) |
 | 6 — at_chops sole security-crypto dependency | **Complete** (in-scope) |
 
 ---
@@ -124,14 +155,14 @@ D1 is done when, per the roadmap
    3.x, `true` in 4.0) lets a client forbid legacy-provider encryption, with a
    `SHOUT` log at creation whenever it is `false`
    ([versioning](crypto-roadmap.md#versioning-contract--the-legacy-encryption-flag-3x-default-off-4x-default-on)).
-5. The **usability acceptance test** holds at each milestone (§5): no new flag a
+5. The **usability acceptance test** holds at each milestone ([section 5](#5-cross-repo-pr--publish-sequence--noports)): no new flag a
    user must pass, file a user must manage, operator step, or peer-by-peer break.
 
 The substantive D1 build is the **`nskey` provider (D1 Tier1)** and the
 **migration/versioning machinery**, on top of the foundation that lands first:
 the M0 seam (#1930), HPKE (#1993), and the carved-out **secret-sharing
 substrate** (WP-SS). Only the at_chops primitives, the commit-log-free keystore,
-and the Phase-6 routing (§1) are already in trunk.
+and the Phase-6 routing ([section 1](#1-current-state-2026-06-22)) are already in trunk.
 
 ---
 
@@ -143,11 +174,12 @@ artifact and acceptance. Design references point at the roadmap. **D1-S
 `WritableAtKeys` + stateless AtChops.
 
 ### D1-S · Structural enablers (prerequisite — lands first)
-Design: roadmap
+*Lands as [WP1–WP5 + WP8](#the-work-package-sequence--single-source-for-ordering)
+across waves 1–3.* Design: roadmap
 [Component responsibilities & WASM-readiness](crypto-roadmap.md#component-responsibilities--wasm-readiness).
 The responsibilities reshape + the `at_auth` WASM split. Sequenced **before**
-the feature workstreams; only `at_auth` takes a major bump (see the roadmap's
-version/sequencing table).
+the feature workstreams; only `at_auth` takes a major bump (see
+[package versions & release sequencing](#package-versions--release-sequencing)).
 
 - [ ] **S1 · AtChops stateless core + `@Deprecated` shim** (`at_chops` minor
   `3.3.0`). Add a stateless functional surface (keys passed per call; the
@@ -189,10 +221,13 @@ version/sequencing table).
 - [ ] **S6 · Consumer constraint bumps + sequencing.** `at_client` /
   `at_onboarding_cli` (`1.17.0`) / `at_client_flutter` (`1.2.0`) /
   `at_cli_commons` adopt `at_auth ^4.0.0`; publish in dependency order
-  (at_chops → at_auth → at_client/onboarding/flutter → at_cli_commons). Roadmap
-  version table is authoritative.
+  (at_chops → at_auth → at_client/onboarding/flutter → at_cli_commons). The
+  [package-versions table (section 7)](#package-versions--release-sequencing) is
+  authoritative.
 
 ### D1-A · Finish the PQ primitives (small)
+*Lands as [WP1 (HPKE) + WP10 (enrollment-conveyance key)](#the-work-package-sequence--single-source-for-ordering),
+waves 1–2.*
 - [ ] **HPKE seal/open over X-Wing** (`at_chops`, from **PR #1993** once the
   requested changes land). `pqSeal(recipientPubKey, plaintext, {info, aad})` /
   `pqOpen(recipientSecretKey, envelope, …)` — KEM = X-Wing, KDF = HKDF-SHA256,
@@ -219,7 +254,8 @@ version/sequencing table).
   `nskey` (D1-B4) — build it first.
 
 ### D1-B · The `nskey` provider (D1 Tier1 — the default)
-Design: roadmap
+*Lands as [WP6 (B1–B4) + WP9 (B5/B6)](#the-work-package-sequence--single-source-for-ordering),
+waves 3–4.* Design: roadmap
 [D1 Tier1](crypto-roadmap.md#d1-tier-1--baseline-the-nskey-provider-default). New provider
 on the M0 seam; legacy-shaped (copyable, enrollment-granular), PQ + namespace
 -scoped. Build order:
@@ -249,12 +285,13 @@ on the M0 seam; legacy-shaped (copyable, enrollment-granular), PQ + namespace
     `pqSeal` envelope (carries the KEM ct + AEAD body); no separate `iv`/`kemCt`.
   - *Acceptance:* unit round-trips (self + shared); byte-exact decrypt; binary
     -safe (seal/open bytes, honour `isBinary` — do **not** repeat the
-    `utf8.encode(toString())` bug, see §3 D1 Tier2 shape tasks).
+    `utf8.encode(toString())` bug, see [section 3](#3-d1--detailed-implementation-plan) D1 Tier2 shape tasks).
 - [ ] **B3 · Capability marker + per-destination negotiation.** Per-`(atSign,
   namespace)` published marker `{nskey: true, nskeyPubKid, …}`, **initially
   not-ready**; the sender reads the recipient's marker (+ its own, for self
   copies) and selects the scheme. Design: roadmap
-  [Mixed-tier](crypto-roadmap.md#mixed-tier-alice--bob) + migration §.
+  [Mixed-tier](crypto-roadmap.md#mixed-tier-alice--bob) +
+  [Application migration & rollout](crypto-roadmap.md#application-migration--rollout).
   *Acceptance:* sender writes `nskey` only when the readers' marker is ready,
   legacy otherwise; mixed-fleet test (one legacy reader ⇒ legacy write).
 - [ ] **B4 · Cold-start fallback + lazy upgrade.** When the recipient has no
@@ -289,6 +326,7 @@ on the M0 seam; legacy-shaped (copyable, enrollment-granular), PQ + namespace
   All but the last phase live in 3.x; the last is the v4 flag (D1-D).
 
 ### D1-C · Migration & rollout machinery
+*Lands as [WP7](#the-work-package-sequence--single-source-for-ordering), wave 4.*
 Design: roadmap
 [Application migration & rollout](crypto-roadmap.md#application-migration--rollout).
 - [ ] **C1 · Readiness-marker lifecycle.** Publish (not-ready) on upgrade; flip
@@ -312,7 +350,8 @@ Design: roadmap
   code = override defaults / D1 Tier2.
 
 ### D1-D · Versioning (the `disallowLegacyEncryption` flag)
-Design: roadmap
+*Lands as [WP7 (flag, default off) + WP-D3 (v4 default flip)](#the-work-package-sequence--single-source-for-ordering),
+waves 4 & 6.* Design: roadmap
 [Versioning contract](crypto-roadmap.md#versioning-contract--the-legacy-encryption-flag-3x-default-off-4x-default-on).
 - [ ] **D1 · All D1 lands in 3.x** — additive, backwards-compatible; a 3.x
   client may write legacy when a reader isn't PQ-ready.
@@ -335,8 +374,9 @@ Design: roadmap
   flag is `false`). Gated on the ecosystem floor.
 
 ### D1-E · D1 Tier2 shape-corrections (fold into WP-GP)
+*Lands as [WP-GP](#the-work-package-sequence--single-source-for-ordering), wave 5.*
 The `group` provider is prototyped on the spike (D1 Tier2 self) and lands as
-WP-GP. These keep its shape honest before the self→shared and MLS transitions;
+WP-GP. These preserve its shape before the self→shared and MLS transitions;
 apply them as part of that carve-out, while touching the area.
 - [ ] **Lift membership into `SecureGroup`** (`members`/`add`/`remove`); v1
   derives them. Avoids a later breaking change to a published abstract.
@@ -353,18 +393,19 @@ apply them as part of that carve-out, while touching the area.
   pattern (a test that fails without the fix).
 - Functional (live virtualenv): nskey self + shared, rotation, mixed-tier
   (nskey↔legacy), cold-start, enrollment-revoke + rotate-exclude.
-- e2e (cross-atSign, `@ce2e*`): the `at_talk` chat scenario from roadmap
-  [Appendix C](crypto-roadmap.md#appendix-c--a-two-atsign-chat-with-client-churn-at_talk-detailed)
+- e2e (cross-atSign, `@ce2e*`): the `at_talk` chat scenario from
+  [Walkthrough C](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-client-churn-at_talk)
   — alice1/2 ↔ bob1/2 bidirectional, then bob3/alice3 join (new + past
   messages). Run concurrently via the base-port `runLocal.sh` rigs (PR #1992).
-- Usability acceptance test (§5) at each milestone.
+- Usability acceptance test ([section 5](#5-cross-repo-pr--publish-sequence--noports)) at each milestone.
 
 ### D1 · PR delivery / publish
 Each work package is its own short-lived branch **merged to trunk when
-complete**, with pub.dev **published as needed** in dependency order (§7) — 4c
+complete**, with pub.dev **published as needed** in dependency order ([section 7](#7-delivery-plan--work-packages)) — 4c
 (secret sharing) and the `nskey`/migration work land the same way, not carved
 from an integration branch at the end. Overall publish order: roadmap
-[Dependencies](crypto-roadmap.md#dependencies) + the version table.
+[Dependencies](crypto-roadmap.md#dependencies) + the
+[package-versions table (section 7)](#package-versions--release-sequencing).
 
 ---
 
@@ -518,7 +559,7 @@ How the D1 work lands across **parallel tracks** with minimal merge friction.
 Principle: **partition by package** (two tracks rarely edit the same file),
 **land contracts first** (others build against stable shapes), keep merges
 **additive / flag-gated** so trunk stays releasable. The work packages below map
-onto the §3 workstreams (D1-S / D1-A…E); this is the parallelisation/sequencing
+onto the [section 3](#3-d1--detailed-implementation-plan) workstreams (D1-S / D1-A…E); this is the parallelisation/sequencing
 view.
 
 ### Tracks (package domains, not people)
@@ -540,7 +581,7 @@ Within `at_client/crypto/`, the file partition keeps A and C apart: **C** owns
 files — low collision by construction.
 
 ### Reconciliations since the slim refactor (`xl-pluggable`)
-The slim-API + registry-fold landed on `xl-pluggable` (PR #1930) after this §7
+The slim-API + registry-fold landed on `xl-pluggable` (PR #1930) after this [section 7](#7-delivery-plan--work-packages)
 was first written; three assumptions shifted:
 1. **`CryptoContext` is `{atClient}`** — no `atChops` field. WP3 just *adds*
    `WritableAtKeys keys`; nothing to deprecate.
@@ -570,6 +611,27 @@ Order is top-to-bottom; items in one **wave** run in parallel (different
 package/track — A crypto-primitives, B key-management, C at_client seam,
 D storage/consumers). **▶** marks a pub.dev release shipping user-visible
 capability.
+
+**WP ↔ workstream map.** Each work package realises one or more of the
+[section 3](#3-d1--detailed-implementation-plan) workstreams; this table is the
+two-way lookup (a WP row here links to its workstream, and each workstream
+header links back to this section):
+
+| WP | Workstream ([section 3](#3-d1--detailed-implementation-plan)) | Wave |
+|---|---|---|
+| #1993 / WP1 | [D1-A](#d1-a--finish-the-pq-primitives-small) (HPKE) + [D1-S](#d1-s--structural-enablers-prerequisite--lands-first) S1 | 0 / 1 |
+| WP2 | [D1-S](#d1-s--structural-enablers-prerequisite--lands-first) S2 | 1 |
+| WP3 | [D1-S](#d1-s--structural-enablers-prerequisite--lands-first) S5 | 1 |
+| WP4 | [D1-S](#d1-s--structural-enablers-prerequisite--lands-first) S2/S3 (+ storage) | 1 |
+| WP-SS | [Foundations — secret sharing](crypto-roadmap.md#foundations) | 2 |
+| WP10 | [D1-A](#d1-a--finish-the-pq-primitives-small) (enrollment-conveyance key) | 2 |
+| WP6 | [D1-B](#d1-b--the-nskey-provider-d1-tier1--the-default) B1–B4 | 3 |
+| WP5 | [D1-S](#d1-s--structural-enablers-prerequisite--lands-first) S4 (WASM cut) | 3 |
+| WP8 | [D1-S](#d1-s--structural-enablers-prerequisite--lands-first) S6 (consumer bumps) | 3 |
+| WP7 | [D1-C](#d1-c--migration--rollout-machinery) + [D1-D](#d1-d--versioning-the-disallowlegacyencryption-flag) D2 | 4 |
+| WP9 | [D1-B](#d1-b--the-nskey-provider-d1-tier1--the-default) B5/B6 | 4 |
+| WP-GP | [D1-E](#d1-e--d1-tier2-shape-corrections-fold-into-wp-gp) | 5 |
+| WP-D3 | [D1-D](#d1-d--versioning-the-disallowlegacyencryption-flag) D3 | 6 |
 
 **Wave 0 — land the in-flight foundation (gates everything).** #1930 is the
 single biggest unblock; #1993 can be reviewed alongside it.
@@ -621,11 +683,31 @@ single biggest unblock; #1993 can be reviewed alongside it.
   to `true` + dead-code removal (the legacy provider itself stays — needed for
   reads). **▶ at_client 4.0.0: PQ-safe on every write path by default.**
 
-D2 (pq-mls) is a separate deliverable — see §4.
+D2 (pq-mls) is a separate deliverable — see [section 4](#4-d2--pq-mls-placeholders-detailed-planning-deferred).
+
+### Package versions & release sequencing
+
+Publish in dependency order. Only `at_auth` takes a major (the breaking WASM
+barrel split); everyone else stays minor. The `at_auth` work is split into an
+additive minor (`3.2.0`, WP2) then a breaking major (`4.0.0`, WP5) so
+`WritableAtKeys` bakes before the barrel cut. Design rationale: roadmap
+[package versions & release sequencing](crypto-roadmap.md#package-versions--release-sequencing).
+
+| # | Package | Bump | WP | Why |
+|---|---|---|---|---|
+| 1 | `at_chops` | minor `3.2.1 → 3.3.0` | WP1 | stateless functional core + HPKE `pqSeal`/`pqOpen` **added**; stateful `AtChopsImpl` kept as `@Deprecated` shim (additive) |
+| 2 | `at_auth` | minor `3.1.1 → 3.2.0` | WP2 | **additive API:** `WritableAtKeys` added; `AtKeysIo`/`WrittenAtKeysIo` widened (add/remove/update, default impls); `InMemoryAtKeysIo`. No barrel change yet — downstream can adopt `WritableAtKeys` immediately |
+| 3 | `at_auth` | **major `3.2.0 → 4.0.0`** | WP5 | **breaking WASM cut:** `FileAtKeysIo` out of the main barrel (→ `at_auth_io.dart`); `FileAtKeysIo()` default removed; registrar → `package:http`; probe extracted; core compiles under `dart2wasm` |
+| 4 | `at_client` | minor `3.13.0 → 3.14.0` | WP3 / WP6 | `at_auth ^4.0.0`; `CryptoContext` gains a `WritableAtKeys keys` field (additive; context is `{atClient}` today — nothing to deprecate); `LocalKeystoreAtKeysIo`; `nskey` provider scaffold |
+| 5 | `at_onboarding_cli` | minor `1.16.0 → 1.17.0` | WP8 | `at_auth ^4.0.0`; imports `FileAtKeysIo` from `at_auth_io.dart`; injects it explicitly (default gone) |
+| 6 | `at_client_flutter` | minor `1.1.3 → 1.2.0` | WP8 | `at_auth ^4.0.0`; `file_picker` imports `at_auth_io.dart` |
+| 7 | `at_cli_commons` | minor (constraint bump) | WP8 | consumes the new `at_onboarding_cli` / `at_client` |
 
 ### Integration is continuous, not a final step
 Each WP **merges to trunk when complete** and is **published to pub.dev as
-needed** in dependency order (roadmap version table). To prove the full stack
+needed** in dependency order (the
+[package-versions table](#package-versions--release-sequencing) above). To prove
+the full stack
 before a batch lands, **spin up an ephemeral integration branch on demand**
 (merge the in-flight WP branches, run unit + functional + e2e via the base-port
 `runLocal.sh` rigs, discard) or rely on CI — so cross-package issues surface
@@ -652,7 +734,7 @@ early, with no standing integration branch to drift.
 
 Four small, additive, single-package PRs — one per track, started in parallel.
 Land the three interface-defining ones (WP1/WP2/WP3 signatures) first, stubs OK,
-so every track compiles against stable shapes. Full acceptance detail is in §3
+so every track compiles against stable shapes. Full acceptance detail is in [section 3](#3-d1--detailed-implementation-plan)
 (D1-S S1/S2/S5, D1-A). **Prereqs on trunk:** PR #1930 (M0 seam), PR #1993 (HPKE),
 the four at_chops-routing PRs (#1995–1998).
 


### PR DESCRIPTION
Restructures the crypto planning into a three-doc set, each with a distinct purpose and a shared shape (design → build → worked example).

The three docs as they now stand:

- **`docs/crypto-roadmap.md`** — the design source of truth: goals, architecture, phasing, and the *why*. Pure design (no build status or release tables). Opens with an orientation block and a document map, then covers the two deliverables, the D1 tiers + migration/rollout + versioning, the milestone/phase narrative, the component/WASM-readiness model, the atServer group Delivery Service design, and the known shape risks.
- **`docs/crypto_impl_plan.md`** — the build plan: current state + phase status, D1 acceptance, the detailed D1 workstreams (D1-S…D1-E), D2 placeholders, the cross-repo publish sequence, the implementation record, and the delivery plan / work packages. Holds the package-versions & release-sequencing table and a WP↔workstream map (two-way links to the section-3 workstreams).
- **`docs/crypto-walkthroughs.md`** *(new)* — worked end-to-end examples that exercise the design: NoPorts (feature-gated tiers 0–2), a large group (against the Delivery Service), and a two-atSign `at_talk` chat with client churn.

Shared conventions across the set:

- Matching orientation blocks naming all three docs and which is the source of truth for what.
- An identical document map pairing each topic's design ↔ build ↔ worked example.
- All section cross-references are clickable "section N" links; every intra- and cross-document anchor resolves.