### PR TITLE
docs(pq): existing-client retrofit design + PQ use-case catalogue

### DIFF
--- a/docs/adr/0001-d1-simplicity-tiers.md
+++ b/docs/adr/0001-d1-simplicity-tiers.md
@@ -50,7 +50,7 @@ Deliver D1 in **two tiers** over the M0 pluggable `CryptoProvider` seam:
   namespace that needs **per-device** revocation or forward secrecy. It is also
   the **substrate D2/MLS swaps its engine into.**
 
-The already-built per-client secret-sharing substrate is **not discarded**: in
+The prototyped per-client secret-sharing substrate is **not discarded**: in
 D1 Tier1 it is the per-enrollment rotation/distribution plumbing; in D1 Tier2 it
 is the per-client data path. Senders **negotiate per-destination** (provider seam +
 `appMetadata.providerId`), downgrading to the recipient's best supported tier,

--- a/docs/crypto-roadmap.md
+++ b/docs/crypto-roadmap.md
@@ -39,6 +39,12 @@ rotation, and giving applications a bootstrap path to pq-mls groups.
   - [Versioning contract — the legacy-encryption flag (3.x default off, 4.x default on)](#versioning-contract--the-legacy-encryption-flag-3x-default-off-4x-default-on)
   - [Steps (any client may sit at any step, within 3.x)](#steps-any-client-may-sit-at-any-step-within-3x)
   - [Capabilities by application code-change level](#capabilities-by-application-code-change-level)
+- [Existing-client retrofit — auth upgrade & key distribution](#existing-client-retrofit--auth-upgrade--key-distribution)
+  - [Conveying a named secret between clients](#conveying-a-named-secret-between-clients)
+  - [The atSign-level PQ key — created once](#the-atsign-level-pq-key--created-once)
+  - [Upgrading an existing client — the sequence](#upgrading-an-existing-client--the-sequence)
+  - [Cardinality, legacy-key deletion, and revocation](#cardinality-legacy-key-deletion-and-revocation)
+  - [atServer support this requires](#atserver-support-this-requires)
 - [Starting point](#starting-point)
 - [The end state](#the-end-state)
   - [Key inventory and rotation](#key-inventory-and-rotation)
@@ -87,6 +93,7 @@ jump.
 | The two deliverables (D1 / D2) | [The two major deliverables](crypto-roadmap.md#the-two-major-deliverables) | [Current state (1)](crypto_impl_plan.md#1-current-state-2026-06-22) · [D1 acceptance (2)](crypto_impl_plan.md#2-d1-acceptance--what-done-means) | — |
 | D1 Tier1 — the `nskey` default | [D1 — preserving legacy simplicity](crypto-roadmap.md#d1--preserving-legacy-simplicity-two-tiers) | [D1-B (3)](crypto_impl_plan.md#d1-b--the-nskey-provider-d1-tier1--the-default) | — |
 | Migration, rollout & versioning | [Application migration & rollout](crypto-roadmap.md#application-migration--rollout) | [D1-C / D1-D (3)](crypto_impl_plan.md#d1-c--migration--rollout-machinery) | — |
+| Existing-client retrofit (auth + key dist) | [Existing-client retrofit](crypto-roadmap.md#existing-client-retrofit--auth-upgrade--key-distribution) | [D1-F (3)](crypto_impl_plan.md#d1-f--existing-client-retrofit--auth-upgrade--secret-conveyance) | — |
 | Identity, KeyPackages, self groups | [Phases 2–3](crypto-roadmap.md#phase-2--identity-layer-keypackages-and-per-client-atkeys) | [D1-E (3)](crypto_impl_plan.md#d1-e--d1-tier2-shape-corrections-fold-into-wp-gp) · [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | — |
 | Cross-atSign shared groups | [Phase 4](crypto-roadmap.md#phase-4--cross-atsign-groups-shared-encryption) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [C — `at_talk` chat](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-client-churn-at_talk) |
 | pq-mls engine + Delivery Service | [atServer group Delivery Service](crypto-roadmap.md#atserver-group-delivery-service-target-design) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [B — a large group](crypto-walkthroughs.md#walkthrough-b--a-large-group-end-to-end) |
@@ -193,8 +200,10 @@ exists from activation). Resolution: **alice uses the most specific key bob has
 published, falling back to the atSign-level PQ key.**
 
 1. Bob always has an atSign-level keypair; Phase 1 publishes a PQ sibling
-   (`public:publickey.pq@bob`). With no `at_talk` key, alice encapsulates to
-   **that** — every bob client can decrypt, instantly, like legacy.
+   (`public:pqpublickey@bob`). With no `at_talk` key, alice encapsulates to
+   **that** — every bob client can decrypt, instantly, like legacy (how every bob
+   client obtains the *private* half is
+   [Existing-client retrofit](#existing-client-retrofit--auth-upgrade--key-distribution)).
 2. The first bob `at_talk` client mints/derives and publishes the `at_talk`
    public key; subsequent messages **upgrade** to namespace-scoped automatically.
 
@@ -220,7 +229,7 @@ and writes the new private key into the `__`-secret self-group channel** as a
 reserved secret (`__nsk.<epoch>`), PQ-wrapped per-enrollment to each `at_talk`
 enrollment's conveyance key. Other clients receive it (push); a client that
 missed it pulls (`requestSecretsFromNamespace`); a *new* client gets the current
-key at enrollment approval. This reuses the **already-built** secret-sharing
+key at enrollment approval. This reuses the **prototyped** secret-sharing
 substrate (`__`-secrets, `excludeEnrollmentIds`) verbatim — the namespace key is
 just another secret on the channel.
 
@@ -256,7 +265,7 @@ membership) becomes an **opt-in** tier a namespace declares when it needs
 per-device revocation or forward secrecy. Most apps never touch it. Crucially
 the **secret-sharing substrate is shared** between tiers: D1 Tier1 uses it as
 *per-enrollment distribution plumbing* for rotation; D1 Tier2 uses it
-*per-client*. So the group work already built is not discarded — it is the
+*per-client*. So the group work already prototyped is not discarded — it is the
 plumbing under D1 Tier1 and the data path of D1 Tier2. D2/MLS swaps D1 Tier2's engine.
 
 ### Mixed-tier `@alice` ↔ `@bob`
@@ -446,6 +455,129 @@ flag* when your fleet is upgraded and your data becomes post-quantum-safe and
 namespace-scoped, negotiated down automatically for anyone still on the old
 build. Reach for *code* only to refuse legacy (strict PQ), drive your own
 rotation, or opt into per-device (D1 Tier2) security.
+
+## Existing-client retrofit — auth upgrade & key distribution
+
+[Application migration & rollout](#application-migration--rollout) covers how an
+*encryption scheme* rolls out per value. This section covers the **one-time retrofit**
+of an existing atSign whose clients onboarded before PQ: how each already-enrolled
+client gains the two PQ keypairs it needs — a **PQ APKAM** keypair (authentication)
+and the **atSign-level PQ encryption key** (`public:pqpublickey@alice`, the
+[Cold-start](#cold-start--bob-has-never-run-an-at_talk-app) fallback) — without
+re-onboarding and without any RSA-tainted shortcut.
+
+**Goal.** Existing atSigns reach PQ-safety for both auth and encryption with no
+re-onboarding, *closing* the last harvest-now-decrypt-later hole rather than inheriting
+it. Only existing clients run this retrofit; two populations never do:
+
+| Population | Gets `pqpublickey` via | Gets its PQ APKAM via |
+|---|---|---|
+| **Existing atSign, existing client** (this section) | **pull** from a peer client | mints its own (one per host) |
+| **New atSign** | generated at onboarding | generated at onboarding |
+| **New enrollment** (post-PQ) | **pushed** by the approver via enroll/approve | set up by enroll/approve |
+
+So the client-to-client *pull* below is fundamentally the retrofit path; in steady state
+PQ keys arrive at onboarding or by enroll/approve push.
+
+### Conveying a named secret between clients
+
+Every retrofit pull is one instance of a single primitive, **`requestSecret`**:
+
+> A client needs a *named secret*; at least one of its sibling clients holds it. The
+> requester asks; a holder **`pqSeal`s** the secret to the requester's
+> [`ClientKeyPackage`](#phase-2--identity-layer-keypackages-and-per-client-atkeys)
+> (X-Wing public key); the requester opens it with its local private half.
+
+PQ-safe by construction — the seal is X-Wing to a public key whose private half never
+transited, so nothing in the path depends on RSA-2048. **Secrets are namespaced, and the
+namespace is the authorisation boundary**: a holder serves a namespaced secret only to a
+requester whose enrollment is authorised for that namespace (the scope the atServer's
+APKAM already enforces), and never to a revoked enrollment. This reuses the
+secret-sharing [Foundations](#foundations) substrate (`requestSecretsFromNamespace` /
+`waitForSecret` / `shareSecretWith` / `excludeEnrollmentIds`), generalised from
+request-by-namespace to request-by-name. The same primitive carries every non-derivable
+secret in D1 — `nskey` private keys, rotation epoch keys, the atSign-level PQ key — so it
+is the reusable core, not a one-off.
+
+**Why not the obvious shortcut.** Wrapping the secret under the shared `selfEncryptionKey`
+and storing it server-side is *not* PQ-safe: the self key is conveyed at enrollment under
+the `apkamSymmetricKey`, which is **RSA-2048-wrapped** in transit — so a harvester who
+breaks RSA later recovers the self key and anything wrapped under it. The per-requester
+X-Wing seal is what avoids re-inheriting that hole.
+
+### The atSign-level PQ key — created once
+
+`public:pqpublickey@alice` is the **root (no-namespace)** encryption key — the universal
+fallback of [Cold-start](#cold-start--bob-has-never-run-an-at_talk-app), the PQ sibling of
+legacy `public:publickey@alice`. Because it is the broad fallback, its private half is
+conveyed to **every** non-revoked client (like the legacy default encryption private key),
+not gated by namespace.
+
+It is **created exactly once** using the atServer's **immutable / create-if-absent** write:
+the first client to try wins and publishes the public half (which can never be
+overwritten); every other client finds it present and *pulls* the private half via
+`requestSecret`. No election, no race — the immutable write is the coordinator. (Naming:
+the key must be `pqpublickey`, not `publickey.pq`, or the `.pq` suffix would place it in a
+namespace called `pq`.)
+
+### Upgrading an existing client — the sequence
+
+Each upgrading client bootstraps both keypairs with one uniform sequence; whether it is the
+*creator* or a *requester* of `pqpublickey` is decided by the immutable create, not known
+in advance:
+
+1. authenticate on the existing legacy connection;
+2. **mint-once per host** a PQ APKAM keypair (or reuse the one already in this host's
+   keyfile) and publish its public half as an immutable per-host record;
+3. verify PQ APKAM authentication works;
+4. **delete the legacy RSA APKAM public key** — only after step 3 confirms PQ auth;
+5. save AtKeys; publish its `ClientKeyPackage`;
+6. **attempt create** `pqpublickey`: won → generate, hold, and serve the private half;
+   exists → pull, verify public/private correspondence, store;
+7. once the roster holds the key, advertise PQ readiness (atSign-wide, once).
+
+The three "which client" cases — first client, a second on the *same* enrollment, a third
+on a *different* enrollment — differ in exactly one place: step 6 (the first creates
+`pqpublickey`; the rest pull it). For the APKAM keypair they are identical; the enrollment
+distinction only re-emerges for *namespaced* secrets, where a namespace-restricted
+enrollment is served a subset.
+
+### Cardinality, legacy-key deletion, and revocation
+
+- **APKAM cardinality is per (host, AtKeys file), not per client.** Many
+  clients/processes sharing one keyfile on one host share **one** minted PQ APKAM keypair.
+  The atServer allows **multiple APKAM keypairs per enrollment**, so a copy of the keyfile
+  on another host mints its own, different key. The new revocation granularity this unlocks
+  is therefore **per-host**, not per-client — sitting alongside the
+  [Phase-2](#phase-2--identity-layer-keypackages-and-per-client-atkeys) split of copyable
+  credential vs device-local material.
+- **Delete the legacy APKAM key by default** (the auth key only — keep the legacy
+  *encryption* key for reading history). It is both quantum-vulnerable and **shared across
+  every copy** of the keyfile; while it remains, per-host revocation is bypassable through
+  it. Deletion enforces "one enrollment's private APKAM key lives in exactly one keyfile" —
+  a copy that has not upgraded gets locked out and must re-enroll, the correct outcome for
+  copying we advise against. A grace period is available as a softer deployment knob.
+- **Revocation is two axes:** *auth* (per-enrollment, or — new — **per-host** by deleting
+  that host's PQ APKAM key, contingent on the legacy key being gone) and *encryption*
+  (per-namespace key rotation, [Revocation](#revocation-end-to-end)), which controls
+  new-data access and is orthogonal to auth.
+- **Where the PQ APKAM key lives.** No universal way to *cryptographically* bind it to a
+  host exists today (TPM/Secure Enclave lack PQ support). Default to storing it in the
+  keyfile/keychain that bootstrapped it (clean for dev/test — a reused keyfile doesn't
+  re-mint); offer OS-keychain/hardware as an opt-in for single-host high-security. Per-host
+  management/revocation comes from a **distinct labelled record per host** plus
+  **server-side TTL / usage-based eviction** of unused APKAM keys, which also self-cleans
+  dev/test and abandoned hosts.
+
+### atServer support this requires
+
+This retrofit reuses the atServer's **existing immutable write** (`Metadata.immutable`) for
+mint-once, plus **four new** atServer capabilities (detailed in the plan's
+[D1-F](crypto_impl_plan.md#d1-f--existing-client-retrofit--auth-upgrade--secret-conveyance)):
+multiple APKAM public keys per enrollment with auth
+against any; **PQ (ML-DSA) APKAM authentication**; deletion of a specific public key
+(legacy on upgrade, a host's PQ key on revocation); and TTL/usage-based eviction of APKAM
+keys (needing a per-key "last authenticated" timestamp).
 
 ## Starting point
 
@@ -878,7 +1010,7 @@ see [Foundations](#foundations). Build status is the plan's
   last harvest-now-decrypt-later hole: `encryptedAPKAMSymmetricKey` is
   RSA-wrapped to `public:publickey@alice`, and everything the approval
   conveys hangs off it. Fix without server changes: publish an X-Wing
-  public key alongside (`public:publickey.pq@alice` or a key-list format);
+  public key alongside (`public:pqpublickey@alice` or a key-list format);
   new enrollees prefer it for wrapping; approvers accept either.
 
 ### Phase 2 — identity layer: KeyPackages and per-client AtKeys

--- a/docs/crypto_impl_plan.md
+++ b/docs/crypto_impl_plan.md
@@ -30,6 +30,7 @@ encryption work.
   - [D1-C · Migration & rollout machinery](#d1-c--migration--rollout-machinery)
   - [D1-D · Versioning (the `disallowLegacyEncryption` flag)](#d1-d--versioning-the-disallowlegacyencryption-flag)
   - [D1-E · D1 Tier2 shape-corrections](#d1-e--d1-tier2-shape-corrections-fold-into-wp-gp)
+  - [D1-F · Existing-client retrofit — auth upgrade & secret conveyance](#d1-f--existing-client-retrofit--auth-upgrade--secret-conveyance)
   - [D1 · Test & acceptance plan](#d1--test--acceptance-plan)
   - [D1 · PR delivery / publish](#d1--pr-delivery--publish)
 - [4. D2 — pq-mls (placeholders; detailed planning deferred)](#4-d2--pq-mls-placeholders-detailed-planning-deferred)
@@ -66,6 +67,7 @@ jump.
 | The two deliverables (D1 / D2) | [The two major deliverables](crypto-roadmap.md#the-two-major-deliverables) | [Current state (1)](crypto_impl_plan.md#1-current-state-2026-06-22) · [D1 acceptance (2)](crypto_impl_plan.md#2-d1-acceptance--what-done-means) | — |
 | D1 Tier1 — the `nskey` default | [D1 — preserving legacy simplicity](crypto-roadmap.md#d1--preserving-legacy-simplicity-two-tiers) | [D1-B (3)](crypto_impl_plan.md#d1-b--the-nskey-provider-d1-tier1--the-default) | — |
 | Migration, rollout & versioning | [Application migration & rollout](crypto-roadmap.md#application-migration--rollout) | [D1-C / D1-D (3)](crypto_impl_plan.md#d1-c--migration--rollout-machinery) | — |
+| Existing-client retrofit (auth + key dist) | [Existing-client retrofit](crypto-roadmap.md#existing-client-retrofit--auth-upgrade--key-distribution) | [D1-F (3)](crypto_impl_plan.md#d1-f--existing-client-retrofit--auth-upgrade--secret-conveyance) | — |
 | Identity, KeyPackages, self groups | [Phases 2–3](crypto-roadmap.md#phase-2--identity-layer-keypackages-and-per-client-atkeys) | [D1-E (3)](crypto_impl_plan.md#d1-e--d1-tier2-shape-corrections-fold-into-wp-gp) · [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | — |
 | Cross-atSign shared groups | [Phase 4](crypto-roadmap.md#phase-4--cross-atsign-groups-shared-encryption) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [C — `at_talk` chat](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-client-churn-at_talk) |
 | pq-mls engine + Delivery Service | [atServer group Delivery Service](crypto-roadmap.md#atserver-group-delivery-service-target-design) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [B — a large group](crypto-walkthroughs.md#walkthrough-b--a-large-group-end-to-end) |
@@ -278,7 +280,7 @@ waves 1–2.*
   stateless surface. *Consumers:* B2 (`nskey`) and the `__ssenv` substrate
   seal/open **through this** (no open-coded encapsulate+GCM).
 - [ ] **PQ enrollment-conveyance public key.** Publish an X-Wing pubkey
-  alongside `public:publickey@alice` (e.g. `public:publickey.pq@alice` or a
+  alongside `public:publickey@alice` (e.g. `public:pqpublickey@alice` or a
   key-list); new enrollees prefer it for wrapping `apkamSymmetricKey`; approvers
   accept either. Closes the last harvest-now-decrypt-later hole; **no server
   change.** Design: roadmap
@@ -304,7 +306,7 @@ on the M0 seam; legacy-shaped (copyable, enrollment-granular), PQ + namespace
     derive bob's per-namespace *public* key from his master public key (ML-KEM
     has no public child-derivation) — so the public key must still be published.
   - Publication: the first upgraded client publishes
-    `public:<ns>.encryptionpublickey@<atSign>` (or a hidden public key);
+    `public:encryptionpublickey.<ns>@<atSign>` (or a hidden public key);
     signed by the publishing enrollment.
   - *Acceptance:* a second client of the same atSign, authorized for the
     namespace, can obtain the private key (at approval or by derivation) and
@@ -419,6 +421,56 @@ apply them as part of that carve-out, while touching the area.
   (currently `utf8.encode(plaintext.toString())` corrupts binary).
 - [ ] **Rename `PairwiseGroup` → `SelfGroup`** to free "pair group" for the
   Phase-4 cross-atSign meaning.
+
+### D1-F · Existing-client retrofit — auth upgrade & secret conveyance
+*Lands as a new **WP-AU** (auth upgrade); gated on the F5 atServer enhancements
+(cross-repo to `at_server`) — slot into the wave sequence at review.* Design: roadmap
+[Existing-client retrofit](crypto-roadmap.md#existing-client-retrofit--auth-upgrade--key-distribution).
+
+The one-time retrofit that brings an existing atSign's already-onboarded clients to
+PQ-safe **auth** (PQ APKAM) and **encryption** (the atSign-level PQ key), reusing the
+secret-sharing substrate (WP-SS). New atSigns (PQ-native at onboarding) and new enrollments
+(approver push via WP10) do **not** run this.
+
+- [ ] **F1 · `requestSecret(name)` primitive.** Generalise the substrate's
+  `requestSecretsFromNamespace` to request a *named* secret; a holder responds with
+  `shareSecretWith(requester.ClientKeyPackage, secret)` (`pqSeal`); requester
+  `waitForSecret`. *Responder authorisation:* serve a namespaced secret only if the
+  requester's enrollment covers that namespace; never to an `excludeEnrollmentIds` member.
+  Handle no-holder-online (request persists; retry/backoff), thundering-herd (jitter +
+  `putIfNewer` dedup), and freshness (version/`kid`). *Files:*
+  `at_client/lib/src/secret_sharing/`.
+- [ ] **F2 · atSign-level `pqpublickey` lifecycle.** `public:pqpublickey@alice` (root, no
+  namespace — *not* `publickey.pq`). Create via immutable create-if-absent (F5); the
+  creator generates the X-Wing keypair, stores the private half, seeds it as a conveyable
+  secret (`pqid:<kid>`), and serves on request. A non-creator pulls via F1, **verifies
+  public/private correspondence**, and stores into the local keystore (`WritableAtKeys`).
+  Conveyed to *every* non-revoked client (root → no namespace gate).
+- [ ] **F3 · Per-host PQ APKAM upgrade.** Mint-once **per (host, AtKeys file)** under a
+  host-local lock (reuse an existing keyfile key; else mint + persist); publish the public
+  half as an immutable per-host record; verify PQ APKAM auth; **then** delete the legacy RSA
+  APKAM public key (delete-by-default, scope = auth key only — keep the legacy encryption
+  key for reads). Uniform sequence per the roadmap; "creator vs requester" decided by F2's
+  immutable create. *Storage:* keyfile/keychain by default; OS-keychain/hardware opt-in; a
+  distinct labelled per-host record drives per-host revocation.
+- [ ] **F4 · Revocation.** Per-host auth revocation = delete that host's PQ APKAM public key
+  (meaningful only after F3's legacy deletion). Encryption revocation stays per-namespace
+  rotation (D1-B / WP9). TTL/usage-based eviction of unused APKAM keys (F5).
+- [ ] **F5 · atServer enhancements** *(cross-repo, `at_server`; gate F2/F3/F4).* Mint-once
+  uses the **existing immutable write** (`Metadata.immutable` — already live, no change). New:
+  - **multiple APKAM public keys per enrollment** + authenticate against any;
+  - **PQ (ML-DSA) APKAM authentication**;
+  - **delete a specific public key** (legacy on upgrade; a host's PQ key on revocation);
+  - **TTL / usage-based eviction of APKAM keys** + a per-key **"last authenticated"
+    timestamp** (updated on each successful auth).
+- [ ] **F6 · Confirm WP10 alignment.** PQ-safe enroll/approve must convey `pqpublickey` +
+  the new enrollment's PQ APKAM over the **PQ enrollment key**, not the RSA-wrapped
+  `apkamSymmetricKey` — else the harvest-now hole reopens for new clients.
+
+*Acceptance:* an existing client upgrades end-to-end (mints PQ APKAM, authenticates PQ,
+legacy APKAM deleted, pulls `pqpublickey`, correspondence verified) with no re-onboarding; a
+second host mints a *distinct* PQ APKAM key; revoking one host's key cuts only that host; no
+secret is ever wrapped under an RSA-derived key.
 
 ### D1 · Test & acceptance plan
 - Unit: `nskey` round-trips (self/shared/binary), negotiation matrix, rotation

--- a/docs/crypto_impl_plan.md
+++ b/docs/crypto_impl_plan.md
@@ -433,12 +433,19 @@ secret-sharing substrate (WP-SS). New atSigns (PQ-native at onboarding) and new 
 (approver push via WP10) do **not** run this.
 
 - [ ] **F1 · `requestSecret(name)` primitive.** Generalise the substrate's
-  `requestSecretsFromNamespace` to request a *named* secret; a holder responds with
-  `shareSecretWith(requester.ClientKeyPackage, secret)` (`pqSeal`); requester
-  `waitForSecret`. *Responder authorisation:* serve a namespaced secret only if the
-  requester's enrollment covers that namespace; never to an `excludeEnrollmentIds` member.
-  Handle no-holder-online (request persists; retry/backoff), thundering-herd (jitter +
-  `putIfNewer` dedup), and freshness (version/`kid`). *Files:*
+  `requestSecretsFromNamespace` to request a *named* secret. A request is a **targeted fan-out**
+  — discover the namespace's clients from their published `ClientKeyPackage`s and send each a
+  `pqSeal`-ed `__ssenv` envelope (no keyless broadcast); a holder responds with
+  `shareSecretWith(requester.ClientKeyPackage, secret)` (`pqSeal`) back to the requester's
+  clientId; requester `waitForSecret`. **Transport:** `atClient.put` of the `__ssenv` key
+  (`<msgId>.<recipientClientId>.__ssenv.<ns>@<atSign>`, self key, `shouldEncrypt=false`) +
+  **sync** delivery (sync-progress listener + periodic sweep → `receivedSecrets`), **plus an
+  optional wake-up `notify`** per put (default on) so **sync-less clients** wake and
+  `get(useRemoteAtServer)` — on both the request and the response. (Future: the atServer
+  auto-notifies on `__ssenv` puts, dropping the client-side notify.) *Responder authorisation:*
+  serve a namespaced secret only if the requester's enrollment covers that namespace; never to an
+  `excludeEnrollmentIds` member. Handle no-holder-online (request persists; retry/backoff),
+  thundering-herd (jitter + `putIfNewer` dedup), and freshness (version/`kid`). *Files:*
   `at_client/lib/src/secret_sharing/`.
 - [ ] **F2 · atSign-level `pqpublickey` lifecycle.** `public:pqpublickey@alice` (root, no
   namespace — *not* `publickey.pq`). Create via immutable create-if-absent (F5); the

--- a/docs/crypto_plan_parallelism.md
+++ b/docs/crypto_plan_parallelism.md
@@ -1,0 +1,70 @@
+# Wave-1 / Wave-2 parallelism: can wave 2 start before wave 1 finishes?
+
+Scope: the D1 delivery plan in
+[section 7 — Delivery plan & work packages](crypto_impl_plan.md#7-delivery-plan--work-packages).
+
+## Table of contents
+
+- [Answer](#answer)
+- [Per wave-2 item](#per-wave-2-item)
+  - [WP-SS — secret-sharing substrate (#2008)](#wp-ss--secret-sharing-substrate-2008)
+  - [WP10 — enrollment-conveyance key (#2009)](#wp10--enrollment-conveyance-key-2009)
+- [The nuance on WP1](#the-nuance-on-wp1)
+- [Summary](#summary)
+- [Caveat](#caveat)
+
+## Answer
+
+**Yes — both wave-2 items can overlap wave 1. The only wave-1 work that
+genuinely gates them is WP1 (at_chops 3.3.0 / `pqSeal`), not WP2 / WP3 / WP4.**
+
+The "waves" in the plan are parallelism groupings, not barriers — the actual
+gating is the per-WP dependency list. The plan says so directly: land the
+interface PRs (WP1 / WP2 / WP3 signatures, "stubs OK") first so every track
+compiles against stable shapes and "never blocks on another."
+
+## Per wave-2 item
+
+### WP-SS — secret-sharing substrate (#2008)
+
+- Only stated prerequisite is *"on at_chops 3.3.0"* — i.e. **WP1**, because the
+  `__ssenv` envelopes seal via `pqSeal`.
+- **No dependency on WP2, WP3, or WP4.** The critical-path line lists
+  `WP1 + WP3 + WP-SS + WP10` as *siblings* feeding WP6, which confirms WP-SS
+  does not wait on WP3 either.
+- Can start the moment `pqSeal` is stable on trunk, while WP2 / WP3 / WP4 are
+  still in flight.
+
+### WP10 — enrollment-conveyance key (#2009)
+
+- Track B, "land before WP6." **No stated dependency on WP2 / WP3 / WP4.**
+- The KEM primitives (X-Wing) are already in the **baseline** (at_chops 3.2.1),
+  so the keypair work can begin immediately.
+- If its conveyance seals via `pqSeal` it wants WP1 for that part, but nothing
+  in wave 1 blocks it from starting.
+
+## The nuance on WP1
+
+`pqSeal` / `pqOpen` is itself already in flight as the **wave-0 PR #1993**. So
+development of WP-SS / WP10 can build against that primitive even before WP1's
+stateless-core repackaging finishes. You only need at_chops **3.3.0 published**
+before WP-SS is *releasable* — not before it is *started*.
+
+## Summary
+
+The wave-1 → wave-2 boundary is **soft**: WP1 / `pqSeal` is the real gate;
+**WP2, WP3, and WP4 do not block wave 2 at all.**
+
+| Wave-1 WP | Blocks wave 2? |
+|-----------|----------------|
+| WP1 (at_chops 3.3.0 / `pqSeal`) | Yes — the one real gate (and already arriving via wave-0 #1993) |
+| WP2 (`WritableAtKeys` + `AtKeysIo`) | No |
+| WP3 (`CryptoContext.keys`) | No — sibling of WP-SS on the critical path, not a prerequisite |
+| WP4 (`LocalKeystoreAtKeysIo`) | No |
+
+## Caveat
+
+This is read off the plan's stated dependencies. To confirm it against reality,
+sanity-check what the `gkc-pqmls-spike` substrate code actually imports — in
+particular whether the prototype `__ssenv` path already touches `CryptoContext`
+(WP3), since the spike is where WP-SS is being carved from.

--- a/docs/pq-atsign-key-distribution.md
+++ b/docs/pq-atsign-key-distribution.md
@@ -49,10 +49,11 @@ Alice client can publish a KeyPackage as Alice.
 
 Given that, the primitive is:
 
-1. **Request.** The requester broadcasts a request for a named secret **within a
-   namespace** (`requestSecretsFromNamespace`), carrying its own `ClientKeyPackage` so
-   responders know where to seal the answer. (The root PQ key is the no-namespace
-   exception — §3.)
+1. **Request.** The requester **discovers** the namespace's clients from their published
+   `ClientKeyPackage`s and **fans out** a sealed request to each (`requestSecretsFromNamespace`)
+   — there is no keyless broadcast: each request is a targeted `pqSeal`-ed envelope addressed to
+   a peer's `clientId`, carrying the requester's *own* clientId so responders know where to seal
+   the answer. (The root PQ key is the no-namespace exception — §3.)
 2. **Serve.** Each peer, on seeing the request, checks its `SecretStore`. If it holds
    the secret *and* the requester's enrollment is authorised for that **namespace**
    (below), it `pqSeal`s the secret to the requester's KeyPackage and writes the
@@ -91,6 +92,16 @@ WP-SS.
 
 ### Details the primitive must pin down
 
+- **Transport = `put` + sync, plus an optional wake-up notify.** Request and response are the
+  *same* targeted envelope key — `<msgId>.<recipientClientId>.__ssenv.<namespace>@<atSign>`, a
+  self key, `shouldEncrypt=false` (already sealed) — written with `atClient.put`. Delivery is the
+  **sync** service (a sync-progress listener + a periodic local sweep surface arrivals on
+  `receivedSecrets`), so it is offline-tolerant by construction. **Some clients don't sync** — so
+  the writer *also* sends an **optional wake-up `notify`** (default on) for that key; a sync-less
+  recipient wakes on its notification monitor and `get`s the key (`useRemoteAtServer`). This
+  applies to *both* the request (to each discovered peer) and the response (to the requester).
+  Ideally the atServer auto-emits the notify on a `put` to `__ssenv` keys (a future server
+  enhancement); until then the client sends it.
 - **Responder authorisation = namespace authorisation.** A peer serves a namespaced
   secret to requester `R` only if `R`'s enrollment is authorised for that
   **namespace** (a `app_1.my_apps`-scoped enrollment must not be handed the `app_2.my_apps` key) — the
@@ -383,6 +394,10 @@ atServer capabilities:
   within N days; bounds the per-enrollment set and self-cleans dev/test and abandoned hosts.
   Requires a **per-APKAM-key "last authenticated" timestamp** on the atServer (updated on
   each successful auth) — a small server-side data addition that eviction reads.
+- **(future, optional) Auto-notify on `__ssenv` puts** — the atServer emits the wake-up
+  notification itself when a secret-envelope key is written, so sync-less clients are covered
+  without the sending client firing it. New functionality; until it exists the sending client
+  sends the optional wake-up `notify` (default on).
 
 **Design points to pin down:**
 - **The §1 request/serve primitive is the real deliverable** — reused by the atSign-level

--- a/docs/pq-atsign-key-distribution.md
+++ b/docs/pq-atsign-key-distribution.md
@@ -1,0 +1,407 @@
+# Same-atSign secret conveyance: requesting a named secret from peer clients
+
+**Status:** proposal / working doc (not plan-of-record). Lives in `docs/`.
+
+**The general problem (the right frame).** Distributing the atSign-level PQ private
+key to Alice's existing clients is one instance of a single reusable primitive:
+
+> **A client needs a *named secret*. At least one of Alice's other clients is
+> expected to hold it. How does the requester obtain it — PQ-safely, with the
+> server never able to read it?**
+
+Almost every secret conveyance in the PQ design is this shape: the atSign-level PQ
+private key, a per-namespace `nskey` private key, a rotation epoch key, a master
+seed. So the deliverable is **one request/serve primitive over the secret-sharing
+substrate**, plus a thin **bootstrap** layer for the one case the primitive cannot
+cover — *no peer holds the secret yet* (someone must create it exactly once). The
+atSign-level PQ key is the worked example throughout.
+
+**Secrets are namespaced** — a request is scoped to a namespace, and that namespace is
+the authorisation boundary for who may receive it (the same APKAM enrollment scoping
+the atServer already enforces). The atSign-level PQ key is the **sole root
+(no-namespace) exception**: it is conveyed to *every* client, like the legacy default
+encryption private key it replaces.
+
+## Table of contents
+
+- [1. The primitive — `requestSecret(name)`](#1-the-primitive--requestsecretname)
+  - [Substrate API this maps onto (prototyped on `gkc-pqmls-spike`, not yet landed)](#substrate-api-this-maps-onto-prototyped-on-gkc-pqmls-spike-not-yet-landed)
+  - [Details the primitive must pin down](#details-the-primitive-must-pin-down)
+- [2. Why the easy conveyances don't qualify](#2-why-the-easy-conveyances-dont-qualify)
+- [3. Worked example — the atSign-level PQ key](#3-worked-example--the-atsign-level-pq-key)
+  - [Naming](#naming)
+- [4. Bootstrap — when *no* peer holds the secret yet](#4-bootstrap--when-no-peer-holds-the-secret-yet)
+- [5. Upgrading existing clients — the three scenarios](#5-upgrading-existing-clients--the-three-scenarios)
+  - [Legacy APKAM deletion & what revocation means](#legacy-apkam-deletion--what-revocation-means)
+  - [Where the PQ APKAM key lives (storage & host binding)](#where-the-pq-apkam-key-lives-storage--host-binding)
+- [6. End-to-end sequence (atSign-level PQ key)](#6-end-to-end-sequence-atsign-level-pq-key)
+- [7. Edge cases](#7-edge-cases)
+- [8. To verify / cross-tier notes](#8-to-verify--cross-tier-notes)
+- [9. How this maps to the plan (no plan edits yet)](#9-how-this-maps-to-the-plan-no-plan-edits-yet)
+
+## 1. The primitive — `requestSecret(name)`
+
+Every Alice client that has upgraded to a PQ build owns a **`ClientKeyPackage`**: an
+X-Wing public key (`pub`, `kid`) it publishes under `@alice`'s secondary, whose
+private half is generated locally and **never leaves the device**. Publishing under
+`@alice` means the atServer's write-auth is the trust anchor — only an authenticated
+Alice client can publish a KeyPackage as Alice.
+
+Given that, the primitive is:
+
+1. **Request.** The requester broadcasts a request for a named secret **within a
+   namespace** (`requestSecretsFromNamespace`), carrying its own `ClientKeyPackage` so
+   responders know where to seal the answer. (The root PQ key is the no-namespace
+   exception — §3.)
+2. **Serve.** Each peer, on seeing the request, checks its `SecretStore`. If it holds
+   the secret *and* the requester's enrollment is authorised for that **namespace**
+   (below), it `pqSeal`s the secret to the requester's KeyPackage and writes the
+   envelope back.
+3. **Receive.** The requester `waitForSecret(name)` resolves on the first valid
+   response.
+4. **Verify.** The envelope is APKAM-signed, proving the responder is a genuine Alice
+   client. For a keypair secret, the requester also re-derives the public key from
+   the received private key and checks it equals the published public key — proving
+   it is *the* key, not an injected one.
+5. **Store.** The verified secret lands in the client's updatable local keystore
+   (`WritableAtKeys` / updatable `.atKeys`), keyed by `name` (+ version).
+
+This is PQ-safe by construction: the seal is X-Wing (hybrid PQ) to a public key whose
+private half never transited; nothing in the path depends on RSA-2048 confidentiality.
+
+### Substrate API this maps onto (prototyped on `gkc-pqmls-spike`, not yet landed)
+
+The substrate prototyped on the spike (`packages/at_client/lib/src/secret_sharing/`,
+**WP-SS — not yet landed**) has the pieces; the primitive is mostly composition, not new
+crypto:
+
+| Need | Prototyped API (WP-SS) |
+|---|---|
+| Per-client X-Wing identity | `ClientKeyPackage` (`registerClient(...)`) |
+| Request a secret | `requestSecretsFromNamespace(...)` → `waitForSecret(...)` |
+| Serve a secret (seal to a requester) | `shareSecretWith(ClientKeyPackage to, Secret)`, `shareAllSecretsWith(to, {excludeEnrollmentIds})` |
+| Revocation guard | `excludeEnrollmentIds` |
+| Authenticity of responder | `EnvelopeSigning` (APKAM-signed envelopes) |
+| Idempotent store / dedup | `SecretStore.putIfNewer(Secret)` |
+| Delivery stream | `receivedSecrets` |
+
+The prototyped `requestSecretsFromNamespace` requests by *namespace*; the generalisation
+— request **by name** (a specific named secret) — is a small extension that lands with
+WP-SS.
+
+### Details the primitive must pin down
+
+- **Responder authorisation = namespace authorisation.** A peer serves a namespaced
+  secret to requester `R` only if `R`'s enrollment is authorised for that
+  **namespace** (a `app_1.my_apps`-scoped enrollment must not be handed the `app_2.my_apps` key) — the
+  same scope the atServer's APKAM already enforces, so the policy is just "does `R`'s
+  enrollment cover this namespace." Never serve to an enrollment in
+  `excludeEnrollmentIds` (revoked). The **root** PQ key is the exception: like the
+  legacy default encryption private key (conveyed to *every* enrollment regardless of
+  scope — `at_enrollment_impl.dart:154-174`), it is served to every non-revoked
+  client.
+- **No holder online.** The request persists on the secondary; when a holder next comes
+  online it sees the pending request and answers. The requester's `waitForSecret` runs
+  on a timeout + backoff.
+- **Thundering herd.** With N holders, avoid N simultaneous seals: responders wait a
+  small random jitter and suppress if they see the answer already delivered (or the
+  requester re-broadcasts "got it"). Worst case extra seals are cheap and dedup via
+  `putIfNewer`.
+- **Freshness / versioning.** Secrets carry a version (e.g. an epoch or `kid`) so a
+  requester can ask for "current" and a responder won't serve a superseded value;
+  `putIfNewer` keeps the newest.
+
+## 2. Why the easy conveyances don't qualify
+
+**Self-encryption-key wrap is NOT PQ-safe — it reinherits the hole we're closing.**
+Wrapping a secret under the shared `selfEncryptionKey` (AES-256, identical on every
+client) and storing it server-side *looks* fine (AES-256 is PQ-safe), but the self
+key's provenance is RSA-tainted:
+
+- At APKAM enrollment the `apkamSymmetricKey` is **RSA-2048-wrapped** under the
+  default encryption public key in transit
+  (`at_auth/lib/src/enroll/at_enrollment_impl.dart:100-102`).
+- That `apkamSymmetricKey` then AES-wraps the conveyed `selfEncryptionKey` +
+  `defaultEncryptionPrivateKey` (`at_enrollment_impl.dart:154-174`).
+- So a harvester who records an enrollment and later breaks RSA-2048 recovers
+  `apkamSymmetricKey` → `selfEncryptionKey` → and any PQ secret wrapped under it.
+  Harvest-now-decrypt-later, unclosed.
+
+This is exactly why the primitive seals per-requester to X-Wing KeyPackages instead.
+
+**Enrollment conveyance only reaches *future* clients.** The approving AtClient *pushes*
+`pqpublickey` (and the enrollment's PQ APKAM material) to a new enrollment via the
+PQ-safe enroll/approve flow (WP10) — but only *at approval*. A freshly onboarded atSign
+is PQ-native and generates the key at onboarding. Existing clients are past both points —
+so this doc is their **retrofit**, via the request/serve pull (§5).
+
+## 3. Worked example — the atSign-level PQ key
+
+The roadmap (`crypto-roadmap.md`, *Cold-start*) already posits an atSign-level PQ key
+as the universal fallback a peer encapsulates to when it has no more-specific `nskey`,
+and says *"every bob client can decrypt, instantly, like legacy"* — without saying how
+the private half reaches every existing client. That "how" **is the §1 primitive**:
+
+- It is the **one root-level (no-namespace) secret**, so — unlike namespaced `nskey`
+  keys — it is conveyed to **every** non-revoked client, mirroring the legacy default
+  encryption private key that every enrollment receives regardless of scope.
+- The public half is published at the root as **`public:pqpublickey@alice`** (see
+  *Naming*).
+- The private half is the root named secret; each existing client requests it, the
+  minter — and thereafter any holder — serves it per §1 (no namespace gate, since the
+  root key is universal). Verify public/private correspondence and store. Done.
+
+No bespoke mechanism: the PQ key rides the generic request/serve path; it differs from
+every other secret only in being root-scoped rather than namespaced.
+
+### Naming
+
+Because this key is **root** (no namespace), its name must carry no namespace suffix.
+Use **`pqpublickey`**, not `publickey.pq`: a `.pq` suffix would land it *in* a
+namespace called `pq`. It mirrors the legacy `public:publickey@alice` exactly, as
+`public:pqpublickey@alice`.
+
+## 4. Bootstrap — when *no* peer holds the secret yet
+
+The §1 primitive assumes ≥1 holder. The exception is genuine creation: the very first
+PQ rollout, a brand-new namespace key, etc. Two concerns: create **exactly once**,
+and — for secrets that have a **published public artifact** like `pqpublickey` —
+**never overwrite** that artifact.
+
+**Exactly-once creation via the immutable write.** The atServer's **immutable** write — a
+long-standing feature (set `Metadata.immutable`), *not* a new requirement — does the work: a
+write to `public:pqpublickey@alice` succeeds only if the key does not yet exist, and the key
+can never be overwritten thereafter. That one primitive does all the work — no
+read-before-write, no convergence dance, no orphaning:
+
+1. **Attempt create** `public:pqpublickey@alice` (create-if-absent).
+   - **Succeeded** → I am the creator: generate keypair `K` (`kid = H(pub)`), store the
+     private half, seed it as the conveyable root secret `pqid:<kid>`, and serve it on
+     request.
+   - **Rejected (already exists)** → someone beat me: **request** the private half via
+     §1, verify public/private correspondence, store. I never overwrite.
+
+Because the immutable write is atomic, exactly one keypair is ever published and every
+other client falls through deterministically to "request." The same immutable write
+protects each **per-(host, keyfile) PQ APKAM public key** — each host writes its own
+record once (§5). (Without a create-if-absent primitive this would need a client-side
+convergence protocol — read-before-write + a confirm-read + a deterministic winner rule,
+kept harmless by the readiness gate — which is exactly the complexity the immutable
+feature removes.)
+
+**Optional variant — derive, don't distribute.** Derive the keypair from a single
+non-derivable PQ root seed (`HKDF(seed, "atSign-default") → X-Wing`); every holder then
+computes the identical keypair, replacing private-key distribution with seed
+distribution. With the immutable write already settling creation, this is now only worth
+it if seed-derivation buys you something else (e.g. deriving many namespace keys from one
+seed). Trade-off: a root seed has atSign-wide blast radius — fine for the atSign-level
+fallback key, but do **not** derive per-namespace `nskey` keys from it (keep their
+tighter blast radius per the roadmap's *D1 Tier 1* design).
+
+## 5. Upgrading existing clients — the three scenarios
+
+**This section is the *retrofit* of an existing atSign's existing clients** — the only
+population that "upgrades." Two populations never run this flow:
+
+| Population | Upgrades? | Gets `pqpublickey` via | Gets its PQ APKAM via |
+|---|---|---|---|
+| **Existing atSign, existing client** (this §) | yes | **pull** — `requestSecret` (§1) | mints its own (multiple per enrollment) |
+| **New atSign** | no — PQ-native | generated at CRAM onboarding (first client) | generated at onboarding |
+| **New enrollment** (post-PQ, after the first client) | no | **push** — the approving AtClient conveys it via the PQ-safe enroll/approve flow | set up by enroll/approve |
+
+So the `requestSecret` pull for `pqpublickey` is fundamentally the **one-time retrofit
+path**. In steady state the key arrives by onboarding (new atSign) or enroll/approve push
+(new enrollment); the pull remains only as an offline/edge backstop.
+
+Each upgrading client bootstraps **two** PQ keypairs:
+
+- a **PQ APKAM keypair** (signing — ML-DSA) for authentication, and
+- a share of the atSign-level **PQ encryption keypair** (`pqpublickey`, X-Wing, root).
+
+The encryption keypair is created once for the atSign and conveyed (§1, §4).
+
+**APKAM cardinality is per (host, AtKeys file), not per client.** Many
+clients/processes may share one AtKeys file on one host; they share **one** minted PQ
+APKAM keypair — a host-local mint-once lock serialises it (the first to upgrade mints,
+writes it into the keyfile/keychain; the rest read it). The atServer allows **multiple
+APKAM keypairs per enrollment**, so if the *same* AtKeys file is also in use on another
+host (copying we advise against), that host mints its own single, *different* PQ APKAM
+keypair. One enrollment therefore ends up with one PQ APKAM keypair **per host its keyfile
+lives on**, plus the legacy RSA key. The new granularity this unlocks is **per-host**,
+not per-client. (The alternative — one APKAM keypair per enrollment — would force later
+hosts to fetch the first host's signing private key over §1; minting-own keeps signing
+keys off the conveyance path.)
+
+**Uniform algorithm.** Every upgrading client runs the same steps; "first" vs
+"subsequent" is decided by the immutable create at step 7, not known in advance:
+
+1. Authenticate on the existing connection (legacy PKAM/APKAM, RSA).
+2. **Mint-once per host/keyfile:** if the AtKeys file already carries a PQ APKAM keypair,
+   use it; else (host-local lock) mint one and write it into the keyfile/keychain. Deliver
+   the public half to the server — an immutable per-(host, keyfile) record.
+3. Verify it can now APKAM-authenticate with the PQ keys. *(atServer enhancement — §8.)*
+4. **Delete the legacy RSA APKAM public key** for this enrollment from the atServer — only
+   *after* step 3 confirms PQ auth works (delete-by-default; *Legacy deletion* below).
+5. Save its AtKeys (incl. the PQ APKAM private key) to file / keychain.
+6. Publish its `ClientKeyPackage` (X-Wing) so peers can seal secrets to it.
+7. **Attempt create** `public:pqpublickey@alice` (immutable create-if-absent):
+   - **won** → generate the keypair, store + seed the private half, serve it (§4);
+   - **exists** → request the private half (§1), verify correspondence, store.
+8. When the roster holds the key, the atSign advertises PQ readiness (once, atSign-wide).
+
+The three scenarios differ in exactly **one** place — step 7 (`pqpublickey`):
+
+| Activity | A · first | B · subsequent, same enrollment | C · subsequent, different enrollment |
+|---|---|---|---|
+| 1 · Initial auth | legacy APKAM (RSA) | legacy APKAM (shared enrollment key) | legacy APKAM (own enrollment key) |
+| 2 · PQ APKAM keypair | mint once / host+keyfile | mint once / host+keyfile | mint once / host+keyfile |
+| 2 · Publish APKAM pubkey | own record, immutable | own record, immutable | own record, immutable |
+| 3 · Verify PQ APKAM auth | ✓ | ✓ | ✓ |
+| 4 · Delete legacy APKAM pubkey | ✓ (first to upgrade) | ✓ idempotent | ✓ idempotent |
+| 5 · Save AtKeys | ✓ | ✓ | ✓ |
+| 6 · Publish ClientKeyPackage | ✓ | ✓ | ✓ |
+| 7 · `public:pqpublickey@alice` | **create** (wins) | exists → don't create | exists → don't create |
+| 7 · pqpublickey private half | **generate + hold + serve** | **request + verify + store** | **request + verify + store** |
+| 8 · PQ-readiness | flips it | already on | already on |
+
+**B and C are identical for this bootstrap.** With one PQ APKAM keypair per host+keyfile,
+same-vs-different-enrollment collapses here: both mint a host-local APKAM key and both
+request the root `pqpublickey` (universal — served to every non-revoked client). The
+distinction only re-emerges for **namespaced** secrets (§1): a namespace-restricted
+enrollment is served only the keys for namespaces it is authorised for, so C on a
+restricted enrollment receives a *subset* of the `nskey` secrets B gets. The root key is
+not subject to that gate.
+
+### Legacy APKAM deletion & what revocation means
+
+Deleting the legacy RSA APKAM public key on upgrade is **recommended as the default** — it
+is what makes per-host revocation actually mean something.
+
+- **Why delete.** The legacy RSA APKAM key is (a) quantum-vulnerable (a future forger can
+  mint signatures) and (b) **shared across every copy** of the keyfile. While it remains on
+  the atServer, any copy can still authenticate with it — so revoking *one* host's PQ APKAM
+  key is bypassable via the shared legacy key. Per-host revocation is meaningless until the
+  legacy key is gone; deletion closes both the quantum hole and the bypass.
+- **Order matters.** Delete only *after* PQ APKAM auth is verified (step 3 → 4), or a host
+  could brick its own authentication.
+- **Scope.** Delete only the legacy **APKAM** (auth) public key. **Keep** the legacy
+  *encryption* keypair — it is still needed to read legacy-encrypted history; `pqpublickey`
+  is additive for new data.
+- **The experience/security trade-off (explicit).** If the user followed our long-standing
+  advice — one keyfile, one host — deletion is invisible. If they copied the keyfile to
+  other hosts, the first host to upgrade deletes the legacy key and **locks out the
+  un-upgraded copies** (their legacy private key no longer matches anything on the server;
+  they must re-enroll). That is arguably the correct outcome: it enforces "a given
+  enrollment's private APKAM key lives in exactly one keyfile" and surfaces copying that
+  shouldn't have happened. We accept harsher behaviour for the copy-violating minority to
+  close the shared-key hole for everyone.
+- **Softer option, if needed.** A grace period (legacy auth survives N days, then
+  auto-deletes) gives stray copies time to upgrade — at the cost of leaving the bypass open
+  during the window. Default to immediate delete; offer the grace period as a deployment
+  knob.
+
+**What "revocation" now means — two axes, three granularities:**
+
+| Axis | Granularity | Mechanism |
+|---|---|---|
+| **Auth** | per enrollment | existing APKAM enrollment revocation (cuts every host of the enrollment) |
+| **Auth** | **per host/keyfile** *(new)* | delete that host's PQ APKAM public key — works **only because** the legacy shared key was deleted |
+| **Encryption** | per namespace | rotate the namespace / `pqpublickey` key **excluding** the revoked party (roadmap *rotation*, WP9) — controls *new-data* access, orthogonal to auth |
+
+So the per-host auth revocation the upgrade unlocks is *contingent* on the legacy-key
+deletion above, and is a different axis from encryption-key rotation.
+
+### Where the PQ APKAM key lives (storage & host binding)
+
+The minted PQ APKAM **private** key must live somewhere, and the choice trades
+portability, host-binding, and dev/test ergonomics. There is **no universal way to
+cryptographically bind it to a host today**, so separate two goals: an
+**individually-revocable per-host identity** (achievable everywhere) from a
+**non-exportable, host-bound key** (hardware only).
+
+| Storage | Host binding | Dev / test | Notes |
+|---|---|---|---|
+| **AtKeys file** (default) | none — copyable | **clean**: the key persists with a reused keyfile, so re-runs don't re-mint | simplest; per-host revocation still works for keys each host minted |
+| **OS keychain** | software-local (off the portable file) | **polluting**: every fresh checkout / CI run / container mints a new key | availability varies — headless/servers may lack one |
+| **TPM / Secure Enclave** | strong — non-exportable | absent in CI/containers | **no PQ (ML-DSA) support in hardware today** — not viable for this key yet |
+| **Platform attestation** (App Attest / Android / TPM-remote) | strong — server admits the key only from a genuine distinct device | blocks CI/container floods (they can't attest) | platform-specific, heavy, excludes headless |
+
+What ties a key to a host for *management / revocation* is not the storage location but a
+**distinct, labelled record per host** (hostname / install-UUID / platform on the
+published APKAM record). The label is spoofable — an administration aid, not a security
+boundary — but it is what lets a revocation UI say "revoke the laptop" and makes per-host
+revocation usable everywhere.
+
+**Decision (2026-06-24): store in the copyable AtKeys file section** (like the legacy APKAM) —
+portable, dev/test-clean (a reused keyfile doesn't re-mint), riding the existing credential
+conveyance. A copy made *after* upgrade shares the key, so revocation is **per-keyfile-key**,
+not strictly per-device. Two supporting choices:
+- **OS-keychain (and hardware, if it ever supports PQ) is an opt-in hardening** for single-host
+  high-security deployments that want the key off the portable file and true per-host binding —
+  **off by default**, so dev/test doesn't auto-pollute.
+- **Server-side TTL / usage-based eviction of APKAM keys** (a key unused for authentication
+  within N days is pruned) bounds the per-enrollment key set and self-cleans throwaway dev/test
+  keys *and* abandoned hosts — independent of storage choice.
+
+## 6. End-to-end sequence (atSign-level PQ key)
+
+1. **Upgrade wave.** Each Alice client runs §5: mints its PQ APKAM keypair, publishes its
+   `ClientKeyPackage`, starts the listener. No PQ readiness advertised yet.
+2. **Create once.** The first client to reach step 7 wins the immutable create of
+   `pqpublickey`, generates the keypair, and seeds the private half as `pqid:<kid>` (§4).
+3. **Convey.** Every other client `requestSecret(pqid:<kid>)`; a holder serves per §1
+   (excluding revoked enrollments). Laggards/offline clients pull on next start.
+4. **Verify + store** (correspondence check; `WritableAtKeys`).
+5. **Flip readiness.** Only once the roster holds the key does Alice advertise PQ
+   readiness; peers encapsulate shared keys to `pqpublickey@alice`; Alice decrypts.
+
+## 7. Edge cases
+
+- **Offline client** — pulls on next startup; the request persists, a holder answers.
+- **Revoked enrollment** — `excludeEnrollmentIds` keeps the secret away; pair with
+  rotation (reuse the `__nsk.<epoch>` rotation channel) to cut a device that already
+  pulled.
+- **New enrollment / new atSign** — never runs the §5 retrofit: a new enrollment receives
+  `pqpublickey` *pushed* from the approver via enroll/approve; a new atSign generates it at
+  onboarding. The §1 pull is only an offline backstop for them.
+- **Two creators race** — impossible: the immutable create-if-absent admits exactly one;
+  the rest fall through to "request" (§4).
+- **Rotation / compromise** — create a successor, bump `kid`/epoch, redistribute
+  excluding the bad enrollment, supersede the old version (WP9 machinery).
+
+## 8. To verify / cross-tier notes
+
+**atServer support.** Mint-once uses the atServer's **existing immutable write**
+(`Metadata.immutable`) — already live, no change needed. The retrofit adds these **new**
+atServer capabilities:
+- **Multiple APKAM public keys per enrollment** — accept and store a set, authenticate
+  against any of them; per-host, enabling per-host auth revocation.
+- **PQ APKAM authentication** — verify an APKAM auth signed with a PQ signature (ML-DSA).
+- **Delete a specific public key** — the legacy APKAM key on upgrade (delete-by-default,
+  after PQ auth is confirmed) and a host's PQ APKAM key on revocation.
+- **TTL / usage-based eviction of APKAM keys** — prune a key not used to authenticate
+  within N days; bounds the per-enrollment set and self-cleans dev/test and abandoned hosts.
+  Requires a **per-APKAM-key "last authenticated" timestamp** on the atServer (updated on
+  each successful auth) — a small server-side data addition that eviction reads.
+
+**Design points to pin down:**
+- **The §1 request/serve primitive is the real deliverable** — reused by the atSign-level
+  PQ key, per-namespace `nskey` distribution, rotation, and master-seed conveyance. Worth
+  promoting in the plan from "substrate plumbing" to a named, spec'd primitive
+  (`requestSecret(name)` + responder authorisation policy).
+- **Responder authorisation policy** (which enrollment may receive which namespaced
+  secret) needs a precise spec — it is the access-control core of the primitive.
+- **Confirm WP10 enroll/approve conveys over the PQ enrollment key, not the RSA-wrapped
+  `apkamSymmetricKey`** — else §2's hole reopens for future clients.
+
+## 9. How this maps to the plan (no plan edits yet)
+
+- Reuses **WP-SS** (KeyPackages, `pqSeal` secrets, `requestSecretsFromNamespace`,
+  `excludeEnrollmentIds`) — generalised to **request-by-name**.
+- Reuses **WP9** rotation/revocation for succession.
+- Complements **WP10** (future enrollments); this is the existing-client counterpart.
+- **New, not yet explicit:** (a) the generic **`requestSecret(name)`** primitive +
+  responder authorisation; (b) the **per-client PQ APKAM upgrade** (mint-own,
+  multiple-per-enrollment) + the atServer enhancements above; and (c) the **atSign-level
+  PQ key lifecycle** (immutable create + existing-client pull). Candidates for added work
+  items once the approach is chosen.

--- a/docs/pq-flows-detailed.md
+++ b/docs/pq-flows-detailed.md
@@ -1,0 +1,360 @@
+# PQ crypto — detailed flows (given / when / then)
+
+**Status:** working planning doc (not plan-of-record). Lives in `docs/`.
+**Companion to** `pq-use-case-catalogue.md` — this elaborates the flows into protocol
+step sequences and testable acceptance ("then"). IDs (UC-A1.1 …) reference the catalogue.
+
+**Conventions.** Notation per the catalogue. Each flow gives **Given** (state),
+**When** (trigger), **Steps** (the protocol sequence), **Then** (acceptance — testable
+assertions). "Working name" marks an at-key name not yet finalised. `aS = pq` (PQ-capable
+atServer) unless stated.
+
+Key objects used throughout:
+- `public:pqpublickey@alice` — atSign-level PQ encryption pubkey (X-Wing; root, no
+  namespace; **immutable** once written). Private half = the root secret `pqid:<kid>`.
+- **PQ APKAM** keypair — ML-DSA signing key for auth; minted **per (host, keyfile)**;
+  public half published as an **immutable per-host record** (working name
+  `<enrollmentId>.<hostId>.pqapkam.__manage@alice`).
+- **Namespace key** (`nskey`) — a per-`(atSign, namespace)` X-Wing keypair. With namespace
+  `app_1.my_apps` (key name `nskey`, namespace `app_1.my_apps` — namespaces read right-to-left,
+  DNS-style: app `app_1` under org `my_apps`), three at-key shapes recur — keep them distinct:
+  - `nskey.app_1.my_apps@alice` — @alice's namespace **keypair** (self); alice's clients hold
+    the **private** half (decrypts both her self data and inbound shares).
+  - `public:nskey.app_1.my_apps@alice` — its **public** half, **published world-readable**;
+    **any** atSign (a peer, or alice for self data) encapsulates to it to send to @alice.
+  - `nskey.app_1.my_apps@bob` / `public:nskey.app_1.my_apps@bob` — @bob's keypair + published
+    public half, symmetric.
+  The private half is distributed via `requestSecret`, held only by the owning atSign's own
+  clients; the `public:` form is the one published key anyone encapsulates to — there is **no**
+  per-recipient key shape.
+- `ClientKeyPackage` (CKP) — per-client X-Wing pubkey for receiving sealed secrets.
+- `appMetadata.providerId ∈ {legacy, nskey, group}` — routes the reader to a provider.
+
+---
+
+## Table of contents
+
+- [1. Onboarding & enrollment](#1-onboarding--enrollment)
+  - [1.1 Onboard a new atSign (PQ-native) — UC-A1.1](#11-onboard-a-new-atsign-pq-native--uc-a11)
+  - [1.2 Enroll a new client — PQ-safe enroll/approve — UC-A2.1](#12-enroll-a-new-client--pq-safe-enrollapprove--uc-a21)
+  - [1.3 Second host on the *same* enrollment — UC-A2.2](#13-second-host-on-the-same-enrollment--uc-a22)
+  - [1.4 Namespace-restricted enrollment — UC-A2.3](#14-namespace-restricted-enrollment--uc-a23)
+- [2. Upgrade paths (existing pre-PQ atSign)](#2-upgrade-paths-existing-pre-pq-atsign)
+  - [2.0 atServer upgrade is a prerequisite — UC-B0.1](#20-atserver-upgrade-is-a-prerequisite--uc-b01)
+  - [2.1 First client upgrade — UC-B1.1](#21-first-client-upgrade--uc-b11)
+  - [2.2 Second client, same enrollment — UC-B1.2](#22-second-client-same-enrollment--uc-b12)
+  - [2.3 Third client, different enrollment — UC-B1.3](#23-third-client-different-enrollment--uc-b13)
+  - [2.4 Legacy APKAM deletion & lockout — UC-B2.1 / B2.2](#24-legacy-apkam-deletion--lockout--uc-b21--b22)
+- [3. E2EE within one atSign (self) — puts & notifications](#3-e2ee-within-one-atsign-self--puts--notifications)
+  - [3.1 Self put, namespace key exists — UC-A3.1](#31-self-put-namespace-key-exists--uc-a31)
+  - [3.2 First self put in a namespace mints + distributes `nskey.app_1.my_apps@alice` — UC-A3.2](#32-first-self-put-in-a-namespace-mints--distributes-nskeyapp_1my_appsalice--uc-a32)
+  - [3.3 Self put falls back to `pqpublickey` (no namespace key) — UC-A3.3](#33-self-put-falls-back-to-pqpublickey-no-namespace-key--uc-a33)
+  - [3.4 Self notification — NEW](#34-self-notification--new)
+  - [3.5 Mixed — upgraded `alice1`, un-upgraded `alice2` — UC-B3.1](#35-mixed--upgraded-alice1-un-upgraded-alice2--uc-b31)
+- [4. E2EE across atSigns — shares & notifications](#4-e2ee-across-atsigns--shares--notifications)
+  - [4.1 Shared put, recipient has the namespace key — UC-A4.1](#41-shared-put-recipient-has-the-namespace-key--uc-a41)
+  - [4.2 Shared put cold-start → `pqpublickey` fallback — UC-A4.2](#42-shared-put-cold-start--pqpublickey-fallback--uc-a42)
+  - [4.3 Cross-atSign notification — NEW](#43-cross-atsign-notification--new)
+  - [4.4 Mixed PQ/legacy across atSigns — UC-B4.1 / B4.3 / B4.4](#44-mixed-pqlegacy-across-atsigns--uc-b41--b43--b44)
+- [Cross-cutting acceptance (applies to all flows)](#cross-cutting-acceptance-applies-to-all-flows)
+- [Decisions (see catalogue)](#decisions-see-catalogue)
+
+# 1. Onboarding & enrollment
+
+## 1.1 Onboard a new atSign (PQ-native) — UC-A1.1
+
+- **Given:** `@alice` unactivated; `aliceS = pq`; CRAM activation secret in hand; no keys.
+- **When:** `alice1` runs onboarding.
+- **Steps:**
+  1. CRAM-authenticate with the activation secret.
+  2. Mint **PQ APKAM** keypair (ML-DSA); publish its public half as an immutable per-host
+     record; set it as this enrollment's (E1) APKAM key.
+  3. Mint the atSign-level **X-Wing** keypair; **immutable-create** `public:pqpublickey@alice`;
+     keep the private half locally and seed it as `pqid:<kid>`.
+  4. Mint the client's **CKP** (X-Wing) and publish it.
+  5. Persist AtKeys (PQ APKAM private + `pqpublickey@alice⁻¹` + CKP private) to keyfile/keychain.
+  6. **Verify**: re-authenticate using the PQ APKAM key (proves the server accepts PQ auth).
+  7. Legacy interop (config flag, **default off**): publish `public:publickey@alice` (RSA)
+     **only if enabled**, for legacy-peer inbound; default is PQ-only (omit it).
+- **Then (acceptance):**
+  - `alice1` authenticates with PQ APKAM; no RSA APKAM key is required for auth.
+  - `public:pqpublickey@alice` exists, is immutable (a second create attempt is rejected),
+    and `alice1` holds its private half.
+  - `alice1.CKP` is published and fetchable by peers.
+  - No `selfEncryptionKey` is minted (self data will use `nskey`/`pqpublickey`).
+  - readiness may be `ready` (no legacy clients exist).
+  - *(Legacy-interop flag on)* `public:publickey@alice` is present; **default (flag off)** it is
+    absent and a legacy peer's send is unsupported (UC-B4.2).
+
+## 1.2 Enroll a new client — PQ-safe enroll/approve — UC-A2.1
+
+- **Given:** `@alice` pq-native; `pqpublickey` published; `alice1` (E1) online and able to approve.
+- **When:** `alice2` requests a new enrollment (E2) for namespaces `[app_1.my_apps]`; `alice1` approves.
+- **Steps:**
+  1. `alice2` mints its own **PQ APKAM** keypair and an `apkamSymmetricKey`.
+  2. `alice2` **encapsulates** `apkamSymmetricKey` to `@alice`'s `pqpublickey` (X-Wing) — **not**
+     RSA — and sends `enroll:request` with its PQ APKAM public half + requested namespaces.
+  3. `alice1` (approver) decapsulates `apkamSymmetricKey` with `pqpublickey@alice⁻¹`; approves E2;
+     registers `alice2`'s PQ APKAM pubkey for E2 (multiple-per-enrollment).
+  4. `alice1` conveys to `alice2`, AEAD-wrapped under `apkamSymmetricKey`: the
+     **`pqpublickey@alice⁻¹`** (root) and the **`nskey.app_1.my_apps@alice⁻¹`** (authorised namespace only).
+  5. `alice2` fetches + decrypts the conveyed bundle; publishes its **CKP**; persists AtKeys.
+  6. `alice2` verifies PQ APKAM auth.
+- **Then:**
+  - Nothing in the conveyance path is RSA-wrapped (`apkamSymmetricKey` rode X-Wing) — the
+    enrollment harvest-now hole is closed.
+  - `alice2.APKAM = pq`, `pqpk⁻¹ = ✓`, `nskey.app_1.my_apps@alice⁻¹ = ✓`, `nskey.app_2.my_apps@alice⁻¹ = ✗`, `CKP = ✓`.
+  - `alice2` can authenticate PQ and decrypt `@alice`'s `app_1.my_apps` self data; a `app_2.my_apps` key request
+    is refused.
+  - E2's APKAM key is a distinct, individually-revocable record.
+
+## 1.3 Second host on the *same* enrollment — UC-A2.2
+
+- **Given:** `@alice` pq-native; `alice1` on E1; the E1 keyfile is copied to a second host (`alice1b`).
+- **When:** `alice1b` first runs.
+- **Steps:**
+  1. `alice1b` authenticates (it has E1's existing APKAM private from the copied keyfile).
+  2. Host-local mint-once: the copied keyfile may already carry a PQ APKAM key (then reuse) or
+     not (then mint a **new** PQ APKAM keypair for this host and publish an immutable per-host
+     record under E1).
+  3. Obtain `pqpublickey@alice⁻¹` — present in the copied keyfile, else `requestSecret`.
+  4. Publish `alice1b`'s CKP.
+- **Then:**
+  - If the second host minted its own (the keyfile copy predated alice1's upgrade), E1 now has
+    **two** PQ APKAM keys (individually revocable); if it inherited the key from the copied
+    keyfile, E1 has **one** shared across both hosts.
+  - Both hosts share `pqpublickey@alice⁻¹` and E1's namespace authorisations.
+  - **Decision (PQ APKAM placement):** the PQ APKAM private lives in the **copyable keyfile**
+    section, so a copy made *after* upgrade inherits/shares it — revocation is per-keyfile-key,
+    not strictly per-device. Device-local/keychain is optional hardening for true per-host
+    binding.
+
+## 1.4 Namespace-restricted enrollment — UC-A2.3
+
+- **Given:** `@alice` pq-native; `alice1` (E1, `*`) approves `alice3` for `[app_1.my_apps]` only (E3).
+- **When:** `alice3` enrolls (as 1.2).
+- **Then:** `alice3.pqpk⁻¹ = ✓` (root, universal); `alice3` receives `nskey.app_1.my_apps@alice⁻¹` only; a
+  `requestSecret` for `app_2.my_apps` is refused (namespace = authz boundary); `alice3` can read/write
+  `app_1.my_apps` data but not `app_2.my_apps`.
+
+---
+
+# 2. Upgrade paths (existing pre-PQ atSign)
+
+Start state: `@alice = legacy` (RSA `publickey`, RSA APKAM per enrollment), `aliceS = pq`,
+no `pqpublickey`.
+
+## 2.0 atServer upgrade is a prerequisite — UC-B0.1
+
+- **Given:** `aliceS = legacy`; `alice1` is a PQ-capable build.
+- **When:** `alice1` attempts the upgrade sequence (2.1).
+- **Then:** the new PQ verbs (PQ-APKAM-auth / multiple-APKAM / delete-pubkey / eviction) are
+  unavailable → `alice1` aborts the upgrade cleanly, **stays legacy**, mints no PQ keys, logs
+  why. No partial state on the server. (The atServer's immutable write is long-standing and
+  present even here — it is *not* a PQ-only verb.)
+
+## 2.1 First client upgrade — UC-B1.1
+
+- **Given:** above; `alice1` on E1 with the legacy RSA APKAM key; `pqpublickey` absent.
+- **When:** `alice1` runs the upgrade.
+- **Steps:**
+  1. Authenticate legacy (RSA APKAM).
+  2. **Mint-once per host** a PQ APKAM keypair; publish its immutable per-host record for E1.
+  3. **Verify** PQ APKAM auth succeeds.
+  4. **Delete** the legacy RSA APKAM pubkey for E1 (only after step 3).
+  5. Persist AtKeys; publish CKP.
+  6. **Immutable-create** `public:pqpublickey@alice` → **wins** → generate X-Wing keypair, hold
+     `pqpublickey@alice⁻¹`, seed `pqid:<kid>`, serve on request.
+  7. When the roster holds the key, flip readiness (or leave `n-r` until siblings upgrade).
+- **Then:**
+  - `alice1.APKAM = pq`; legacy RSA APKAM pubkey **gone**; PQ auth works.
+  - `public:pqpublickey@alice` created; `alice1.pqpk⁻¹ = ✓`; `alice1` serves the private on request.
+  - Legacy *encryption* key retained (history still readable). No re-onboarding.
+
+## 2.2 Second client, same enrollment — UC-B1.2
+
+- **Given:** after 2.1; `pqpublickey` exists; `alice2` on E1 (RSA APKAM).
+- **When:** `alice2` runs the upgrade.
+- **Steps:** 1–5 as 2.1 (mints its **own** PQ APKAM, publishes, verifies, deletes *its* legacy
+  view if applicable, persists, publishes CKP). Step 6: **immutable-create rejected (exists)**
+  → `requestSecret(pqid:<kid>)` → verify public/private correspondence → store.
+- **Then:** `alice2.APKAM = pq`, `pqpk⁻¹ = ✓`; it never created or overwrote `pqpublickey`; E1
+  now has two PQ APKAM keys.
+
+## 2.3 Third client, different enrollment — UC-B1.3
+
+- **Given:** after 2.1; `alice3` on E2 (its own legacy RSA APKAM).
+- **When:** `alice3` runs the upgrade.
+- **Then:** identical to 2.2 for the bootstrap (own PQ APKAM, request `pqpublickey@alice⁻¹`). For
+  **namespaced** secrets, a restricted E2 receives only its authorised `nskey` keys.
+
+## 2.4 Legacy APKAM deletion & lockout — UC-B2.1 / B2.2
+
+- **Given:** E1 keyfile copied to `alice1b` (un-upgraded); `alice1` upgraded and deleted E1's
+  legacy APKAM pubkey.
+- **When:** `alice1b` authenticates (legacy).
+- **Then (default, immediate delete):** auth **fails** (pubkey gone) → `alice1b` must re-enroll.
+  This is the intended enforcement.
+- **Then (grace-period knob):** legacy auth succeeds for N days; `alice1b` may upgrade in the
+  window; after expiry the legacy pubkey auto-deletes and the default applies. (Bypass open
+  during the window — explicit trade-off.)
+
+---
+
+# 3. E2EE within one atSign (self) — puts & notifications
+
+## 3.1 Self put, namespace key exists — UC-A3.1
+
+- **Given:** `@alice` pq-native; `public:nskey.app_1.my_apps@alice` published; `alice1`, `alice2` hold `nskey.app_1.my_apps@alice⁻¹`.
+- **When:** `alice1` does `put <k>.app_1.my_apps@alice` (shouldEncrypt).
+- **Steps:**
+  1. Generate a random data key; encrypt the value with it (AES-256-GCM).
+  2. **Encapsulate** the data key to @alice's own published public key
+     `public:nskey.app_1.my_apps@alice` (X-Wing); store the encapsulation in `appMetadata.additional`.
+  3. Stamp `appMetadata.providerId = nskey`, `isEncrypted = true`; write the key; sync.
+- **Then:**
+  - `alice2` syncs the key, routes by `providerId = nskey`, decapsulates the data key with
+    `nskey.app_1.my_apps@alice⁻¹`, decrypts the value.
+  - No legacy provider, no `selfEncryptionKey` used.
+  - Acceptance test: round-trip equals plaintext; `providerId = nskey`; a client lacking
+    `nskey.app_1.my_apps@alice⁻¹` cannot read.
+
+## 3.2 First self put in a namespace mints + distributes `nskey.app_1.my_apps@alice` — UC-A3.2
+
+- **Given:** `@alice` pq-native; **no** `public:nskey.app_1.my_apps@alice` yet; `alice1`, `alice2` PQ, both have CKP.
+- **When:** `alice1` does the first `put <k>.app_1.my_apps@alice`.
+- **Steps:**
+  1. `alice1` mints the `app_1.my_apps` X-Wing keypair `nskey.app_1.my_apps@alice`; **immutable-create**
+     `public:nskey.app_1.my_apps@alice`; seed `nskey.app_1.my_apps@alice⁻¹` as an **`app_1.my_apps`-namespaced**
+     secret (`__nsk.app_1.my_apps.<epoch>`, working name).
+  2. Encrypt the value to the new namespace key (as 3.1).
+  3. `alice2` `requestSecret` in `app_1.my_apps` (authorised), receives `nskey.app_1.my_apps@alice⁻¹` pqSealed to its CKP,
+     verifies correspondence, stores.
+- **Then:**
+  - `public:nskey.app_1.my_apps@alice` published once (immutable); `alice2` obtains the private and can read.
+  - An `app_2.my_apps`-only client is refused `nskey.app_1.my_apps@alice⁻¹`.
+
+## 3.3 Self put falls back to `pqpublickey` (no namespace key) — UC-A3.3
+
+- **Given:** `@alice` pq-native; no `public:nskey.app_1.my_apps@alice`; "seal-and-hold" **not** selected (send-now is the default; seal-and-hold is the per-namespace opt-in).
+- **When:** `alice1` writes self data before any namespace key exists.
+- **Then:** data key encapsulated to `public:pqpublickey@alice` (root); any `@alice` client decrypts;
+  `providerId = nskey` with a root-key marker (or a dedicated marker — to spec). Self-heals to
+  the namespace key on the first namespaced write.
+
+## 3.4 Self notification — NEW
+
+- **Given:** `@alice` pq-native; `alice1`, `alice2` PQ; `alice2` running a monitor.
+- **When:** `alice1` does `notify` to `@alice` (self) carrying an encrypted value (e.g. an
+  `update`/`delete` notification with `value` + shouldEncrypt).
+- **Steps:**
+  1. Encrypt the notification value exactly as a self put (data key → namespace/`pqpublickey`).
+  2. Stamp `appMetadata.providerId` on the **notification** payload; send `notify:`.
+  3. atServer queues/delivers; `alice2`'s monitor receives the notification frame.
+  4. `alice2` reads `providerId` from the notification, decapsulates, decrypts the value.
+- **Then:**
+  - The notification's value decrypts on `alice2` with the same provider routing as a put.
+  - `providerId` travels **on the notification**, not only on stored keys (notification framing
+    must carry `appMetadata`).
+  - Offline `alice2`: the queued notification still decrypts on later delivery (key still held).
+  - Acceptance test: a self-notification with an encrypted value round-trips on a sibling;
+    a notification with no value (signal-only) needs no decryption and is unaffected.
+
+## 3.5 Mixed — upgraded `alice1`, un-upgraded `alice2` — UC-B3.1
+
+- **Given:** `alice1` PQ; `alice2` legacy-only; `@alice` readiness `n-r`.
+- **When:** `alice1` puts/notifies self data both must read.
+- **Then:** `alice1` writes/notifies **legacy** (the scheme `alice2` can read) until readiness
+  flips; `alice2` reads via the legacy provider; no self data is unreadable by `alice2`. After
+  all `@alice` clients are PQ and readiness flips `ready`, new self puts/notifications go
+  `nskey` (UC-B3.2).
+
+---
+
+# 4. E2EE across atSigns — shares & notifications
+
+## 4.1 Shared put, recipient has the namespace key — UC-A4.1
+
+- **Given:** `@alice`, `@bob` pq-native; `@bob` published `public:nskey.app_1.my_apps@bob`; `bob1`,`bob2` hold
+  `nskey.app_1.my_apps@bob⁻¹`; `@bob` readiness `ready`.
+- **When:** `alice1` does `put @bob:<k>.app_1.my_apps@alice` (shouldEncrypt).
+- **Steps:**
+  1. Generate a data key; encrypt the value.
+  2. **Encapsulate** the data key to **bob's** published public key `public:nskey.app_1.my_apps@bob`
+     (fetched from `@bob`).
+  3. Stamp `providerId = nskey`; write the shared key; sync (delivered to `@bob`).
+  4. Write the **self-copy** for alice's own clients (encapsulated to **alice's** own published public key
+     `public:nskey.app_1.my_apps@alice`).
+- **Then:**
+  - `bob1` and `bob2` decapsulate with `nskey.app_1.my_apps@bob⁻¹` and read; `alice`'s clients read the self-copy.
+  - PQ end to end; `providerId = nskey`; no RSA on any path.
+  - Acceptance: every authorised reader on both atSigns decrypts; an unauthorised `@bob`
+    enrollment cannot fetch the ciphertext (server-gated) nor decrypt.
+
+## 4.2 Shared put cold-start → `pqpublickey` fallback — UC-A4.2
+
+- **Given:** `@alice`, `@bob` pq-native; `@bob` has `public:pqpublickey@bob` but **no** `public:nskey.app_1.my_apps@bob`.
+- **When:** `alice1` shares `@bob:<k>.app_1.my_apps@alice`.
+- **Steps:** as 4.1 but encapsulate the data key to **bob's `public:pqpublickey@bob`** (root fallback);
+  mark the fallback in `appMetadata`.
+- **Then:** every bob client reads instantly (all hold `pqpublickey@bob⁻¹`); when a bob `app_1.my_apps` client
+  later publishes `public:nskey.app_1.my_apps@bob`, subsequent writes **upgrade** to the namespace key. (High-security
+  `app_1.my_apps` may instead seal-and-hold — the per-namespace opt-in.)
+
+## 4.3 Cross-atSign notification — NEW
+
+- **Given:** `@alice`, `@bob` pq-native; `@bob` published `public:nskey.app_1.my_apps@bob` (or `public:pqpublickey@bob` fallback);
+  `@bob` readiness `ready`; `bob1` running a monitor.
+- **When:** `alice1` `notify`s `@bob` with an encrypted value (e.g. share a key + notify).
+- **Steps:**
+  1. Encrypt the notification value to bob's `public:nskey.app_1.my_apps@bob` (or `public:pqpublickey@bob`) — same
+     encapsulation as 4.1/4.2.
+  2. Stamp `appMetadata.providerId` on the notification; `notify:@bob…`.
+  3. `bobS` queues; on `bob1` reconnect the monitor delivers the notification frame.
+  4. `bob1` routes by `providerId`, decapsulates, decrypts; `bob2` likewise on its monitor.
+- **Then:**
+  - The notification value decrypts on every authorised bob client with the same routing as a
+    shared put.
+  - Negotiation gates the notification's scheme on **bob's** readiness (a legacy bob → legacy
+    notification — UC-B4.1).
+  - Offline-then-online bob still decrypts the queued notification (key held; or pulled if the
+    key arrived meanwhile).
+  - Acceptance: encrypted-value notification round-trips across atSigns to all authorised bob
+    clients; signal-only notifications are unaffected; `appMetadata` is present on the
+    notification frame (not only on stored keys).
+
+## 4.4 Mixed PQ/legacy across atSigns — UC-B4.1 / B4.3 / B4.4
+
+- **B4.1 — `@alice` PQ-ready, `@bob` legacy.** `alice1` shares/notifies `@bob`: writes **legacy**
+  RSA to bob's `publickey` (bob's readiness `n-r` gates it); alice's self-copy may be PQ
+  independently. **Then:** no write/notification bob can't read; alice's own clients still get a
+  PQ self-copy if all alice clients are PQ.
+- **B4.3 — partially-upgraded `@alice` (alice1 PQ, alice2 legacy) → `@bob` PQ-ready.** The write
+  to `@bob` may be PQ (bob ready), but alice's **self-copy** is legacy (alice2 can't read PQ)
+  until `@alice` readiness flips. **Then:** two directions, two schemes, one `put`/`notify`.
+- **B4.4 — `@bob` finishes upgrading.** Once all bob clients PQ and bob readiness `ready`,
+  alice's next share/notify to `@bob` goes PQ. **Then:** legacy path no longer used toward bob.
+
+---
+
+## Cross-cutting acceptance (applies to all flows)
+
+- **Reads are universal:** a client decrypts anything ever written to it (all providers retained);
+  upgrading only ever adds read-capability.
+- **Writes gated by reader readiness:** a value/notification is only written in a scheme **every**
+  required reader supports; otherwise legacy (3.x) or refused (`disallowLegacyEncryption=true`).
+- **`appMetadata.providerId` is authoritative** and present on **both** stored keys and
+  **notification frames**.
+- **No RSA in any confidentiality path** for a fully-PQ interaction (auth, enrollment conveyance,
+  self, shared, notification).
+- **Immutability:** `pqpublickey` and namespace public keys are create-once; a second create is
+  rejected, never an overwrite.
+
+## Decisions (see catalogue)
+
+Resolved 2026-06-24 (full text in the catalogue's *Decisions* section):
+1. Legacy-peer interop (1.1, 4.4) — **config flag, default off** (PQ-only by default).
+2. Readiness granularity (3.5, 4.x) — **per (atSign, namespace)** (+ atSign-level root).
+3. PQ APKAM placement (1.3, 2.x) — **copyable keyfile** (a copy after upgrade shares it).
+4. `nskey` to a new enrollment (1.2, 3.2) — **push at approve + pull fallback**.
+5. Seal-and-hold vs send-now (3.3, 4.2) — **send-now default; per-namespace seal-and-hold opt-in**.

--- a/docs/pq-use-case-catalogue.md
+++ b/docs/pq-use-case-catalogue.md
@@ -1,0 +1,355 @@
+# PQ crypto — use-case catalogue (given / when / then burn-down)
+
+**Status:** working planning doc (not plan-of-record). Lives in `docs/`.
+**Purpose:** a comprehensive, ordered target of use cases and their acceptance
+("then"), so dev can be burned down against a known list. Build order is
+**Part A — the new world** (greenfield, PQ-native) **before Part B — retrofit/upgrade**
+(mixtures of pre-PQ and post-PQ). First-cut "then" rows are starting points to refine.
+
+## Table of contents
+
+- [Notation & state model](#notation--state-model)
+- [Part A — The new world (PQ-native, PQ-capable atServer)](#part-a--the-new-world-pq-native-pq-capable-atserver)
+  - [A1 · Onboard a new atSign](#a1--onboard-a-new-atsign)
+  - [A2 · Enrollments (a new client joins)](#a2--enrollments-a-new-client-joins)
+  - [A3 · E2EE within one atSign (self data)](#a3--e2ee-within-one-atsign-self-data)
+  - [A4 · E2EE across atSigns (shared data)](#a4--e2ee-across-atsigns-shared-data)
+  - [A5 · Rotation & revocation (new world)](#a5--rotation--revocation-new-world)
+- [Part B — Retrofit / upgrade (mixtures of pre-PQ and post-PQ)](#part-b--retrofit--upgrade-mixtures-of-pre-pq-and-post-pq)
+  - [B0 · Prerequisite — atServer upgrade](#b0--prerequisite--atserver-upgrade)
+  - [B1 · Upgrade an existing (pre-PQ) atSign — the three scenarios](#b1--upgrade-an-existing-pre-pq-atsign--the-three-scenarios)
+  - [B2 · Legacy APKAM deletion consequences](#b2--legacy-apkam-deletion-consequences)
+  - [B3 · Mixed-PQ within one atSign (some clients upgraded)](#b3--mixed-pq-within-one-atsign-some-clients-upgraded)
+  - [B4 · Mixed-PQ across atSigns](#b4--mixed-pq-across-atsigns)
+  - [B5 · Retrofit edge cases](#b5--retrofit-edge-cases)
+- [Decisions](#decisions)
+- [Coverage map (build-order checklist)](#coverage-map-build-order-checklist)
+
+## Notation & state model
+
+**Actors.** `@alice`, `@bob` are atSigns. `alice1`, `alice2`, `alice3` are *clients*
+(a client = one running instance bound to one keyfile/keychain on one host) of `@alice`;
+likewise `bob1`, `bob2`. `aliceS` / `bobS` are their atServers.
+
+**Per-client state** (table columns):
+
+| Col | Meaning |
+|---|---|
+| `enr` | enrollment the client is on (`E1`, `E2`, …) |
+| `APKAM` | auth keypair held: `rsa` (legacy) · `pq` (ML-DSA) · `both` |
+| `pqpk⁻¹` | holds the atSign-level `pqpublickey` **private** half? |
+| `nskey⁻¹` | holds its **own** atSign's namespace keypair **private** half, per namespace (an `@alice` client holds `nskey.<ns>@alice`'s private) — see *Namespace key shapes* |
+| `CKP` | has published its `ClientKeyPackage` (X-Wing, for receiving sealed secrets)? |
+
+**Per-atSign / server state:**
+
+| Col | Meaning |
+|---|---|
+| atSign | `legacy` · `pq-native` · `mixed` |
+| `aS` | atServer: `pq` (new verbs) · `legacy` |
+| `publickey` | legacy RSA encryption pubkey published? |
+| `pqpublickey` | atSign-level PQ encryption pubkey published (immutable)? |
+| `nskey.ns` | namespace PQ pubkey published for namespace `ns`? |
+| `ready` | PQ-readiness marker, **per (atSign, namespace)** (+ an atSign-level marker for the root `pqpublickey`): `n-r` (not ready) · `ready` |
+
+**Namespace key shapes.** A namespace keypair (`nskey`) for namespace `app_1.my_apps`
+(key name `nskey`, namespace `app_1.my_apps` — namespaces read right-to-left, DNS-style, so
+app `app_1` under org `my_apps`) has **two** at-key shapes per atSign (shown for both) — keep
+them distinct:
+
+| Shape | Meaning |
+|---|---|
+| `nskey.app_1.my_apps@alice` | @alice's namespace **keypair** (self) — alice's own clients hold the **private** half, decrypting both her self data and inbound shares |
+| `public:nskey.app_1.my_apps@alice` | its **public** half, **published world-readable** — **any** atSign (a peer, or alice for her own self data) encapsulates to it to send to @alice |
+| `nskey.app_1.my_apps@bob` | @bob's namespace keypair (self) — symmetric; bob's clients hold its private half |
+| `public:nskey.app_1.my_apps@bob` | @bob's **published public** half — any atSign (incl. @alice) encapsulates to it to send to @bob |
+
+The private half is held only by the owning atSign's own clients (the `nskey⁻¹` column); the
+`public:` form is the one published key anyone encapsulates to — there is **no** per-recipient
+key shape.
+
+**atServer PQ capabilities** (Part A and B both assume `aS = pq` unless stated): the
+**existing** immutable write (`Metadata.immutable`) for mint-once, plus the **new** verbs —
+multiple APKAM keys per enrollment + auth-against-any · PQ (ML-DSA) APKAM auth · delete a
+specific pubkey · TTL/usage eviction of APKAM keys.
+
+---
+
+# Part A — The new world (PQ-native, PQ-capable atServer)
+
+## A1 · Onboard a new atSign
+
+**UC-A1.1 — First-client CRAM onboard is PQ-native**
+- **Given:** `@alice` unactivated; `aliceS = pq`; no keys exist.
+- **When:** `alice1` runs CRAM onboarding.
+- **Then:** `alice1.APKAM = pq` and it authenticates via PQ APKAM; `public:pqpublickey@alice`
+  is published (immutable) and `alice1.pqpk⁻¹ = ✓`; `alice1.CKP = ✓`; readiness can be
+  `ready` (no legacy clients exist). **Legacy interop is a config flag (default off):** by
+  default a PQ-native atSign is PQ-only — no RSA `public:publickey@alice`; enable the flag to
+  publish it for legacy-peer inbound (see UC-B4.2).
+
+| client | enr | APKAM | pqpk⁻¹ | nskey⁻¹ | CKP |
+|---|---|---|---|---|---|
+| alice1 | E1 | pq | ✓ | — | ✓ |
+
+## A2 · Enrollments (a new client joins)
+
+**UC-A2.1 — New enrollment, approved by an online client (PQ-safe enroll/approve)**
+- **Given:** `@alice` pq-native; `pqpublickey` published; `alice1` enrolled (E1) & online.
+- **When:** `alice2` requests enrollment (E2); `alice1` approves.
+- **Then:** `alice2.APKAM = pq` (its own); `alice2.pqpk⁻¹ = ✓` (pushed by approver over the
+  **PQ** enrollment-conveyance key, *not* RSA-wrapped); `alice2.CKP = ✓`; `alice2` can
+  authenticate PQ and decrypt `@alice`'s PQ self data within its authorised namespaces.
+
+**UC-A2.2 — Second host on the *same* enrollment (copied keyfile, E1)**
+- **Given:** `@alice` pq-native; `alice1` on E1; `alice2` is a second host using E1's keyfile.
+- **When:** `alice2` first runs.
+- **Then:** per the *multiple-APKAM-per-enrollment* rule, `alice2` mints its **own** PQ APKAM
+  keypair (host-local), publishes it as a distinct per-host record; obtains `pqpublickey@alice⁻¹`
+  (already in the copied keyfile, or pulled). One enrollment now has **two** PQ APKAM keys,
+  individually revocable.
+
+**UC-A2.3 — Namespace-restricted enrollment**
+- **Given:** `@alice` pq-native; `alice1` (E1, `*`) approves `alice3` for namespace `app_1.my_apps` only (E3).
+- **When:** `alice3` enrolls.
+- **Then:** `alice3` gets `pqpublickey@alice⁻¹` (root — universal) but only `nskey⁻¹` for `app_1.my_apps`; a
+  request for `app_2.my_apps`'s key is refused (namespace = authz boundary).
+
+## A3 · E2EE within one atSign (self data)
+
+**UC-A3.1 — Self write/read, namespace key already exists**
+- **Given:** `@alice` pq-native; `public:nskey.app_1.my_apps@alice` published; alice1 & alice2 hold `nskey.app_1.my_apps@alice⁻¹`.
+- **When:** `alice1` puts self key `<k>.app_1.my_apps@alice`.
+- **Then:** value encapsulated to @alice's own published public key `public:nskey.app_1.my_apps@alice`; `providerId = nskey`;
+  `alice2` decrypts with `nskey.app_1.my_apps@alice⁻¹`; no legacy provider used.
+
+**UC-A3.2 — First self write in a namespace mints + distributes `nskey.app_1.my_apps@alice`**
+- **Given:** `@alice` pq-native; no `public:nskey.app_1.my_apps@alice` yet; alice1 & alice2 PQ.
+- **When:** `alice1` puts the first `app_1.my_apps` self key.
+- **Then:** `alice1` mints the `app_1.my_apps` namespace keypair `nskey.app_1.my_apps@alice`, publishes `public:nskey.app_1.my_apps@alice` (immutable),
+  seeds `nskey.app_1.my_apps@alice⁻¹` as an `app_1.my_apps`-namespaced secret; `alice2` obtains it via `requestSecret`
+  (authorised for `app_1.my_apps`), verifies correspondence, stores; both can read.
+
+**UC-A3.3 — Self fallback to the atSign-level PQ key (no namespace key)**
+- **Given:** `@alice` pq-native; alice1 wants to write self data but no `nskey.app_1.my_apps@alice` minted and
+  "seal-and-hold" not chosen.
+- **When:** `alice1` puts self data.
+- **Then:** encapsulated to `public:pqpublickey@alice` (root fallback); any `@alice` client decrypts;
+  self-heals to `nskey` on first namespaced write.
+
+| client | enr | APKAM | pqpk⁻¹ | nskey⁻¹ | CKP |
+|---|---|---|---|---|---|
+| alice1 | E1 | pq | ✓ | ✓ | ✓ |
+| alice2 | E2 | pq | ✓ | ✓ | ✓ |
+
+## A4 · E2EE across atSigns (shared data)
+
+**UC-A4.1 — alice → bob, both PQ-native, bob has the namespace key**
+- **Given:** `@alice`, `@bob` pq-native; `@bob` published `public:nskey.app_1.my_apps@bob`; bob1/bob2 hold `nskey.app_1.my_apps@bob⁻¹`.
+- **When:** `alice1` shares `@bob:<k>.app_1.my_apps@alice`.
+- **Then:** data key encapsulated to **bob's** published public key `public:nskey.app_1.my_apps@bob`; `providerId = nskey`;
+  bob1 & bob2 both decrypt; PQ-safe end to end; alice keeps a self-copy readable by her clients.
+
+**UC-A4.2 — alice → bob cold-start (bob has no `app_1.my_apps` key) → pqpublickey fallback**
+- **Given:** `@alice`, `@bob` pq-native; `@bob` has `public:pqpublickey@bob` but **no** `public:nskey.app_1.my_apps@bob`.
+- **When:** `alice1` shares `@bob:<k>.app_1.my_apps@alice`.
+- **Then:** encapsulated to bob's `public:pqpublickey@bob` (every bob client can read); upgrades to
+  `public:nskey.app_1.my_apps@bob` once a bob `app_1.my_apps` client publishes it. (Or seal-and-hold for high-security `app_1.my_apps`.)
+
+**UC-A4.3 — Multi-client both ends**
+- **Given:** alice1/alice2 and bob1/bob2 all PQ; bob has `public:nskey.app_1.my_apps@bob`.
+- **When:** `alice2` shares with `@bob`.
+- **Then:** all of bob's authorised clients read; all of alice's authorised clients read the
+  self-copy; no client is left unable to decrypt.
+
+| client | enr | APKAM | pqpk⁻¹ | nskey⁻¹ | CKP |
+|---|---|---|---|---|---|
+| alice1 | aE1 | pq | ✓ | ✓ | ✓ |
+| alice2 | aE2 | pq | ✓ | ✓ | ✓ |
+| bob1 | bE1 | pq | ✓ | ✓ | ✓ |
+| bob2 | bE2 | pq | ✓ | ✓ | ✓ |
+
+## A5 · Rotation & revocation (new world)
+
+**UC-A5.1 — Rotate a namespace key (post-compromise)**
+- **Given:** `nskey.app_1.my_apps@alice` exists; alice1 wants to rotate.
+- **When:** `alice1` mints `nskey.app_1.my_apps@alice` epoch+1, publishes the new `public:nskey.app_1.my_apps@alice`, distributes the new
+  private excluding nobody.
+- **Then:** new writes use epoch+1; clients retain old private to read old data (no FS);
+  peers re-encapsulate to the new pubkey.
+
+**UC-A5.2 — Per-host auth revocation**
+- **Given:** `@alice` pq-native; alice2's host is lost; legacy APKAM already deleted.
+- **When:** operator revokes `alice2`'s PQ APKAM public key (delete it on aliceS).
+- **Then:** `alice2` can no longer authenticate; `alice1` unaffected; alice2 gets no new
+  secrets (excluded from future `requestSecret` serves).
+
+**UC-A5.3 — Enrollment revocation**
+- **Given:** enrollment E2 compromised (may span hosts).
+- **When:** operator revokes E2.
+- **Then:** every host of E2 is cut at auth; pair with `nskey` rotation excluding E2 to deny
+  new-data keys.
+
+---
+
+# Part B — Retrofit / upgrade (mixtures of pre-PQ and post-PQ)
+
+## B0 · Prerequisite — atServer upgrade
+
+**UC-B0.1 — Client cannot PQ-upgrade against a legacy atServer**
+- **Given:** `aliceS = legacy` (no PQ verbs); `alice1` is a PQ-capable build.
+- **When:** `alice1` attempts the upgrade sequence.
+- **Then:** the new PQ verbs (PQ-APKAM auth / multiple-APKAM / delete-pubkey / eviction) are unavailable → `alice1`
+  **stays legacy**, no PQ keys minted, no harm. atServer upgrade is a hard prerequisite for
+  Part B.
+
+## B1 · Upgrade an existing (pre-PQ) atSign — the three scenarios
+
+Start state for B1: `@alice = legacy`, `aliceS = pq`, no `pqpublickey` yet.
+
+| client | enr | APKAM | pqpk⁻¹ | CKP | note |
+|---|---|---|---|---|---|
+| alice1 | E1 | rsa | — | — | first to upgrade |
+| alice2 | E1 | rsa | — | — | same enrollment (B1.2) |
+| alice3 | E2 | rsa | — | — | different enrollment (B1.3) |
+
+**UC-B1.1 — First client to upgrade (`alice1`)**
+- **Given:** above; `pqpublickey` absent.
+- **When:** `alice1` runs the upgrade sequence.
+- **Then:** mints PQ APKAM (host-local), publishes it (immutable per-host); verifies PQ auth;
+  **deletes the legacy RSA APKAM pubkey**; **wins** the immutable create of `pqpublickey`,
+  generates + holds + seeds its private; publishes CKP. End: `alice1.APKAM = pq`,
+  `pqpk⁻¹ = ✓`, `pqpublickey` published.
+
+**UC-B1.2 — Second client, same enrollment (`alice2`, E1)**
+- **Given:** after B1.1; `pqpublickey` exists.
+- **When:** `alice2` runs the sequence.
+- **Then:** mints its **own** PQ APKAM (multiple-per-enrollment), publishes it; verifies PQ
+  auth; **requests** `pqpublickey@alice⁻¹` (exists → does not create), verifies correspondence,
+  stores. Identical to B1.1 except step 6 is *request*, not *create*.
+
+**UC-B1.3 — Third client, different enrollment (`alice3`, E2)**
+- **Given:** after B1.1; `pqpublickey` exists.
+- **When:** `alice3` runs the sequence.
+- **Then:** identical to B1.2 for this bootstrap (mints own PQ APKAM, requests root
+  `pqpublickey@alice⁻¹`). Distinction appears only for **namespaced** secrets — a restricted E2
+  receives a subset of `nskey` keys.
+
+## B2 · Legacy APKAM deletion consequences
+
+**UC-B2.1 — Un-upgraded copy is locked out after deletion**
+- **Given:** E1's keyfile was copied to a second host `alice1b` (against advice); `alice1`
+  upgraded and deleted the legacy APKAM pubkey; `alice1b` has not upgraded.
+- **When:** `alice1b` tries to authenticate (legacy).
+- **Then:** auth **fails** (legacy pubkey gone); `alice1b` must re-enroll. Acceptance: this is
+  the intended enforcement of "one enrollment key per keyfile."
+
+**UC-B2.2 — Grace-period variant**
+- **Given:** deployment opted into a grace period.
+- **When:** `alice1` upgrades.
+- **Then:** legacy auth survives N days then auto-deletes; `alice1b` can upgrade within the
+  window; after it, UC-B2.1 applies. (Bypass open during the window — explicit trade-off.)
+
+## B3 · Mixed-PQ within one atSign (some clients upgraded)
+
+**UC-B3.1 — Upgraded client must still write legacy for an un-upgraded sibling**
+- **Given:** `alice1.APKAM/enc = pq`, `alice2` still legacy-only; `@alice` readiness `n-r`.
+- **When:** `alice1` writes a self key both must read.
+- **Then:** `alice1` writes **legacy** (the scheme alice2 can read) — migration invariant
+  "write only what every reader supports"; no data is unreadable by alice2.
+
+**UC-B3.2 — Readiness flips once all `@alice` clients are upgraded**
+- **Given:** all `@alice` clients now PQ; operator (or auto-detect) flips readiness `ready`.
+- **When:** `alice1` writes self data.
+- **Then:** self data goes `nskey`/`pqpublickey` (PQ); no `@alice` client loses access.
+
+| client | enr | APKAM | enc-reads | enc-writes |
+|---|---|---|---|---|
+| alice1 | E1 | pq | legacy+pq | legacy (until ready) → pq |
+| alice2 | E1 | rsa | legacy | legacy |
+
+## B4 · Mixed-PQ across atSigns
+
+**UC-B4.1 — PQ-ready `@alice` shares with legacy `@bob`**
+- **Given:** `@alice` PQ-ready; `@bob` legacy (only `publickey` RSA), bob readiness `n-r`.
+- **When:** `alice1` shares `@bob:<k>.app_1.my_apps@alice`.
+- **Then:** alice writes **legacy** to bob (gated by bob's readiness); PQ self-copy for alice's
+  own clients is allowed independently. No write bob can't read.
+
+**UC-B4.2 — Legacy `@alice` receives from PQ `@bob` (and the interop question)**
+- **Given:** `@alice` legacy (no `pqpublickey`); `@bob` PQ-native.
+- **When:** `bob1` shares with `@alice`.
+- **Then:** bob must encapsulate in a scheme alice can read → **legacy RSA to alice's
+  `public:publickey@alice`**, which exists only if alice enabled the legacy-interop flag
+  (default off). **Resolved:** a PQ-native atSign is PQ-only by default, so legacy-peer send
+  to it is **unsupported unless** that flag is on (UC-A1.1).
+
+**UC-B4.3 — Partially-upgraded `@alice` (alice1 PQ, alice2 legacy) shares with `@bob`**
+- **Given:** `@alice` mixed; `@bob` PQ-ready.
+- **When:** `alice1` shares with `@bob`.
+- **Then:** to `@bob` the write may be PQ (bob is ready); but alice's **self-copy** must be
+  legacy (alice2 can't read PQ) until `@alice` readiness flips. Two directions, two schemes,
+  same `put`.
+
+**UC-B4.4 — `@bob` finishes upgrading → shared flips to PQ**
+- **Given:** `@bob` was legacy; now all bob clients PQ and bob readiness `ready`.
+- **When:** `alice1` next shares with `@bob`.
+- **Then:** alice writes `nskey`/`pqpublickey` PQ to bob; legacy path no longer needed for bob.
+
+## B5 · Retrofit edge cases
+
+**UC-B5.1 — Offline client pulls `pqpublickey` later**
+- **Given:** `alice2` was offline during the upgrade wave; `pqpublickey` created by `alice1`.
+- **When:** `alice2` next comes online and upgrades.
+- **Then:** its `requestSecret` for `pqpublickey@alice⁻¹` is answered by any online holder; persists
+  if none online until one answers.
+
+**UC-B5.2 — Reading legacy history after upgrade**
+- **Given:** `alice1` upgraded; legacy *encryption* key retained (only legacy APKAM deleted).
+- **When:** `alice1` reads pre-PQ data.
+- **Then:** decrypts via the legacy provider (reads are universal); `providerId` routes per
+  value. PQ upgrade never makes old data unreadable.
+
+**UC-B5.3 — Two clients race to create `pqpublickey`**
+- **Given:** `alice1` and `alice3` both reach the create step with `pqpublickey` absent.
+- **When:** both attempt the immutable create.
+- **Then:** exactly one wins; the other gets "already exists" and falls through to *request*.
+  No orphaned data (readiness not yet flipped).
+
+---
+
+## Decisions
+
+Resolved 2026-06-24:
+
+1. **Legacy-peer interop** (UC-A1.1, UC-B4.2): **config flag, default off** — a PQ-native
+   atSign is PQ-only by default (no RSA `public:publickey@<atSign>`); enable the flag to
+   publish it for legacy-peer inbound. A legacy peer can reach a PQ-native atSign only when
+   the flag is on.
+2. **Readiness granularity** (B3/B4): **per (atSign, namespace)**, plus an atSign-level marker
+   for the root `pqpublickey` fallback — enabling independent per-namespace rollout.
+3. **PQ APKAM placement**: **copyable keyfile** section (like the legacy APKAM). A copy made
+   *after* upgrade shares the key (revocation is per-keyfile-key, not strictly per-device); a
+   copy made *before* upgrade mints its own. Device-local/keychain is an optional hardening for
+   deployments wanting true per-host binding.
+4. **`nskey` to a new enrollment**: **push at approve + pull fallback** — the approver conveys
+   the authorised-namespace `nskey` privates in the enroll/approve bundle; `requestSecret` is
+   the backstop. (Derive-from-seed rejected — over-grants restricted enrollments.)
+5. **Seal-and-hold vs send-now** (A3.3, A4.2): **send-now via the `pqpublickey` fallback by
+   default; seal-and-hold a per-namespace opt-in** for high-security namespaces.
+
+## Coverage map (build-order checklist)
+
+| # | Cluster | UCs | Depends on |
+|---|---|---|---|
+| A1 | Onboard new atSign | A1.1 | atServer `pq` |
+| A2 | Enrollments | A2.1–A2.3 | A1 |
+| A3 | Self e2ee | A3.1–A3.3 | A2 |
+| A4 | Cross-atSign e2ee | A4.1–A4.3 | A3, peer atSign |
+| A5 | Rotation/revocation | A5.1–A5.3 | A3/A4 |
+| B0 | atServer upgrade | B0.1 | — |
+| B1 | Upgrade existing atSign | B1.1–B1.3 | B0, A* |
+| B2 | Legacy deletion | B2.1–B2.2 | B1 |
+| B3 | Mixed within atSign | B3.1–B3.2 | B1 |
+| B4 | Mixed across atSigns | B4.1–B4.4 | B1, B3 |
+| B5 | Retrofit edges | B5.1–B5.3 | B1 |


### PR DESCRIPTION
**- What I did**

Expanded the crypto planning docs with the **existing-client retrofit** design (PQ auth
upgrade + PQ-safe secret conveyance) and a **PQ use-case catalogue / detailed flows** to burn
dev down against, and resolved five open design decisions.

- **Roadmap** — new section *Existing-client retrofit — auth upgrade & key distribution*: the
  `requestSecret` named-secret primitive, the atSign-level `pqpublickey` lifecycle, the
  per-client upgrade sequence, and cardinality / legacy-key-deletion / revocation / storage.
- **Plan** — new workstream **D1-F**: the primitive, `pqpublickey` lifecycle, per-host PQ APKAM
  upgrade, revocation, the new atServer capabilities, WP10 alignment, + acceptance.
- **New docs under `docs/`**: `pq-use-case-catalogue.md` (given/when/then; Part A new-world →
  Part B retrofit), `pq-flows-detailed.md` (detailed flows incl. puts/shares **and**
  notifications), `pq-atsign-key-distribution.md` (the secret-conveyance design), and
  `crypto_plan_parallelism.md` (wave-1/wave-2 dependency analysis).
- **Resolved decisions** (catalogue *Decisions* section): legacy-peer interop = config flag,
  default off (PQ-only by default); readiness = per (atSign, namespace); PQ APKAM = copyable
  keyfile; `nskey` to a new enrollment = push-at-approve + pull fallback; cold-start = send-now
  default with per-namespace seal-and-hold opt-in.

**- How I did it**

Docs-only. Added TOCs (per the established convention) and Document-map rows; fixed
`publickey.pq`→`pqpublickey` naming; made every at-key shape complete (`public:` / self /
`@peer:` with `@owner`; example namespace `app_1.my_apps`); reframed the immutable write as the
**existing** `Metadata.immutable` feature (not a new requirement) and the secret-sharing
substrate API as **prototyped on the spike (WP-SS), not landed**.

**- How to verify it**

Read the rich diff. All intra/cross-doc anchors verified (343 links, 0 broken).

**- Skills impact**

- [x] No public API change — skill unaffected
