### PR TITLE
fix: allow at_chops to use pqcrypto 0.3.0+

### DIFF
--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   meta: ^1.9.0
   better_cryptography: ^1.0.0+1
   ffi: ^2.1.0
-  pqcrypto: 0.3.0
+  pqcrypto: ^0.3.0
 
 dev_dependencies:
   lints: ^6.0.0


### PR DESCRIPTION
## What
- update at_chops deps `pqcrypto: 0.3.0` -> `pqcrypto: ^0.3.0`

## Skills impact

If this PR changes a public API in `at_client`, `at_client_flutter`, or `at_auth`,
consider whether `packages/at_client_skills/` needs a follow-up release.

- [x] No public API change — skill unaffected
- [ ] Public API changed — I have opened or will open an `at_client_skills` PR to reflect this
