### PR TITLE
docs(crypto): single-tier D1 nskey data path + per-APKAM model (ADR 0002)

### DIFF
--- a/docs/adr/0001-d1-simplicity-tiers.md
+++ b/docs/adr/0001-d1-simplicity-tiers.md
@@ -1,6 +1,8 @@
-# ADR 0001 — D1 delivers as two tiers (shared `nskey` default, per-client `group` opt-in)
+# ADR 0001 — D1 delivers as two tiers (shared `nskey` default, per-APKAM `group` opt-in)
 
-- **Status:** Accepted (2026-06-20)
+> ⚠ **Superseded by [ADR 0002](0002-d1-single-tier-nskey.md).** D1 is single-tier `nskey`; the two-tier framing and the 'no forward secrecy' / 'copyable vs per-device' claims below are retained for history only — see ADR 0002 for the current model.
+
+- **Status:** Superseded by [ADR 0002](0002-d1-single-tier-nskey.md) (2026-06-25) — was Accepted (2026-06-20)
 - **Context doc:** [`docs/crypto-roadmap.md`](../crypto-roadmap.md) →
   "D1 — preserving legacy simplicity (two tiers)" and "Application migration &
   rollout".
@@ -19,7 +21,7 @@ developer experience**: *Alice shares with `@bob`; every bob client with
 namespace access, present and future, decrypts it instantly, offline, with no
 ceremony.*
 
-The earlier D1 framing made the **per-client group** model (X-Wing leaves,
+The earlier D1 framing made the **per-APKAM group** model (X-Wing leaves,
 epoch keys, explicit membership, single-owner lock) the path for *all* self and
 shared encryption. That delivers per-device revocation and a route to forward
 secrecy, but it is in direct tension with legacy simplicity:
@@ -28,7 +30,7 @@ secrecy, but it is in direct tension with legacy simplicity:
 > **copyable shared key**. Non-copyable per-device keys force re-encryption to
 > each new device (online, not instant). You cannot have both.
 
-Making per-client groups mandatory for D1 therefore taxes every app with
+Making per-APKAM groups mandatory for D1 therefore taxes every app with
 identity/membership machinery it does not need, and regresses the
 "future device just works" property that legacy apps rely on — to buy
 per-device security most namespaces never ask for.
@@ -46,17 +48,17 @@ Deliver D1 in **two tiers** over the M0 pluggable `CryptoProvider` seam:
   **opt-in** (post-compromise security at namespace granularity), distributed
   over the self-group secret channel and doubling as the revocation primitive.
 
-- **D1 Tier2 — `group` (opt-in).** The per-client group provider, declared by a
+- **D1 Tier2 — `group` (opt-in).** The per-APKAM group provider, declared by a
   namespace that needs **per-device** revocation or forward secrecy. It is also
   the **substrate D2/MLS swaps its engine into.**
 
-The prototyped per-client secret-sharing substrate is **not discarded**: in
+The prototyped per-APKAM secret-sharing substrate is **not discarded**: in
 D1 Tier1 it is the per-enrollment rotation/distribution plumbing; in D1 Tier2 it
-is the per-client data path. Senders **negotiate per-destination** (provider seam +
+is the per-APKAM data path. Senders **negotiate per-destination** (provider seam +
 `appMetadata.providerId`), downgrading to the recipient's best supported tier,
 so mixed-tier and legacy peers interoperate automatically.
 
-This reframes the *delivery* of milestones M2–M4 (per-client group → opt-in
+This reframes the *delivery* of milestones M2–M4 (per-APKAM group → opt-in
 D1 Tier2 + substrate); the milestones themselves and D2 (M5–M6) are unchanged.
 
 ## Consequences
@@ -86,10 +88,10 @@ D1 Tier2 + substrate); the milestones themselves and D2 (M5–M6) are unchanged.
 
 ## Alternatives considered
 
-- **Per-client groups mandatory for all of D1** (the prior framing) — rejected:
+- **Per-APKAM groups mandatory for all of D1** (the prior framing) — rejected:
   taxes every app, regresses instant future-client access, over-buys
   per-device security for the common case.
-- **Server-stored per-client leaf secrets** (to recover convenience) — rejected
+- **Server-stored per-APKAM leaf secrets** (to recover convenience) — rejected
   in the roadmap (Phase 2): makes cloning the default, opens a PQ
   harvest-now-decrypt-later hole, and couples key/data blast radii.
 - **Keep one atSign-wide PQ keypair** (simplest) — rejected: leaves the

--- a/docs/adr/0002-d1-single-tier-nskey.md
+++ b/docs/adr/0002-d1-single-tier-nskey.md
@@ -1,0 +1,127 @@
+# ADR 0002 — D1 is single-tier `nskey`; `at/pqmls` is D2
+
+- **Status:** Accepted (2026-06-25). **Supersedes [ADR 0001](0001-d1-simplicity-tiers.md)**.
+- **Context docs:** [`docs/crypto-roadmap.md`](../crypto-roadmap.md),
+  [`docs/pq-secret-push.md`](../pq-secret-push.md),
+  [`docs/pq-atsign-key-distribution.md`](../pq-atsign-key-distribution.md).
+
+## Table of contents
+
+- [Context](#context)
+- [The corrected key model](#the-corrected-key-model)
+- [Decision](#decision)
+- [Consequences](#consequences)
+- [Alternatives considered](#alternatives-considered)
+
+## Context
+
+[ADR 0001](0001-d1-simplicity-tiers.md) split D1 into two tiers — `nskey` (default) and an
+`at/pqmls` provider (opt-in) — on the premise that **forward secrecy / per-device revocation
+require the group (MLS-style) model**, and that a copyable shared key and per-device keys are
+mutually exclusive ("instant offline access for a future device requires a copyable shared
+key… you cannot have both").
+
+Decisions taken **since** 0001 dissolve that premise:
+
+- **Per-APKAM delivery + push** (the `enroll:listfornamespace` verb): a secret is delivered to
+  every authorised APKAM keypair, definitively and proactively. A *future* device gets the key
+  **pushed** to it — instant, offline — regardless of tier. So "future device just works" no
+  longer argues for a copyable-shared-key tier. (See `pq-secret-push.md`.)
+- **`nskey` is a KEM wrapper, not the data key.** Data is encrypted under a symmetric
+  **content/epoch key (CK)**; the CK is X-Wing-encapsulated to a per-`(atSign, namespace)`
+  `nskey`. **Neither model encrypts data per-device** — both use symmetric data keys delivered
+  per-APKAM. So 0001's "copyable shared key vs per-device keys" was a **false dichotomy**.
+
+With those corrected, `nskey` already gives D1 **coarse forward secrecy** (content-key rotation)
+and **post-compromise security** (nskey-keypair rotation); what `at/pqmls` adds is *stronger* FS,
+not FS itself. The genuine `at/pqmls`/MLS delta is **robust/per-message FS, O(log n) scale, and
+membership decoupled from namespace authorisation** — all D2 concerns. **There is no D1-internal
+Tier-1/Tier-2 boundary left.**
+
+## The corrected key model
+
+Stated explicitly so it is not re-derived wrongly (it was, repeatedly, while reaching this
+ADR):
+
+- **`nskey` is an asymmetric X-Wing KEM keypair** — the thing we *encapsulate symmetric keys
+  to*, not the thing that encrypts data. Per namespace there are **two**: a **self nskey**
+  (**not published**; Alice encapsulates her *own* content keys to it; her authorised clients
+  hold its private) and a **public nskey** (**published world-readable**; external senders
+  encapsulate content keys to it; Alice's authorised clients hold its private). Both convey
+  symmetric CKs; neither encrypts application data directly.
+- **Data is encrypted under a symmetric content/epoch key (CK)** with AES-256-GCM. The CK is
+  X-Wing-encapsulated to an `nskey`; holders of the nskey private unwrap the CK.
+- **Two delivery levels, very different costs:**
+  - *Convey the nskey private* to each authorised APKAM keypair — **per-APKAM, O(n), rare**
+    (the push + `enroll:listfornamespace` substrate; pull as backstop).
+  - *Rotate the symmetric CK* — wrap the new CK **once** to the shared nskey; every authorised
+    client unwraps with the shared private — **O(1), frequent.** This is the FS lever.
+
+## Decision
+
+**D1 ships as a single tier: `nskey`.** Forward secrecy is **in scope for D1** as a *policy*,
+not a separate tier:
+
+- Coarse FS = **rotate + delete the symmetric content/epoch keys** over the stable nskey
+  KEMs. Routine rotation is cheap (O(1) wrap to the shared nskey). FS strength is **coarse**
+  and bounded by the stable shared nskey private remaining a standing decryption capability
+  for any wrapped-CK that persists — so **deletion discipline is the FS TCB**.
+- Per-APKAM **future-data revocation** = rotate excluding the revoked keypair (the expensive
+  lever: a fresh nskey conveyed per-APKAM, since the shared-nskey O(1) path can't exclude a
+  holder of that private).
+
+**The forward-secure `at/pqmls` provider is D2, not a D1 tier.** Ratcheted per-APKAM leaves (no
+standing master key → robust/per-message FS), TreeKEM (O(log n) churn), and groups whose
+membership is decoupled from namespace authorisation are the MLS engine's job. The **same
+per-APKAM secret-sharing substrate** underpins both `nskey` (now) and MLS (later); only the
+labelling changes — what 0001 called "D1 Tier 2" is **D2's first increment**.
+
+## Consequences
+
+**Positive**
+- One D1 data path — the **`nskey` data path** (`at/nskey` conveys the content key,
+  `at/symmetric/AES/GCM` encrypts the data) — plus `legacy`; no `SecureGroup`, `KeyPackage`,
+  membership commits, or single-owner lock in the app's face for D1.
+- Legacy developer experience preserved — a future device "just works" via push; PQ +
+  namespace scoping + per-namespace blast radius by default.
+- Forward secrecy is **available** in D1 (coarse, cheap) rather than withheld to D2 — a strict
+  improvement over legacy's none, for namespaces that opt into rotation.
+
+**Negative / accepted**
+- D1 FS is **coarse** and rests on deletion discipline over **all** CK conveyances (self and
+  inbound alike) + the stable shared nskey private being a standing capability. The uniform
+  cut-CK → `at/nskey` → `at/symmetric/AES/GCM` flow makes self and inbound conveyances the same
+  kind of deletable artifact. Robust/per-message FS, large-group O(log n) scale, and
+  decoupled-membership groups require D2.
+- **Inbound (cross-atSign) data flow is structurally identical to self, but inbound FS is
+  harder to *achieve unilaterally*.** Inbound uses the SAME flow as self: the sender (`@bob`)
+  cuts a CK, delivers it **once** as a discrete `at/nskey` conveyance (encapsulated to Alice's
+  published public nskey), and writes data under `at/symmetric/AES/GCM` by kid — there is **no**
+  per-message inline-wrapped CK that "persists with the message." The same coarse-FS lever
+  (rotate + delete CKs and their `at/nskey` conveyances, bounded by the standing nskey private
+  as the TCB) applies to inbound. The residual is that forward secrecy across two atSigns is
+  inherently **bilateral**: (1) the inbound CK is cut by `@bob` on **his** cadence, so Alice
+  cannot force an FS cut finer than the sender's rotation; (2) the authoritative `at/nskey`
+  conveyance lives in a record **owned by `@bob` on bob's atServer** — Alice holds only a
+  synced cached replica, so she can purge her cache but cannot unilaterally delete bob's copy,
+  which her stable published-nskey private re-decapsulates. For **self**, Alice is both
+  endpoints — she cuts the CK and owns the authoritative conveyance + cache — so FS is
+  unilateral and complete. Closing inbound FS depends on the sender's cooperation, or the
+  heavier published-nskey rotation lever, or D2 (this bilaterality is normal for any FS system,
+  not specific to nskey).
+- **Doc cascade (completed in this change):** `crypto-roadmap.md`'s "D1 — two tiers" framing and
+  the milestone reframing were rewritten single-tier; the catalogue/flows "nskey shapes" were
+  corrected to "`nskey` is a KEM wrapping symmetric content keys" (they previously read as if
+  data were encrypted directly to the nskey).
+
+## Alternatives considered
+
+- **Keep the two D1 tiers (ADR 0001)** — rejected: the distinguishing property (FS) is a
+  rotation *policy* of the single `nskey` data path, not a separate provider; the only genuine
+  delta (fine FS, scale, decoupled membership) is D2. Two D1 tiers split on the wrong axis.
+- **Withhold forward secrecy entirely to D2** — rejected: `nskey` gives coarse FS cheaply
+  (O(1) epoch-key rotation); no reason to deny D1 a strict improvement over legacy.
+- **The 0001 "copyable shared key vs per-device keys" framing** — rejected as a false
+  dichotomy: data is encrypted under symmetric keys delivered per-APKAM; there are no
+  per-device data keys, and a future device is served by push, so instant/offline access and
+  per-APKAM revocation coexist.

--- a/docs/crypto-roadmap.md
+++ b/docs/crypto-roadmap.md
@@ -26,13 +26,13 @@ rotation, and giving applications a bootstrap path to pq-mls groups.
 - [The two major deliverables](#the-two-major-deliverables)
   - [Deliverable 1 — make Atsign Protocol messaging post-quantum safe](#deliverable-1--make-atsign-protocol-messaging-post-quantum-safe)
   - [Deliverable 2 — implement pq-mls](#deliverable-2--implement-pq-mls)
-- [D1 — preserving legacy simplicity (two tiers)](#d1--preserving-legacy-simplicity-two-tiers)
-  - [D1 Tier 1 — Baseline (the `nskey` provider, default)](#d1-tier-1--baseline-the-nskey-provider-default)
+- [D1 — preserving legacy simplicity (single-tier: the nskey data path)](#d1--preserving-legacy-simplicity-single-tier-the-nskey-data-path)
+  - [The nskey data path (D1's data path)](#the-nskey-data-path-d1s-data-path)
   - [Cold-start — bob has never run an at_talk app](#cold-start--bob-has-never-run-an-at_talk-app)
-  - [Opt-in key rotation (D1 Tier1)](#opt-in-key-rotation-d1-tier1)
+  - [Opt-in key rotation](#opt-in-key-rotation)
   - [Revocation, end to end](#revocation-end-to-end)
-  - [D1 Tier 2 — Hardened (opt-in per-device, the D2 substrate)](#d1-tier-2--hardened-opt-in-per-device-the-d2-substrate)
-  - [Mixed-tier `@alice` ↔ `@bob`](#mixed-tier-alice--bob)
+  - [`at/pqmls` is D2, not a D1 tier](#atpqmls-is-d2-not-a-d1-tier)
+  - [Mixed-scheme `@alice` ↔ `@bob`](#mixed-scheme-alice--bob)
   - [What this reframes (M0–M4)](#what-this-reframes-m0m4)
 - [Application migration & rollout](#application-migration--rollout)
   - [The invariant that makes independent upgrade safe](#the-invariant-that-makes-independent-upgrade-safe)
@@ -62,10 +62,11 @@ rotation, and giving applications a bootstrap path to pq-mls groups.
 - [Phases](#phases)
   - [Phase 0 — land the foundations](#phase-0--land-the-foundations)
   - [Phase 1 — complete the PQ primitives (at_chops)](#phase-1--complete-the-pq-primitives-at_chops)
-  - [Phase 2 — identity layer: KeyPackages and per-client AtKeys](#phase-2--identity-layer-keypackages-and-per-client-atkeys)
-  - [Phase 3 — SecureGroup v1 + the `group` provider (self encryption)](#phase-3--securegroup-v1--the-group-provider-self-encryption)
-  - [Phase 4 — cross-atSign groups (shared encryption)](#phase-4--cross-atsign-groups-shared-encryption)
-  - [Phase 5 — pq-mls engine (SecureGroup v2)](#phase-5--pq-mls-engine-securegroup-v2)
+  - [Phase 2 — identity layer: per-APKAM KeyPackages and per-APKAM AtKeys](#phase-2--identity-layer-per-apkam-keypackages-and-per-apkam-atkeys)
+  - [Phase 3 — the nskey data path (D1 self + shared)](#phase-3--the-nskey-data-path-d1-self--shared)
+  - [Phase 4 — at/pqmls (D2): intra-atSign forward-secure groups (SecureGroup v1)](#phase-4--atpqmls-d2-intra-atsign-forward-secure-groups-securegroup-v1)
+  - [Phase 5 — at/pqmls (D2): cross-atSign groups + Group Delivery Service](#phase-5--atpqmls-d2-cross-atsign-groups--group-delivery-service)
+  - [Phase 6 — pq-mls engine (SecureGroup v2)](#phase-6--pq-mls-engine-securegroup-v2)
 - [Retiring selfEncryptionKey (and shared_key.*)](#retiring-selfencryptionkey-and-shared_key)
 - [Dependencies](#dependencies)
 - [Upgrading NoPorts (with daemon-ping feature discovery)](#upgrading-noports-with-daemon-ping-feature-discovery)
@@ -91,11 +92,11 @@ jump.
 | Topic | Design (roadmap) | Build (plan) | Worked example |
 |---|---|---|---|
 | The two deliverables (D1 / D2) | [The two major deliverables](crypto-roadmap.md#the-two-major-deliverables) | [Current state (1)](crypto_impl_plan.md#1-current-state-2026-06-22) · [D1 acceptance (2)](crypto_impl_plan.md#2-d1-acceptance--what-done-means) | — |
-| D1 Tier1 — the `nskey` default | [D1 — preserving legacy simplicity](crypto-roadmap.md#d1--preserving-legacy-simplicity-two-tiers) | [D1-B (3)](crypto_impl_plan.md#d1-b--the-nskey-provider-d1-tier1--the-default) | — |
+| D1 — the nskey data path | [D1 — preserving legacy simplicity](crypto-roadmap.md#d1--preserving-legacy-simplicity-single-tier-the-nskey-data-path) | [D1-B (3)](crypto_impl_plan.md#d1-b--the-nskey-data-path-the-default-data-path) | — |
 | Migration, rollout & versioning | [Application migration & rollout](crypto-roadmap.md#application-migration--rollout) | [D1-C / D1-D (3)](crypto_impl_plan.md#d1-c--migration--rollout-machinery) | — |
 | Existing-client retrofit (auth + key dist) | [Existing-client retrofit](crypto-roadmap.md#existing-client-retrofit--auth-upgrade--key-distribution) | [D1-F (3)](crypto_impl_plan.md#d1-f--existing-client-retrofit--auth-upgrade--secret-conveyance) | — |
-| Identity, KeyPackages, self groups | [Phases 2–3](crypto-roadmap.md#phase-2--identity-layer-keypackages-and-per-client-atkeys) | [D1-E (3)](crypto_impl_plan.md#d1-e--d1-tier2-shape-corrections-fold-into-wp-gp) · [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | — |
-| Cross-atSign shared groups | [Phase 4](crypto-roadmap.md#phase-4--cross-atsign-groups-shared-encryption) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [C — `at_talk` chat](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-client-churn-at_talk) |
+| Identity, KeyPackages, the nskey data path | [Phases 2–3](crypto-roadmap.md#phase-2--identity-layer-per-apkam-keypackages-and-per-apkam-atkeys) | [D1-E (3)](crypto_impl_plan.md#d1-e--atpqmls-provider-shape-corrections-fold-into-wp-gp) · [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | — |
+| Cross-atSign shared groups (D2) | [Phase 5](crypto-roadmap.md#phase-5--atpqmls-d2-cross-atsign-groups--group-delivery-service) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [C — `at_talk` chat](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-apkam-keypair-churn-at_talk) |
 | pq-mls engine + Delivery Service | [atServer group Delivery Service](crypto-roadmap.md#atserver-group-delivery-service-target-design) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [B — a large group](crypto-walkthroughs.md#walkthrough-b--a-large-group-end-to-end) |
 | NoPorts adoption | [Upgrading NoPorts](crypto-roadmap.md#upgrading-noports-with-daemon-ping-feature-discovery) | [Cross-repo & NoPorts (5)](crypto_impl_plan.md#5-cross-repo-pr--publish-sequence--noports) | [A — NoPorts](crypto-walkthroughs.md#walkthrough-a--noports-end-to-end) |
 | Structural enablers / WASM split | [Component responsibilities & WASM-readiness](crypto-roadmap.md#component-responsibilities--wasm-readiness) | [D1-S (3)](crypto_impl_plan.md#d1-s--structural-enablers-prerequisite--lands-first) | — |
@@ -119,60 +120,92 @@ confidentiality is the defense.
 It does **not** require MLS. It is reached by routing every encryption path
 through pluggable PQ providers — X-Wing hybrid KEM (ML-KEM-768 + X25519) for key
 transport, AES-256-GCM for data — publishing a PQ enrollment-conveyance key,
-then making those providers the default for self and shared data and retiring
-the classical-only `selfEncryptionKey` and `shared_key.*`. Milestones **M0–M4**
-carry it; the v1 group engine is already PQ-native, so PQ-safe messaging does
-not wait on the MLS work.
+then making the **nskey data path** the default for self and shared data and
+retiring the classical-only `selfEncryptionKey` and `shared_key.*`. D1's data
+path is the **nskey data path** — `at/nskey` conveys a symmetric content key
+(CK) and `at/symmetric/AES/GCM` encrypts the data under it (see
+[`pq-data-encryption.md`](pq-data-encryption.md)) — **not** the group engine.
+Milestones **M0–M4** carry it; the nskey data path is PQ-native by
+construction, so PQ-safe messaging does not wait on the MLS (group) work, which
+is the separate D2 `at/pqmls` provider.
 
 ### Deliverable 2 — implement pq-mls
 
 Replace the interim v1 group engine with a real MLS engine (RFC 9420 — TreeKEM,
 forward secrecy, post-compromise security) on post-quantum ciphersuites, behind
 the same `SecureGroup` interface and served by the atServer group Delivery
-Service. This adds what D1 does not: **forward secrecy** (a compromised key
-does not expose past traffic), **post-compromise security** (a group self-heals
-after a member is compromised, once that member rotates), standardized and
-audited group semantics, and **O(log n)** membership changes that make large
-groups practical. This is the **end-state architecture**. Milestones **M5–M6**
-carry it.
+Service. D1 already gives *coarse* forward secrecy (CK rotation + delete) and
+post-compromise security (nskey-keypair rotation); what D2 adds is
+**robust/per-message FS** (ratcheted leaves, no standing master key, so a
+compromised key does not expose past traffic at message granularity),
+**scale** (O(log n) membership changes that make large groups practical), and
+**decoupled membership** (groups whose membership is not tied to namespace
+authorisation), with standardized and audited group semantics. This is the
+**end-state architecture** for the *group* path. Milestones **M5–M6** carry it.
 
-D1 makes the bytes quantum-safe; D2 makes the *group* quantum-safe,
-forward-secret, and scalable. The roadmap is deliberately shaped so D2 is an
-engine swap under D1's stable interface — not a second migration. NoPorts
-adoption (the production payoff) is reachable as soon as D1 lands, and is
-strengthened — not gated — by D2.
+D1 makes the bytes quantum-safe (with coarse FS + PCS available); D2 makes the
+*group* quantum-safe with robust/per-message forward secrecy, scale, and
+decoupled membership. The roadmap is deliberately shaped so D2 is an engine
+swap under D1's stable interface — not a second migration. NoPorts adoption
+(the production payoff) is reachable as soon as D1 lands, and is strengthened —
+not gated — by D2.
 
-## D1 — preserving legacy simplicity (two tiers)
+## D1 — preserving legacy simplicity (single-tier: the nskey data path)
 
 D1's design objective is to keep the **legacy developer experience** — *Alice
 shares with `@bob`; every bob client with namespace access, present and future,
 decrypts it instantly, offline, with no ceremony* — while making it
 post-quantum-safe and closing the cheap legacy weaknesses.
 
-The tension is real and worth stating plainly. Legacy's simplicity comes from
-**one static, shared, copyable key** (the atSign-level encryption keypair in
-every `.atKeys`), which is exactly what gives per-device security its problems.
-Per-device non-copyable rotating keys are the opposite. **You cannot have both
-"a future device just works, instantly and offline" and "non-copyable per-device
-keys"** — instant offline access for a new device fundamentally requires a
-copyable shared key (otherwise someone must re-encrypt to the new device,
-online). Legacy chose copyable; full MLS chooses re-encrypt. D1 resolves this by
-**tiering**: the default keeps legacy's shape (hardened), and per-device
-security is opt-in.
+D1 ships as a **single tier: the nskey data path** — the only data path for
+both self and shared data. The nskey data path is **two providers** —
+`at/nskey` (which conveys a symmetric content key, sealing it once to an nskey
+as a discrete record) and `at/symmetric/AES/GCM` (which encrypts the data under
+that content key) — plus the built-in `legacy` provider (a value with no
+`providerId` defaults to legacy). The "two tiers" framing of [ADR
+0001](adr/0001-d1-simplicity-tiers.md) is superseded by [ADR
+0002](adr/0002-d1-single-tier-nskey.md): the property that earlier framing
+withheld to a "Tier 2" — forward secrecy — is a *rotation policy* of the single
+nskey data path, not a separate provider, and D1 provides it **coarsely and
+cheaply** (see [`pq-data-encryption.md`](pq-data-encryption.md)). The genuine
+delta of the forward-secure (MLS) group model — robust/per-message forward
+secrecy, O(log n) large-group scale, and groups whose membership is decoupled
+from namespace authorisation — is **D2**, the `at/pqmls` provider, not a D1
+tier.
 
-The two tiers are **D1 Tier 1 — Baseline** (the simple, legacy-shaped default)
-and **D1 Tier 2 — Hardened** (opt-in per-device security). They are abbreviated
-**D1 Tier1** and **D1 Tier2** below and throughout these docs.
+What earlier framing treated as a tension — *"you cannot have both a future
+device working instantly/offline and non-copyable per-device keys"* — was a
+false dichotomy (ADR 0002). Data is encrypted under symmetric content keys
+delivered **per-APKAM** (the secret-sharing substrate + push); there are no
+per-device data keys, and a *future* device is served by **push** —
+instant, offline — so instant/offline access and per-APKAM revocation coexist
+without a second tier.
 
-### D1 Tier 1 — Baseline (the `nskey` provider, default)
+### The nskey data path (D1's data path)
 
 Replace the one atSign-wide RSA default keypair (and `selfEncryptionKey`, and
-`shared_key.*`) with a **per-`(atSign, namespace)` X-Wing keypair**:
+`shared_key.*`) with a **pair of per-`(atSign, namespace)` X-Wing KEM keypairs** —
+a **self nskey** (not published; you encapsulate your *own* content keys to it)
+and a **public nskey** (`public:nskey.<ns>@<owner>`, published for external
+senders). An nskey only ever *wraps a symmetric content key (CK)*; it never
+encrypts application data directly. The CK is conveyed **once** — sealed to an
+nskey and written as its own discrete `<ckKid>.__ck.<ns>@<owner>` record by the
+`at/nskey` provider — and every data value just **cites it by `ckKid`** (no
+sealed CK is embedded per value; this is decision (a) of
+[`pq-data-encryption.md`](pq-data-encryption.md)). Two providers therefore make
+up the path: `at/nskey` (the CK-conveyance record) and `at/symmetric/AES/GCM`
+(the data, AES-256-GCM under the cited CK).
 
-- **Self data** → encapsulate the value's data key to *your own* namespace
-  public key. **Shared data** → encapsulate it to the *recipient's* namespace
-  public key. One mechanism, both directions; `selfEncryptionKey` and
-  `shared_key.*` both retire into "encrypt to the namespace keypair".
+- **Self data** → wrap the value's symmetric CK by encapsulating the CK to *your
+  own* **self nskey**, written once as an `at/nskey` CK-conveyance record; the
+  data value is then `at/symmetric/AES/GCM` (AES-256-GCM under that CK, citing
+  `ckKid`). **Shared data** → encapsulate the CK to the *recipient's* published
+  **public nskey** (again, a discrete `at/nskey` record), and write the data
+  with `at/symmetric/AES/GCM` citing `ckKid`. One mechanism, both directions —
+  differing only in *which* nskey the CK is sealed to; `selfEncryptionKey` and
+  `shared_key.*` both retire into "convey a content key once via `at/nskey`,
+  then `at/symmetric/AES/GCM` the data under that CK, cited by `ckKid`". See
+  [`pq-data-encryption.md`](pq-data-encryption.md) for the full model.
 - **Enrollment-granular, copyable** (the legacy bargain, kept): every client of
   an `at_talk`-authorized enrollment holds the `at_talk` private key. A new
   client receives it at **enrollment approval** (the approver hands it over) or
@@ -182,15 +215,15 @@ Replace the one atSign-wide RSA default keypair (and `selfEncryptionKey`, and
   `KeyPackage`, `members`, `clientId`, or single-owner lock anywhere in the
   app's face. Identity stays the *enrollment*, exactly as legacy.
 
-What D1 Tier1 closes vs legacy, at **zero developer-visible change**:
+What D1 closes vs legacy, at **zero developer-visible change**:
 
-| Legacy weakness | D1 Tier1 (`nskey`) |
+| Legacy weakness | D1 (nskey data path) |
 |---|---|
 | Not PQ-safe (RSA-2048) | **Closed** — X-Wing hybrid KEM |
 | Crypto broader than transport (one key spans all namespaces) | **Closed** — per-namespace keypair mirrors enrollment authorization |
 | `selfEncryptionKey` sits still forever, conveyed to every enrollment | **Closed** — per-namespace, **rotatable**; per-namespace blast radius, not atSign-wide |
-| No per-device revocation granularity | **Partial** — enrollment revocation cuts future access for free (below); per-device is D1 Tier2 |
-| No rotation / forward secrecy | **Partial** — rotatable on demand (post-compromise security); no per-message FS — D1 Tier2 |
+| No per-device revocation granularity | **Closed** — per-APKAM future-data revocation: rotate the nskey keypair excluding the revoked keypair (the expensive lever, the successor nskey conveyed per-APKAM) |
+| No rotation / forward secrecy | **Coarse FS** — rotate + delete the content keys (O(1) wrap to the shared nskey); robust/per-message FS is D2 (`at/pqmls`) |
 
 ### Cold-start — bob has never run an at_talk app
 
@@ -200,9 +233,11 @@ exists from activation). Resolution: **alice uses the most specific key bob has
 published, falling back to the atSign-level PQ key.**
 
 1. Bob always has an atSign-level keypair; Phase 1 publishes a PQ sibling
-   (`public:pqpublickey@bob`). With no `at_talk` key, alice encapsulates to
-   **that** — every bob client can decrypt, instantly, like legacy (how every bob
-   client obtains the *private* half is
+   (`public:pqpublickey@bob`). With no `at_talk` public nskey, alice encapsulates
+   the **content key** to **that** root key (the data is still AES-256-GCM under
+   the CK; **data is never encrypted directly to the root key** — only the CK
+   targets it) — every bob client can then unwrap the CK and decrypt, instantly,
+   like legacy (how every bob client obtains the root key's *private* half is
    [Existing-client retrofit](#existing-client-retrofit--auth-upgrade--key-distribution)).
 2. The first bob `at_talk` client mints/derives and publishes the `at_talk`
    public key; subsequent messages **upgrade** to namespace-scoped automatically.
@@ -216,83 +251,130 @@ The tight alternative — **seal-and-hold** (don't send until bob publishes an
 `at_talk` key) — sacrifices instant send for a namespace bob may never open, so
 it is the **opt-in** choice for high-security namespaces; the default is
 send-now with the atSign fallback. *Optional optimisation:* derive bob's
-namespace keypair deterministically (HKDF(master-seed, namespace) → X-Wing
-seed), so any bob client derives the private key with **no distribution** — this
-removes bob-side distribution but not alice's need for a published public key,
-so the atSign fallback still covers true cold-start.
+namespace nskey keypair deterministically (HKDF(master-seed, namespace) → X-Wing
+seed), so any bob client derives the nskey private with **no distribution** —
+this removes bob-side distribution but not alice's need for a published public
+nskey, so the atSign fallback still covers true cold-start.
 
-### Opt-in key rotation (D1 Tier1)
+### Opt-in key rotation
 
-Rotation is the same channel the self group already uses, at enrollment
-granularity. **bob1 mints a new namespace keypair, publishes the new public key,
-and writes the new private key into the `__`-secret self-group channel** as a
-reserved secret (`__nsk.<epoch>`), PQ-wrapped per-enrollment to each `at_talk`
-enrollment's conveyance key. Other clients receive it (push); a client that
-missed it pulls (`requestSecretsFromNamespace`); a *new* client gets the current
-key at enrollment approval. This reuses the **prototyped** secret-sharing
-substrate (`__`-secrets, `excludeEnrollmentIds`) verbatim — the namespace key is
-just another secret on the channel.
+D1 has **two distinct rotation levers**, at very different costs (see [ADR
+0002](adr/0002-d1-single-tier-nskey.md) and
+[`pq-data-encryption.md` §5.4](pq-data-encryption.md#54-ck-rotation--coarse-forward-secrecy)):
 
-- **Buys:** *post-compromise security at namespace granularity* — after a
-  rotation, a key captured *before* it reads nothing written *after*. Legacy's
-  `selfEncryptionKey` could never rotate; this is a real, cheap, opt-in upgrade.
-- **Does not buy:** forward secrecy or history re-encryption — clients **retain
-  old private keys** to read old messages (history-on), so rotation changes the
-  key for *new* data only.
-- **Rotation is also the revocation primitive:** distribute the new key
-  **excluding** the revoked enrollment(s).
+- **Content-key (CK) rotation — the routine, cheap (O(1)) lever; this is the
+  coarse-FS lever.** Cut a new CK, wrap it **once** to the *shared* nskey, and
+  write that one `<ckKid>.__ck.<ns>@<owner>` record (`at/nskey`) on ordinary
+  sync; every authorised client unwraps it with the shared nskey private. New
+  data uses the new CK. For forward secrecy, **delete** the old CK's `at/nskey`
+  conveyance record and evict the cached CK — old-CK data is then undecryptable
+  (decision (a) makes this possible: the CK was never embedded in the data
+  values). The nskey keypair is unchanged; this is one record on the normal
+  data path, **not** a substrate push.
+
+- **nskey-keypair rotation — the expensive (O(n)) per-APKAM revocation +
+  post-compromise-security lever.** A client mints a new namespace nskey
+  keypair, supersedes the published `public:nskey.<ns>@<owner>`, and the new
+  **private** half is conveyed **per-APKAM** through the secret-sharing
+  substrate (`__ssenv` envelopes sealed to each authorised APKAM key package,
+  pushed via `enroll:listfornamespace`; a client that missed the push pulls it
+  via `requestSecret`; a *new* APKAM keypair receives it at enrollment
+  approval). This is O(n) in authorised APKAM keypairs — costly precisely
+  because, to **exclude** a revoked keypair, the successor cannot use the O(1)
+  shared-nskey path (a revoked holder still has the old private). This reuses
+  the **prototyped** secret-sharing substrate (`__ssenv`, `enroll:listfornamespace`,
+  `excludeEnrollmentIds`) verbatim — the nskey private is just another secret
+  on the channel.
+
+- **CK rotation buys:** *coarse forward secrecy* — after rotate-and-delete, a CK
+  captured before the cut reads nothing written after (subject to deletion
+  discipline + eviction reachability, the FS TCB). Legacy's `selfEncryptionKey`
+  could never rotate; this is a real, cheap, opt-in upgrade.
+- **nskey-keypair rotation buys:** *post-compromise security at namespace
+  granularity* — after the keypair rotates, a private captured before it reads
+  nothing wrapped to the successor.
+- **Neither buys** history re-encryption — by default clients **retain** old CKs
+  / old nskey privates to read old data (history-on), so rotation changes the
+  key for *new* data only unless FS-mode deletes the old CK.
+- **nskey-keypair rotation is also the revocation primitive:** convey the
+  successor nskey private to every authorised member **excluding** the revoked
+  APKAM keypair(s).
 
 ### Revocation, end to end
 
 Three composable moves, increasing cost:
 
-1. **Revoke the enrollment (APKAM) — free, immediate.** The atServer stops
-   authenticating that device → no new data, no new keys. Cuts *future access*
-   with zero crypto work.
-2. **Rotate the namespace key excluding that enrollment — cheap, opt-in.** Even
-   a device with cached access gets no post-rotation key.
+1. **Revoke the enrollment / APKAM keypair — free, immediate.** The atServer
+   stops authenticating that keypair → no new data, no new keys. Cuts *future
+   access* with zero crypto work.
+2. **Rotate the nskey keypair excluding that APKAM keypair — expensive (O(n)),
+   opt-in.** This is the heavier lever: the successor nskey private is conveyed
+   per-APKAM through the substrate to every member *except* the revoked one, so
+   even a device with cached access gets no successor private. (Distinct from
+   the cheap O(1) **CK rotation** above, which is the routine coarse-FS lever
+   but cannot *exclude* a holder of the shared nskey private — that is exactly
+   why excluding a keypair forces the costly per-APKAM keypair rotation.)
 3. **Re-encrypt history — expensive, rarely needed.** The only way to revoke
-   access to data the device *already pulled* — and the boundary where D1 Tier2 /
-   D2 (per-device leaves + FS) actually earns its complexity.
+   access to data the device *already pulled* — and the boundary where robust,
+   per-message forward secrecy (D2's `at/pqmls`, per-APKAM ratcheted leaves)
+   actually earns its complexity.
 
-D1 Tier1 gives "stop future access" cheaply and partly for free; "scrub the past"
-is the opt-in tier's job.
+The nskey data path gives "stop future access" two ways: cheap **coarse FS** by
+rotating + deleting the content keys (O(1)), and **per-APKAM future-data
+revocation** by rotating the nskey keypair excluding the revoked keypair (the
+expensive O(n) lever); robust per-message "scrub the past" is D2's job.
 
-### D1 Tier 2 — Hardened (opt-in per-device, the D2 substrate)
+### `at/pqmls` is D2, not a D1 tier
 
-The per-client `group` provider (KeyPackages + epoch keys + per-device
-membership) becomes an **opt-in** tier a namespace declares when it needs
-per-device revocation or forward secrecy. Most apps never touch it. Crucially
-the **secret-sharing substrate is shared** between tiers: D1 Tier1 uses it as
-*per-enrollment distribution plumbing* for rotation; D1 Tier2 uses it
-*per-client*. So the group work already prototyped is not discarded — it is the
-plumbing under D1 Tier1 and the data path of D1 Tier2. D2/MLS swaps D1 Tier2's engine.
+The per-APKAM MLS group provider — `at/pqmls`, with KeyPackages, ratcheted leaf
+keys (no standing master key → robust/per-message FS), TreeKEM (O(log n)
+churn), and membership decoupled from namespace authorisation — is **D2**, not a
+D1 tier. Most apps never touch it; the **nskey data path** serves both self and
+shared data. Crucially the **secret-sharing substrate is shared**: the nskey
+data path uses it to convey nskey **privates** per-APKAM (Layer 1); `at/pqmls`
+uses the same substrate per-APKAM for its group messages. (Routine **CK
+rotation** does *not* ride the substrate — a new CK is conveyed as one ordinary
+`at/nskey` record on normal sync, O(1); only the heavier nskey-private
+conveyance uses the per-APKAM substrate.) So the group work already prototyped
+is not discarded — it is the plumbing under the nskey data path (D1) and the
+data path of `at/pqmls` (D2). D2/MLS swaps `at/pqmls`'s engine for a full RFC
+9420 MLS engine. (See [ADR 0002](adr/0002-d1-single-tier-nskey.md).)
 
-### Mixed-tier `@alice` ↔ `@bob`
+### Mixed-scheme `@alice` ↔ `@bob`
 
 The M0 provider seam lets schemes coexist per value, so the **sender encrypts in
 the scheme the recipient can decrypt**, discovered from what the recipient
-publishes (namespace key → `nskey`; KeyPackages+group advertised → `group`; only
-an RSA pubkey → `legacy`); `appMetadata.providerId` tells the recipient which
-provider to open with. The developer writes the same `put`; the SDK negotiates
-per-destination, downgrading to the recipient's best supported tier. D1 Tier1
-clients **retain legacy capability** for un-upgraded peers.
+publishes (a published public nskey → the **nskey data path**, i.e. an
+`at/nskey` CK-conveyance record plus `at/symmetric/AES/GCM` data; KeyPackages +
+group advertised → `at/pqmls`; only an RSA pubkey → `legacy`);
+`appMetadata.providerId` on each stored value tells the recipient which provider
+to open it with — so a CK record carries `at/nskey` and a data value carries
+`at/symmetric/AES/GCM` (there is no single `nskey` providerId to open with). The
+developer writes the same `put`; the SDK negotiates per-destination, downgrading
+to the recipient's best supported scheme. nskey-data-path clients **retain
+legacy capability** for un-upgraded peers.
 
 ### What this reframes (M0–M4)
 
-The milestones stand; the *delivery* shifts from "per-client groups are the
-path" to "per-client groups are the opt-in tier and the D2 substrate":
+The milestones stand; the *delivery* shifts from "per-APKAM groups are the D1
+data path" to "the **nskey data path** is D1's single data path; the per-APKAM
+MLS group provider is **D2** (`at/pqmls`) and the secret-sharing substrate
+underpins both":
 
-- **M0 / M1** unchanged — D1 Tier1 *is* a pluggable PQ provider; it uses X-Wing +
-  the Phase-1 enrollment-conveyance PQ key.
-- **M2** (per-client identity / KeyPackages) → the **substrate + D1 Tier2**, not a
-  prerequisite for the D1 Tier1 data path; the single-owner lock is D1 Tier2 only.
-- **M3** (self encryption) → D1 Tier1 ships `nskey` self-encryption (default);
-  the per-client `group` self-encryption is D1 Tier2.
-- **M4** (cross-atSign) → D1 Tier1 ships `nskey` shared-encryption (legacy-shaped,
-  the `(atSign, namespace)` keypair used toward another atSign); the per-client
-  `(pair, namespace)` group is D1 Tier2.
-- **D2 (M5–M6)** is D1 Tier2's MLS engine — unchanged.
+- **M0 / M1** unchanged — the nskey data path's providers (`at/nskey` +
+  `at/symmetric/AES/GCM`) are pluggable PQ providers; they use X-Wing + the
+  Phase-1 enrollment-conveyance PQ key.
+- **M2** (per-APKAM identity / KeyPackages) → the **substrate** (conveys nskey
+  privates per-APKAM for D1; underpins `at/pqmls` for D2), not a separate D1
+  data path; the single-owner lock is a D2 (`at/pqmls`) concern.
+- **M3** (self encryption) → D1 ships the **nskey data path** (`at/nskey`
+  conveying the CK + `at/symmetric/AES/GCM` encrypting data) as the default self
+  *and* shared data path; the per-APKAM forward-secure group provider
+  (`at/pqmls`) is D2, not the self path.
+- **M4** (cross-atSign) → D1 ships nskey-data-path shared-encryption
+  (legacy-shaped, the recipient's published public nskey targeted toward another
+  atSign); the per-APKAM `(pair, namespace)` MLS group is D2 (`at/pqmls`).
+- **D2 (M5–M6)** is `at/pqmls`'s MLS engine — unchanged.
 
 ## Application migration & rollout
 
@@ -337,9 +419,10 @@ behaviour change:
 - **`disallowLegacyEncryption`** (working name) — a flag on `AtClientPreference`
   meaning literally *"never write new data using the legacy provider for
   encryption."* When `true`, the SDK will not use the `legacy` `CryptoProvider`
-  to encrypt; it uses a PQ provider (`nskey`, `group`, or the atSign-level PQ
-  fallback), or — if a reader can only be reached via legacy — **refuses the
-  write** rather than fall back.
+  to encrypt; it uses a PQ path (the nskey data path's `at/nskey` +
+  `at/symmetric/AES/GCM`, `at/pqmls`, or the atSign-level PQ fallback), or — if a
+  reader can only be reached via legacy — **refuses the write** rather than fall
+  back.
 - **Defaults: `false` in 3.x, `true` in 4.0.** A 3.x app is legacy-compatible by
   default and may opt into PQ-only writes early; a 4.0 app is PQ-only by default
   and may opt back out (e.g. during a long migration tail).
@@ -380,25 +463,27 @@ silently (a `false` flag SHOUTs at startup).**
 0. **Baseline.** All legacy; every value legacy-encrypted (`providerId`
    absent / `legacy`).
 1. **Rebuild, behaviour-neutral (the soak).** Rebuild any subset against the new
-   AtClient. Rebuild *alone* adds the `nskey`/`group` providers and
-   provider-routing on **read** (decrypts any future PQ data) but keeps
-   **writing legacy**. Nothing observable changes; deploy client-by-client at
-   will — a zero-risk soak.
-2. **Publish the namespace key + capability marker (still writing legacy).** The
-   first upgraded client of an atSign mints/derives the `at_talk` `nskey` public
-   key and distributes the private key to that atSign's at_talk enrollments over
-   the self-group secret channel; each atSign publishes a per-`(atSign,
-   namespace)` capability marker, **initially not-ready**. Reads can consume
-   `nskey` if any appears; writes stay legacy.
+   AtClient. Rebuild *alone* adds the nskey-data-path providers (`at/nskey` +
+   `at/symmetric/AES/GCM`) and `at/pqmls`, plus provider-routing on **read**
+   (decrypts any future PQ data) but keeps **writing legacy**. Nothing
+   observable changes; deploy client-by-client at will — a zero-risk soak.
+2. **Publish the namespace nskey + capability marker (still writing legacy).**
+   The first upgraded client of an atSign mints/derives the `at_talk` public
+   nskey, and the nskey **privates** are conveyed **per-APKAM** to that atSign's
+   `at_talk`-authorised APKAM keypairs through the secret-sharing substrate
+   (`__ssenv` push + `enroll:listfornamespace`, pull backstop); each atSign
+   publishes a per-`(atSign, namespace)` capability marker, **initially
+   not-ready**. Reads can consume nskey-data-path values if any appear; writes
+   stay legacy.
 3. **Flip readiness (per atSign, per namespace).** When an atSign's at_talk
    fleet is fully upgraded — operator-declared, or auto-detected by "no legacy
    client has checked in" — mark it ready. Then, per-destination and
    automatically: senders writing **to** that atSign's at_talk switch new writes
-   to `nskey`; that atSign's **self** data switches to `nskey`; peers still
-   legacy elsewhere keep getting legacy.
+   to the nskey data path; that atSign's **self** data switches to the nskey data
+   path; peers still legacy elsewhere keep getting legacy.
 4. **Both ends ready ⇒ end-to-end D1.** Once alice *and* bob are marked ready,
-   alice↔bob at_talk runs `nskey` (PQ + namespace-scoped) both directions. A
-   mixed pair stays legacy *in that direction only*, automatically.
+   alice↔bob at_talk runs the nskey data path (PQ + namespace-scoped) both
+   directions. A mixed pair stays legacy *in that direction only*, automatically.
 5. **Retire legacy (gradual, then the v4 default flip).** Lazy re-encrypt old
    values on touch; stop conveying `selfEncryptionKey` for at_talk — all within
    3.x. The final phase is **`at_client` 4.0**, which flips the **default** of
@@ -411,14 +496,15 @@ silently (a `false` flag SHOUTs at startup).**
 The Step-3 marker flip is the only operator judgement call: flipping it while a
 legacy client of that atSign still runs is the one way to break a reader, so it
 defaults off and the SDK can warn on a recent legacy check-in. Everywhere else,
-a write only goes `nskey` when the readers' marker says all of them can read it,
-so no client ever receives a value it cannot decrypt.
+a write only goes to the nskey data path when the readers' marker says all of
+them can read it, so no client ever receives a value it cannot decrypt.
 
 *Independence example.* alice1 upgrades alone → reads everything, writes legacy
 to bob and legacy self (alice2 legacy) → nothing changes. alice2 upgrades →
-alice marks at_talk ready → alice's *self* data goes `nskey` (both alice clients
-read it) while *shared* to bob stays legacy (bob not ready). bob1+bob2 upgrade,
-bob marks ready → shared flips to `nskey`. At no step does anyone lose access.
+alice marks at_talk ready → alice's *self* data goes to the nskey data path
+(both alice clients read it) while *shared* to bob stays legacy (bob not ready).
+bob1+bob2 upgrade, bob marks ready → shared flips to the nskey data path. At no
+step does anyone lose access.
 
 ### Capabilities by application code-change level
 
@@ -432,16 +518,17 @@ refuses rather than write legacy (see the versioning contract).
 | Capability | Rebuild only (no code) | Flag flip (minimal config) | Simple code changes |
 |---|---|---|---|
 | Read all legacy / pre-existing data | ✓ | ✓ | ✓ (incl. v4) |
-| Read PQ (`nskey`) data from upgraded peers | ✓ | ✓ | ✓ |
+| Read PQ (nskey-data-path) data from upgraded peers | ✓ | ✓ | ✓ |
 | Stay compatible with un-upgraded **legacy** peers (auto-downgrade writes) | ✓ | ✓ | ✓ when `disallowLegacyEncryption=false` (3.x default); **off when `true`** (4.x default) |
 | Per-destination auto-negotiation of scheme | ✓ | ✓ | ✓ |
 | Your new writes are PQ + namespace-scoped | ◐ off by default¹ | ✓ (prefer-best + publish readiness) | ✓ |
-| Be a PQ recipient (peers send you `nskey`); self-data PQ | ✗ (still legacy-advertised) | ✓ (readiness marker) | ✓ |
+| Be a PQ recipient (peers send you nskey-data-path values); self-data PQ | ✗ (still legacy-advertised) | ✓ (readiness marker) | ✓ |
 | `selfEncryptionKey` retired for the namespace | lazy/auto as data migrates | ✓ (accelerated) | ✓ |
-| Opt-in key rotation (namespace-granular PCS) | ✗ | ✓ (enable in `CryptoConfig`) | ✓ (+ own rotation/revocation triggers) |
+| Coarse FS — CK rotation + delete (the cheap O(1) lever) | ✗ | ✓ (enable in `CryptoConfig`) | ✓ (+ own rotation triggers) |
+| Post-compromise security — nskey-keypair rotation (namespace-granular) | ✗ | ✓ (enable in `CryptoConfig`) | ✓ (+ own rotation/revocation triggers) |
 | Strict cold-start: refuse legacy fallback, require PQ | ✗ (defaults to fallback) | ◐ (policy toggle: hold vs send) | ✓ (custom seal-and-hold / error / notify) |
-| Per-device revocation — D1 Tier2 (`group` provider) | ✗ | ✗ | ✓ (opt-in per namespace) |
-| Forward secrecy / MLS — D2 | ✗ | ✗ | ✗ (future; opt-in when shipped) |
+| Per-APKAM future-data revocation — D1 (nskey-keypair rotation, the expensive lever) | ✗ | ✓ (rotate the nskey keypair excluding the revoked keypair) | ✓ (+ own revocation triggers) |
+| Robust/per-message forward secrecy / MLS — D2 (`at/pqmls`) | ✗ | ✗ | ✗ (future; opt-in when shipped) |
 | Consent hooks / custom membership policy | ✗ | ✗ | ✓ |
 
 ¹ ◐ = available but recommended off so rebuild stays behaviour-neutral; an
@@ -454,7 +541,7 @@ everything, stay fully compatible, and become PQ-ready. *Flip one readiness
 flag* when your fleet is upgraded and your data becomes post-quantum-safe and
 namespace-scoped, negotiated down automatically for anyone still on the old
 build. Reach for *code* only to refuse legacy (strict PQ), drive your own
-rotation, or opt into per-device (D1 Tier2) security.
+rotation/revocation, or opt into robust forward-secure groups (D2, `at/pqmls`).
 
 ## Existing-client retrofit — auth upgrade & key distribution
 
@@ -483,9 +570,10 @@ PQ keys arrive at onboarding or by enroll/approve push.
 
 Every retrofit pull is one instance of a single primitive, **`requestSecret`**:
 
-> A client needs a *named secret*; at least one of its sibling clients holds it. The
-> requester asks; a holder **`pqSeal`s** the secret to the requester's
-> [`ClientKeyPackage`](#phase-2--identity-layer-keypackages-and-per-client-atkeys)
+> A client (an APKAM keypair) needs a *named secret*; at least one of its sibling APKAM
+> keypairs holds it. The requester asks; a holder **`pqSeal`s** the secret to the
+> requester's APKAM
+> [`KeyPackage`](#phase-2--identity-layer-per-apkam-keypackages-and-per-apkam-atkeys)
 > (X-Wing public key); the requester opens it with its local private half.
 
 PQ-safe by construction — the seal is X-Wing to a public key whose private half never
@@ -496,8 +584,10 @@ APKAM already enforces), and never to a revoked enrollment. This reuses the
 secret-sharing [Foundations](#foundations) substrate (`requestSecretsFromNamespace` /
 `waitForSecret` / `shareSecretWith` / `excludeEnrollmentIds`), generalised from
 request-by-namespace to request-by-name. The same primitive carries every non-derivable
-secret in D1 — `nskey` private keys, rotation epoch keys, the atSign-level PQ key — so it
-is the reusable core, not a one-off.
+secret in D1 — nskey private keys (self and public nskey), successor nskey privates on
+keypair rotation, the atSign-level PQ key — so it is the reusable core, not a one-off.
+(Routine content-key rotation does *not* use this primitive: a new CK rides ordinary sync
+as one `at/nskey` record.)
 
 **Why not the obvious shortcut.** Wrapping the secret under the shared `selfEncryptionKey`
 and storing it server-side is *not* PQ-safe: the self key is conveyed at enrollment under
@@ -527,11 +617,11 @@ Each upgrading client bootstraps both keypairs with one uniform sequence; whethe
 in advance:
 
 1. authenticate on the existing legacy connection;
-2. **mint-once per host** a PQ APKAM keypair (or reuse the one already in this host's
-   keyfile) and publish its public half as an immutable per-host record;
+2. **mint-once per keyfile** a PQ APKAM keypair (or reuse the one already in this
+   keyfile) and publish its public half as an immutable per-APKAM record;
 3. verify PQ APKAM authentication works;
 4. **delete the legacy RSA APKAM public key** — only after step 3 confirms PQ auth;
-5. save AtKeys; publish its `ClientKeyPackage`;
+5. save AtKeys; store its per-APKAM KeyPackage (a self key, not published);
 6. **attempt create** `pqpublickey`: won → generate, hold, and serve the private half;
    exists → pull, verify public/private correspondence, store;
 7. once the roster holds the key, advertise PQ readiness (atSign-wide, once).
@@ -548,24 +638,25 @@ enrollment is served a subset.
   clients/processes sharing one keyfile on one host share **one** minted PQ APKAM keypair.
   The atServer allows **multiple APKAM keypairs per enrollment**, so a copy of the keyfile
   on another host mints its own, different key. The new revocation granularity this unlocks
-  is therefore **per-host**, not per-client — sitting alongside the
-  [Phase-2](#phase-2--identity-layer-keypackages-and-per-client-atkeys) split of copyable
-  credential vs device-local material.
+  is therefore **per-APKAM**, not per-client — sitting alongside the
+  [Phase-2](#phase-2--identity-layer-per-apkam-keypackages-and-per-apkam-atkeys) split of
+  copyable credential vs device-local material.
 - **Delete the legacy APKAM key by default** (the auth key only — keep the legacy
   *encryption* key for reading history). It is both quantum-vulnerable and **shared across
-  every copy** of the keyfile; while it remains, per-host revocation is bypassable through
+  every copy** of the keyfile; while it remains, per-APKAM revocation is bypassable through
   it. Deletion enforces "one enrollment's private APKAM key lives in exactly one keyfile" —
   a copy that has not upgraded gets locked out and must re-enroll, the correct outcome for
   copying we advise against. A grace period is available as a softer deployment knob.
-- **Revocation is two axes:** *auth* (per-enrollment, or — new — **per-host** by deleting
-  that host's PQ APKAM key, contingent on the legacy key being gone) and *encryption*
-  (per-namespace key rotation, [Revocation](#revocation-end-to-end)), which controls
-  new-data access and is orthogonal to auth.
+- **Revocation is two axes:** *auth* (per-enrollment, or — new — **per-APKAM keypair** by
+  deleting that keypair's PQ APKAM key, contingent on the legacy key being gone; since one
+  host's keyfile holds one APKAM keypair, this is per-APKAM granularity) and *encryption*
+  (per-namespace nskey-keypair rotation, [Revocation](#revocation-end-to-end)), which
+  controls new-data access and is orthogonal to auth.
 - **Where the PQ APKAM key lives.** No universal way to *cryptographically* bind it to a
   host exists today (TPM/Secure Enclave lack PQ support). Default to storing it in the
   keyfile/keychain that bootstrapped it (clean for dev/test — a reused keyfile doesn't
-  re-mint); offer OS-keychain/hardware as an opt-in for single-host high-security. Per-host
-  management/revocation comes from a **distinct labelled record per host** plus
+  re-mint); offer OS-keychain/hardware as an opt-in for single-host high-security. Per-APKAM
+  management/revocation comes from a **distinct labelled record per APKAM keypair** plus
   **server-side TTL / usage-based eviction** of unused APKAM keys, which also self-cleans
   dev/test and abandoned hosts.
 
@@ -591,17 +682,40 @@ implementation plan's
 
 ## The end state
 
-The organizing idea is that the end state is a *group* abstraction in both
-directions: "the clients of @alice" is a group, and "@alice's and @bob's
-clients" is a group. Legacy treats self and shared encryption as unrelated
-mechanisms; MLS unifies them. So everything becomes a group, with a
-deliberately MLS-shaped interim implementation, and "bootstrap to pq-mls"
-is an engine swap under a stable interface rather than a redesign.
+The end state has **two data paths**, not one (see [ADR
+0002](adr/0002-d1-single-tier-nskey.md)):
+
+- **The nskey data path (D1) — the default for self *and* shared data.** Per
+  `(atSign, namespace)` X-Wing nskey keypairs (self + public) convey symmetric
+  content keys; `at/symmetric/AES/GCM` encrypts the data under them. This is
+  *not* a group abstraction — Alice's self data and her shares to `@bob` both
+  ride it, differing only in which nskey the CK is sealed to.
+- **`at/pqmls` groups (D2) — robust/per-message FS, scale, decoupled
+  membership.** "The clients of @alice" and "@alice's and @bob's clients" are
+  *groups* here, with a deliberately MLS-shaped interim engine; "bootstrap to
+  pq-mls" is an engine swap under the stable `SecureGroup` interface rather than
+  a redesign. Most apps never need it; the nskey data path covers the common
+  case.
+
+The two share the **per-APKAM secret-sharing substrate** as plumbing. The key
+hierarchies differ per path.
+
+**The nskey data-path hierarchy (D1):**
 
 ```
 enrollment approval ceremony (human/policy decision)
-  └─ APKAM keypair                    (per enrollment — auth + signing root)
-      └─ leaf identity                (per client — KeyPackage: KEM init keys + leaf signing key)
+  └─ APKAM keypair                    (per keyfile — auth root; ≥1 per enrollment)
+      └─ nskey privates               (per (atSign, namespace) — self + public; conveyed per-APKAM via the substrate)
+          └─ content key (CK)         (per (atSign, namespace) per epoch — X-Wing-sealed to an nskey; the FS lever)
+              └─ data values          (AES-256-GCM under the CK, cited by ckKid)
+```
+
+**The `at/pqmls` group hierarchy (D2):**
+
+```
+enrollment approval ceremony (human/policy decision)
+  └─ APKAM keypair                    (per keyfile — auth root; ≥1 per enrollment)
+      └─ leaf identity                (per APKAM keypair — KeyPackage: KEM init keys + leaf signing key)
           └─ group membership          (per scope — commits)
               └─ epoch secrets         (per group — lever A)
                   └─ exported secrets  (per use — ephemeral)
@@ -610,35 +724,47 @@ enrollment approval ceremony (human/policy decision)
 Each tier anchors the one below; rotating a tier invalidates downward,
 never upward.
 
-**Two-lever rotation**, independently pullable:
+**Rotation levers per path:**
 
-- **Lever A (fast/cheap): data-key epochs.** Rotate the symmetric key a
-  group encrypts under — mandatorily on every membership change, by policy
-  on time/volume. Pre-MLS: distribute a new epoch key; in MLS: a commit.
-- **Lever B (slow/identity): leaf-key rotation.** A client retires its KEM
-  or signing keypair and publishes a fresh KeyPackage; peers encapsulate to
-  the new key thereafter. In MLS: a leaf Update. Neither lever forces the
-  other.
+- **D1 nskey data path — two levers:** **CK rotation** (cheap, O(1) — wrap a new
+  content key once to the shared nskey; the coarse-FS lever) and **nskey-keypair
+  rotation** (expensive, O(n) per-APKAM — a fresh nskey conveyed via the
+  substrate; the revocation + post-compromise-security lever).
+- **D2 `at/pqmls` groups — two levers, independently pullable:** **Lever A
+  (fast/cheap): data-key epochs.** Rotate the symmetric key a group encrypts
+  under — mandatorily on every membership change, by policy on time/volume.
+  Pre-MLS: distribute a new epoch key; in MLS: a commit. **Lever B
+  (slow/identity): leaf-key rotation.** A client retires its KEM or signing
+  keypair and publishes a fresh KeyPackage; peers encapsulate to the new key
+  thereafter. In MLS: a leaf Update. Neither lever forces the other.
 
 **What becomes obsolete**: `selfEncryptionKey` (one symmetric key for all
 self data, held identically by every client, never rotated, re-conveyed to
 every new enrollment forever) and the static per-pair `shared_key.bob@alice`
-keys. Both are replaced by groups and retire on the four-phase path in
+keys. Both retire into the **nskey data path** — a content key wrapped to an
+nskey via `at/nskey`, the data AES-256-GCM under it via `at/symmetric/AES/GCM` —
+on the four-phase path in
 [Retiring selfEncryptionKey](#retiring-selfencryptionkey-and-shared_key).
 
 ### Key inventory and rotation
 
-| Key                        | Scope          | Role in the end state                                                       | Rotation                                                                              |
-|----------------------------|----------------|------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
-| APKAM keypair              | per enrollment | atServer auth + trust root for everything the client publishes (`_apsk`)      | Rare; rotation ≈ revoke + re-enroll. Revocation must pull lever A in every group touched |
-| Default encryption keypair | per atSign     | Shrinks to enrollment-approval conveyance + legacy interop                    | Rare; blast radius shrinks as legacy data migrates. Gains a PQ sibling (phase 1)         |
-| apkamSymmetricKey          | per enrollment | Approval conveyance                                                           | n/a — lives and dies with the enrollment                                                 |
-| Leaf KEM init keys         | per client     | The KeyPackage; what others encapsulate to                                    | Lever B, frequent and cheap — scheduled with bundle TTL, after use as join material      |
-| Leaf signing key           | per client     | Signs KeyPackages/envelopes (v1: = APKAM key; MLS: per-leaf, APKAM-certified) | Lever B, months / on compromise                                                          |
-| Device storage master key  | per device     | Encrypts local dynamic state (epoch table, ratchet state)                     | Local decision, on compromise; re-encrypt local store only                               |
-| Group epoch secret         | per group      | Data encryption                                                               | Lever A: every membership change (mandatory) + schedule/volume (policy)                  |
-| selfEncryptionKey          | per atSign     | Legacy self data only                                                         | **Retired** — see below                                                                  |
-| shared_key.\<atSign\>      | per pair       | Legacy shared data only                                                       | **Retired** — same path                                                                  |
+The first block is shared by both paths; the **D1** block is the nskey data
+path; the **D2** block is the `at/pqmls` group engine.
+
+| Key                        | Scope                 | Role in the end state                                                       | Rotation                                                                              |
+|----------------------------|-----------------------|------------------------------------------------------------------------------|----------------------------------------------------------------------------------------|
+| APKAM keypair              | per keyfile (= per APKAM) | atServer auth + trust root for everything the client publishes (`_apsk`); the recipient/identity unit (≥1 per enrollment) | Rare; rotation ≈ revoke + re-enroll                                              |
+| Default encryption keypair | per atSign            | Shrinks to enrollment-approval conveyance + legacy interop                    | Rare; blast radius shrinks as legacy data migrates. Gains a PQ sibling `public:pqpublickey@<owner>` (phase 1) |
+| apkamSymmetricKey          | per enrollment        | Approval conveyance                                                           | n/a — lives and dies with the enrollment                                                 |
+| **D1 — self nskey keypair**   | per (atSign, namespace) | **not published**; owner encapsulates her own CKs to it; private conveyed per-APKAM via the substrate | Keypair rotation = the expensive per-APKAM revocation lever                          |
+| **D1 — public nskey keypair** | per (atSign, namespace) | `public:nskey.<ns>@<owner>`; external senders encapsulate CKs to it; private conveyed per-APKAM | Keypair rotation = the per-APKAM revocation + PCS lever                              |
+| **D1 — content key (CK)**     | per (atSign, namespace), per epoch | AES-256-GCM data encryption; X-Wing-sealed to an nskey, cited by `ckKid` | CK rotation = the cheap O(1) coarse-FS lever (rotate + delete, conveyed as one `at/nskey` record on sync) |
+| **D2 — leaf KEM init keys**   | per-APKAM             | The KeyPackage; what others encapsulate to                                    | Lever B, frequent and cheap — scheduled with bundle TTL, after use as join material      |
+| **D2 — leaf signing key**     | per-APKAM             | Signs KeyPackages/envelopes (v1: = APKAM key; MLS: per-leaf, APKAM-certified) | Lever B, months / on compromise                                                          |
+| **D2 — device storage master key** | per device      | Encrypts local dynamic state (epoch table, ratchet state)                     | Local decision, on compromise; re-encrypt local store only                               |
+| **D2 — group epoch secret**   | per group             | Group-message data encryption                                                 | Lever A: every membership change (mandatory) + schedule/volume (policy)                  |
+| selfEncryptionKey          | per atSign            | Legacy self data only                                                         | **Retired** into the nskey data path — see below                                         |
+| shared_key.\<atSign\>      | per pair              | Legacy shared data only                                                       | **Retired** into the nskey data path — same path                                         |
 
 ## Milestones and capabilities
 
@@ -650,26 +776,30 @@ its own; later ones build on earlier. (Phase numbers cross-reference the
 |-----------|------------------|----------------|
 | **M0 · Pluggable crypto seam** (Phase 0) | Per-value `CryptoProvider` routing via `AppMetadata`; legacy + new schemes coexist | The migration machinery — old data stays readable forever, new schemes drop in as providers, no flag-day. Everything rides this seam. |
 | **M1 · PQ primitives** (Phase 1) | X-Wing hybrid KEM, AES-256-GCM, HKDF in at_chops; PQ enrollment-conveyance pubkey | Post-quantum/hybrid building blocks; closes the last harvest-now-decrypt-later hole (enrollment); the crypto-agile base. |
-| **M2 · Per-client identity / KeyPackages** (Phase 2) | Each client = a leaf (clientId + X-Wing leaf keys + signing) as an APKAM-signed KeyPackage; AtKeys device-local split | The MLS identity layer; per-device granularity + revocability; the one-leaf-per-instance correctness precondition. |
-| **M3 · SecureGroup v1 + `group` provider** (Phase 3) | `seal/open/rotate/export` + a v1 epoch engine; self data encrypted as group messages; two-lever rotation; retires `selfEncryptionKey` | First real (intra-atSign) group encryption with rotating keys + revocation; the stable interface MLS later swaps under. |
-| **M4 · Cross-atSign groups** (Phase 4) | `(pair, namespace)`-scoped groups (distinct from either self group); epoch-key delivery server-gated by namespace (push + pull); `group` serves shared keys; retires static `shared_key.*` | First cross-atSign group encryption; per-client granularity/revocability for shared data; the precursor to NoPorts sessions. |
-| **M5 · Group Delivery Service** (atServer groups) | Ciphertext-only DS atSign + group object/verbs (`seq`, log, ack, fetch); wake-then-pull; ordering + catch-up + retention | Makes group-addressed delivery scale on the pairwise substrate; solves fan-out + ordering + retention; operable as infrastructure. This is what makes *large* groups work. |
-| **M6 · pq-mls engine** (Phase 5) | Swap the v1 engine for MLS (TreeKEM, RFC 9420 FS/PCS, PQ ciphersuites) behind the same interface + DS | O(log n) commits, standardized + audited group security — the actual end state. |
+| **M2 · Per-APKAM identity / KeyPackages** (Phase 2) | Each APKAM keypair = a leaf (X-Wing leaf keys + signing) as an APKAM-signed KeyPackage; per-APKAM AtKeys (per-client AtKeys storage retired) | The MLS identity layer + the substrate beneath the nskey data path; per-APKAM granularity + revocability; the one-leaf-per-APKAM-keypair correctness precondition. |
+| **M3 · the nskey data path** (Phase 3) | The nskey data path — `at/nskey` conveys the content key + `at/symmetric/AES/GCM` encrypts the data — ships as D1's default self **and** shared encryption; coarse FS via CK rotation; per-APKAM future-data revocation + PCS via nskey-keypair rotation; retires `selfEncryptionKey`/`shared_key.*` | **Completes Deliverable 1** — PQ-safe self + shared messaging, no group machinery in the app's face. No `at/pqmls`. |
+| **M4 · `at/pqmls` intra-atSign groups (D2)** (Phase 4) | `SecureGroup` v1 epoch engine (`seal/open/rotate/export`); per-APKAM leaves; two-lever rotation | First forward-secure (intra-atSign) group encryption with rotating keys + revocation; the stable interface MLS later swaps under. |
+| **M5 · `at/pqmls` cross-atSign groups + Group Delivery Service (D2)** (Phase 5) | `(pair, namespace)`-scoped groups; `at/pqmls` serves shared group keys (cross-atSign shared data otherwise rides the nskey data path); retires static `shared_key.*`; the ciphertext-only Group Delivery Service (`seq`, log, ack, fetch; wake-then-pull; ordering/catch-up/retention) | First cross-atSign group encryption + the delivery service that makes *large* groups scale; precursor to NoPorts sessions. |
+| **M6 · pq-mls engine** (Phase 6) | Swap the v1 engine for MLS (TreeKEM, RFC 9420 FS/PCS, PQ ciphersuites) behind the same interface + DS | O(log n) commits, standardized + audited group security — the actual end state. |
 | **NoPorts adoption** (finish line) | Session keys via `SecureGroup.export`; daemon-feature-gated tiers 0–2 | The production payoff: PQ-safe NoPorts, derived (not transmitted) session keys, fleet management. |
 
 In deliverable terms (see
-[The two major deliverables](#the-two-major-deliverables)): **M0–M4 are
-Deliverable 1** (PQ-safe messaging) and **M5–M6 are Deliverable 2** (pq-mls).
+[The two major deliverables](#the-two-major-deliverables)): **M0–M3 are
+Deliverable 1** (PQ-safe messaging via the nskey data path) and **M4–M6 are
+Deliverable 2** (the `at/pqmls` group provider through to the pq-mls engine).
 The authoritative build status is the plan's
 [phase status](crypto_impl_plan.md#phase-status); in brief — M1 (X-Wing/GCM/HKDF)
-and Phase 6 (at_chops as the sole security-crypto dependency) are in trunk; the
-M0 seam is in flight (#1930); the per-client KeyPackage framing (M2) and `group`
-provider (M3) are **prototyped on the spike, not yet landed**; M4 is the main
-remaining D1 piece and M5–M6 are the D2 build ahead. The M2–M4 rows above
-describe the **per-client group** capability; per
-[D1 — preserving legacy simplicity](#d1--preserving-legacy-simplicity-two-tiers)
-that is the **opt-in D1 Tier2** and the D2 substrate — D1's *default* path is the
-simpler `nskey` shared-namespace-key tier, with the same milestones reframed.
+and the at_chops-sole-security-crypto-dependency record (a separate
+impl-plan numbering, unrelated to these crypto phases) are in trunk; the
+M0 seam is in flight (#1930); the per-APKAM KeyPackage framing (M2) and the
+v1 `at/pqmls` group provider are **prototyped on the spike, not yet landed**;
+the nskey data path is the remaining D1 piece and the cross-atSign groups, the
+MLS engine, and the DS are the D2 build ahead. The group-provider parts of the
+M3–M4 rows describe the **per-APKAM group** capability; per
+[D1 — preserving legacy simplicity](#d1--preserving-legacy-simplicity-single-tier-the-nskey-data-path)
+that is **D2** (`at/pqmls`) and the shared secret-sharing substrate — D1's data
+path (self *and* shared) is the simpler **nskey data path** (`at/nskey` +
+`at/symmetric/AES/GCM`), with the same milestones reframed.
 
 ## How it works — in brief
 
@@ -700,11 +830,12 @@ no new task and the app author writes no new code in the common case.** Every
 milestone is held to that bar; the UX mechanisms elsewhere in this doc all
 exist to keep it true. The promises, each linking to where it's realised:
 
-- **No per-invocation identity tax.** A program is never told *which* client
-  it is. The SDK resolves the leaf by label (resume / fork-ephemeral / mint),
-  so many CLI programs (sshnp, npt) and the desktop app run under one atSign
-  with **zero `--client-id` args and no clones**. →
-  [Phase 2 · Client identity resolution](#phase-2--identity-layer-keypackages-and-per-client-atkeys)
+- **No per-invocation identity tax.** A program is never told *which* APKAM
+  keypair it is. The SDK resolves the APKAM keypair (and hence its leaf) by
+  label (resume / fork-to-fresh-APKAM / mint), so many CLI programs (sshnp, npt)
+  and the desktop app run under one atSign with **zero `--client-id` args and no
+  clones** (ephemeral CLI runs use throwaway per-APKAM keypairs). →
+  [Phase 2 · Client identity resolution](#phase-2--identity-layer-per-apkam-keypackages-and-per-apkam-atkeys)
 - **No manual "add to group" step.** Admission is a *consequence* of decisions
   already made — self-group membership is derived from enrollment
   authorisation; session/cross-atSign admission rides the existing accept
@@ -721,9 +852,10 @@ exist to keep it true. The promises, each linking to where it's realised:
   (daemon-ping `supportedFeatures`) gates new behaviour per peer; an old peer
   silently keeps the legacy path. →
   [Upgrading NoPorts](#upgrading-noports-with-daemon-ping-feature-discovery)
-- **Safety is automatic.** The single-owner lock prevents leaf cloning without
-  the user knowing it exists; a duplicate same-identity launch forks or
-  refuses deterministically rather than corrupting state.
+- **Safety is automatic.** The single-owner lock prevents cloning of an APKAM
+  keypair's leaf without the user knowing it exists; a duplicate same-identity
+  launch forks (to a fresh APKAM keypair) or refuses deterministically rather
+  than corrupting state.
 - **For NoPorts the target is _zero_ user-visible delta** — same commands,
   args, setup and authorisation — contingent on the port mapping existing
   identifiers onto the new machinery. →
@@ -734,9 +866,10 @@ must pass, a file a user must manage, a step an operator must perform, or a
 peer-by-peer break? If yes, it isn't done. Two standing requirements carry
 most of the weight: **identity is derived from identifiers the program already
 has** (program/device name, an `.atsign-client` context file — never a forced
-arg), and **admission stays per-atSign** (any validly-credentialed leaf of an
-authorised atSign is accepted; per-leaf is only an *optional* refinement for
-revocation and audit). The corresponding builder-facing surface is the
+arg), and **admission stays per-atSign** (any validly-credentialed leaf — one
+per APKAM keypair — of an authorised atSign is accepted; per-APKAM granularity is
+only an *optional* refinement for revocation and audit). The corresponding
+builder-facing surface is the
 `SecureGroup` interface plus sensible `CryptoConfig` defaults — the same
 "LLM-friendly verbs, explicit semantics, no hidden invariants" goal as the
 rest of `AtCollection`.
@@ -766,17 +899,25 @@ lazy.
 `pqSeal`/`pqOpen` is the one audited public-key-encryption primitive the
 providers seal through.
 
-**Secret sharing — identity + same-atSign delivery.** Per-client identity
-(clientId + X-Wing keypair) published as an APKAM-signed `ClientKeyPackage`:
-canonical hidden public key in the enrollment's reserved namespace (location
-exclusivity = identity anchor) plus namespace-scoped copies whose *presence*
-proves the enrollment holds `rw` on that namespace (server-enforced).
-Store-and-forward encrypted envelopes scoped by application namespace;
-`SecretStore` with newest-wins merge; enrollment-approval sharing; race-free
-`waitForSecret`; crypto-agile formats (`{kid, use, alg}` key lists,
-`{keyAlg, kid, encAlg}` envelopes) so algorithms upgrade by id with no schema
-change. PQ-native: `x-wing` key transport + `aes-256-gcm` payloads. The durable
-app-facing surface will be `SecureGroup`.
+**Secret sharing — identity + same-atSign delivery.** Per-APKAM identity
+(X-Wing keypair) carried as an APKAM-signed `KeyPackage`. KeyPackages are
+**never published** — each is **enrollment-internal**, registered in that APKAM
+keypair's enrollment record alongside its ML-DSA APKAM public key, and
+discovered only via the gated **`enroll:listfornamespace:<ns>`** verb (≥`r` on
+`<ns>`; see [`pq-secret-push.md`](pq-secret-push.md)). Store-and-forward
+encrypted envelopes (`<msgId>.<kpid>.__ssenv.<ns>@<owner>`) addressed by `kpid`
+(per-APKAM) and scoped by application namespace; the atServer gates delivery by
+namespace; `SecretStore` with newest-wins merge (`putIfNewer`);
+enrollment-approval sharing; race-free `waitForSecret`; crypto-agile formats
+(`{kid, use, alg}` key lists, `{keyAlg, kid, encAlg}` envelopes) so algorithms
+upgrade by id with no schema change. PQ-native: `x-wing` key transport +
+`aes-256-gcm` payloads. **This substrate is the shared transport beneath both
+D1 and D2:** it conveys the **nskey privates** per-APKAM (Layer 1 of the nskey
+data path — `__ssenv` push via `enroll:listfornamespace`, with `requestSecret`
+pull as the offline backstop; see
+[`pq-data-encryption.md`](pq-data-encryption.md)), and it carries `at/pqmls`
+group messages per-APKAM in D2. The durable app-facing surface for the group
+path will be `SecureGroup`.
 
 **Get-path invariants** (both the secret-sharing and pluggable-crypto paths
 touch get):
@@ -805,16 +946,18 @@ metadata, or public keys:
 
 | What | How |
 |------|-----|
-| Application data — self keys, shared keys | Encrypted by the active `CryptoProvider`; `isEncrypted` metadata tracks it. End-to-end: the server never holds the data key. |
-| Secret-sharing envelopes — epoch keys (`__rk`), pairwise payloads | X-Wing-encapsulated + AES-256-GCM sealed *before* the put; written `shouldEncrypt=false` *because* the value is already ciphertext, never to store plaintext. |
+| Application data — self keys, shared keys | `at/symmetric/AES/GCM` (AES-256-GCM under a content key cited by `ckKid`); `isEncrypted` metadata tracks it. End-to-end: the server never holds the content key. |
+| Content-key conveyance — `at/nskey` records (`<ckKid>.__ck.<ns>@<owner>`) | The CK is X-Wing-sealed to an nskey *before* the put; written `shouldEncrypt=false` *because* the value is already ciphertext. The server holds only the sealed CK, never the plaintext CK or the nskey private. |
+| Secret-sharing envelopes — nskey privates (D1, Layer 1), `at/pqmls` group epoch keys (D2, `__rk`), pairwise payloads | `pqSeal` (X-Wing-encapsulated + AES-256-GCM) *before* the put; written `shouldEncrypt=false` because the value is already ciphertext. |
 | Enrollment conveyance — `apkamSymmetricKey`, `selfEncryptionKey` hand-off | RSA / X-Wing-wrapped to the recipient's encryption public key. |
 
 **Never on the atServer at all:**
 
 | What | Where it lives |
 |------|----------------|
-| Raw epoch keys (`__rk.<epoch>.<kid>` plaintext) | Local `SecretStore` (in-memory / app-pluggable persistence). Reaches the server *only* as a sealed envelope. |
-| Private keys — PKAM / encryption private, leaf KEM seed | Device-local (`.atKeys` / device-local section). The roadmap explicitly *rejects* server-side leaf secrets (Phase 2). |
+| Plaintext content keys (CKs) and nskey privates | Local `SecretStore` / keystore (in-memory / app-pluggable persistence). A CK reaches the server only as a sealed `at/nskey` record; an nskey private only as a sealed `__ssenv` envelope. |
+| Raw `at/pqmls` epoch keys (`__rk.<epoch>.<kid>` plaintext) | Local `SecretStore`. Reaches the server *only* as a sealed envelope. |
+| Private keys — PKAM / APKAM private, encryption private, nskey privates, leaf KEM seed | Device-local (`.atKeys` / device-local section). The roadmap explicitly *rejects* server-side leaf secrets (Phase 2). |
 
 **Plaintext on the atServer — by design, and not secret values:**
 
@@ -852,13 +995,14 @@ moves it implies — including making `at_auth`'s core compile under `dart2wasm`
   `CryptoProvider` for each read/write by `appMetadata.providerId` — unchanged.
 - **CryptoProviders are stateless** and encrypt/decrypt via stateless AtChops
   primitives; everything they need arrives in the per-operation `CryptoContext`.
-  A **`WritableAtKeys`** holder — the single in-memory holder of every key the
-  client knows (per-enrollment *and* per-client-id), which providers read keys
-  from and **mint/add (and occasionally remove) keys through and have them
+  A **`WritableAtKeys`** (working name; deferred — read as "the APKAM keypair's
+  updatable `.atKeys` keystore") holder — the single in-memory holder of every
+  key the client knows (per-enrollment *and* per-APKAM), which providers read
+  keys from and **mint/add (and occasionally remove) keys through and have them
   *written*** (the backing `.atKeys` file, keychain entry, or local keystore
   updated) — is added as a `CryptoContext` field alongside its first consumer
-  (D1-S). Today the context carries the client. *(`WritableAtKeys` should
-  subclass at_auth's `AtKeys`, not wrap an `AtChops`.)*
+  (D1-S). Today the context carries the client. *(It should subclass at_auth's
+  `AtKeys`, not wrap an `AtChops`.)*
 - **AtChops is fully stateless** — a grab-bag of primitive functions
   (sign/verify/encrypt/decrypt/HKDF/HMAC/…) that take keys as arguments and hold
   no key material. A `@Deprecated` stateful `AtChopsImpl` shim ships for one
@@ -874,8 +1018,8 @@ secret-sharing substrate.
 | Key class | Store | Persistence |
 |---|---|---|
 | Enrollment bootstrap (encryption/PKAM/APKAM keypair, selfEnc, apkamSym) | `.atKeys` file **or** keychain | persisted, now **updatable** (today write-once) |
-| Distributed / rotating (nskey namespace keypairs, epoch `__rk`, persistent leaf) | local keystore (Hive) | persisted, per-key |
-| Ephemeral client-id leaf | in-memory | write-only; regenerated each run |
+| Distributed / rotating (nskey namespace keypairs, content keys, D2 epoch `__rk`, persistent leaf) | local keystore (Hive) | persisted, per-key |
+| Ephemeral per-APKAM leaf (npt/sshnp throwaway keypairs) | in-memory | write-only; regenerated each run |
 
 `WritableAtKeys` is **born at AtClient construction**, composed with the stores
 then available (the auth-loaded bootstrap bundle as seed + the local keystore +
@@ -945,14 +1089,14 @@ substrate owns epoch/nskey convergence and persists *through* `WritableAtKeys`.
 ```mermaid
 graph TD
   RT["AtClient · CryptoRuntime<br/>picks provider by appMetadata.providerId"]
-  PV["CryptoProvider<br/>legacy / nskey / group"]
+  PV["CryptoProvider<br/>legacy / at/nskey / at/symmetric/AES/GCM / at/pqmls"]
   CTX["CryptoContext { WritableAtKeys }"]
   W["WritableAtKeys<br/>holder: add / remove / write"]
   AC["at_chops stateless fns<br/>seal/open · sign · HKDF (keys per call)"]
   SUB["secret-sharing substrate<br/>convergence (newest-wins) + pull"]
-  MEM["InMemoryAtKeysIo<br/>ephemeral leaf"]
+  MEM["InMemoryAtKeysIo<br/>ephemeral per-APKAM leaf"]
   BOOT["File / Keychain AtKeysIo<br/>enrollment bootstrap (updatable)"]
-  LKS["LocalKeystoreAtKeysIo<br/>nskey keypairs · epoch keys · persistent leaf"]
+  LKS["LocalKeystoreAtKeysIo<br/>nskey keypairs · content keys · D2 epoch keys · persistent leaf"]
 
   RT -->|read & write| PV
   PV --> CTX
@@ -1000,12 +1144,12 @@ see [Foundations](#foundations). Build status is the plan's
   upstream in `pqcrypto`** (which already provides ML-KEM and experimental
   ML-DSA) — offer the implementation as a contribution; the
   `AtKemAlgorithm` seam makes the swap invisible to callers. ML-DSA
-  (needed around phase 5 for PQ signatures) is likewise pqcrypto's domain;
+  (needed around phase 6 for PQ signatures) is likewise pqcrypto's domain;
   register interest, adopt when it stabilizes against FIPS 204 vectors.
 - **AES-256-GCM AEAD** — **done on `gkc-pqmls-spike`**
   (`AesGcm256EncryptionAlgo`, NIST-vector verified). **HKDF** (via
   `cryptography`) — adapter only, when its first consumer (the rotating
-  provider's `export()`) arrives in phase 3.
+  provider's `export()`) arrives in phase 4.
 - **PQ public key for enrollment conveyance.** The enrollment flow is the
   last harvest-now-decrypt-later hole: `encryptedAPKAMSymmetricKey` is
   RSA-wrapped to `public:publickey@alice`, and everything the approval
@@ -1013,36 +1157,46 @@ see [Foundations](#foundations). Build status is the plan's
   public key alongside (`public:pqpublickey@alice` or a key-list format);
   new enrollees prefer it for wrapping; approvers accept either.
 
-### Phase 2 — identity layer: KeyPackages and per-client AtKeys
+### Phase 2 — identity layer: per-APKAM KeyPackages and per-APKAM AtKeys
+
+The identity/recipient unit is the **APKAM keypair** (one per keyfile/install,
+≥1 per enrollment), not a client process. Each APKAM keypair carries exactly one
+KeyPackage and (in D2) one MLS leaf. KeyPackages are part of the D1
+secret-sharing substrate as well as the D2 identity layer, and are
+**enrollment-internal** — registered in the per-APKAM enrollment record,
+discovered only via the gated `enroll:listfornamespace` verb, never published
+(see [`pq-secret-push.md`](pq-secret-push.md)).
 
 - **Frame bundles as KeyPackages.** **Done on `gkc-pqmls-spike`**, and
   more strongly than originally planned: since `jt-pq` merged before PR
   #1976 shipped, the classical interim was deleted outright — the identity
-  layer is **PQ-native from day one** (`ClientKeyPackage` carries a single
+  layer is **PQ-native from day one** (`KeyPackage` carries a single
   `x-wing` key; envelopes carry the KEM encapsulation ciphertext and seal
   payloads with `aes-256-gcm` under the encapsulated secret; nothing
   rsa-2048 ever shipped). The Dart types use the KeyPackage naming so the
-  phase-5 MLS join is mechanical; the API surface is marked
-  `@experimental` pending the `SecureGroup` reshaping in phase 3.
-- **Evolve AtKeys for per-client persistence.** Today's `.atKeys` file is
+  phase-6 MLS join is mechanical; the API surface is marked
+  `@experimental` pending the `SecureGroup` reshaping in phase 4.
+- **Evolve AtKeys for per-APKAM persistence.** Today's `.atKeys` file is
   per-credential and routinely copied across devices; leaf keys must not be
-  (copying would clone the client identity). Split:
+  (copying would clone the APKAM keypair's leaf identity). The D1 requirement to
+  store *per-client* AtKeys no longer exists — AtKeys are stored **per-APKAM**.
+  Split:
   - *Shareable credential section* (today's content): PKAM/APKAM keypair,
     encryption keypair, apkamSymmetricKey. Copyable as today.
-  - *Device-local client section* (new; marked section or sibling file):
-    clientId, leaf KEM private keys, leaf signing key, storage master key.
-    Never copied; importing a credential file without one mints a fresh
-    client identity.
+  - *Device-local section* (new; marked section or sibling file, keyed to the
+    APKAM keypair): leaf KEM private keys, leaf signing key, storage master key,
+    plus the nskey privates the substrate conveys. Never copied; importing a
+    credential file without one mints/uses a fresh APKAM keypair.
     **This is an MLS correctness precondition, not just key hygiene.** MLS
     gives each member one ratchet-tree leaf with exclusive, linearly-evolving
-    send/commit state, so two instances sharing one clientId + leaf keys
+    send/commit state, so two instances sharing one APKAM keypair's leaf keys
     cannot both act as that leaf: concurrent sends collide on the per-leaf
     generation counter (receivers drop the duplicate as a replay, or lose the
     key to forward secrecy) and concurrent commits race on the epoch. v1's
     stateless `seal()` (epoch key + random IV, no per-sender ratchet) masks
-    this — same-clientId clones "work" on v1 and break on the MLS swap. The
-    rule: **one clientId per running instance, leaf keys never copied → one
-    leaf per instance.** Two machines that should share an identity join as
+    this — leaf-sharing clones "work" on v1 and break on the MLS swap. The
+    rule: **one leaf per APKAM keypair, leaf keys never copied.** Two machines
+    that should share an identity each mint their own APKAM keypair and join as
     two leaves of the same group, not one shared leaf.
   Dynamic state (epoch tables, ratchet state) stays out — it churns per
   commit and lives in provider-owned storage encrypted under the
@@ -1051,9 +1205,10 @@ see [Foundations](#foundations). Build status is the plan's
   `SecretStorePersistence` hooks get default SDK implementations over the
   existing keychain/biometric/file plumbing, so apps supply nothing.
 
-  **Rejected alternative — per-clientId secrets on the atServer.** Storing
-  the leaf private keys + storage master key server-side (instead of
-  device-local) was considered and rejected. To be usable they must be
+  **Rejected alternative — per-APKAM leaf secrets on the atServer.** AtKeys
+  themselves are stored per-APKAM device-local; this rejects a *different* move
+  — storing the per-APKAM **leaf private keys + storage master key**
+  server-side (instead of device-local). To be usable they must be
   wrapped under a *locally-held* key, and the only local material here is the
   *portable* enrollment credential — so the leaf becomes reconstructable by
   any enrollment-holder. That (1) makes **cloning the default** rather than a
@@ -1081,31 +1236,32 @@ see [Foundations](#foundations). Build status is the plan's
   acquisition** — eyes open that it still leaves a server-resident PQ-key
   ciphertext and complicates lever-B (superseded leaf keys linger
   server-side until actively deleted).
-- **Client identity resolution (multi-program UX).** Requiring every CLI
+- **APKAM-keypair identity resolution (multi-program UX).** Requiring every CLI
   invocation to pass `--client-id` is a usability fail; the SDK should
-  *determine* the leaf. Each device-local keyset is
-  `{clientId (random), label (local selection metadata), leafKeys, lockfile}`,
+  *determine* the APKAM keypair (and hence its leaf). Each device-local keyset
+  is `{APKAM keypair, label (local selection metadata), leafKeys, lockfile}`,
   stored per-atSign. Default `label` = program-set, falling back to the
   executable basename. Resolution at startup:
   - explicit `--client-id` → claim it (lock; error if already live);
   - else scan keysets, filter to **claimable** (not locked by a live owner):
     a claimable label-match → **resume** it (the common case); a label-match
-    that is **locked** (another instance of me) → **fork** to an *ephemeral*
-    leaf (not persisted, so no keyset proliferation); no label-match → **mint**
-    a persistent keyset for the label; keysets exist but none is mine and no
-    label to go on → an **actionable error** listing the leaves and how to
-    pick.
+    that is **locked** (another instance of me) → **fork** to a *fresh,
+    ephemeral APKAM keypair* (not persisted, so no keyset proliferation); no
+    label-match → **mint** a persistent APKAM keypair for the label; keysets
+    exist but none is mine and no label to go on → an **actionable error**
+    listing the APKAM keypairs and how to pick.
   The owner lockfile (the single-owner advisory lock) doubles as the
   resolver's liveness check — it both prevents clones and drives
-  resume-vs-fork. *Prefer resume* (fork/mint leaves are brand-new and must
-  join groups first — see Phase 4). Intentional multi-instance (a daemon
+  resume-vs-fork. *Prefer resume* (fork/mint APKAM keypairs are brand-new and
+  must join groups first — see Phase 5). Intentional multi-instance (a daemon
   fleet of stable members) uses **distinct labels / keyset dirs** (persistent
-  leaves), not forks. Per-workspace identity, if wanted, comes from a
-  discoverable `.atsign-client` file (cwd/ancestor, like `.git`/`.env`), not
-  raw cwd. Ships as the default `loadClientKeys`/`saveClientKeys`
-  implementation, so apps supply nothing; zero-argument for the normal
-  multi-program case, never clones, asks for an id only when genuinely
-  ambiguous.
+  APKAM keypairs), not forks. Ephemeral one-shot clients (npt/sshnp) are
+  throwaway per-APKAM keypairs minted fresh each run. Per-workspace identity, if
+  wanted, comes from a discoverable `.atsign-client` file (cwd/ancestor, like
+  `.git`/`.env`), not raw cwd. Ships as the default
+  `loadClientKeys`/`saveClientKeys` implementation, so apps supply nothing;
+  zero-argument for the normal multi-program case, never clones, asks for an id
+  only when genuinely ambiguous.
 - **Cross-machine single-owner (atServer lease).** The device-local lock above
   only catches duplicates on *one* machine. To stop the same logical identity
   coming live on *two* machines — e.g. an `sshnpd` labelled `device1` deployed
@@ -1119,30 +1275,93 @@ see [Foundations](#foundations). Build status is the plan's
   self-heals a crashed holder (a genuine failover/standby takes over after
   expiry), while an accidental duplicate against a *live* holder fails
   immediately; the token fences a paused-then-resumed holder (on heartbeat it
-  sees a foreign token and yields). Keying on **label** (not clientId) catches
-  the duplicate whether host B copied A's keyset or fresh-installed — both are
-  trying to be the one logical `device1`; active/standby HA falls out (the
-  standby waits for the lease to lapse). This needs **no atServer code change**
-  — an ordinary TTL'd key used as a lease, honoured by the SDK (rule of thumb:
+  sees a foreign token and yields). Keying on **label** (not the APKAM keypair)
+  catches the duplicate whether host B copied A's keyset or fresh-installed —
+  both are trying to be the one logical `device1`; active/standby HA falls out
+  (the standby waits for the lease to lapse). The secret the lease protects is
+  the APKAM keypair's leaf — two instances driving one keypair's leaf is the
+  clone, not two processes per se. This needs **no atServer code change** — an
+  ordinary TTL'd key used as a lease, honoured by the SDK (rule of thumb:
   client-side coordination via an existing primitive). A fully-authoritative
-  variant — the atServer asserts `(enrollment, clientId)` on connect and
+  variant — the atServer asserts `(enrollment, APKAM keypair)` on connect and
   rejects/evicts a duplicate session — closes the TTL window and covers
   non-SDK clients, but it is a real server change, so it is an *optional*
   escalation. (Local file lock + atServer lease compose: same-machine vs
   cross-machine.)
-- **Cross-atSign KeyPackage publication**: each atSign exposes its clients'
-  KeyPackages as public keys so other atSigns can fetch and verify them
-  (signature chain to the publishing enrollment's `_apsk` / the atSign's
-  public key, with pubkey-hash pinning as today).
-- **Per-enrollment vs per-client differences**: `.atKeys` files, keychain
+- **Cross-atSign KeyPackage discovery**: KeyPackages are **not** published as
+  public keys — they are enrollment-internal. Another atSign discovers a
+  counterparty's per-APKAM KeyPackages only via the gated
+  `enroll:listfornamespace` verb (≥`r` on the namespace), then verifies them by
+  signature chain to the publishing enrollment's `_apsk` / the atSign's public
+  key, with pubkey-hash pinning as today (see
+  [`pq-secret-push.md`](pq-secret-push.md)).
+- **Per-enrollment vs per-APKAM differences**: `.atKeys` files, keychain
   entries, and future portable key implementations contain only copyable
   enrollment-scoped material. Rotating `nskey` keypairs and persistent
-  per-client keys live in the client's local keystore (`LocalKeystoreAtKeysIo`);
-  ephemeral one-shot clients (`npt`, `sshnp`) keep per-client keys in memory
-  only and mint fresh keys on the next run. A NoPorts Desktop reinstall may
-  also mint fresh per-client keys rather than recovering the old client keys.
+  per-APKAM keys (the leaf, the nskey privates conveyed to it) live in the
+  local keystore (`LocalKeystoreAtKeysIo`); ephemeral one-shot clients (`npt`,
+  `sshnp`) are throwaway per-APKAM keypairs that keep their leaf keys in memory
+  only and mint fresh keypairs on the next run. A NoPorts Desktop reinstall
+  likewise mints a fresh APKAM keypair rather than recovering the old one.
 
-### Phase 3 — SecureGroup v1 + the `group` provider (self encryption)
+### Phase 3 — the nskey data path (D1 self + shared)
+
+D1's default data path — for **self and shared data alike** — is the **nskey
+data path**, two providers plus `legacy`. It is fully specified in
+[`pq-data-encryption.md`](pq-data-encryption.md); this is the roadmap summary.
+It does **not** involve `SecureGroup`, KeyPackages, or group membership in the
+app's face — `put`/`get`/AtCollection are unchanged.
+
+**The three layers** (the seam routes each stored value by its
+`appMetadata.providerId`):
+
+- **Layer 3 — data** (`at/symmetric/AES/GCM`): the value is AES-256-GCM
+  ciphertext under a symmetric content key (CK) and references that CK by
+  `ckKid` — no asymmetric crypto, no sealed key embedded per value.
+- **Layer 2 — CK conveyance** (`at/nskey`): the CK is X-Wing-sealed to an nskey
+  and written **once** as its own `<ckKid>.__ck.<ns>@<owner>` record; every
+  Layer-3 value under that CK just cites `ckKid` (decision (a)).
+- **Layer 1 — nskey bootstrap** (the secret-sharing substrate, beneath the
+  seam): the nskey **private** is delivered **per-APKAM** to each authorised
+  APKAM keypair's keystore (`__ssenv` push via `enroll:listfornamespace`, with
+  `requestSecret` pull as the offline backstop) — transport, not a value-level
+  provider.
+
+**Two nskeys per `(atSign, namespace)`:** a **self nskey** (not published; the
+owner encapsulates her own CKs to it) and a **public nskey**
+(`public:nskey.<ns>@<owner>`, published; external senders encapsulate CKs to
+it). An nskey only ever wraps a CK; its private only ever **decapsulates** CKs —
+neither encrypts application data.
+
+**Self and cross-atSign use one identical flow**, differing only in which nskey
+the CK is sealed to (self → own self nskey; shared → recipient's published
+public nskey). `selfEncryptionKey` and `shared_key.*` both retire into it.
+
+**Forward secrecy / revocation — two levers, very different costs:**
+
+- **CK rotation — cheap (O(1)), the coarse-FS lever.** Cut a new CK, wrap it
+  once to the shared nskey, write one `at/nskey` record on ordinary sync; for FS,
+  delete the old CK's conveyance record and evict the cached CK (decision (a)
+  makes old-CK data undecryptable). Bounded by deletion discipline + eviction
+  reachability (the FS TCB). Cross-atSign FS is bilateral — the inbound CK is
+  cut and owned by the sender, so the recipient cannot unilaterally scrub it.
+- **nskey-keypair rotation — expensive (O(n) per-APKAM), the revocation + PCS
+  lever.** Mint a fresh nskey keypair, supersede the published public nskey, and
+  convey the successor private per-APKAM through the substrate **excluding** the
+  revoked keypair (the O(1) shared path cannot exclude a holder of the old
+  private).
+
+**Cold-start.** With no `public:nskey.<ns>@<recipient>` yet, the sender seals the
+**CK** to the recipient's atSign-level `public:pqpublickey@<recipient>` (root) as
+a bootstrap target; **data is never encrypted directly to the root key** — only
+the CK is. Once the namespace publishes its public nskey, new CKs target it; the
+root-keyed conveyance is the transient bridge.
+
+This retires `selfEncryptionKey` and `shared_key.*` (see
+[Retiring selfEncryptionKey](#retiring-selfencryptionkey-and-shared_key)). The
+forward-secure group provider `at/pqmls` is **D2**, not this path — see Phase 4.
+
+### Phase 4 — at/pqmls (D2): intra-atSign forward-secure groups (SecureGroup v1)
 
 One interface, two implementations over time:
 
@@ -1169,8 +1388,10 @@ abstract class SecureGroup {
   resolvable; no coordination protocol. O(n) per commit; forward secrecy on
   rotation; PCS via full rotation. Its state — member KeyPackages, epoch
   keys, delivery channel — is exactly MLS bootstrap material.
-- **`group` CryptoProvider**: encrypts self data as group messages.
-  `AppMetadata(providerId: 'group', additional: {groupId, epoch, kid, enc,
+- **`at/pqmls` CryptoProvider** (the **D2** forward-secure group data path —
+  *not* D1's self/shared path, which is the nskey data path; see [ADR
+  0002](adr/0002-d1-single-tier-nskey.md)): encrypts group messages.
+  `AppMetadata(providerId: 'at/pqmls', additional: {groupId, epoch, kid, enc,
   iv})`. Scope = **(atSign, namespace)** — the group key topology must
   mirror the server's enrollment authorization topology, or the crypto
   layer is more permissive than the transport layer (one atSign-wide group
@@ -1200,11 +1421,11 @@ abstract class SecureGroup {
   hook was removed in the slim-API refactor).
 - **selfEncryptionKey retirement phases 1–2** begin here (below).
 
-### Phase 4 — cross-atSign groups (shared encryption)
+### Phase 5 — at/pqmls (D2): cross-atSign groups + Group Delivery Service
 
 - **Pair groups** scoped to **`(pair, namespace)`** — `groupId` e.g.
   `pair:@alice:@bob:at_talk` — not merely per atSign pair. The namespace
-  component is mandatory, for the same reason self groups carry it (Phase 3):
+  component is mandatory, for the same reason self groups carry it (Phase 4):
   the group key topology must mirror the server's enrollment authorization
   topology. A shared key `@bob:<key>.at_talk@alice` is gated on *both* sides by
   `at_talk` enrollment access, so its group must be (a) **distinct from either
@@ -1214,11 +1435,12 @@ abstract class SecureGroup {
   authorized only for `at_talk` the keys to alice→bob `banking` shared data,
   re-introducing the crypto-more-permissive-than-transport bug at the pair
   level. Members = alice's `at_talk` clients + bob's `at_talk` clients;
-  per-client leaves give cross-atSign data the same per-device granularity and
+  per-APKAM leaves give cross-atSign data the same per-APKAM granularity and
   revocability as self data (vs. legacy `shared_key.bob@alice` — one static key
   decryptable by every bob client, any namespace, forever).
-- **Add flow for another atSign's client**: fetch + verify their published
-  KeyPackages → consent hook on the invitee's side (apps may auto-accept
+- **Add flow for another atSign's client**: discover + verify their per-APKAM
+  KeyPackages (via the gated `enroll:listfornamespace` verb, not a public
+  fetch) → consent hook on the invitee's side (apps may auto-accept
   for namespaces they manage) → Add + Commit by any current member →
   Welcome delivered by ordinary cross-atSign notification (a Welcome is
   already encrypted to the KeyPackage init key; transport needs integrity
@@ -1228,10 +1450,10 @@ abstract class SecureGroup {
 - **The namespace-authorization gate is enforced by the atServer on the
   epoch-key envelopes, not chosen by the sender.** Epoch keys travel as
   secret-sharing envelopes whose key carries the application-namespace suffix
-  (`<msgId>.<recipientClientId>.__ssenv.at_talk@…`), so **the atServer gates
+  (`<msgId>.<recipientKpId>.__ssenv.at_talk@…`), so **the atServer gates
   their deliverability by `at_talk` enrollment access — the same gate as the
   shared data key itself.** The sender therefore does **not** need to (and
-  cannot) evaluate bob's per-client authorization: the committer encapsulates
+  cannot) evaluate bob's per-APKAM authorization: the committer encapsulates
   the epoch key (X-Wing) to every counterparty KeyPackage that namespace
   discovery returns (`discoverClients(namespace:)` already lists only clients
   whose enrollment is approved for the namespace), and even if it pushed to a
@@ -1250,13 +1472,16 @@ abstract class SecureGroup {
     never blocks on a recipient join, and no bob client outside `at_talk` can
     obtain the key — so first contact is eventually-consistent (bounded by the
     recipient coming online + at most one pull round-trip), never synchronous.
-- The `group` provider now serves both self and shared keys: one code path,
-  the scope key widening from `(atSign, namespace)` to `(memberSet, namespace)`
-  (self = `{atSign}`, shared = `{alice, bob}`), for the first time.
+- The `at/pqmls` provider's group scope now widens from a self group to a
+  cross-atSign group with one code path: the scope key goes from `(atSign,
+  namespace)` to `(memberSet, namespace)` (self group = `{atSign}`, shared group
+  = `{alice, bob}`), for the first time. (This is D2's forward-secure group path;
+  D1's self *and* shared data path is the nskey data path — see [ADR
+  0002](adr/0002-d1-single-tier-nskey.md).)
 - Static `shared_key.*` retirement follows the same four-phase path as
   selfEncryptionKey.
 
-### Phase 5 — pq-mls engine (SecureGroup v2)
+### Phase 6 — pq-mls engine (SecureGroup v2)
 
 - **Engine decision**: pub.dev `openmls` wrapper (ships an experimental
   X-Wing ciphersuite; third-party Rust binary — supply-chain and
@@ -1264,10 +1489,10 @@ abstract class SecureGroup {
   (multi-month). If native, ship as a separate package so `at_client`
   stays pure Dart.
 - **Bootstrap**: create the MLS group from the *same member set* (their
-  KeyPackages are already published in MLS-compatible shape), flip
+  per-APKAM KeyPackages are already registered in MLS-compatible shape), flip
   `groupId`/`providerId` on new writes, lazily re-encrypt old values on
-  touch. Welcome/Commit ride the same delivery channels (phase 3 within an
-  atSign, phase 4 across atSigns). Apps see an engine swap under the same
+  touch. Welcome/Commit ride the same delivery channels (phase 4 within an
+  atSign, phase 5 across atSigns). Apps see an engine swap under the same
   `SecureGroup` interface; the consent/membership hooks are unchanged.
 - Gains over v1: TreeKEM (O(log n) commits), real forward secrecy and
   post-compromise security per RFC 9420, standardized group semantics, and
@@ -1279,9 +1504,11 @@ abstract class SecureGroup {
 
 "Obsolete" means three different things at different times; four phases:
 
-1. **Stops being used for new writes** — the default provider flips to
-   `'group'`. Old values keep routing to `LegacyCryptoProvider` via
-   `AppMetadata`; zero breakage.
+1. **Stops being used for new writes** — the default data path flips to the
+   **nskey data path** (`at/nskey` conveys the content key; `at/symmetric/AES/GCM`
+   encrypts the data under it — there is no single `'nskey'` provider to flip
+   to). Old values keep routing to `LegacyCryptoProvider` via `AppMetadata`;
+   zero breakage.
 2. **Stops protecting old data** — lazy re-encryption on touch plus an
    optional background sweep; migration progress is observable per atSign.
 3. **Stops being conveyed** — the real kill. `enroll:approve` today always
@@ -1296,18 +1523,22 @@ abstract class SecureGroup {
 
 End state: the only symmetric key that ever sat still is gone; every
 long-lived secret is either per-enrollment (rare rotation, anchored in an
-approval ceremony) or per-client (routine lever-B rotation); everything
-that actually encrypts data is epochal and rotates as a matter of course.
+approval ceremony) or per-APKAM (the nskey privates, or — in D2 — leaf keys on
+routine lever-B rotation). What actually encrypts data is epochal and rotates as
+a matter of course: in the **nskey data path** that is the symmetric **content
+key (CK)** (rotated cheaply, conveyed via `at/nskey`); in D2 groups it is the
+epoch secret.
 
 ## Dependencies
 
 ```
 0 (foundations: provider seam + PQ primitives + secret-sharing substrate)
 └─► 1 (X-Wing, GCM, HKDF, PQ enrollment pubkey)
-    └─► 2 (KeyPackages PQ-native, AtKeys split, cross-atSign publication)
-        └─► 3 (SecureGroup v1 + group provider, self)  ─► retire sEK 1–2
-            └─► 4 (cross-atSign pair groups, shared)   ─► retire shared_key
-                └─► 5 (pq-mls engine, bootstrap)       ─► retire sEK 3–4
+    └─► 2 (per-APKAM KeyPackages PQ-native, per-APKAM AtKeys, KeyPackage discovery)
+        └─► 3 (the nskey data path: at/nskey + at/symmetric/AES/GCM, self + shared)  ─► retire sEK / shared_key 1–2
+            └─► 4 (at/pqmls D2: SecureGroup v1 + group provider, intra-atSign)
+                └─► 5 (at/pqmls D2: cross-atSign pair groups + Delivery Service)   ─► retire shared_key
+                    └─► 6 (pq-mls engine, bootstrap)       ─► retire sEK 3–4
 ```
 
 ## Upgrading NoPorts (with daemon-ping feature discovery)
@@ -1327,7 +1558,7 @@ an old daemon), and features gate behavior per session — exactly how
 
 | Feature         | Daemon advertises that it...                                                  |
 |-----------------|-------------------------------------------------------------------------------|
-| `groupCrypto`   | can decrypt notifications encrypted by the SDK's `group` provider             |
+| `groupCrypto`   | can decrypt notifications encrypted by the SDK's `at/pqmls` provider          |
 | `pqSessionKeys` | supports deriving session keys from a pair-group `export()` (none in flight)  |
 
 The crucial subtlety: a client must NOT flip its default provider for
@@ -1340,7 +1571,7 @@ Three feature-gated tiers, each strictly compatible with un-upgraded peers:
 - **Tier 0 — transport becomes PQ-safe (no protocol change).** Daemons upgrade
   first (the new SDK decrypts both legacy- and group-encrypted values via
   `AppMetadata` routing) and advertise `groupCrypto`; clients then route
-  per-destination through `group` or fall back to `legacy`. The RSA-wrapped
+  per-destination through `at/pqmls` or fall back to `legacy`. The RSA-wrapped
   session keys travel *inside* these payloads, so tier 0 alone closes the
   harvest-now hole — a recorded exchange can no longer be peeled open later.
 - **Tier 1 — derive session keys, never transmit them.** Gated on
@@ -1444,7 +1675,7 @@ nuking all of `@client`); finer `@events` audit (attribute activity to a
 leaf/device).
 
 **Residuals (the under-the-hood changes):** more SDK-managed key files
-(one persistent leaf keyset per client program + transient, non-persisted
+(one persistent leaf keyset per APKAM keypair + transient, non-persisted
 ephemerals); transient short-TTL KeyPackage churn on `@client`'s atServer
 (self-cleaning); deterministic behaviour on a duplicate same-identity launch
 (fork/refuse instead of silent coexistence — visible only at the misuse
@@ -1478,45 +1709,45 @@ survive the swap.
 
 Risks, ordered by how much cheaper they are to fix now than later:
 
-1. **Membership is implicit — a Phase-3-only shape.** The implemented
+1. **Membership is implicit — a Phase-4-only shape.** The implemented
    `SecureGroup` is `groupId / currentEpoch / seal / open / rotate /
-   export`; it dropped the `members` / `add` / `remove` that the Phase 3
+   export`; it dropped the `members` / `add` / `remove` that the Phase 4
    sketch above lists. v1 self-groups *derive* membership (`rotate()`
    re-runs `discoverClients(namespace)`), which works only because one
-   server is the authority on authorization. Cross-atSign groups (Phase 4)
+   server is the authority on authorization. Cross-atSign groups (Phase 5)
    and MLS are explicit-roster, so the interface must grow membership ops
    there — and adding methods to a published abstract is a breaking change.
    **Action: lift `members` / `add` / `remove` into the durable
    `SecureGroup` interface now, with v1 implementing them by derivation, so
-   the app surface is stable across Phases 3→4→5.** (Cheap now.)
+   the app surface is stable across Phases 4→5→6.** (Cheap now.)
 
 2. **The delivery channel is a KeyPackage directory + best-effort secret
    channel, not an ordered MLS Delivery Service.** Epoch keys and envelopes
    converge newest-`createdAt`-wins, with no ordering guarantee; the v1
    model embraces forks. MLS requires agreement on commit *order*.
-   **Action: before Phase 5, decide where commit ordering comes from —
+   **Action: before Phase 6, decide where commit ordering comes from —
    atServer sequencing, a designated per-group committer, or per-epoch
-   compare-and-set — and record it in the Phase 5 plan.** The v1 "forks are
+   compare-and-set — and record it in the Phase 6 plan.** The v1 "forks are
    fine" assumption must not leak into MLS expectations.
 
-3. **Phase 3 → Phase 4 is the real discontinuity.** The code is solidly
-   Phase 3 (`GroupCryptoProvider.encrypt` hard-rejects shared keys).
+3. **Phase 4 → Phase 5 is the real discontinuity.** The code is solidly
+   Phase 4 (`GroupCryptoProvider.encrypt` hard-rejects shared keys).
    Cross-atSign pair groups — what NoPorts actually needs — require
-   cross-atSign KeyPackage fetch+verify, a consent hook, explicit
+   cross-atSign KeyPackage discovery+verify, a consent hook, explicit
    membership, and group state not derivable from one server. That is
    mostly greenfield; the substrate covers identity + transport only.
-   **Action: scope Phase 4 as the major build it is — treat
+   **Action: scope Phase 5 as the major build it is — treat
    membership/consent/group-state as new, not as an extension of the
    self-group path.**
 
 4. **`GroupCryptoProvider` corrupts binary values.** It does
    `utf8.encode(plaintext.toString())` / `utf8.decode(...)`; the legacy
-   path honours `isBinary` but the group provider does not.
-   **Action: make the `group` provider seal/open bytes (binary-safe)
+   path honours `isBinary` but the `at/pqmls` provider does not.
+   **Action: make the `at/pqmls` provider seal/open bytes (binary-safe)
    before any binary value relies on it.**
 
 5. **Naming collision.** The v1 self engine is `PairwiseGroup` ("pairwise"
-   = the X-Wing encapsulation method), but Phase 4's cross-atSign groups
+   = the X-Wing encapsulation method), but Phase 5's cross-atSign groups
    are also called "pair groups" above. **Action: rename the v1 engine
    (e.g. `SelfGroup`) to free "pair group" for the cross-atSign meaning.**
 
@@ -1524,35 +1755,36 @@ Risks, ordered by how much cheaper they are to fix now than later:
 
 at_client uses several physical connections to the atServer (monitor /
 request-response / sync) that collectively act as one logical client. This
-is **not** the cloning hazard: the MLS leaf binds to the logical client
-that exclusively owns the mutable crypto state — the `AtClientImpl` instance
-(it owns `atChops`, `cryptoRegistry`, and the group provider via
-`CryptoRuntime`) — **not** to a connection. MLS rides above transport, so N
+is **not** the cloning hazard: the MLS leaf binds to the **APKAM keypair**,
+not to a connection or a process — a process driving an APKAM keypair acts as
+that keypair's single leaf, and the `AtClientImpl` instance exclusively owns
+the mutable crypto state for it (it owns `atChops`, `cryptoRegistry`, and the
+`at/pqmls` provider via `CryptoRuntime`). MLS rides above transport, so N
 connections under one instance = one leaf, by construction. The default
-makes this safe out of the box: `clientId` is per-process and ephemeral
-(`Uuid().v4()`, lives until the process ends), so each instance is a fresh
-leaf regardless of socket count. If anything, the model is a *positive* — it
-hands MLS a single logical-client object to anchor leaf identity and group
-state on; multiplexing connections (fewer or more) is orthogonal.
+makes this safe out of the box: an ephemeral one-shot client mints a fresh
+APKAM keypair per run (it lives until the process ends), so each such instance
+is a fresh leaf regardless of socket count. If anything, the model is a
+*positive* — it hands MLS a single APKAM-keypair leaf to anchor identity and
+group state on; multiplexing connections (fewer or more) is orthogonal.
 
 The model is safe *because* one instance owns the state, which turns into
 three obligations:
 
-- **Serialize crypto-state mutation within the instance** (engine, Phase 5).
+- **Serialize crypto-state mutation within the instance** (engine, Phase 6).
   Connections drive concurrent async work — the monitor can deliver a Commit
   (epoch change) while a request connection is mid-`seal()`. MLS generation
   /ratchet/epoch transitions are not reentrancy-safe; a mutex/sequencer must
   guard seal/open/apply-commit. Intra-instance lock, cheap — not distributed.
 - **Apply inbound handshake before sealing under the new epoch** (engine,
-  Phase 5). Commits/Welcomes arrive on the notification connection; data on
+  Phase 6). Commits/Welcomes arrive on the notification connection; data on
   get/notify; sync on its own — all converge on one epoch/ratchet that must
   advance in order. Handshake and data are one state machine, not independent
   streams.
-- **One live owner per persisted `clientId`** (identity, Phase 2). The sharp
-  edge is `loadClientKeys`, not connections: handing the same stored
-  clientId + leaf seed to two *concurrent* instances (two apps, app + daemon,
+- **One live owner per persisted APKAM keypair** (identity, Phase 2). The sharp
+  edge is `loadClientKeys`, not connections: handing the same stored APKAM
+  keypair + leaf keys to two *concurrent* instances (two apps, app + daemon,
   overlapping restart, HA pair) is the clone bug regardless of socket count.
-  Rule: a persisted leaf identity has exactly one live owner at a time —
+  Rule: a persisted APKAM-keypair leaf has exactly one live owner at a time —
   mint-fresh by default (today's behavior) or persist-with-an-exclusive
   runtime lock. That lock is two layers: a device-local file lock
   (same-machine) and an **atServer lease keyed on `(atSign, label)`**
@@ -1779,6 +2011,6 @@ The end-to-end traces that exercise this design live in their own companion,
   — Deliverable 2 at scale against the
   [group Delivery Service](#atserver-group-delivery-service-target-design):
   create, add, append, catch-up, revoke, GC.
-- **[A two-atSign chat with client churn (`at_talk`)](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-client-churn-at_talk)**
-  — the Phase 4 `(pair, namespace)` shared group with late-joining clients
+- **[A two-atSign chat with client churn (`at_talk`)](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-apkam-keypair-churn-at_talk)**
+  — the Phase 5 `(pair, namespace)` shared group with late-joining clients
   reading new *and* past messages.

--- a/docs/crypto-walkthroughs.md
+++ b/docs/crypto-walkthroughs.md
@@ -1,8 +1,8 @@
 # Crypto walkthroughs — worked end-to-end examples
 
-Worked, end-to-end traces of the post-quantum / group-first encryption design
-in action — the "how does it actually play out" companion in a three-doc set
-that shares one shape (design → build → worked example):
+Worked, end-to-end traces of the post-quantum encryption design in action — the
+"how does it actually play out" companion in a three-doc set that shares one
+shape (design → build → worked example):
 
 > - **[crypto-roadmap.md](crypto-roadmap.md)** — the design source of truth
 >   (goals, architecture, phasing, the *why*).
@@ -14,35 +14,59 @@ that shares one shape (design → build → worked example):
 > roadmap wins. See the roadmap's
 > [document map](crypto-roadmap.md#document-map) for how the sections pair up.
 
+The design has two deliverables and, per
+[ADR 0002](adr/0002-d1-single-tier-nskey.md), **D1 is a single tier — the
+`nskey` data path**:
+
+- **D1 — the nskey data path.** Application data is encrypted under a symmetric
+  **content key (CK)** with the provider **`at/symmetric/AES/GCM`**; the CK is
+  conveyed once, X-Wing-sealed to an **nskey**, by the provider **`at/nskey`**
+  (a discrete `<ckKid>.__ck` record cited by `ckKid`, never inlined per value).
+  Self data and cross-atSign sharing use the *identical* flow — only *which*
+  nskey the CK is sealed to differs (Alice's **self nskey** for her own data;
+  the recipient's published **public nskey** for a peer). The nskey *privates*
+  reach each authorised APKAM keypair per-APKAM via the secret-sharing
+  substrate (`__ssenv` push + `enroll:listfornamespace`, with `requestSecret`
+  as the pull backstop). This is D1's default for self **and** shared data;
+  see [pq-data-encryption.md](pq-data-encryption.md).
+- **D2 — `at/pqmls`.** The MLS-based forward-secure **group** provider
+  (`SecureGroup` v1 → pq-mls; TreeKEM; the atServer group Delivery Service).
+  Groups, scale, and robust/per-message forward secrecy live here — not in D1.
+
 ## Table of contents
 
 - [Walkthrough A — NoPorts, end to end](#walkthrough-a--noports-end-to-end)
   - [Feature discovery — the backwards-compatibility lever](#feature-discovery--the-backwards-compatibility-lever)
   - [One session, step by step](#one-session-step-by-step)
 - [Walkthrough B — a large group, end to end](#walkthrough-b--a-large-group-end-to-end)
-- [Walkthrough C — a two-atSign chat with client churn (`at_talk`)](#walkthrough-c--a-two-atsign-chat-with-client-churn-at_talk)
-  - [How a new client obtains the epoch key](#how-a-new-client-obtains-the-epoch-key)
-  - [New clients: new vs. past messages](#new-clients-new-vs-past-messages)
+- [Walkthrough C — a two-atSign chat with APKAM-keypair churn (`at_talk`)](#walkthrough-c--a-two-atsign-chat-with-apkam-keypair-churn-at_talk)
+  - [How a new APKAM keypair obtains the nskey private (and thence the CK)](#how-a-new-apkam-keypair-obtains-the-nskey-private-and-thence-the-ck)
+  - [New APKAM keypairs: new vs. past data](#new-apkam-keypairs-new-vs-past-data)
   - [Caveats this example surfaces](#caveats-this-example-surfaces)
 
 The three walkthroughs map onto the design's two deliverables (see
 [the two deliverables](crypto-roadmap.md#the-two-major-deliverables)):
 
 - **[Walkthrough A — NoPorts](#walkthrough-a--noports-end-to-end)** exercises
-  Deliverable 1 (PQ-safe messaging) on small groups — the production payoff.
+  Deliverable 1 (the nskey data path) for self and pair traffic and fleet
+  config — the production payoff.
 - **[Walkthrough B — a large group](#walkthrough-b--a-large-group-end-to-end)**
-  exercises Deliverable 2 (pq-mls) at scale, against the atServer group
-  Delivery Service.
-- **[Walkthrough C — a two-atSign chat](#walkthrough-c--a-two-atsign-chat-with-client-churn-at_talk)**
-  exercises the cross-atSign `(pair, namespace)` shared group with client churn.
+  exercises Deliverable 2 (`at/pqmls` / pq-mls) at scale, against the atServer
+  group Delivery Service.
+- **[Walkthrough C — a two-atSign chat](#walkthrough-c--a-two-atsign-chat-with-apkam-keypair-churn-at_talk)**
+  exercises the cross-atSign nskey data path with APKAM-keypair churn.
 
 ## Walkthrough A — NoPorts, end to end
 
 Actors: **@client** (sshnp), **@daemon** (sshnpd; a device may run many),
-**@srvd** (relay; a third atSign). Each client is a leaf with a published
-KeyPackage.
+**@srvd** (relay; a third atSign). The identity/recipient unit is the **APKAM
+keypair** (one per keyfile/install — a daemon or client may hold more than one);
+each APKAM keypair has a **per-APKAM key package** registered in its enrollment
+record (never published — see
+[pq-secret-push.md](pq-secret-push.md) section 2). NoPorts' ephemeral one-shot
+clients (npt/sshnp sessions) use throwaway per-APKAM keypairs.
 
-NoPorts is the canonical consumer: it already has the many-clients-per-atSign
+NoPorts is the canonical consumer: it already has the many-keyfiles-per-atSign
 problem (multiple sshnpd daemons per device atSign), already signs envelopes
 (its `validation_utils` is the ancestor of the SDK's `EnvelopeSigning`), and its
 main harvest-now-decrypt-later exposure is the session-key exchange (sshnpd
@@ -56,10 +80,10 @@ daemon's ping response carries `supportedFeatures: {name: bool}`
 old daemon), and features gate behaviour per session — exactly how `twinKeys`
 rolled out. Two new `DaemonFeature`s:
 
-| Feature         | Daemon advertises that it...                                                  |
-|-----------------|-------------------------------------------------------------------------------|
-| `groupCrypto`   | can decrypt notifications encrypted by the SDK's `group` provider             |
-| `pqSessionKeys` | supports deriving session keys from a pair-group `export()` (none in flight)  |
+| Feature         | Daemon advertises that it...                                                   |
+|-----------------|--------------------------------------------------------------------------------|
+| `pqData`        | can decrypt notifications written on the D1 nskey data path (`at/nskey` + GCM) |
+| `pqSessionKeys` | supports deriving session keys via the D2 `at/pqmls` group `export()` (none in flight) |
 
 The crucial subtlety: a client must NOT flip its default provider for traffic to
 a daemon that can't decrypt it. `PutRequestOptions.cryptoProviderId`
@@ -70,32 +94,35 @@ destination based on the ping response.
 
 1. **Discovery.** sshnp pings @daemon (existing flow); the ping response
    carries `supportedFeatures`, read null-tolerantly (a missing map = old
-   daemon). The client learns `groupCrypto` and `pqSessionKeys`.
-2. **Session request (Tier 0 — transport).** The client picks a provider per
-   the ping — `provider = features['groupCrypto'] ? 'group' : 'legacy'`, set
-   via `PutRequestOptions.cryptoProviderId`. With `group`, the request
-   notification is a PQ-safe group message of the @client↔@daemon pair group;
-   with `legacy`, byte-identical to today. Because the (still RSA-wrapped)
-   session key rides *inside* this payload, a recorded exchange can no longer
-   be peeled open later — the harvest-now hole is closed even before Tier 1.
+   daemon). The client learns `pqData` and `pqSessionKeys`.
+2. **Session request (the nskey data path).** The client picks a provider per
+   the ping. With `pqData`, the request notification is written on the **D1
+   nskey data path**: the client cuts (or reuses) a content key CK, conveys it
+   once via `at/nskey` sealed to @daemon's **published public nskey** for the
+   session namespace, and seals the request body with `at/symmetric/AES/GCM`
+   under that CK (citing `ckKid`). With `legacy`, it is byte-identical to
+   today. Because the (still RSA-wrapped) session key rides *inside* this
+   PQ-safe payload, a recorded exchange can no longer be peeled open later — the
+   harvest-now hole is closed.
 
    ```dart
    final features = await pingDaemon(device);            // existing flow
-   final provider = features['groupCrypto'] == true ? 'group' : 'legacy';
+   final provider = features['pqData'] == true
+       ? 'at/symmetric/AES/GCM'   // D1 nskey data path; CK conveyed via at/nskey
+       : 'legacy';
    await notify(req, ..., putRequestOptions: PutRequestOptions()
      ..cryptoProviderId = provider);
    ```
 
-3. **Session keys (Tier 1 — derive, don't transmit).** If `pqSessionKeys`,
-   both sides resolve the same pair group and derive
-   `aesC2D = pair.export('c2d:'+sessionId)` and
-   `aesD2C = pair.export('d2c:'+sessionId)`. Same `(label, epoch)` → identical
-   bytes on both sides; the response carries only `sessionId`, no key material
-   in flight, and the per-session RSA keypair generation is deleted. Without
-   `pqSessionKeys`, fall back to today's ephemeral-RSA exchange (already
-   protected by Tier 0).
+3. **Session keys (convey as a CK, don't transmit raw).** The session material
+   is conveyed as a CK on the nskey data path: it rides inside the AES-GCM body
+   above, so no key travels in the clear and the per-session RSA-2048 keypair
+   generation can be deleted. If both sides advertise `pqSessionKeys`, they may
+   *optionally* derive the session keys from a D2 `at/pqmls` pair-group
+   `export()` instead of conveying them — a D2 optimisation, not a D1 step:
 
    ```dart
+   // OPTIONAL D2 (at/pqmls) optimisation, gated on pqSessionKeys:
    // sshnpd, replacing genBundle():
    final pair = await atClient.groups
        .withAtSigns([requestingAtsign], namespace: '$device.sshnp');
@@ -106,66 +133,86 @@ destination based on the ping response.
    // sshnp: the same two export() calls; both sides derive independently
    ```
 
-   Side benefit: deletes the per-session RSA-2048 keypair generation — a
-   measurable startup win on small devices.
-4. **srvd relay.** The relay-auth key involves a third atSign; a per-session
-   3-party group is overkill, so it stays transmitted, protected by Tier 0.
-5. **Delivery.** The group is 2 atSigns (or a self group within one atSign for
-   Tier 2). The member-atSign count is tiny, so there is **no DS host** —
-   pairwise notify + the recipient atServer's sync to its own clients.
-   (Walkthrough B's Delivery Service is only for large groups.)
-6. **Fleet management (Tier 2 — self group).** Many sshnpd on one device atSign
-   plus a policy/management client are a self `SecureGroup`. Management writes
-   a config secret once; every daemon reads it, joined automatically at
-   enrollment. A stolen device → `enroll:revoke` → the daemon's leaf is
-   removed and the group rotates → everything shared after that instant is
-   unreadable by it.
+   Side benefit when this D2 path is used: deletes the per-session RSA-2048
+   keypair generation — a measurable startup win on small devices.
+4. **srvd relay.** The relay-auth key involves a third atSign; rather than seal
+   a CK to a third party's public nskey per session, it stays transmitted,
+   protected by the nskey data path of the request that carries it.
+5. **Delivery.** Self data within one atSign, and the @client↔@daemon pair, are
+   both the nskey data path — there is no group and **no DS host**. The CK
+   conveyance and the data ride ordinary pairwise notify + sync; the recipient
+   atServer syncs to that atSign's authorised APKAM keypairs. (Walkthrough B's
+   Delivery Service is only for large D2 groups.)
+6. **Fleet management (self data on the nskey data path).** Many sshnpd on one
+   device atSign plus a policy/management client share a config secret as
+   **self data**, encrypted under a CK conveyed via `at/nskey` to the device
+   atSign's **self nskey**. Management writes the secret once; every authorised
+   daemon reads it after one sync (it already holds the self-nskey private,
+   delivered per-APKAM by the substrate at enrollment). A stolen device →
+   `enroll:revoke` the offending enrollment, then **rotate the nskey keypair
+   excluding the revoked APKAM keypair** (and rotate the CK): the successor
+   conveyance is never sealed to the revoked keypair, so everything shared after
+   that instant is unreadable by it.
 
    ```dart
-   // management client, once:
-   await atClient.groups.self('policy_v2.sshnp')
-       .putSecret('webhook-token', token);
+   // management client, once — self data on the nskey data path:
+   await atClient.put(
+     AtKey()..key = 'webhook-token'..namespace = 'policy_v2.sshnp',
+     token,
+     putRequestOptions: PutRequestOptions()
+       ..cryptoProviderId = 'at/symmetric/AES/GCM'); // CK sealed to the self nskey
 
-   // every sshnpd, joined automatically at enrollment:
-   final token = await atClient.groups.self('policy_v2.sshnp')
-       .getSecret('webhook-token');
+   // every authorised sshnpd, after one sync (holds the self-nskey private):
+   final token = await atClient.get(
+     AtKey()..key = 'webhook-token'..namespace = 'policy_v2.sshnp');
 
-   // stolen device: enroll:revoke → leaf removed + group rotates;
-   // everything shared after that moment is unreadable by it
+   // stolen device: enroll:revoke → rotate the nskey keypair + CK, excluding
+   // the revoked APKAM keypair → everything after that moment is unreadable by it
    ```
 
 7. **Rollout.** (1) ship dual-stack daemons that advertise the features — safe,
-   nothing changes on the wire; (2) ship clients that prefer the features when
-   advertised; (3) once the deployed-daemon floor includes `groupCrypto`, flip
-   the client default; (4) `pqSessionKeys` retires `genBundle`/ephemeral-keypair
+   nothing changes on the wire; (2) ship clients that prefer the nskey data path
+   when `pqData` is advertised; (3) once the deployed-daemon floor includes
+   `pqData`, flip the client default to the nskey data path; (4) `pqSessionKeys`
+   (the optional D2 `at/pqmls` derivation) retires `genBundle`/ephemeral-keypair
    code when the floor allows. Consolidation bonus at any point: NoPorts can
    replace `validation_utils` signing with the SDK's `EnvelopeSigning` (its
    descendant), moving verification onto the per-enrollment `_apsk` trust chain
    — strictly better for multi-daemon deployments.
 
-Net: every request/response/heartbeat becomes PQ-safe (Tier 0), session keys
-stop travelling at all (Tier 1), and fleet secrets get rotating-key
-distribution with instant revocation (Tier 2) — with old peers always
-negotiating cleanly via feature discovery. The design requirements that keep
-this user-invisible (admission stays per-atSign; identity is derived from
-identifiers the program already has) live in the roadmap's
+Net: every request/response/heartbeat becomes PQ-safe on the nskey data path;
+the session key stops travelling raw (conveyed as a CK, or derived via the
+optional D2 `export()`); and fleet secrets distribute per-APKAM via the
+secret-sharing substrate, with **coarse forward secrecy** by CK rotation +
+deleting the old `at/nskey` conveyance and **per-APKAM future-data revocation**
+by rotating the nskey keypair to exclude a revoked keypair — with old peers
+always negotiating cleanly via feature discovery. The design requirements that
+keep this user-invisible (admission is per-APKAM within an atSign's namespace
+authorisation; identity is derived from identifiers the program already has)
+live in the roadmap's
 [NoPorts adoption](crypto-roadmap.md#upgrading-noports-with-daemon-ping-feature-discovery).
 
 ## Walkthrough B — a large group, end to end
 
+This is a **D2 (`at/pqmls`)** scenario — genuine forward-secure groups, not the
+D1 nskey data path.
+
 Actors: a dedicated DS atSign **`@my_org_groups`** running the
 [group Delivery Service](crypto-roadmap.md#atserver-group-delivery-service-target-design);
-admins **@alice**, **@bob**; members across many atSigns, each a leaf with a
-published KeyPackage.
+admins **@alice**, **@bob**; members across many atSigns. The membership unit is
+the **APKAM keypair**: each authorised APKAM keypair is a leaf with a **per-APKAM
+key package** registered in its enrollment record (never published; discovered
+only via the gated `enroll:listfornamespace` verb).
 
 1. **Provision the DS.** `@my_org_groups` is operated as infrastructure (HA,
    monitored, backed up). It is ciphertext-only — never a group member, never
    holds group keys.
 2. **Create.** `@alice` → `group:create{groupId, ownerAcl:[@alice,@bob]}`. The
    DS provisions the group object: roster, `seq=0`, empty TTL'd log.
-3. **Add a member (@frank).** An admin: fetches + verifies @frank's published
-   KeyPackage; commits an Add locally (advances the epoch), producing a Commit
-   + a Welcome; sends the **Welcome pairwise** to @frank (1:1); then
+3. **Add a member (@frank).** An admin: fetches + verifies @frank's per-APKAM
+   key package (via the gated verb, not a public lookup); commits an Add locally
+   (advances the epoch), producing a Commit + a Welcome; sends the **Welcome
+   pairwise** to @frank (1:1); then
    `group:append{kind:commit, value:<commit ct>, msgId}` + `group:add @frank`
    to the DS. The DS assigns `seq=N`, logs it, adds @frank to the roster, and
    fans out `{group, N}` **wakes** to every member atSign. Members
@@ -175,9 +222,10 @@ published KeyPackage.
    the epoch key, then one `group:append{kind:app, value:<ct>, expiresAt,...}`
    to the DS. The DS assigns the next `seq`, logs (with the app TTL), fans out
    wakes. Each member atServer pulls the delta into local storage; that
-   atSign's many clients then read it via ordinary sync — including the
-   sender's *own* other clients (the DS fans out to the sender's atSign too).
-   Cost: one append + O(member-atSigns) wakes/pulls — never O(member-clients).
+   atSign's authorised APKAM keypairs then read it via ordinary sync —
+   including the sender's *own* other APKAM keypairs (the DS fans out to the
+   sender's atSign too). Cost: one append + O(member-atSigns) wakes/pulls —
+   never O(member-APKAMs).
 5. **Concurrent admins.** @alice and @bob both commit at epoch N. Both
    `group:append`; the DS's atomic `seq` orders them — one lands at N, the
    other gets a conflict, rebases to N+1, resubmits. No fork.
@@ -188,9 +236,11 @@ published KeyPackage.
    admin **re-adds it at the current epoch** (fresh Welcome), not a
    full-history replay.
 7. **Remove / revoke (@grace).** An admin commits a Remove + rotates the epoch
-   (`excludeEnrollmentIds`), then `group:append{kind:commit}` +
-   `group:remove @grace`. The DS sequences, fans out, drops @grace from the
-   roster. Everything from the new epoch on is unreadable by @grace.
+   (`excludeEnrollmentIds` — the per-enrollment/per-APKAM revocation lever, the
+   same lever the D1 nskey data path uses for keypair rotation), then
+   `group:append{kind:commit}` + `group:remove @grace`. The DS sequences, fans
+   out, drops @grace from the roster. Everything from the new epoch on is
+   unreadable by @grace.
 8. **Retention & GC.** Members periodically `group:ack{seq}`; the DS truncates
    the log below the min high-water mark (everyone has those) or a deadline.
    App messages expire per their `expiresAt`; commits are retained until
@@ -201,153 +251,195 @@ published KeyPackage.
    leaf, and reorder/withhold is detectable via the MLS transcript hash.
 10. **Engine (v2).** The crypto is MLS: TreeKEM makes each commit O(log n)
     instead of O(n), with RFC 9420 forward secrecy and post-compromise
-    security — all behind the same `SecureGroup` interface and the same DS.
+    security — all behind the same `SecureGroup` engine symbol and the same DS.
+    The **provider id is `at/pqmls`** (the D2 provider); the Dart engine symbols
+    (`SecureGroup`, `GroupCryptoProvider`) are unchanged. This is D2, not a D1
+    tier.
 
 Net: members send/admin once to the DS; the DS sequences and fans out
 ciphertext it can't read; catch-up, retention, ordering, and revocation are
 handled at the group object — and the per-message cost scales with the number
-of member *atSigns*, not member *clients*.
+of member *atSigns*, not member *APKAM keypairs*.
 
-## Walkthrough C — a two-atSign chat with client churn (`at_talk`)
+## Walkthrough C — a two-atSign chat with APKAM-keypair churn (`at_talk`)
 
-A worked example of the Phase 4 `(pair, namespace)` shared group: two atSigns,
-multiple clients each, bidirectional messaging, and late-joining clients. It
-shows exactly how decryption stays scoped to namespace-authorized clients on
-both sides, and how a freshly-created client reads new *and* past messages. The
-design it realises is the roadmap's
-[Phase 4 — cross-atSign groups](crypto-roadmap.md#phase-4--cross-atsign-groups-shared-encryption).
+A worked example of the **cross-atSign nskey data path** (D1): two atSigns,
+multiple APKAM keypairs each, bidirectional messaging, and late-joining APKAM
+keypairs. It shows exactly how decryption stays scoped to the namespace-authorised
+APKAM keypairs on both sides, and how a freshly-enrolled APKAM keypair reads new
+*and* past data. The design it realises is the roadmap's
+[Phase 3 — the nskey data path](crypto-roadmap.md#phase-3--the-nskey-data-path-d1-self--shared)
+and [pq-data-encryption.md](pq-data-encryption.md) section 5.3 (cross-atSign put
++ read).
 
-**Setup.** `alice1`, `alice2`, `bob1`, `bob2` exist, each has `rw` on the
-`at_talk` namespace and has published a KeyPackage (X-Wing leaf KEM key +
-APKAM-certified signing key). The group is **`pair:@alice:@bob:at_talk`** —
-canonical atSign ordering so both sides compute the same `groupId`; one
-symmetric group, both directions sealing under the same epoch key. Members =
-`{alice1, alice2, bob1, bob2}`. Epoch key `E1` is the AES-256-GCM key the group
-encrypts under, minted lazily on first use.
+**Setup.** Four APKAM keypairs — `Ka1`, `Ka2` under `@alice` and `Kb1`, `Kb2`
+under `@bob` — each authorised (`rw`) on the `at_talk` namespace, each with a
+**per-APKAM key package** registered in its enrollment record (an X-Wing
+encapsulation key + APKAM-certified signing key; **not** published). The
+relevant keys are each atSign's `at_talk` **nskeys**: `@alice`'s self nskey +
+published `public:nskey.at_talk@alice`, and `@bob`'s likewise. There is **no
+group and no epoch key** — Alice→Bob data is encrypted under a content key
+**CK** (AES-256-GCM), conveyed once via `at/nskey` sealed to **Bob's published
+public nskey**; Bob→Alice symmetrically, sealed to Alice's public nskey. Alice's
+own clients read her sent CKs via her **self nskey**. CKs are minted lazily on
+first use.
 
-**Why scope = `(pair, namespace)`.** The group is *not* `pair:@alice:@bob`
-(would leak alice→bob `banking` to an at_talk-only bob client) and *not*
-`self:@alice:at_talk` (would hand bob alice's private self data). It is the
-unique group whose membership equals "both sides' `at_talk` clients", mirroring
-the atServer's enrollment-authorization topology for the `at_talk` keys it
-carries.
+**Which nskey the CK is sealed to.** The choice is per recipient, not a group:
+
+- Alice writing data **Bob should read** → seal the CK to
+  `public:nskey.at_talk@bob`.
+- Alice writing data **only her own clients read** (self data) → seal the CK to
+  Alice's **self nskey**; this is never shared cross-atSign by construction, so
+  Bob never sees Alice's self data.
+
+There is no "(pair, namespace) group" to scope: the atServer's
+namespace-authorisation gate decides who may *fetch* the records, and the nskey
+the CK is sealed to decides who can *decapsulate* it. Both gates are keyed to
+`at_talk`, so the set is exactly "both sides' `at_talk`-authorised APKAM
+keypairs."
 
 ```mermaid
 sequenceDiagram
     autonumber
-    participant a1 as alice1
-    participant a2 as alice2
-    participant a3 as alice3
+    participant a1 as Ka1 (@alice)
+    participant a2 as Ka2 (@alice)
+    participant a3 as Ka3 (@alice)
     participant S as atServers
-    participant b1 as bob1
-    participant b2 as bob2
-    participant b3 as bob3
+    participant b1 as Kb1 (@bob)
+    participant b2 as Kb2 (@bob)
+    participant b3 as Kb3 (@bob)
 
-    Note over a1,b2: Step 0 — a1,a2,b1,b2 published KeyPackages, rw on at_talk. Group pair:@alice:@bob:at_talk, members {a1,a2,b1,b2}
-    Note over S: atServers gate every at_talk key (data AND epoch-key envelopes) by enrollment access
+    Note over a1,b2: Step 0 — Ka1,Ka2,Kb1,Kb2 hold per-APKAM key packages, rw on at_talk. No group; @alice and @bob each have at_talk nskeys
+    Note over S: atServers gate every at_talk key (data AND __ck conveyance records) by enrollment access
 
     rect rgb(232,242,255)
-    Note over a1: Step 1 — alice1 sends to @bob
-    a1->>a1: lazily create group; mint epoch E1; seal M1 under E1
-    a1->>S: put @bob:msg1.at_talk@alice {group, epoch 1, kid k1}
-    a1->>S: push E1 to a2,b1,b2 — X-Wing per leaf, via __ssenv.at_talk envelopes
+    Note over a1: Step 1 — Ka1 sends to @bob
+    a1->>a1: cut CK; seal CK ONCE via at/nskey to public:nskey.at_talk@bob; AES-GCM-seal M1 under CK
+    a1->>S: put @bob:ckB1.__ck.at_talk@alice (sealed to bob public nskey) + @bob:msg1.at_talk@alice {ckKid}
+    Note over a1,S: nskey PRIVATES already on each APKAM keypair via the substrate (per-APKAM); NOT pushed per message
     end
 
     rect rgb(232,255,236)
-    Note over b1,b2: Step 2 — bob1 and bob2 decrypt M1
-    S-->>b1: @bob:msg1... + E1 envelope (allowed: at_talk)
-    S-->>b2: @bob:msg1... + E1 envelope (allowed: at_talk)
-    b1->>b1: decapsulate E1 with leaf key; open M1
-    b2->>b2: decapsulate E1; open M1
-    Note over b1,b2: a client missed at push-time pulls E1 (requestSecretsFromNamespace at_talk)
+    Note over b1,b2: Step 2 — Kb1 and Kb2 decrypt M1
+    S-->>b1: ckB1.__ck + msg1 (allowed: at_talk)
+    S-->>b2: ckB1.__ck + msg1 (allowed: at_talk)
+    b1->>b1: decapsulate CK with public-nskey private; cache by ckKid; AES-GCM-open M1
+    b2->>b2: decapsulate CK; open M1
+    Note over b1,b2: an APKAM keypair missing the nskey private pulls it (requestSecret in at_talk) — the PRIVATE, not the CK
     end
 
     rect rgb(255,250,232)
-    Note over b2: Step 3 — bob2 replies to @alice (same group, same E1)
-    b2->>b2: seal M2 under E1
-    b2->>S: put @alice:msg2.at_talk@bob {group, epoch 1, kid k1}
+    Note over b2: Step 3 — Kb2 replies to @alice (same CK epoch, sealed to alice's public nskey)
+    b2->>b2: AES-GCM-seal M2 under a CK conveyed to public:nskey.at_talk@alice
+    b2->>S: put @alice:msg2.at_talk@bob {ckKid} (+ __ck if not already conveyed)
     end
 
     rect rgb(232,255,236)
-    Note over a1,a2: Step 4 — alice1 and alice2 decrypt M2
-    S-->>a1: @alice:msg2...
+    Note over a1,a2: Step 4 — Ka1 and Ka2 decrypt M2
+    S-->>a1: @alice:msg2... (+ __ck)
     S-->>a2: @alice:msg2...
-    a1->>a1: open M2 with E1 (already a member)
-    a2->>a2: open M2 with E1
+    a1->>a1: decapsulate CK with alice's public-nskey private; open M2
+    a2->>a2: open M2 (CK already cached)
     end
 
     rect rgb(255,232,244)
-    Note over b3: Step 5 — bob3 created, publishes KeyPackage (at_talk)
-    b3->>S: publish KeyPackage; register for at_talk
-    b1->>b1: roster-watch sees b3 → Add b3 + Commit → epoch E2 (mandatory rotation)
-    b1->>S: push E2 to {a1,a2,b1,b2,b3} (fans out cross-atSign)
-    Note over b3: NEW: holds E2 → opens every message from epoch 2 on
-    b3->>S: PAST: pull __rk.1 (request in at_talk)
-    S-->>b3: E1 (allowed: b3 is at_talk-authorized)
-    Note over b3: history-ON → opens M1,M2 · history-OFF (strict FS) → M1,M2 stay opaque
+    Note over b3: Step 5 — Kb3 enrolled, registers its key package (at_talk)
+    b3->>S: register per-APKAM key package; gain rw on at_talk
+    Note over b1: a holder (Kb1) pushes the at_talk nskey PRIVATES to Kb3 per-APKAM
+    b1->>S: __ssenv.at_talk envelope to kp(Kb3) — conveys nskey privates (substrate, Layer 1)
+    Note over b3: holds nskey privates → reads CURRENT __ck conveyances → opens new data. NO epoch rotation on join
+    b3->>S: PAST: pull nskey privates if it missed the push (requestSecret) — never a per-message key
+    S-->>b3: nskey privates (allowed: Kb3 is at_talk-authorised)
+    Note over b3: retain __ck records → opens M1,M2 · delete-for-FS → pre-rotation data stays opaque
     end
 
     rect rgb(244,232,255)
-    Note over a3: Step 6 — alice3 created, publishes KeyPackage (at_talk)
-    a3->>S: publish KeyPackage; register for at_talk
-    a1->>a1: roster-watch sees a3 → Add a3 + Commit → epoch E3
-    a1->>S: push E3 to {a1,a2,a3,b1,b2,b3}
-    Note over a3: NEW: holds E3 → opens every message from epoch 3 on
-    a3->>S: PAST: pull __rk.1, __rk.2
-    S-->>a3: E1, E2 (allowed: a3 is at_talk-authorized)
-    Note over a3: history-ON → opens M1,M2 · also joins self:@alice:at_talk for alice's self data
+    Note over a3: Step 6 — Ka3 enrolled, registers its key package (at_talk)
+    a3->>S: register per-APKAM key package; gain rw on at_talk
+    Note over a1: a holder (Ka1) pushes the at_talk nskey PRIVATES (self + public) to Ka3 per-APKAM
+    a1->>S: __ssenv.at_talk envelope to kp(Ka3) — conveys nskey privates incl. the SELF nskey private
+    Note over a3: holds nskey privates → reads current __ck conveyances → opens new data
+    a3->>S: PAST: pull nskey privates if missed (requestSecret)
+    S-->>a3: nskey privates (allowed: Ka3 is at_talk-authorised)
+    Note over a3: SELF nskey private also lets Ka3 decapsulate alice's OWN self CKs — no self group to join
     end
 ```
 
-### How a new client obtains the epoch key
+### How a new APKAM keypair obtains the nskey private (and thence the CK)
 
-The epoch key is never sent in the clear and never wrapped under a static
-per-atSign key. For each member leaf, the committer **X-Wing-encapsulates** the
-epoch key to *that leaf's* published KEM public key and writes the result as a
-secret-sharing envelope keyed `<msgId>.<clientId>.__ssenv.at_talk@<atsign>`.
-Two independent gates therefore protect every copy of the key:
+The CK is never sent in the clear, and the **nskey private** that unwraps it is
+never published. Two independent steps get a new APKAM keypair reading:
 
-1. **Transport gate (atServer, by namespace).** The envelope key carries the
-   `at_talk` suffix, so the atServer only lets a client *read* the envelope if
-   its enrollment is authorized for `at_talk` — identical to the gate on the
-   message itself. A client without `at_talk` can't even fetch the envelope.
-2. **Crypto gate (the leaf KEM key).** The envelope body is encapsulated to one
-   specific leaf's KEM public key, so only the holder of that leaf's private
-   key can **decapsulate** it. Possessing a different member's envelope is
-   useless.
+1. **Layer 1 — the nskey private, per-APKAM (substrate).** A holder seals the
+   namespace's nskey **privates** to the new APKAM keypair's key package with
+   `pqSeal` and writes a substrate envelope keyed
+   `<msgId>.<kpid>.__ssenv.at_talk@<atsign>` — addressed by **key-package id
+   (`kpid`)**, per-APKAM, **not** by a per-process client id. This happens once
+   per APKAM keypair (approval-time push / `enroll:listfornamespace` /
+   `requestSecret` pull backstop). Two gates protect every copy:
 
-So for **bob3** (Step 5): bob3 generates its leaf keypair locally and publishes
-the *public* KeyPackage. A current member (bob1, via same-atSign roster watch)
-Adds bob3 and Commits a new epoch `E2`, encapsulating `E2` to bob3's published
-KEM public key and writing the `__ssenv.at_talk` envelope addressed to bob3.
-bob3's atServer delivers it (bob3 is at_talk-authorized → gate 1 passes); bob3
-decapsulates with its leaf KEM **private** key, which never left the device →
-recovers `E2` (gate 2 passes). For past messages, bob3 issues a pull for
-`__rk.1`; a member re-encapsulates `E1` to bob3's leaf and delivers it through
-the same two gates. Nothing about bob3's identity is special — it succeeds iff
-(a) its enrollment authorizes `at_talk` and (b) it holds its own leaf private
-key. That is exactly "all bob clients with `at_talk` access, and only those."
+   - **Transport gate (atServer, by namespace).** The envelope carries the
+     `at_talk` suffix, so the atServer only lets an enrollment *read* it if it
+     is authorised for `at_talk` — identical to the gate on the data itself.
+   - **Crypto gate (the key package private).** The envelope body is `pqSeal`ed
+     to one specific APKAM keypair's key package, so only the holder of that
+     keyfile's key-package private half can open it.
 
-### New clients: new vs. past messages
+2. **Layer 2 — the CK, on ordinary sync.** Once an APKAM keypair holds the nskey
+   private, it reads CKs with no further per-APKAM step: on syncing a
+   `<ckKid>.__ck.at_talk@<owner>` conveyance record, the `at/nskey` provider
+   **decapsulates** the CK with the matching nskey private and caches it by
+   `kid`; the `at/symmetric/AES/GCM` provider then resolves data values by
+   `ckKid` and AES-GCM-decrypts.
 
-| Client | New messages | Past messages |
-|--------|--------------|---------------|
-| **bob3** | A same-atSign member Adds+Commits → mandatory rotation to `E2`, pushed to all members; bob3 decapsulates `E2` and reads from epoch 2 on. (If not proactively added, bob3 pulls `__rk.current`.) | Pulls retained `__rk.1`; server allows (at_talk-authorized). **history-ON** → opens M1, M2. **history-OFF** (strict FS) → pre-join epochs stay opaque. |
-| **alice3** | Symmetric: alice1/alice2 Add+Commit → `E3`, fanned out cross-atSign to all six clients; alice3 reads from epoch 3 on. Also joins `self:@alice:at_talk` for alice's self data. | Pulls `__rk.1`, `__rk.2`; server-allowed. Same history-ON/OFF fork. |
+So for **Kb3** (Step 5): Kb3 generates its key package locally and registers the
+*public* half in its enrollment record (gated, never published). A holder (Kb1)
+pushes the `at_talk` nskey privates to Kb3's key package via the substrate;
+Kb3's atServer delivers it (Kb3 is at_talk-authorised → gate 1 passes); Kb3
+opens it with its key-package private half, which never left the device → holds
+the nskey privates (gate 2 passes). Now Kb3 syncs the current `__ck` conveyances,
+decapsulates the live CK with the public-nskey private, and reads new data — **no
+epoch rotation on join, no per-message key push, no Add+Commit**. For history,
+Kb3 reads whatever `__ck` conveyances are still retained (see
+[New APKAM keypairs: new vs. past data](#new-apkam-keypairs-new-vs-past-data)).
+Nothing about Kb3 is special — it succeeds iff (a) its enrollment authorises
+`at_talk` and (b) it holds its own key-package private. That is exactly "all
+@bob APKAM keypairs with `at_talk` access, and only those."
+
+### New APKAM keypairs: new vs. past data
+
+| APKAM keypair | New data | Past data |
+|---|---|---|
+| **Kb3** (@bob) | Receives the `at_talk` nskey private per-APKAM via the substrate (push, or `requestSecret` pull), then syncs the current `__ck` conveyances and decapsulates the live CK → reads all new data. **No epoch rotation, no `__ck` re-mint required on join.** | Reads whatever `__ck` conveyances are still **retained** (server allows — Kb3 is at_talk-authorised). **Retain** → opens M1, M2. **Delete-for-FS** → CKs whose conveyance was deleted on rotation stay opaque. |
+| **Ka3** (@alice) | Symmetric: receives @alice's `at_talk` nskey privates (self **and** public) per-APKAM; reads current `__ck` conveyances → reads all new data. The **self** nskey private also lets it decapsulate @alice's own self CKs. | Reads retained `__ck` conveyances; server-allowed. Same retain-vs-delete fork. |
 
 ### Caveats this example surfaces
 
-- **History is a policy fork, not a mechanism gap.** v1 retains old epoch keys
-  and lets any namespace-authorized client pull them, so chat history works —
-  but that is in tension with forward secrecy. The MLS swap (D2) gives true FS,
-  under which a joiner cannot read pre-join traffic by design; "new member reads
-  history" then needs an explicit history-sharing mechanism (re-encrypt to the
-  new member, or a separate history key). Decide the `at_talk` policy
-  deliberately.
-- **Every join rotates the epoch** (lever A, mandatory). Churny fleets rotate
-  often; fine at pair scale, and a motivation for the Delivery Service (M5) at
-  large scale.
-- **M4, not yet built.** Today shared keys still route to `legacy` (the `group`
-  provider refuses shared keys), so currently *all* bob clients decrypt via
-  bob's shared keypair — the loose superset, not the namespace-scoped flow
-  above. This walkthrough is the target the Phase 4 design specifies.
+- **History is a policy fork, not a mechanism gap.** The D1 artefact is the
+  `at/nskey` CK-conveyance record (the `<ckKid>.__ck` record), not a per-group
+  epoch key. **Retain** the `__ck` records and any at_talk-authorised APKAM
+  keypair can read history; **delete** them on CK rotation (and evict the cached
+  CK) and that era's data becomes undecryptable — D1's **coarse forward secrecy**
+  (see [pq-data-encryption.md](pq-data-encryption.md) section 6). D1 therefore
+  *does* have forward secrecy: coarse FS by CK rotation + conveyance deletion,
+  plus post-compromise security via the (expensive, O(n) per-APKAM) nskey-keypair
+  rotation lever. D2 (`at/pqmls`) adds *robust/per-message* FS, scale, and
+  membership decoupled from namespace authorisation — it is not the only source
+  of FS. Decide the `at_talk` retention policy deliberately.
+- **A new APKAM keypair does NOT force a rotation.** Joining `at_talk` just
+  conveys the nskey private to the new keypair (per-APKAM) and lets it read the
+  existing CKs — no mandatory epoch rotation. (Mandatory rotation on join is a
+  D2 / `at/pqmls` MLS property — see Walkthrough B — not a D1 behaviour.)
+- **Cross-atSign FS is bilateral.** Alice forward-secures her *outbound* data
+  unilaterally (she owns the CK conveyance + cache). For *inbound*, Bob owns the
+  authoritative `@alice:<ckKid>.__ck.at_talk@bob` replica's source; Alice can
+  purge her cache but closing inbound FS depends on Bob's rotation (or the
+  heavier public-nskey *keypair* rotation). Normal for any FS system.
+- **Target, partly built.** The D1 cross-atSign target is the nskey data path
+  above (CK conveyed via `at/nskey` to the recipient's public nskey; data under
+  `at/symmetric/AES/GCM`). Until the nskey-data-path milestone lands, shared
+  data still routes to `legacy`, so currently *all* @bob APKAM keypairs decrypt
+  via @bob's legacy shared keypair — the loose superset, not the
+  namespace-scoped flow above. This walkthrough is the target the
+  [Phase 3 design](crypto-roadmap.md#phase-3--the-nskey-data-path-d1-self--shared)
+  specifies.

--- a/docs/crypto_impl_plan.md
+++ b/docs/crypto_impl_plan.md
@@ -26,10 +26,10 @@ encryption work.
 - [3. D1 — detailed implementation plan](#3-d1--detailed-implementation-plan)
   - [D1-S · Structural enablers (prerequisite — lands first)](#d1-s--structural-enablers-prerequisite--lands-first)
   - [D1-A · Finish the PQ primitives (small)](#d1-a--finish-the-pq-primitives-small)
-  - [D1-B · The `nskey` provider (D1 Tier1 — the default)](#d1-b--the-nskey-provider-d1-tier1--the-default)
+  - [D1-B · The nskey data path (the default data path)](#d1-b--the-nskey-data-path-the-default-data-path)
   - [D1-C · Migration & rollout machinery](#d1-c--migration--rollout-machinery)
   - [D1-D · Versioning (the `disallowLegacyEncryption` flag)](#d1-d--versioning-the-disallowlegacyencryption-flag)
-  - [D1-E · D1 Tier2 shape-corrections](#d1-e--d1-tier2-shape-corrections-fold-into-wp-gp)
+  - [D1-E · `at/pqmls` provider shape-corrections](#d1-e--atpqmls-provider-shape-corrections-fold-into-wp-gp)
   - [D1-F · Existing-client retrofit — auth upgrade & secret conveyance](#d1-f--existing-client-retrofit--auth-upgrade--secret-conveyance)
   - [D1 · Test & acceptance plan](#d1--test--acceptance-plan)
   - [D1 · PR delivery / publish](#d1--pr-delivery--publish)
@@ -65,11 +65,11 @@ jump.
 | Topic | Design (roadmap) | Build (plan) | Worked example |
 |---|---|---|---|
 | The two deliverables (D1 / D2) | [The two major deliverables](crypto-roadmap.md#the-two-major-deliverables) | [Current state (1)](crypto_impl_plan.md#1-current-state-2026-06-22) · [D1 acceptance (2)](crypto_impl_plan.md#2-d1-acceptance--what-done-means) | — |
-| D1 Tier1 — the `nskey` default | [D1 — preserving legacy simplicity](crypto-roadmap.md#d1--preserving-legacy-simplicity-two-tiers) | [D1-B (3)](crypto_impl_plan.md#d1-b--the-nskey-provider-d1-tier1--the-default) | — |
+| D1 — the nskey data path default | [D1 — preserving legacy simplicity](crypto-roadmap.md#d1--preserving-legacy-simplicity-single-tier-the-nskey-data-path) | [D1-B (3)](crypto_impl_plan.md#d1-b--the-nskey-data-path-the-default-data-path) | — |
 | Migration, rollout & versioning | [Application migration & rollout](crypto-roadmap.md#application-migration--rollout) | [D1-C / D1-D (3)](crypto_impl_plan.md#d1-c--migration--rollout-machinery) | — |
 | Existing-client retrofit (auth + key dist) | [Existing-client retrofit](crypto-roadmap.md#existing-client-retrofit--auth-upgrade--key-distribution) | [D1-F (3)](crypto_impl_plan.md#d1-f--existing-client-retrofit--auth-upgrade--secret-conveyance) | — |
-| Identity, KeyPackages, self groups | [Phases 2–3](crypto-roadmap.md#phase-2--identity-layer-keypackages-and-per-client-atkeys) | [D1-E (3)](crypto_impl_plan.md#d1-e--d1-tier2-shape-corrections-fold-into-wp-gp) · [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | — |
-| Cross-atSign shared groups | [Phase 4](crypto-roadmap.md#phase-4--cross-atsign-groups-shared-encryption) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [C — `at_talk` chat](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-client-churn-at_talk) |
+| Identity, per-APKAM KeyPackages, the nskey data path | [Phase 2](crypto-roadmap.md#phase-2--identity-layer-per-apkam-keypackages-and-per-apkam-atkeys) · [Phase 3](crypto-roadmap.md#phase-3--the-nskey-data-path-d1-self--shared) | [D1-B (3)](crypto_impl_plan.md#d1-b--the-nskey-data-path-the-default-data-path) · [D1-E (3)](crypto_impl_plan.md#d1-e--atpqmls-provider-shape-corrections-fold-into-wp-gp) · [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | — |
+| Cross-atSign `at/pqmls` (D2) groups | [Phase 5](crypto-roadmap.md#phase-5--atpqmls-d2-cross-atsign-groups--group-delivery-service) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [C — `at_talk` chat](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-apkam-keypair-churn-at_talk) |
 | pq-mls engine + Delivery Service | [atServer group Delivery Service](crypto-roadmap.md#atserver-group-delivery-service-target-design) | [D2 (4)](crypto_impl_plan.md#4-d2--pq-mls-placeholders-detailed-planning-deferred) | [B — a large group](crypto-walkthroughs.md#walkthrough-b--a-large-group-end-to-end) |
 | NoPorts adoption | [Upgrading NoPorts](crypto-roadmap.md#upgrading-noports-with-daemon-ping-feature-discovery) | [Cross-repo & NoPorts (5)](crypto_impl_plan.md#5-cross-repo-pr--publish-sequence--noports) | [A — NoPorts](crypto-walkthroughs.md#walkthrough-a--noports-end-to-end) |
 | Structural enablers / WASM split | [Component responsibilities & WASM-readiness](crypto-roadmap.md#component-responsibilities--wasm-readiness) | [D1-S (3)](crypto_impl_plan.md#d1-s--structural-enablers-prerequisite--lands-first) | — |
@@ -89,7 +89,7 @@ jump.
 - **`gkc-pqmls-spike`** is now just a **personal working branch + historical
   context** (it holds the pre-trunk-based integration of the in-flight work:
   `5493f6504` = `origin/xl-pluggable` `391f55f67` (the 4b base / PR #1930) **+
-  51 cherry-picked commits**: secret sharing, the `group` provider,
+  51 cherry-picked commits**: secret sharing, the `at/pqmls` provider,
   `onDecryptFailed`, the Phase-6 at_chops migration, the CRAM test). That work
   flows to trunk as its WPs complete.
 - These **docs live on `trunk`** (canonical, shared, edited via small PRs).
@@ -109,8 +109,8 @@ jump.
 4. **`at_client 3.x`** — in progress:
    - **(4a)** commit-log-free persistence migration — **MERGED to trunk (#1984).**
    - **(4b)** pluggable crypto seam (slim) — **PR #1930, OPEN + green.**
-   - **(4c)** the secret-sharing substrate, `nskey` / D1 Tier1, and the `group`
-     provider — **land on trunk as the [section 7](#7-delivery-plan--work-packages) work packages complete** (WP-SS /
+   - **(4c)** the secret-sharing substrate, the `nskey` D1 data path, and the
+     `at/pqmls` (D2) provider — **land on trunk as the [section 7](#7-delivery-plan--work-packages) work packages complete** (WP-SS /
      WP6 / WP-GP …); the spike (`gkc-pqmls-spike`) holds working prototypes.
 
 ### What is built vs prototyped — re-baselined: assume only trunk + #1930 + #1993
@@ -139,16 +139,25 @@ jump.
 **Prototyped on `gkc-pqmls-spike` but NOT landed — first-class WPs ([section 7](#7-delivery-plan--work-packages)), not
 foundation.** The spike has working code for these; treat re-landing it on trunk
 as real work (carve-out + alignment to the slim seam + `pqSeal`):
-- **Secret-sharing substrate (PQ-native)** → **WP-SS**: per-client X-Wing
-  `ClientKeyPackage`/`PackageKey`; namespace-scoped registration + discovery
-  (`registerClient` / `discoverClients(namespace:)`, server-gated); AES-256-GCM
+- **Secret-sharing substrate (PQ-native)** → **WP-SS**: per-APKAM X-Wing key
+  packages (the spike's `ClientKeyPackage`/`PackageKey`); AES-256-GCM
   `__ssenv.<ns>` envelopes (open-coded encapsulate+GCM on the spike — **to
   consolidate onto `pqSeal`/`pqOpen`**); in-memory `SecretStore`;
   `requestSecretsFromNamespace`; `waitForSecret`; `excludeEnrollmentIds`;
-  reserved `__` system-secret names.
-- **`group` provider (D1 Tier2 self)** → **WP-GP**: `SecureGroup`/`PairwiseGroup`
-  v1 + the `group` `GroupCryptoProvider`; `__rk.<epoch>.<kid>` epoch keys; scope
-  `self:<atSign>:<namespace>`; self-encryption only (refuses shared keys).
+  reserved `__` system-secret names. **Re-key per-APKAM at carve-out:** the spike
+  API is per-client (`registerClient` / `discoverClients(namespace:)`, keyed by
+  `clientId`); the canonical model addresses envelopes by `kpid` (per-APKAM) and
+  moves discovery to the gated **`enroll:listfornamespace:<ns>`** verb, with key
+  packages held **enrollment-internal** (never published) — see
+  [pq-secret-push.md](pq-secret-push.md). The `registerClient` /
+  `discoverClients` / `clientId` names are **replaced**, not landed as-is.
+- **`at/pqmls` provider (D2's forward-secure groups)** → **WP-GP**:
+  `SecureGroup`/`PairwiseGroup` v1 + the `at/pqmls` `GroupCryptoProvider`;
+  `__rk.<epoch>.<kid>` epoch keys; scope `self:<atSign>:<namespace>`. The MLS-based
+  provider for robust/per-message forward secrecy + O(log n) scale +
+  decoupled-membership groups. (This `self:` scope is the `at/pqmls` SelfGroup
+  scope, a **D2** concept — **not** D1 self-encryption: D1 self/shared data uses
+  the nskey data path, see [ADR 0002](adr/0002-d1-single-tier-nskey.md).)
 
 *(The original `CryptoRegistry` / `CryptoPolicy` / `CryptoStorage` / `initialize`
 / Request-Result wrappers were removed in #1930's slim refactor; the
@@ -160,23 +169,30 @@ Cross-ref roadmap [Milestones](crypto-roadmap.md#milestones-and-capabilities).
 trunk** — first-class work to land (a WP), not "done". "In flight" is reserved
 for the open PRs **#1930 / #1993**.
 
+Numbering follows the roadmap's restructured **0–6 backbone** (D1 = the nskey
+data path, per-APKAM; D2 = `at/pqmls`).
+
 | Phase / Milestone | Status |
 |---|---|
-| 0 — foundations (secret sharing, pluggable crypto, jt-pq) | **Partial**: jt-pq + Phase-6 in trunk; pluggable crypto **in flight** (#1930); secret sharing **prototyped on spike, not landed** (→ WP-SS) |
+| 0 — foundations (secret sharing, pluggable crypto, jt-pq) | **Partial**: jt-pq + the at_chops-routing record in trunk; pluggable crypto **in flight** (#1930); secret sharing **prototyped on spike, not landed** (→ WP-SS) |
 | 1 — PQ primitives in at_chops (X-Wing, GCM, HKDF, HMAC) | **Done** (trunk); remaining: PQ enrollment-conveyance pubkey |
-| 2 — identity layer (KeyPackages + per-client AtKeys) | KeyPackage framing **prototyped on spike, not landed** (→ WP-SS); AtKeys device-local split + identity resolution: not started (mostly D2 / D1 Tier2) |
+| 2 — identity layer (per-APKAM KeyPackages + per-APKAM AtKeys) | KeyPackage framing **prototyped on spike, not landed** (→ WP-SS) — re-keyed per-APKAM (`kpid`), key packages enrollment-internal; AtKeys stored per-APKAM (per-client AtKeys storage retired); device-local split + identity resolution: not started (D2) |
 | 2.5 — at_persistence 5.x migration | **Done & verified** |
-| 3 — `SecureGroup` v1 + `group` provider (self) | **Prototyped on spike, not landed** (→ WP-GP); D1 Tier1 `nskey` self is **new D1 work** ([section 3](#3-d1--detailed-implementation-plan)) |
-| 4 — cross-atSign shared | D1 Tier1 `nskey` shared is **new D1 work** ([section 3](#3-d1--detailed-implementation-plan)); per-client pair group is D1 Tier2 / D2 |
-| 5 — pq-mls engine | **D2 placeholder** ([section 4](#4-d2--pq-mls-placeholders-detailed-planning-deferred)) |
-| 6 — at_chops sole security-crypto dependency | **Complete** (in-scope) |
+| 3 — the nskey data path (D1 self + shared) | **New D1 work** ([section 3](#3-d1--detailed-implementation-plan)): the `at/nskey` CK-conveyance + `at/symmetric/AES/GCM` data providers; self and shared share one flow |
+| 4 — `at/pqmls` (D2): intra-atSign forward-secure groups (`SecureGroup` v1) | **Prototyped on spike, not landed** (→ WP-GP, D2); robust/per-message FS, scale, decoupled membership — **not** D1's self path (self = the nskey data path) |
+| 5 — `at/pqmls` (D2): cross-atSign groups + Group Delivery Service | **D2 placeholder** ([section 4](#4-d2--pq-mls-placeholders-detailed-planning-deferred)); D1's nskey data path already covers cross-atSign **shared** data at enrollment granularity |
+| 6 — pq-mls engine (`SecureGroup` v2) | **D2 placeholder** ([section 4](#4-d2--pq-mls-placeholders-detailed-planning-deferred)) |
+
+Separately (a different numbering scheme — not part of the 0–6 backbone): the
+**at_chops sole security-crypto dependency** work is **complete** (record in
+[section 6](#6-standing-verification--implementation-record)).
 
 ---
 
 ## 2. D1 acceptance — what "done" means
 
 D1 is done when, per the roadmap
-([D1 tiers](crypto-roadmap.md#d1--preserving-legacy-simplicity-two-tiers) +
+([D1 — preserving legacy simplicity](crypto-roadmap.md#d1--preserving-legacy-simplicity-single-tier-the-nskey-data-path) +
 [migration](crypto-roadmap.md#application-migration--rollout)):
 
 1. An app **rebuilt with no code change** reads all legacy + PQ data and stays
@@ -195,7 +211,8 @@ D1 is done when, per the roadmap
 5. The **usability acceptance test** holds at each milestone ([section 5](#5-cross-repo-pr--publish-sequence--noports)): no new flag a
    user must pass, file a user must manage, operator step, or peer-by-peer break.
 
-The substantive D1 build is the **`nskey` provider (D1 Tier1)** and the
+The substantive D1 build is the **nskey data path** (the `at/nskey` CK-conveyance
+provider + the `at/symmetric/AES/GCM` data provider) and the
 **migration/versioning machinery**, on top of the foundation that lands first:
 the M0 seam (#1930), HPKE (#1993), and the carved-out **secret-sharing
 substrate** (WP-SS). Only the at_chops primitives, the commit-log-free keystore,
@@ -207,8 +224,9 @@ and the Phase-6 routing ([section 1](#1-current-state-2026-06-22)) are already i
 
 Workstreams are roughly ordered; B is the centrepiece. Each task notes its
 artifact and acceptance. Design references point at the roadmap. **D1-S
-(structural enablers) lands first** — the `nskey` provider (D1-B) is built on
-`WritableAtKeys` + stateless AtChops.
+(structural enablers) lands first** — the nskey data path (D1-B) is built on
+`WritableAtKeys` (**working name** for the APKAM keypair's updatable `.atKeys`
+keystore) + stateless AtChops.
 
 ### D1-S · Structural enablers (prerequisite — lands first)
 *Lands as [WP1–WP5 + WP8](#the-work-package-sequence--single-source-for-ordering)
@@ -253,7 +271,7 @@ the feature workstreams; only `at_auth` takes a major bump (see
   deprecate**); the (stateless) `LegacyCryptoProvider` reads keys from
   `context.keys` instead of `context.atClient`; `LocalKeystoreAtKeysIo` is
   injected into `WritableAtKeys` at AtClient construction.
-  *Acceptance:* legacy + group providers operate via `context.keys`; existing
+  *Acceptance:* legacy + `at/pqmls` providers operate via `context.keys`; existing
   unit/functional suites green.
 - [ ] **S6 · Consumer constraint bumps + sequencing.** `at_client` /
   `at_onboarding_cli` (`1.17.0`) / `at_client_flutter` (`1.2.0`) /
@@ -290,69 +308,110 @@ waves 1–2.*
   *Note:* this same atSign-level PQ key is the **cold-start fallback** for
   `nskey` (D1-B4) — build it first.
 
-### D1-B · The `nskey` provider (D1 Tier1 — the default)
+### D1-B · The nskey data path (the default data path)
 *Lands as [WP6 (B1–B4) + WP9 (B5/B6)](#the-work-package-sequence--single-source-for-ordering),
 waves 3–4.* Design: roadmap
-[D1 Tier1](crypto-roadmap.md#d1-tier-1--baseline-the-nskey-provider-default). New provider
-on the M0 seam; legacy-shaped (copyable, enrollment-granular), PQ + namespace
+[The nskey data path](crypto-roadmap.md#the-nskey-data-path-d1s-data-path). The two
+new providers on the M0 seam (`at/nskey` conveys the CK; `at/symmetric/AES/GCM`
+encrypts the data); legacy-shaped (copyable, enrollment-granular), PQ + namespace
 -scoped. Build order:
 
-- [ ] **B1 · Namespace keypair.** A per-`(atSign, namespace)` X-Wing keypair.
-  - Type + storage: the private key held by every client of a namespace
-    -authorized enrollment; new clients receive it at **enrollment approval**.
+- [ ] **B1 · Namespace nskeys (two per namespace).** Per-`(atSign, namespace)`
+  there are **two** X-Wing nskey keypairs (per [pq-data-encryption.md](pq-data-encryption.md)
+  section 2): a **self nskey** (the owner encapsulates her own CKs to it; its
+  public half is **not** published) and a **public nskey** (external senders
+  encapsulate to it; its public half **is** published). Both are KEM keypairs —
+  they *wrap/unwrap* symmetric content keys (CKs), never encrypt application data.
+  - Type + storage: **both** nskey privates held per-APKAM by every authorised
+    enrollment's APKAM keypairs; conveyed per-APKAM via the substrate (push at
+    **enrollment approval** + the pull backstop — see B5/F1).
   - *Optional* deterministic derivation: `HKDF(master-seed, namespace [, epoch])
-    → X-Wing seed`, so any client of the atSign derives the private key with **no
-    distribution** (master seed is in `.atKeys`). Note the limit: alice cannot
-    derive bob's per-namespace *public* key from his master public key (ML-KEM
-    has no public child-derivation) — so the public key must still be published.
-  - Publication: the first upgraded client publishes
-    `public:encryptionpublickey.<ns>@<atSign>` (or a hidden public key);
-    signed by the publishing enrollment.
-  - *Acceptance:* a second client of the same atSign, authorized for the
-    namespace, can obtain the private key (at approval or by derivation) and
-    decrypt data sealed to the public key.
-- [ ] **B2 · `nskey` `CryptoProvider`.** Encrypt/decrypt over the seam, sealing
-  via **`pqSeal`/`pqOpen`** (D1-A) — do not open-code encapsulate+GCM.
-  - **Self** → `pqSeal` the value's data key to *your own* namespace public
-    key. **Shared** → `pqSeal` to the *recipient's* namespace public key. One
-    code path, both directions. `selfEncryptionKey` and `shared_key.*` both
-    collapse into "encrypt to the namespace keypair." Bind the scope via HPKE
-    `info` (e.g. `groupId`/namespace) so an envelope can't be replayed cross-scope.
-  - `appMetadata(providerId: 'nskey', additional: {ns, kid, env})` — `env` is the
-    `pqSeal` envelope (carries the KEM ct + AEAD body); no separate `iv`/`kemCt`.
+    → X-Wing seed` for **each** nskey private, so any client of the atSign derives
+    both privates with **no distribution** (master seed is in `.atKeys`). The
+    public nskey's public half must **still be published** regardless: ML-KEM has
+    no public child-derivation, so alice cannot derive bob's per-namespace public
+    nskey from his master public key.
+  - Publication: the first upgraded client publishes the **public nskey** as
+    `public:nskey.<ns>@<atSign>`, signed by the publishing enrollment. The **self
+    nskey** is never published.
+  - *Acceptance:* a second APKAM keypair of the same atSign, authorised for the
+    namespace, obtains **both** nskey privates (via substrate push/pull or
+    derivation) and can decapsulate CKs sealed to either nskey.
+- [ ] **B2 · `at/nskey` + `at/symmetric/AES/GCM` providers.** Two providers over
+  the seam (not one): a value-level **`at/nskey`** CK-conveyance provider that
+  seals a symmetric content key (CK) to an nskey via **`pqSeal`/`pqOpen`** (D1-A),
+  and an **`at/symmetric/AES/GCM`** data provider that AES-256-GCM-encrypts the
+  application value under that CK. A CK is conveyed **once** as its own
+  `<ckKid>.__ck.<ns>@<owner>` record; data values cite the CK by `kid` and carry
+  **no** inline sealed key (decision (a)). The nskey is asymmetric and only ever
+  *wraps* the symmetric CK — it never encrypts application data, and its private
+  *decapsulates* CKs.
+  - **Self** → `pqSeal` the CK to *your own* **self** nskey (the unpublished
+    nskey, not a published public key). **Shared** → `pqSeal` the CK to the
+    *recipient's* **published public** nskey. One code path, both directions —
+    only which nskey the CK is sealed to differs. `selfEncryptionKey` and
+    `shared_key.*` both collapse into "wrap a symmetric CK to the nskey; encrypt
+    data under the CK with AES-256-GCM." Bind the scope via HPKE `info`
+    (namespace) so a conveyance can't be replayed cross-scope. (D1 is scoped by
+    `(owner, namespace)`; `groupId` is a D2 `at/pqmls` concept, not D1.)
+  - **CK-conveyance record** (`at/nskey`):
+    `appMetadata(providerId: 'at/nskey', additional: {ns, recipientKind, ckKid})`
+    — value is the `pqSeal` envelope wrapping the CK (KEM ct + AEAD body); no
+    separate `iv`/`kemCt`.
+  - **Data value** (`at/symmetric/AES/GCM`):
+    `appMetadata(providerId: 'at/symmetric/AES/GCM', additional: {ns, ckKid, iv})`
+    — cites the CK by `ckKid`; **no per-value KEM envelope** (decision (a)).
   - *Acceptance:* unit round-trips (self + shared); byte-exact decrypt; binary
     -safe (seal/open bytes, honour `isBinary` — do **not** repeat the
-    `utf8.encode(toString())` bug, see [section 3](#3-d1--detailed-implementation-plan) D1 Tier2 shape tasks).
+    `utf8.encode(toString())` bug, see [section 3](#3-d1--detailed-implementation-plan) `at/pqmls` shape tasks).
 - [ ] **B3 · Capability marker + per-destination negotiation.** Per-`(atSign,
   namespace)` published marker `{nskey: true, nskeyPubKid, …}`, **initially
   not-ready**; the sender reads the recipient's marker (+ its own, for self
   copies) and selects the scheme. Design: roadmap
-  [Mixed-tier](crypto-roadmap.md#mixed-tier-alice--bob) +
+  [Mixed-scheme](crypto-roadmap.md#mixed-scheme-alice--bob) +
   [Application migration & rollout](crypto-roadmap.md#application-migration--rollout).
   *Acceptance:* sender writes `nskey` only when the readers' marker is ready,
   legacy otherwise; mixed-fleet test (one legacy reader ⇒ legacy write).
 - [ ] **B4 · Cold-start fallback + lazy upgrade.** When the recipient has no
-  namespace key published, encapsulate to the **atSign-level PQ key** (D1-A);
-  first namespace run mints/derives + publishes the namespace key; subsequent
-  writes upgrade. Design: roadmap
+  **public nskey** published for the namespace, seal the **CK** to the recipient's
+  **atSign-level PQ key** (`public:pqpublickey`, D1-A) — only the CK is sealed to
+  root; the data is still AES-256-GCM under that CK (data is **never** encrypted
+  directly to root). The first namespace run mints/derives + publishes the public
+  nskey; subsequent writes upgrade to namespace-scoped. Design: roadmap
   [Cold-start](crypto-roadmap.md#cold-start--bob-has-never-run-an-at_talk-app).
   *Acceptance:* alice→bob (bob never ran at_talk) is PQ (atSign-level) and
   readable by any bob at_talk client; upgrades to namespace-scoped after bob's
   first run. Strict-mode alternative (seal-and-hold) is a policy toggle (D1-C).
-- [ ] **B5 · Opt-in rotation.** Mint a new namespace keypair → publish new
-  public key → write the new private key as `__nsk.<epoch>` over the
-  **per-enrollment** self-group secret channel (PQ-wrapped to each at_talk
-  enrollment's conveyance key); reuse the **WP-SS** `__`-secret substrate +
-  `requestSecretsFromNamespace` (push) + pull. Design: roadmap
-  [Opt-in rotation](crypto-roadmap.md#opt-in-key-rotation-d1-tier1).
-  *Buys:* namespace-granular **post-compromise security**; **not** FS / history
-  re-encryption (old private keys retained → history-on).
-  *Acceptance:* after rotation, new writes use epoch N+1; all current at_talk
-  clients converge; a pre-rotation key reads nothing post-rotation.
+- [ ] **B5a · CK rotation (the cheap, coarse forward-secrecy lever).** Mint a
+  fresh symmetric content key, cut a new `<ckKid>.__ck` conveyance record sealed
+  to the namespace's nskey, and **delete the old `at/nskey` conveyance** so the
+  superseded CK can no longer be unwrapped. O(1) and cheap — this is D1's coarse
+  FS mechanism, and it rides ordinary sync (not the substrate). Run it on a
+  cadence or on demand. Design: roadmap
+  [Opt-in rotation](crypto-roadmap.md#opt-in-key-rotation) +
+  [pq-data-encryption.md](pq-data-encryption.md) section 6.
+  *Acceptance:* after CK rotation, new writes cite epoch N+1's `ckKid`; a peer
+  that only held the old `__ck` conveyance (now deleted) cannot read new data.
+- [ ] **B5b · nskey-keypair rotation (the expensive post-compromise-security
+  lever).** Mint a new **self nskey AND public nskey** → publish the new **public
+  nskey** (`public:nskey.<ns>@<atSign>`) → convey **both** new nskey privates
+  **per-APKAM via the secret-sharing substrate** (`__ssenv` envelopes sealed to
+  each authorised APKAM keypair's key package, pushed via `enroll:listfornamespace`
+  + the pull backstop — WP-SS / [pq-secret-push.md](pq-secret-push.md)). This is
+  **expensive**: it is an O(n) per-APKAM re-conveyance, the per-APKAM revocation
+  lever — **not cheap**. Design: roadmap
+  [Opt-in rotation](crypto-roadmap.md#opt-in-key-rotation).
+  *Buys:* namespace-granular **post-compromise security**; **not** per-message FS
+  / history re-encryption (old nskey privates retained → history-on). Coarse FS
+  comes from B5a (CK rotation + delete), not from this.
+  *Acceptance:* after a keypair rotation, new CKs are sealed to the epoch-N+1
+  nskeys; all current authorised APKAM keypairs converge (substrate push/pull);
+  an APKAM keypair that holds only a pre-rotation nskey private reads nothing
+  sealed post-rotation.
 - [ ] **B6 · Revocation wiring.** Compose: (1) enrollment revocation (APKAM —
   free, cuts future server access); (2) rotation **excluding** the revoked
   enrollment (`excludeEnrollmentIds`); (3) optional re-encrypt of history
-  (expensive — D1 Tier2/D2). Design: roadmap
+  (expensive — D2). Design: roadmap
   [Revocation](crypto-roadmap.md#revocation-end-to-end).
   *Acceptance:* a revoked enrollment, excluded from a rotation, cannot read
   post-rotation data.
@@ -384,14 +443,18 @@ Design: roadmap
 - [ ] **C4 · Capability conformance.** Implement so the
   [capabilities table](crypto-roadmap.md#capabilities-by-application-code-change-level)
   holds: no-code = universal reader + back-compat; flag = PQ writer/recipient;
-  code = override defaults / D1 Tier2.
+  code = override defaults / D2 (`at/pqmls`).
 
 ### D1-D · Versioning (the `disallowLegacyEncryption` flag)
 *Lands as [WP7 (flag, default off) + WP-D3 (v4 default flip)](#the-work-package-sequence--single-source-for-ordering),
 waves 4 & 6.* Design: roadmap
 [Versioning contract](crypto-roadmap.md#versioning-contract--the-legacy-encryption-flag-3x-default-off-4x-default-on).
 - [ ] **D1 · All D1 lands in 3.x** — additive, backwards-compatible; a 3.x
-  client may write legacy when a reader isn't PQ-ready.
+  client may write legacy when a reader isn't PQ-ready. **No-providerId default:**
+  a stored value with **no** `appMetadata.providerId` is the **legacy** provider
+  (RSA-2048 + AES, monolithic, key inline-wrapped per value); the negotiation and
+  migration logic depends on this default (per
+  [pq-data-encryption.md](pq-data-encryption.md) section 3).
 - [ ] **D2 · The `disallowLegacyEncryption` flag** on `AtClientPreference`.
   Means literally "never write new data using the legacy provider for
   encryption." **Final at AtClient construction** (immutable for the client's
@@ -401,7 +464,10 @@ waves 4 & 6.* Design: roadmap
   `shouldEncrypt=false` *no-encryption* path are unaffected
   ([confidentiality](crypto-roadmap.md#what-the-atserver-can-and-cannot-see)).
   *Acceptance:* with the flag `true`, no write uses the legacy provider (test:
-  every write's `appMetadata.providerId ∈ {nskey, group}` or the PQ fallback; a
+  every write's `appMetadata.providerId ∈ {at/nskey, at/symmetric/AES/GCM}` —
+  the cold-start "PQ fallback" is **not** a third providerId, it is still an
+  `at/nskey` CK conveyance whose recipient is the root `pqpublickey` instead of a
+  namespace nskey; a
   legacy-only recipient causes a refused write, never a legacy write; legacy
   **read** still works; the flag cannot be mutated after construction). With the
   flag `false`, a single `SHOUT` is logged at creation.
@@ -410,17 +476,19 @@ waves 4 & 6.* Design: roadmap
   provider itself **stays** — needed for reads always and for writes when the
   flag is `false`). Gated on the ecosystem floor.
 
-### D1-E · D1 Tier2 shape-corrections (fold into WP-GP)
+### D1-E · `at/pqmls` provider shape-corrections (fold into WP-GP)
 *Lands as [WP-GP](#the-work-package-sequence--single-source-for-ordering), wave 5.*
-The `group` provider is prototyped on the spike (D1 Tier2 self) and lands as
-WP-GP. These preserve its shape before the self→shared and MLS transitions;
-apply them as part of that carve-out, while touching the area.
+The `at/pqmls` provider is prototyped on the spike and lands as WP-GP. It is
+**D2's** forward-secure (MLS-based) provider — not a D1 tier; D1 self/shared data
+uses the nskey data path ([ADR 0002](adr/0002-d1-single-tier-nskey.md)). These shape-corrections
+preserve the provider's shape before the self→shared and MLS transitions; apply
+them as part of that carve-out, while touching the area.
 - [ ] **Lift membership into `SecureGroup`** (`members`/`add`/`remove`); v1
   derives them. Avoids a later breaking change to a published abstract.
-- [ ] **Binary-safe `group` provider** — seal/open bytes, honour `isBinary`
+- [ ] **Binary-safe `at/pqmls` provider** — seal/open bytes, honour `isBinary`
   (currently `utf8.encode(plaintext.toString())` corrupts binary).
 - [ ] **Rename `PairwiseGroup` → `SelfGroup`** to free "pair group" for the
-  Phase-4 cross-atSign meaning.
+  Phase-5 cross-atSign meaning.
 
 ### D1-F · Existing-client retrofit — auth upgrade & secret conveyance
 *Lands as a new **WP-AU** (auth upgrade); gated on the F5 atServer enhancements
@@ -434,11 +502,13 @@ secret-sharing substrate (WP-SS). New atSigns (PQ-native at onboarding) and new 
 
 - [ ] **F1 · `requestSecret(name)` primitive.** Generalise the substrate's
   `requestSecretsFromNamespace` to request a *named* secret. A request is a **targeted fan-out**
-  — discover the namespace's clients from their published `ClientKeyPackage`s and send each a
-  `pqSeal`-ed `__ssenv` envelope (no keyless broadcast); a holder responds with
-  `shareSecretWith(requester.ClientKeyPackage, secret)` (`pqSeal`) back to the requester's
-  clientId; requester `waitForSecret`. **Transport:** `atClient.put` of the `__ssenv` key
-  (`<msgId>.<recipientClientId>.__ssenv.<ns>@<atSign>`, self key, `shouldEncrypt=false`) +
+  — discover the namespace's authorised enrollments and their **per-APKAM key packages** via the
+  gated **`enroll:listfornamespace:<ns>`** verb (key packages are enrollment-internal, **not**
+  published — see [pq-secret-push.md](pq-secret-push.md)), and seal a `pqSeal`-ed `__ssenv`
+  envelope to each APKAM key package (`kpid`); no keyless broadcast. A holder responds with
+  `shareSecretWith(requester key package, secret)` (`pqSeal`) back to the requester's key
+  package (addressed by `kpid`); requester `waitForSecret`. **Transport:** `atClient.put` of the `__ssenv` key
+  (`<msgId>.<recipientKpId>.__ssenv.<ns>@<atSign>`, self key, `shouldEncrypt=false`) +
   **sync** delivery (sync-progress listener + periodic sweep → `receivedSecrets`), **plus an
   optional wake-up `notify`** per put (default on) so **sync-less clients** wake and
   `get(useRemoteAtServer)` — on both the request and the response. (Future: the atServer
@@ -451,16 +521,18 @@ secret-sharing substrate (WP-SS). New atSigns (PQ-native at onboarding) and new 
   namespace — *not* `publickey.pq`). Create via immutable create-if-absent (F5); the
   creator generates the X-Wing keypair, stores the private half, seeds it as a conveyable
   secret (`pqid:<kid>`), and serves on request. A non-creator pulls via F1, **verifies
-  public/private correspondence**, and stores into the local keystore (`WritableAtKeys`).
-  Conveyed to *every* non-revoked client (root → no namespace gate).
-- [ ] **F3 · Per-host PQ APKAM upgrade.** Mint-once **per (host, AtKeys file)** under a
-  host-local lock (reuse an existing keyfile key; else mint + persist); publish the public
-  half as an immutable per-host record; verify PQ APKAM auth; **then** delete the legacy RSA
+  public/private correspondence**, and stores into the local keystore (the APKAM keypair's
+  updatable `.atKeys` keystore; working name `WritableAtKeys`). Conveyed per-APKAM to *every*
+  non-revoked enrollment (push at approval + pull backstop; root → no namespace gate).
+- [ ] **F3 · Per-keyfile PQ APKAM upgrade.** Mint-once **per (host, AtKeys file)** — i.e. **one
+  per APKAM keypair**, the canonical recipient unit (a keyfile carries one APKAM keypair) —
+  under a host-local lock (reuse an existing keyfile key; else mint + persist); publish the public
+  half as an immutable per-APKAM record; verify PQ APKAM auth; **then** delete the legacy RSA
   APKAM public key (delete-by-default, scope = auth key only — keep the legacy encryption
   key for reads). Uniform sequence per the roadmap; "creator vs requester" decided by F2's
   immutable create. *Storage:* keyfile/keychain by default; OS-keychain/hardware opt-in; a
-  distinct labelled per-host record drives per-host revocation.
-- [ ] **F4 · Revocation.** Per-host auth revocation = delete that host's PQ APKAM public key
+  distinct labelled per-APKAM record drives per-APKAM revocation.
+- [ ] **F4 · Revocation.** Per-APKAM auth revocation = delete that keypair's PQ APKAM public key
   (meaningful only after F3's legacy deletion). Encryption revocation stays per-namespace
   rotation (D1-B / WP9). TTL/usage-based eviction of unused APKAM keys (F5).
 - [ ] **F5 · atServer enhancements** *(cross-repo, `at_server`; gate F2/F3/F4).* Mint-once
@@ -485,10 +557,10 @@ secret is ever wrapped under an RSA-derived key.
   `SHOUT` when `false`, + immutability after construction), cold-start fallback,
   the regression test
   pattern (a test that fails without the fix).
-- Functional (live virtualenv): nskey self + shared, rotation, mixed-tier
+- Functional (live virtualenv): nskey self + shared, rotation, mixed-scheme
   (nskey↔legacy), cold-start, enrollment-revoke + rotate-exclude.
 - e2e (cross-atSign, `@ce2e*`): the `at_talk` chat scenario from
-  [Walkthrough C](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-client-churn-at_talk)
+  [Walkthrough C](crypto-walkthroughs.md#walkthrough-c--a-two-atsign-chat-with-apkam-keypair-churn-at_talk)
   — alice1/2 ↔ bob1/2 bidirectional, then bob3/alice3 join (new + past
   messages). Run concurrently via the base-port `runLocal.sh` rigs (PR #1992).
 - Usability acceptance test ([section 5](#5-cross-repo-pr--publish-sequence--noports)) at each milestone.
@@ -505,30 +577,37 @@ from an integration branch at the end. Overall publish order: roadmap
 
 ## 4. D2 — pq-mls (placeholders; detailed planning deferred)
 
-D2 swaps D1 Tier2's engine for MLS and adds the scaling/ordering infrastructure.
+D2 is the forward-secure (MLS-based) `at/pqmls` provider plus the scaling/ordering
+infrastructure — robust/per-message FS, O(log n) scale, and decoupled-membership
+groups ([ADR 0002](adr/0002-d1-single-tier-nskey.md)). D1's nskey data path
+already provides **coarse FS** via content-key rotation + deletion of the old
+`at/nskey` conveyance, **plus post-compromise security** via the (expensive,
+per-APKAM) nskey-keypair rotation lever; D2 adds robust/per-message FS, O(log n)
+scale, and decoupled membership on top.
 The **design** is in the roadmap; the **detailed build plan is intentionally
 deferred** — each item below is a placeholder that **requires its own planning
 pass** before implementation. Design refs:
 [Deliverable 2](crypto-roadmap.md#deliverable-2--implement-pq-mls),
-[Phase 5](crypto-roadmap.md#phase-5--pq-mls-engine-securegroup-v2),
+[Phase 6](crypto-roadmap.md#phase-6--pq-mls-engine-securegroup-v2),
 [Delivery Service](crypto-roadmap.md#atserver-group-delivery-service-target-design).
 
 > **⚠ DETAILED PLANNING REQUIRED** for every item in this section. Treat the
 > bullets as scope markers, not a task breakdown.
 
-- [ ] **Phase 4 (cross-atSign per-client pair groups) as D1 Tier2.** *Note:* D1's
-  `nskey` covers cross-atSign **shared** data at enrollment granularity; the
-  **per-client** `(pair, namespace)` group (per-device revocation/FS) is the
-  D1 Tier2/D2 form. Greenfield: cross-atSign KeyPackage fetch+verify, consent
-  hook, explicit membership, group state not derivable from one server. *Plan
-  when starting D1 Tier2 cross-atSign.*
-- [ ] **Phase 5 — MLS engine (`SecureGroup` v2).** Engine choice still open
+- [ ] **Phase 5 (cross-atSign per-APKAM pair groups) as D2.** *Note:* D1's
+  nskey data path covers cross-atSign **shared** data at enrollment granularity;
+  the **per-APKAM** `(pair, namespace)` group (per-device revocation / per-message
+  FS) is the D2 (`at/pqmls`) form. Greenfield: cross-atSign KeyPackage
+  fetch+verify, consent hook, explicit membership, group state not derivable from
+  one server. *Plan when starting D2 cross-atSign.*
+- [ ] **Phase 6 — MLS engine (`SecureGroup` v2).** Engine choice still open
   (openmls / mls-rs / pure-Dart); native bindings as a separate package so
-  `at_client` stays pure Dart. Bootstrap from the same published KeyPackages;
-  flip `groupId`/`providerId` on new writes; lazy re-encrypt on touch.
-  **History vs forward-secrecy:** D1 is history-on (retained keys); MLS gives
-  true FS, so "new member reads history" needs an explicit mechanism
-  (re-encrypt-to-member or a separate history key) — *decide in the Phase-5
+  `at_client` stays pure Dart. Bootstrap from the same per-APKAM KeyPackages
+  (enrollment-internal, discovered via `enroll:listfornamespace` — never
+  published); flip `groupId`/`providerId` on new writes; lazy re-encrypt on touch.
+  **History vs forward-secrecy:** D1 is history-on (retained nskey privates); MLS
+  gives true FS, so "new member reads history" needs an explicit mechanism
+  (re-encrypt-to-member or a separate history key) — *decide in the Phase-6
   plan.* *Plan: engine selection spike + binding package + state-ownership.*
 - [ ] **atServer group Delivery Service.** Ciphertext-only group object
   (`ownerAcl` + plaintext roster + monotonic `seq` + TTL'd log) + verbs
@@ -543,14 +622,15 @@ pass** before implementation. Design refs:
   apply inbound handshake before sealing under the new epoch. Roadmap
   [Connection model & the MLS leaf](crypto-roadmap.md#connection-model--the-mls-leaf).
   *Plan with the engine integration.*
-- [ ] **Per-client identity hardening (Phase 2 / D1 Tier2).** AtKeys device-local
-  split (leaf keys never copied); client-identity resolution
-  (label-keyed keysets, resume/fork/mint); **two-layer single-owner lock**
-  (device-local file lock + atServer `(atSign, label)` lease w/ fencing token +
-  TTL + heartbeat). MLS correctness precondition (one leaf per instance), not
-  needed by D1 Tier1. Roadmap
-  [Phase 2](crypto-roadmap.md#phase-2--identity-layer-keypackages-and-per-client-atkeys).
-  *Plan with Phase 5.*
+- [ ] **Per-APKAM identity hardening (Phase 2 / D2).** AtKeys device-local
+  split (leaf keys never copied; AtKeys are stored **per-APKAM**, not per-client);
+  per-APKAM identity resolution (label-keyed keysets, resume/fork/mint);
+  **two-layer single-owner lock** (device-local file lock + atServer
+  `(atSign, label)` lease w/ fencing token + TTL + heartbeat). MLS correctness
+  precondition (**one leaf per APKAM keypair**), not needed by D1's nskey data
+  path. Roadmap
+  [Phase 2](crypto-roadmap.md#phase-2--identity-layer-per-apkam-keypackages-and-per-apkam-atkeys).
+  *Plan with Phase 6.*
 
 Guidance (carries from the roadmap): the v1 `PairwiseGroup` epoch engine + its
 leaderless `kid`-is-truth convergence is **thrown away at the MLS swap** — don't
@@ -575,9 +655,9 @@ Nothing reaches NoPorts until the SDK ships in dependency order. Roadmap
 
 **NoPorts adoption (finish line, mostly D2-gated).** Route session keys through
 the group abstraction, daemon-feature-gated tiers 0–2; **target: zero
-user-visible delta**. Tier 0 (transport PQ-safe) is reachable with the `nskey`
-/ `group` path; tiers 1–2 (derive-don't-transmit, fleet self-group) lean on
-D1 Tier2 / D2. Roadmap
+user-visible delta**. Tier 0 (transport PQ-safe) is reachable with the nskey data
+path / `at/pqmls` path; tiers 1–2 (derive-don't-transmit, fleet `SelfGroup`) lean
+on D2 (`at/pqmls`). Roadmap
 [Upgrading NoPorts](crypto-roadmap.md#upgrading-noports-with-daemon-ping-feature-discovery)
 + Admission UX / User-visible-delta. *Detailed sshnoports plan: deferred.*
 
@@ -645,7 +725,8 @@ tests. Plan archived at `untracked/AT_PERSISTENCE_5_MIGRATION_PLAN.md`.
   `VIRTUALENV_BASE_PORT`).
 
 ### ADRs
-- [ADR 0001 — D1 delivers as two tiers](adr/0001-d1-simplicity-tiers.md).
+- [ADR 0002 — D1 is single-tier `nskey`; `at/pqmls` is D2](adr/0002-d1-single-tier-nskey.md)
+  (supersedes [ADR 0001 — D1 delivers as two tiers](adr/0001-d1-simplicity-tiers.md)).
 
 ## 7. Delivery plan & work packages
 
@@ -658,8 +739,9 @@ view.
 
 ### Tracks (package domains, not people)
 
-- **Track A — crypto primitives + provider:** `at_chops` (stateless core +
-  HPKE) → the `nskey` provider, `secret_sharing/`, `crypto/group/`.
+- **Track A — crypto primitives + providers:** `at_chops` (stateless core +
+  HPKE) → the nskey data path providers (`at/nskey` + `at/symmetric/AES/GCM`),
+  `secret_sharing/`, `crypto/group/`.
 - **Track B — key management:** `at_auth` (`WritableAtKeys`, `AtKeysIo`
   widening, the WASM barrel split) → PQ enrollment-conveyance key.
 - **Track C — at_client crypto seam + migration:** `crypto.dart` /
@@ -671,8 +753,8 @@ view.
 
 Within `at_client/crypto/`, the file partition keeps A and C apart: **C** owns
 `crypto.dart`, `crypto_runtime.dart`, `legacy/`; **A** owns `crypto/group/`,
-`crypto/nskey/` (new), `secret_sharing/`. The `nskey` provider is mostly new
-files — low collision by construction.
+`crypto/nskey/` (new), `secret_sharing/`. The nskey data path providers are mostly
+new files — low collision by construction.
 
 ### Reconciliations since the slim refactor (`xl-pluggable`)
 The slim-API + registry-fold landed on `xl-pluggable` (PR #1930) after this [section 7](#7-delivery-plan--work-packages)
@@ -697,7 +779,7 @@ at_lookup / at_auth / at_onboarding_cli (#1995–1998, **merged**). **In flight:
 #1993 (at_chops HPKE), #1930 (at_client M0 seam).
 
 **Prototyped on `gkc-pqmls-spike` but NOT landed — first-class work to do, not
-foundation:** the **secret-sharing substrate** (WP-SS) and the **`group`
+foundation:** the **secret-sharing substrate** (WP-SS) and the **`at/pqmls`
 provider** (WP-GP). They were previously folded into WP11/WP9 as "assumed
 built"; they are now their own carve-out WPs.
 
@@ -719,12 +801,12 @@ header links back to this section):
 | WP4 | [D1-S](#d1-s--structural-enablers-prerequisite--lands-first) S2/S3 (+ storage) | 1 |
 | WP-SS | [Foundations — secret sharing](crypto-roadmap.md#foundations) | 2 |
 | WP10 | [D1-A](#d1-a--finish-the-pq-primitives-small) (enrollment-conveyance key) | 2 |
-| WP6 | [D1-B](#d1-b--the-nskey-provider-d1-tier1--the-default) B1–B4 | 3 |
+| WP6 | [D1-B](#d1-b--the-nskey-data-path-the-default-data-path) B1–B4 | 3 |
 | WP5 | [D1-S](#d1-s--structural-enablers-prerequisite--lands-first) S4 (WASM cut) | 3 |
 | WP8 | [D1-S](#d1-s--structural-enablers-prerequisite--lands-first) S6 (consumer bumps) | 3 |
 | WP7 | [D1-C](#d1-c--migration--rollout-machinery) + [D1-D](#d1-d--versioning-the-disallowlegacyencryption-flag) D2 | 4 |
-| WP9 | [D1-B](#d1-b--the-nskey-provider-d1-tier1--the-default) B5/B6 | 4 |
-| WP-GP | [D1-E](#d1-e--d1-tier2-shape-corrections-fold-into-wp-gp) | 5 |
+| WP9 | [D1-B](#d1-b--the-nskey-data-path-the-default-data-path) B5/B6 | 4 |
+| WP-GP | [D1-E](#d1-e--atpqmls-provider-shape-corrections-fold-into-wp-gp) | 5 |
 | WP-D3 | [D1-D](#d1-d--versioning-the-disallowlegacyencryption-flag) D3 | 6 |
 
 **Wave 0 — land the in-flight foundation (gates everything).** #1930 is the
@@ -741,35 +823,38 @@ single biggest unblock; #1993 can be reviewed alongside it.
 - **WP4** (D) `LocalKeystoreAtKeysIo` + updatable `.atKeys`.
 
 **Wave 2 — substrate + enrollment key (parallel; on at_chops 3.3.0).**
-- **WP-SS** (A/C) carve the **secret-sharing substrate** spike → trunk:
-  `ClientKeyPackage`, `SecretStore`, namespace registration/discovery, `__ssenv`
-  envelopes **via `pqSeal`**, `requestSecretsFromNamespace`, `waitForSecret`,
-  `excludeEnrollmentIds`.
+- **WP-SS** (A/C) carve the **secret-sharing substrate** spike → trunk: per-APKAM
+  X-Wing key packages (enrollment-internal), `SecretStore`, discovery via the gated
+  `enroll:listfornamespace:<ns>` verb, `__ssenv` envelopes addressed by `kpid`
+  **via `pqSeal`**, `requestSecretsFromNamespace`, `waitForSecret`,
+  `excludeEnrollmentIds`. (Re-keys the spike's per-client `registerClient` /
+  `discoverClients` / `clientId` to per-APKAM `kpid`.)
 - **WP10** (B) PQ enrollment-conveyance public key (also the nskey cold-start
   fallback) — land before WP6.
 
-**Wave 3 — `nskey` core + the at_auth 4.0 cut (parallel).**
-- **WP6** (C/A, D1-B B1–B4) the **`nskey` provider** — namespace keypair
-  (derive/publish), seal/open via `pqSeal`, capability marker + negotiation,
-  cold-start fallback. Needs WP1, WP3, WP10 (+ WP-SS for the non-derivable
-  distribution path).
+**Wave 3 — nskey data path core + the at_auth 4.0 cut (parallel).**
+- **WP6** (C/A, D1-B B1–B4) the **nskey data path** (`at/nskey` +
+  `at/symmetric/AES/GCM`) — the two namespace nskeys (self + public;
+  derive/publish the public one), seal/open via `pqSeal`, capability marker +
+  negotiation, cold-start fallback. Needs WP1, WP3, WP10 (+ WP-SS for the
+  non-derivable distribution path).
   **▶ at_client (minor): PQ-safe writes available** — a rebuilt app is a
   universal reader; one readiness-flag flip makes its new writes `nskey`.
 - **WP5** (B) **`at_auth 4.0.0`** WASM barrel split (the one breaking cut). Needs WP2.
   **▶ at_auth 4.0.0** with **WP8** (D, consumer bumps onboarding/flutter/
   cli_commons) **▶** their minors right behind it.
 
-**Wave 4 — D1 Tier1 completion (migration, rotation, versioning).**
+**Wave 4 — D1 completion (migration, rotation, versioning).**
 - **WP7** (C, D1-C + D1-D flag) migration machinery (readiness-marker lifecycle,
   negotiation default, strict-mode toggles) + `disallowLegacyEncryption`
   (default `false`); legacy provider reads `WritableAtKeys`. Needs WP6.
 - **WP9** (A/C, D1-B B5/B6) nskey **rotation + revocation**; `__ssenv`
   consolidated on `pqSeal`. Needs WP-SS, WP6.
-  **▶ at_client `3.14.x`: D1 Tier1 GA — PQ-safe namespace messaging** (the
+  **▶ at_client `3.14.x`: D1 GA — PQ-safe namespace messaging** (the
   headline: rebuild = universal reader, one flag = PQ writer, opt-in rotation).
 
-**Wave 5 — D1 Tier2 (opt-in hardened) — parallel, off the Tier1 critical path.**
-- **WP-GP** (A/C) carve the **`group` provider** (`SecureGroup` / `SelfGroup`)
+**Wave 5 — D2's `at/pqmls` provider (forward-secure groups) — parallel, off the D1 critical path.**
+- **WP-GP** (A/C) carve the **`at/pqmls` provider** (`SecureGroup` / `SelfGroup`)
   spike → trunk + the D1-E shape fixes (binary-safe, lift membership, rename).
 
 **Wave 6 — the v4 cut (gated on the ecosystem floor).**
@@ -792,7 +877,7 @@ additive minor (`3.2.0`, WP2) then a breaking major (`4.0.0`, WP5) so
 | 1 | `at_chops` | minor `3.2.1 → 3.3.0` | WP1 | stateless functional core + HPKE `pqSeal`/`pqOpen` **added**; stateful `AtChopsImpl` kept as `@Deprecated` shim (additive) |
 | 2 | `at_auth` | minor `3.1.1 → 3.2.0` | WP2 | **additive API:** `WritableAtKeys` added; `AtKeysIo`/`WrittenAtKeysIo` widened (add/remove/update, default impls); `InMemoryAtKeysIo`. No barrel change yet — downstream can adopt `WritableAtKeys` immediately |
 | 3 | `at_auth` | **major `3.2.0 → 4.0.0`** | WP5 | **breaking WASM cut:** `FileAtKeysIo` out of the main barrel (→ `at_auth_io.dart`); `FileAtKeysIo()` default removed; registrar → `package:http`; probe extracted; core compiles under `dart2wasm` |
-| 4 | `at_client` | minor `3.13.0 → 3.14.0` | WP3 / WP6 | `at_auth ^4.0.0`; `CryptoContext` gains a `WritableAtKeys keys` field (additive; context is `{atClient}` today — nothing to deprecate); `LocalKeystoreAtKeysIo`; `nskey` provider scaffold |
+| 4 | `at_client` | minor `3.13.0 → 3.14.0` | WP3 / WP6 | `at_auth ^4.0.0`; `CryptoContext` gains a `WritableAtKeys keys` field (additive; context is `{atClient}` today — nothing to deprecate); `LocalKeystoreAtKeysIo`; nskey data path scaffold (`at/nskey` + `at/symmetric/AES/GCM`) |
 | 5 | `at_onboarding_cli` | minor `1.16.0 → 1.17.0` | WP8 | `at_auth ^4.0.0`; imports `FileAtKeysIo` from `at_auth_io.dart`; injects it explicitly (default gone) |
 | 6 | `at_client_flutter` | minor `1.1.3 → 1.2.0` | WP8 | `at_auth ^4.0.0`; `file_picker` imports `at_auth_io.dart` |
 | 7 | `at_cli_commons` | minor (constraint bump) | WP8 | consumes the new `at_onboarding_cli` / `at_client` |
@@ -808,10 +893,10 @@ before a batch lands, **spin up an ephemeral integration branch on demand**
 early, with no standing integration branch to drift.
 
 ### Critical path & merge discipline
-- **Critical path to D1 Tier1 GA:** #1930 → WP1 (`pqSeal`) + WP3
+- **Critical path to D1 GA:** #1930 → WP1 (`pqSeal`) + WP3
   (`CryptoContext`) + WP-SS (substrate) + WP10 (enrollment key) → WP6 (`nskey`)
   → WP7 (migration/flag) → WP9 (rotation). `at_auth 4.0` (WP5, WASM-readiness)
-  and WP-GP (the `group` provider) run **in parallel, off this path**.
+  and WP-GP (the `at/pqmls` provider) run **in parallel, off this path**.
 - **Interface-first:** the `pqSeal` signature (WP1), `WritableAtKeys` API (WP2),
   and `CryptoContext` field (WP3) are tiny PRs — merge them first (stubs OK) so
   every track compiles against stable shapes and never blocks on another.

--- a/docs/pq-atsign-key-distribution.md
+++ b/docs/pq-atsign-key-distribution.md
@@ -19,7 +19,7 @@ atSign-level PQ key is the worked example throughout.
 **Secrets are namespaced** — a request is scoped to a namespace, and that namespace is
 the authorisation boundary for who may receive it (the same APKAM enrollment scoping
 the atServer already enforces). The atSign-level PQ key is the **sole root
-(no-namespace) exception**: it is conveyed to *every* client, like the legacy default
+(no-namespace) exception**: it is conveyed to *every* APKAM keypair, like the legacy default
 encryption private key it replaces.
 
 ## Table of contents
@@ -41,31 +41,36 @@ encryption private key it replaces.
 
 ## 1. The primitive — `requestSecret(name)`
 
-Every Alice client that has upgraded to a PQ build owns a **`ClientKeyPackage`**: an
-X-Wing public key (`pub`, `kid`) it publishes under `@alice`'s secondary, whose
-private half is generated locally and **never leaves the device**. Publishing under
-`@alice` means the atServer's write-auth is the trust anchor — only an authenticated
-Alice client can publish a KeyPackage as Alice.
+Every Alice **APKAM keypair** on a PQ build is accompanied by a **key package**: an
+X-Wing public key (`pub`, `kpid` = kid of its X-Wing public key) whose private half is
+generated locally and **never leaves the keyfile**. The key package is **not published** —
+it is carried in the per-APKAM enrollment record (`<E>.<apkamId>.pqapkam.__manage@alice`)
+next to the ML-DSA APKAM public key, registered by the authenticated APKAM keypair. The
+trust anchor is that enrollment-record registration; the key package is discovered only via
+the gated `enroll:listfornamespace` verb (`pq-secret-push.md`), never as a public at-key.
 
 Given that, the primitive is:
 
-1. **Request.** The requester **discovers** the namespace's clients from their published
-   `ClientKeyPackage`s and **fans out** a sealed request to each (`requestSecretsFromNamespace`)
-   — there is no keyless broadcast: each request is a targeted `pqSeal`-ed envelope addressed to
-   a peer's `clientId`, carrying the requester's *own* clientId so responders know where to seal
-   the answer. (The root PQ key is the no-namespace exception — §3.)
+1. **Request.** The requester **discovers** the namespace's authorised APKAM keypairs via
+   the gated atServer verb `enroll:listfornamespace:<ns>` (`pq-secret-push.md` §2), which
+   returns the authorised enrollments and their per-APKAM key packages, and **fans out** a
+   sealed request to each — there is no keyless broadcast: each request is a targeted
+   `pqSeal`-ed envelope addressed to a peer's `kpid`, carrying the requester's *own* `kpid`
+   so responders know where to seal the answer. (The root PQ key is the no-namespace
+   exception — §3.)
 2. **Serve.** Each peer, on seeing the request, checks its `SecretStore`. If it holds
    the secret *and* the requester's enrollment is authorised for that **namespace**
-   (below), it `pqSeal`s the secret to the requester's KeyPackage and writes the
-   envelope back.
+   (below), it `pqSeal`s the secret to the requester's key package (by `kpid`) and writes
+   the envelope back.
 3. **Receive.** The requester `waitForSecret(name)` resolves on the first valid
    response.
 4. **Verify.** The envelope is APKAM-signed, proving the responder is a genuine Alice
    client. For a keypair secret, the requester also re-derives the public key from
    the received private key and checks it equals the published public key — proving
    it is *the* key, not an injected one.
-5. **Store.** The verified secret lands in the client's updatable local keystore
-   (`WritableAtKeys` / updatable `.atKeys`), keyed by `name` (+ version).
+5. **Store.** The verified secret lands in the APKAM keypair's updatable keystore (its
+   updatable `.atKeys`, working name *WritableAtKeys* — deferred, not a landed type), keyed
+   by `name` (+ version).
 
 This is PQ-safe by construction: the seal is X-Wing (hybrid PQ) to a public key whose
 private half never transited; nothing in the path depends on RSA-2048 confidentiality.
@@ -76,24 +81,26 @@ The substrate prototyped on the spike (`packages/at_client/lib/src/secret_sharin
 **WP-SS — not yet landed**) has the pieces; the primitive is mostly composition, not new
 crypto:
 
-| Need | Prototyped API (WP-SS) |
-|---|---|
-| Per-client X-Wing identity | `ClientKeyPackage` (`registerClient(...)`) |
-| Request a secret | `requestSecretsFromNamespace(...)` → `waitForSecret(...)` |
-| Serve a secret (seal to a requester) | `shareSecretWith(ClientKeyPackage to, Secret)`, `shareAllSecretsWith(to, {excludeEnrollmentIds})` |
-| Revocation guard | `excludeEnrollmentIds` |
-| Authenticity of responder | `EnvelopeSigning` (APKAM-signed envelopes) |
-| Idempotent store / dedup | `SecretStore.putIfNewer(Secret)` |
-| Delivery stream | `receivedSecrets` |
+| Need                                 | Prototyped API (WP-SS)                                                     |
+|--------------------------------------|----------------------------------------------------------------------------|
+| Per-APKAM X-Wing identity            | key package (`registerClient(...)`)                                        |
+| Request a secret                     | `requestSecretsFromNamespace(...)` → `waitForSecret(...)`                  |
+| Serve a secret (seal to a requester) | `shareSecretWith(keyPackage, Secret)`, `shareAllSecretsWith(to, {excludeEnrollmentIds})` |
+| Revocation guard                     | `excludeEnrollmentIds`                                                     |
+| Authenticity of responder            | `EnvelopeSigning` (APKAM-signed envelopes)                                 |
+| Idempotent store / dedup             | `SecretStore.putIfNewer(Secret)`                                           |
+| Delivery stream                      | `receivedSecrets`                                                          |
 
-The prototyped `requestSecretsFromNamespace` requests by *namespace*; the generalisation
-— request **by name** (a specific named secret) — is a small extension that lands with
-WP-SS.
+The spike substrate keys the recipient by a per-client `clientId`; WP-SS re-keys it to the
+per-APKAM `kpid` (`pq-secret-push.md` §3/§7) — the per-client → per-APKAM migration is the
+planned end state, not the spike's current shape. The prototyped
+`requestSecretsFromNamespace` requests by *namespace*; the generalisation — request **by
+name** (a specific named secret) — is a small extension that lands with WP-SS.
 
 ### Details the primitive must pin down
 
 - **Transport = `put` + sync, plus an optional wake-up notify.** Request and response are the
-  *same* targeted envelope key — `<msgId>.<recipientClientId>.__ssenv.<namespace>@<atSign>`, a
+  *same* targeted envelope key — `<msgId>.<kpid>.__ssenv.<ns>@<owner>`, a
   self key, `shouldEncrypt=false` (already sealed) — written with `atClient.put`. Delivery is the
   **sync** service (a sync-progress listener + a periodic local sweep surface arrivals on
   `receivedSecrets`), so it is offline-tolerant by construction. **Some clients don't sync** — so
@@ -106,8 +113,11 @@ WP-SS.
   secret to requester `R` only if `R`'s enrollment is authorised for that
   **namespace** (a `app_1.my_apps`-scoped enrollment must not be handed the `app_2.my_apps` key) — the
   same scope the atServer's APKAM already enforces, so the policy is just "does `R`'s
-  enrollment cover this namespace." Never serve to an enrollment in
-  `excludeEnrollmentIds` (revoked). The **root** PQ key is the exception: like the
+  enrollment cover this namespace." The authoritative source is the server-sourced
+  `enroll:listfornamespace` verb (`pq-secret-push.md` §2/§5), not a client self-claim, and
+  delivery is additionally enforced by the namespace gate on the `__ssenv.<ns>` key (the
+  seal is the confidentiality boundary; the gate is defence in depth). Never serve to an
+  enrollment in `excludeEnrollmentIds` (revoked). The **root** PQ key is the exception: like the
   legacy default encryption private key (conveyed to *every* enrollment regardless of
   scope — `at_enrollment_impl.dart:154-174`), it is served to every non-revoked
   client.
@@ -148,17 +158,19 @@ so this doc is their **retrofit**, via the request/serve pull (§5).
 
 ## 3. Worked example — the atSign-level PQ key
 
-The roadmap (`crypto-roadmap.md`, *Cold-start*) already posits an atSign-level PQ key
-as the universal fallback a peer encapsulates to when it has no more-specific `nskey`,
-and says *"every bob client can decrypt, instantly, like legacy"* — without saying how
-the private half reaches every existing client. That "how" **is the §1 primitive**:
+The roadmap (`crypto-roadmap.md`, *Cold-start*) already posits an atSign-level PQ key as
+the universal fallback a peer encapsulates the **content key (CK)** to when it has no
+more-specific `nskey` (data is never encrypted directly to the root — `pq-data-encryption.md`
+§4), and says every authorised bob APKAM keypair can decrypt instantly, like legacy — without
+saying how the private half reaches every existing APKAM keypair. That "how" **is the §1
+primitive**:
 
 - It is the **one root-level (no-namespace) secret**, so — unlike namespaced `nskey`
-  keys — it is conveyed to **every** non-revoked client, mirroring the legacy default
+  keys — it is conveyed to **every** non-revoked APKAM keypair, mirroring the legacy default
   encryption private key that every enrollment receives regardless of scope.
 - The public half is published at the root as **`public:pqpublickey@alice`** (see
   *Naming*).
-- The private half is the root named secret; each existing client requests it, the
+- The private half is the root named secret; each existing APKAM keypair requests it, the
   minter — and thereafter any holder — serves it per §1 (no namespace gate, since the
   root key is universal). Verify public/private correspondence and store. Done.
 
@@ -207,7 +219,7 @@ distribution. With the immutable write already settling creation, this is now on
 it if seed-derivation buys you something else (e.g. deriving many namespace keys from one
 seed). Trade-off: a root seed has atSign-wide blast radius — fine for the atSign-level
 fallback key, but do **not** derive per-namespace `nskey` keys from it (keep their
-tighter blast radius per the roadmap's *D1 Tier 1* design).
+tighter per-`(atSign, namespace)` blast radius per the roadmap's nskey data path design).
 
 ## 5. Upgrading existing clients — the three scenarios
 
@@ -216,7 +228,7 @@ population that "upgrades." Two populations never run this flow:
 
 | Population | Upgrades? | Gets `pqpublickey` via | Gets its PQ APKAM via |
 |---|---|---|---|
-| **Existing atSign, existing client** (this §) | yes | **pull** — `requestSecret` (§1) | mints its own (multiple per enrollment) |
+| **Existing atSign, existing APKAM keypair / keyfile install** (this §) | yes | **pull** — `requestSecret` (§1) | mints its own (multiple APKAM keypairs per enrollment) |
 | **New atSign** | no — PQ-native | generated at CRAM onboarding (first client) | generated at onboarding |
 | **New enrollment** (post-PQ, after the first client) | no | **push** — the approving AtClient conveys it via the PQ-safe enroll/approve flow | set up by enroll/approve |
 
@@ -231,14 +243,15 @@ Each upgrading client bootstraps **two** PQ keypairs:
 
 The encryption keypair is created once for the atSign and conveyed (§1, §4).
 
-**APKAM cardinality is per (host, AtKeys file), not per client.** Many
-clients/processes may share one AtKeys file on one host; they share **one** minted PQ
+**APKAM cardinality is per (host, AtKeys file), not per client — the recipient/identity unit
+is the APKAM keypair (per keyfile/install), and "per (host, AtKeys file)" names the same
+unit.** Many clients/processes may share one AtKeys file on one host; they share **one** minted PQ
 APKAM keypair — a host-local mint-once lock serialises it (the first to upgrade mints,
 writes it into the keyfile/keychain; the rest read it). The atServer allows **multiple
 APKAM keypairs per enrollment**, so if the *same* AtKeys file is also in use on another
 host (copying we advise against), that host mints its own single, *different* PQ APKAM
 keypair. One enrollment therefore ends up with one PQ APKAM keypair **per host its keyfile
-lives on**, plus the legacy RSA key. The new granularity this unlocks is **per-host**,
+lives on**, plus the legacy RSA key. The new granularity this unlocks is **per-APKAM**,
 not per-client. (The alternative — one APKAM keypair per enrollment — would force later
 hosts to fetch the first host's signing private key over §1; minting-own keeps signing
 keys off the conveyance path.)
@@ -254,11 +267,14 @@ keys off the conveyance path.)
 4. **Delete the legacy RSA APKAM public key** for this enrollment from the atServer — only
    *after* step 3 confirms PQ auth works (delete-by-default; *Legacy deletion* below).
 5. Save its AtKeys (incl. the PQ APKAM private key) to file / keychain.
-6. Publish its `ClientKeyPackage` (X-Wing) so peers can seal secrets to it.
+6. Register its per-APKAM **key package** (X-Wing public) in its enrollment record
+   (`<E>.<apkamId>.pqapkam.__manage@alice`) so the `enroll:listfornamespace` verb can return
+   it to authorised pushers/requesters. (Not published — enrollment-internal.)
 7. **Attempt create** `public:pqpublickey@alice` (immutable create-if-absent):
    - **won** → generate the keypair, store + seed the private half, serve it (§4);
    - **exists** → request the private half (§1), verify correspondence, store.
-8. When the roster holds the key, the atSign advertises PQ readiness (once, atSign-wide).
+8. When the roster (the set of authorised APKAM keypairs) holds the key, the atSign
+   advertises PQ readiness (once, atSign-wide).
 
 The three scenarios differ in exactly **one** place — step 7 (`pqpublickey`):
 
@@ -270,14 +286,14 @@ The three scenarios differ in exactly **one** place — step 7 (`pqpublickey`):
 | 3 · Verify PQ APKAM auth | ✓ | ✓ | ✓ |
 | 4 · Delete legacy APKAM pubkey | ✓ (first to upgrade) | ✓ idempotent | ✓ idempotent |
 | 5 · Save AtKeys | ✓ | ✓ | ✓ |
-| 6 · Publish ClientKeyPackage | ✓ | ✓ | ✓ |
+| 6 · Register key package (per-APKAM enrollment record) | ✓ | ✓ | ✓ |
 | 7 · `public:pqpublickey@alice` | **create** (wins) | exists → don't create | exists → don't create |
 | 7 · pqpublickey private half | **generate + hold + serve** | **request + verify + store** | **request + verify + store** |
 | 8 · PQ-readiness | flips it | already on | already on |
 
 **B and C are identical for this bootstrap.** With one PQ APKAM keypair per host+keyfile,
 same-vs-different-enrollment collapses here: both mint a host-local APKAM key and both
-request the root `pqpublickey` (universal — served to every non-revoked client). The
+request the root `pqpublickey` (universal — served to every non-revoked APKAM keypair). The
 distinction only re-emerges for **namespaced** secrets (§1): a namespace-restricted
 enrollment is served only the keys for namespaces it is authorised for, so C on a
 restricted enrollment receives a *subset* of the `nskey` secrets B gets. The root key is
@@ -286,12 +302,12 @@ not subject to that gate.
 ### Legacy APKAM deletion & what revocation means
 
 Deleting the legacy RSA APKAM public key on upgrade is **recommended as the default** — it
-is what makes per-host revocation actually mean something.
+is what makes per-APKAM revocation actually mean something.
 
 - **Why delete.** The legacy RSA APKAM key is (a) quantum-vulnerable (a future forger can
   mint signatures) and (b) **shared across every copy** of the keyfile. While it remains on
   the atServer, any copy can still authenticate with it — so revoking *one* host's PQ APKAM
-  key is bypassable via the shared legacy key. Per-host revocation is meaningless until the
+  key is bypassable via the shared legacy key. Per-APKAM revocation is meaningless until the
   legacy key is gone; deletion closes both the quantum hole and the bypass.
 - **Order matters.** Delete only *after* PQ APKAM auth is verified (step 3 → 4), or a host
   could brick its own authentication.
@@ -316,10 +332,10 @@ is what makes per-host revocation actually mean something.
 | Axis | Granularity | Mechanism |
 |---|---|---|
 | **Auth** | per enrollment | existing APKAM enrollment revocation (cuts every host of the enrollment) |
-| **Auth** | **per host/keyfile** *(new)* | delete that host's PQ APKAM public key — works **only because** the legacy shared key was deleted |
+| **Auth** | **per-APKAM keypair** *(new)* | delete that keypair's PQ APKAM public key — works **only because** the legacy shared key was deleted |
 | **Encryption** | per namespace | rotate the namespace / `pqpublickey` key **excluding** the revoked party (roadmap *rotation*, WP9) — controls *new-data* access, orthogonal to auth |
 
-So the per-host auth revocation the upgrade unlocks is *contingent* on the legacy-key
+So the per-APKAM auth revocation the upgrade unlocks is *contingent* on the legacy-key
 deletion above, and is a different axis from encryption-key rotation.
 
 ### Where the PQ APKAM key lives (storage & host binding)
@@ -327,20 +343,20 @@ deletion above, and is a different axis from encryption-key rotation.
 The minted PQ APKAM **private** key must live somewhere, and the choice trades
 portability, host-binding, and dev/test ergonomics. There is **no universal way to
 cryptographically bind it to a host today**, so separate two goals: an
-**individually-revocable per-host identity** (achievable everywhere) from a
+**individually-revocable per-APKAM identity** (achievable everywhere) from a
 **non-exportable, host-bound key** (hardware only).
 
 | Storage | Host binding | Dev / test | Notes |
 |---|---|---|---|
-| **AtKeys file** (default) | none — copyable | **clean**: the key persists with a reused keyfile, so re-runs don't re-mint | simplest; per-host revocation still works for keys each host minted |
+| **AtKeys file** (default) | none — copyable | **clean**: the key persists with a reused keyfile, so re-runs don't re-mint | simplest; per-APKAM revocation still works for keys each host minted |
 | **OS keychain** | software-local (off the portable file) | **polluting**: every fresh checkout / CI run / container mints a new key | availability varies — headless/servers may lack one |
 | **TPM / Secure Enclave** | strong — non-exportable | absent in CI/containers | **no PQ (ML-DSA) support in hardware today** — not viable for this key yet |
 | **Platform attestation** (App Attest / Android / TPM-remote) | strong — server admits the key only from a genuine distinct device | blocks CI/container floods (they can't attest) | platform-specific, heavy, excludes headless |
 
 What ties a key to a host for *management / revocation* is not the storage location but a
-**distinct, labelled record per host** (hostname / install-UUID / platform on the
+**distinct, labelled record per APKAM keypair** (hostname / install-UUID / platform on the
 published APKAM record). The label is spoofable — an administration aid, not a security
-boundary — but it is what lets a revocation UI say "revoke the laptop" and makes per-host
+boundary — but it is what lets a revocation UI say "revoke the laptop" and makes per-APKAM
 revocation usable everywhere.
 
 **Decision (2026-06-24): store in the copyable AtKeys file section** (like the legacy APKAM) —
@@ -348,7 +364,7 @@ portable, dev/test-clean (a reused keyfile doesn't re-mint), riding the existing
 conveyance. A copy made *after* upgrade shares the key, so revocation is **per-keyfile-key**,
 not strictly per-device. Two supporting choices:
 - **OS-keychain (and hardware, if it ever supports PQ) is an opt-in hardening** for single-host
-  high-security deployments that want the key off the portable file and true per-host binding —
+  high-security deployments that want the key off the portable file and true host binding —
   **off by default**, so dev/test doesn't auto-pollute.
 - **Server-side TTL / usage-based eviction of APKAM keys** (a key unused for authentication
   within N days is pruned) bounds the per-enrollment key set and self-cleans throwaway dev/test
@@ -356,29 +372,36 @@ not strictly per-device. Two supporting choices:
 
 ## 6. End-to-end sequence (atSign-level PQ key)
 
-1. **Upgrade wave.** Each Alice client runs §5: mints its PQ APKAM keypair, publishes its
-   `ClientKeyPackage`, starts the listener. No PQ readiness advertised yet.
-2. **Create once.** The first client to reach step 7 wins the immutable create of
+1. **Upgrade wave.** Each Alice APKAM keypair runs §5: mints its PQ APKAM keypair, registers
+   its key package in its enrollment record, starts the listener. No PQ readiness advertised yet.
+2. **Create once.** The first APKAM keypair to reach step 7 wins the immutable create of
    `pqpublickey`, generates the keypair, and seeds the private half as `pqid:<kid>` (§4).
-3. **Convey.** Every other client `requestSecret(pqid:<kid>)`; a holder serves per §1
-   (excluding revoked enrollments). Laggards/offline clients pull on next start.
-4. **Verify + store** (correspondence check; `WritableAtKeys`).
+3. **Convey.** Every other APKAM keypair `requestSecret(pqid:<kid>)`; a holder serves per §1
+   (excluding revoked enrollments). Laggards/offline APKAM keypairs pull on next start.
+4. **Verify + store** (correspondence check; the APKAM keypair's updatable keystore).
 5. **Flip readiness.** Only once the roster holds the key does Alice advertise PQ
-   readiness; peers encapsulate shared keys to `pqpublickey@alice`; Alice decrypts.
+   readiness; peers encapsulate the **content key (CK)** to `public:pqpublickey@alice`
+   (never application data — `pq-data-encryption.md` §4); Alice decrypts.
 
 ## 7. Edge cases
 
-- **Offline client** — pulls on next startup; the request persists, a holder answers.
-- **Revoked enrollment** — `excludeEnrollmentIds` keeps the secret away; pair with
-  rotation (reuse the `__nsk.<epoch>` rotation channel) to cut a device that already
-  pulled.
+- **Offline APKAM keypair** — pulls on next startup; the request persists, a holder answers.
+- **Revoked enrollment** — `excludeEnrollmentIds` keeps the secret away; to cut an APKAM
+  keypair that already pulled, use the per-APKAM **revocation lever**: rotate the `nskey`
+  **keypair** excluding the revoked keypair and push the successor (`pq-secret-push.md` §6.4)
+  — distinct from routine CK rotation (`pq-data-encryption.md` §5.4), which is the coarse-FS
+  lever, not a revocation tool.
 - **New enrollment / new atSign** — never runs the §5 retrofit: a new enrollment receives
   `pqpublickey` *pushed* from the approver via enroll/approve; a new atSign generates it at
   onboarding. The §1 pull is only an offline backstop for them.
 - **Two creators race** — impossible: the immutable create-if-absent admits exactly one;
   the rest fall through to "request" (§4).
-- **Rotation / compromise** — create a successor, bump `kid`/epoch, redistribute
-  excluding the bad enrollment, supersede the old version (WP9 machinery).
+- **Rotation / compromise** — two distinct levers (ADR 0002 / `pq-data-encryption.md` §5.4):
+  routine forward secrecy is **CK rotation** (rotate the symmetric content key + delete the
+  old `at/nskey` conveyance — O(1), no exclusion); a **compromise** triggers **nskey-keypair
+  rotation** — mint a successor nskey keypair, bump `kid`/epoch, push it excluding the revoked
+  APKAM keypair, supersede the old version (WP9 machinery — the expensive O(n) per-APKAM
+  revocation + post-compromise-security lever, not cheap).
 
 ## 8. To verify / cross-tier notes
 
@@ -386,7 +409,7 @@ not strictly per-device. Two supporting choices:
 (`Metadata.immutable`) — already live, no change needed. The retrofit adds these **new**
 atServer capabilities:
 - **Multiple APKAM public keys per enrollment** — accept and store a set, authenticate
-  against any of them; per-host, enabling per-host auth revocation.
+  against any of them; per-APKAM, enabling per-APKAM auth revocation.
 - **PQ APKAM authentication** — verify an APKAM auth signed with a PQ signature (ML-DSA).
 - **Delete a specific public key** — the legacy APKAM key on upgrade (delete-by-default,
   after PQ auth is confirmed) and a host's PQ APKAM key on revocation.
@@ -401,9 +424,11 @@ atServer capabilities:
 
 **Design points to pin down:**
 - **The §1 request/serve primitive is the real deliverable** — reused by the atSign-level
-  PQ key, per-namespace `nskey` distribution, rotation, and master-seed conveyance. Worth
-  promoting in the plan from "substrate plumbing" to a named, spec'd primitive
-  (`requestSecret(name)` + responder authorisation policy).
+  PQ key, per-namespace `nskey` **private** distribution (the nskey is a KEM keypair; the
+  conveyed value is its private half, not a data key), rotation, and master-seed conveyance.
+  Steady-state conveyance is the **push** (`pq-secret-push.md`, the dual of this doc), with
+  this pull as the offline backstop. Worth promoting in the plan from "substrate plumbing"
+  to a named, spec'd primitive (`requestSecret(name)` + responder authorisation policy).
 - **Responder authorisation policy** (which enrollment may receive which namespaced
   secret) needs a precise spec — it is the access-control core of the primitive.
 - **Confirm WP10 enroll/approve conveys over the PQ enrollment key, not the RSA-wrapped
@@ -411,12 +436,14 @@ atServer capabilities:
 
 ## 9. How this maps to the plan (no plan edits yet)
 
-- Reuses **WP-SS** (KeyPackages, `pqSeal` secrets, `requestSecretsFromNamespace`,
-  `excludeEnrollmentIds`) — generalised to **request-by-name**.
+- Reuses **WP-SS** (per-APKAM key packages, `pqSeal` secrets, `requestSecretsFromNamespace`,
+  `excludeEnrollmentIds`) — generalised to **request-by-name**, with discovery via the
+  `enroll:listfornamespace` verb (not scanning published key packages) and the substrate
+  re-keyed from per-client `clientId` to per-APKAM `kpid` (`pq-secret-push.md` §3/§7).
 - Reuses **WP9** rotation/revocation for succession.
 - Complements **WP10** (future enrollments); this is the existing-client counterpart.
 - **New, not yet explicit:** (a) the generic **`requestSecret(name)`** primitive +
-  responder authorisation; (b) the **per-client PQ APKAM upgrade** (mint-own,
+  responder authorisation; (b) the **per-APKAM PQ upgrade** (mint-own,
   multiple-per-enrollment) + the atServer enhancements above; and (c) the **atSign-level
   PQ key lifecycle** (immutable create + existing-client pull). Candidates for added work
   items once the approach is chosen.

--- a/docs/pq-data-encryption.md
+++ b/docs/pq-data-encryption.md
@@ -1,0 +1,299 @@
+# PQ crypto — D1 data encryption (the nskey data path)
+
+**Status:** working planning doc (not plan-of-record). Lives in `docs/`.
+**Source of truth** for how D1 encrypts application data. Decision recorded in
+[ADR 0002](adr/0002-d1-single-tier-nskey.md); per-APKAM key conveyance in
+[`pq-secret-push.md`](pq-secret-push.md); named-secret pull in
+[`pq-atsign-key-distribution.md`](pq-atsign-key-distribution.md).
+
+**Conventions.** Notation per `pq-use-case-catalogue.md`. Worked examples are
+**Given / When / Then**. Key names are shown **complete** (`@<owner>` suffix). "Working
+name" marks an at-key/provider name not yet finalised. `aS = pq` unless stated.
+
+**Locked decisions (this doc encodes them):**
+- **Two `nskey` KEM keypairs per `(atSign, namespace)`** — a **self nskey** (not published) and
+  a **public nskey** (published). `nskey` is asymmetric (X-Wing); it is what you *encapsulate
+  symmetric content keys to*, never what encrypts data.
+- **Three D1 providers:** `legacy`, `at/nskey`, `at/symmetric/AES/GCM` (the `at/` prefix is the
+  first-party namespace; app authors write their own providers under their own prefixes).
+- **(a) Decoupled content keys.** A symmetric content key (CK) is conveyed **once** via
+  `at/nskey`; application-data values reference it by `kid` and are encrypted under it with
+  `at/symmetric/AES/GCM`. CKs are **not** embedded per data value.
+- **(ii) Substrate is plumbing.** The per-APKAM conveyance of `nskey` **privates** (push +
+  `enroll:listfornamespace`, pull backstop) is transport *beneath* the provider seam; the
+  value-level `at/nskey` provider tags the **CK-conveyance records** that ride ordinary sync.
+- **Self and cross-atSign use the identical flow**, differing only in *which* nskey the CK is
+  sealed to. Forward secrecy is a coarse, opt-in rotation policy; cross-atSign FS is bilateral.
+
+## Table of contents
+
+- [1. The three layers](#1-the-three-layers)
+- [2. Keys and key shapes](#2-keys-and-key-shapes)
+- [3. The three providers](#3-the-three-providers)
+- [4. The uniform data flow](#4-the-uniform-data-flow)
+- [5. Worked examples (given / when / then)](#5-worked-examples-given--when--then)
+  - [5.1 Self put](#51-self-put)
+  - [5.2 Self read (second client)](#52-self-read-second-client)
+  - [5.3 Cross-atSign put + read](#53-cross-atsign-put--read)
+  - [5.4 CK rotation = coarse forward secrecy](#54-ck-rotation--coarse-forward-secrecy)
+  - [5.5 Bootstrap: a new APKAM keypair joins (the substrate, beneath the seam)](#55-bootstrap-a-new-apkam-keypair-joins-the-substrate-beneath-the-seam)
+- [6. Forward secrecy](#6-forward-secrecy)
+- [7. Implementation notes](#7-implementation-notes)
+- [8. Relationship to the rest of the design](#8-relationship-to-the-rest-of-the-design)
+
+# 1. The three layers
+
+D1 data encryption is three layers; the seam routes each stored value to a provider by its
+`appMetadata.providerId`:
+
+```
+LAYER 3  application data     ── AES-256-GCM under a symmetric CK ──▶  provider at/symmetric/AES/GCM
+LAYER 2  content key (CK)     ── X-Wing-sealed to an nskey ──────────▶  provider at/nskey   (a discrete, once-delivered conveyance record)
+LAYER 1  nskey PRIVATE        ── X-Wing-sealed to an APKAM key package ▶  the secret-sharing substrate  (plumbing, beneath the seam — decision (ii))
+```
+
+- **Layer 3 (data)** is pure symmetric: a value carries its AES-256-GCM ciphertext and *references*
+  a CK by `kid`. It never touches asymmetric crypto.
+- **Layer 2 (CK conveyance)** is the `at/nskey` provider: the CK is X-Wing-encapsulated to an
+  nskey and written **once** as its own record; every Layer-3 value under that CK just cites the
+  `kid`. This is decision **(a)**.
+- **Layer 1 (nskey bootstrap)** gets the nskey *private* into each authorised APKAM keypair's
+  keystore. It uses the same X-Wing sealing but is delivered **per-APKAM** by the secret-sharing
+  substrate (`__ssenv` push + `enroll:listfornamespace`, pull backstop) — **transport, not a
+  value-level provider** (decision **(ii)**). Once a client holds the nskey private, it can
+  unwrap any Layer-2 CK with one sync, O(1).
+
+Layer 1 happens rarely (a client joins/upgrades); Layer 2 happens per CK (per epoch); Layer 3
+happens per data write.
+
+# 2. Keys and key shapes
+
+Concrete, `@alice` owner, namespace `app_1.my_apps` (reads right-to-left, DNS-style). `K1…` =
+APKAM keypairs, `kp1…` their key-package kids, `ck7…` content-key kids. Working names marked.
+
+| Object | Shape | Published? | Who holds the private | Role |
+|---|---|---|---|---|
+| **self nskey** | keypair; its public is **not** an at-key | no | Alice's authorised clients (conveyed via substrate) | Alice encapsulates **her own** CKs to it |
+| **public nskey** | `public:nskey.app_1.my_apps@alice` (public half) | **yes**, world-readable | Alice's authorised clients | external senders encapsulate CKs to it |
+| **CK conveyance** *(working)* | `<ckKid>.__ck.app_1.my_apps@alice` (self key) | no | n/a (it *is* a sealed CK) | `at/nskey` value: `X-Wing-seal(ck)` to an nskey |
+| **data value** | `<key>.app_1.my_apps@alice` | no | n/a | `at/symmetric/AES/GCM`: AES-GCM under a CK, cites `ckKid` |
+| **substrate envelope** *(working)* | `<msgId>.<kpid>.__ssenv.app_1.my_apps@alice` (self key) | no | n/a | Layer-1 plumbing: `pqSeal(nskey private)` to key package `kp` |
+| **APKAM key package** | per-`pq-secret-push.md` | (enrollment record) | the APKAM keypair | recipient unit for Layer-1 |
+
+Cross-atSign mirrors this with `@bob` as owner of the values he writes for Alice — e.g. the data
+value `@alice:<key>.app_1.my_apps@bob` and the CK conveyance `@alice:<ckKid>.__ck.app_1.my_apps@bob`,
+both sealed/encrypted to Alice's **published public nskey** and synced to Alice as cached
+replicas. (This ownership is why cross-atSign FS is bilateral — section [6](#6-forward-secrecy).)
+
+**Both nskey privates** for a namespace live in an authorised client's keystore: the self-nskey
+private (unwraps Alice's own CKs) and the public-nskey private (unwraps CKs external senders sent
+her). Both are KEM privates — they **decapsulate CKs**, they do not decrypt application data.
+
+**Where the self-nskey *public* half comes from.** The self nskey is never a published at-key, but
+a client still needs its public to *encapsulate* its own CKs. The substrate envelope that conveys
+the self-nskey private carries both halves (or the client derives the public from the X-Wing
+private), so any authorised client can both encapsulate (needs the public) and decapsulate (needs
+the private). Only Alice's own clients ever encapsulate to the self nskey, so it needs no
+world-readable artifact.
+
+**Multi-namespace keying.** nskey privates are keyed by `(owner atSign, namespace)`; the CK cache
+by `(owner, namespace, ckKid)` — never `ckKid` alone, since kids are not unique across namespaces.
+A value in a namespace for which the client holds no nskey private is left **undecryptable**
+(yielded as an error), not silently skipped — mirroring the `(owner, id)` identity discipline used
+elsewhere in the SDK.
+
+# 3. The three providers
+
+| `providerId` | Tags a value that is… | Mechanism | Recipient (kid in metadata) |
+|---|---|---|---|
+| `legacy` | legacy data + inline-wrapped key (the model (a) replaces — modern data values never inline a key) | RSA-2048 + AES (monolithic) | RSA keypair. Bare name (pre-convention default; existing data already tagged this) |
+| `at/nskey` | a **CK-conveyance record** (a sealed content key, cited by `kid`) | `X-Wing-seal` (the content key encapsulated to an nskey public) | the nskey the CK was sealed to — **self nskey** (Alice's own) or a recipient's **public nskey** |
+| `at/symmetric/AES/GCM` | **application data** | AES-256-GCM under a CK | n/a (symmetric); the CK is cited by `kid` and resolved from cache (populated by the `at/nskey` provider when its conveyance record synced) |
+
+Notes:
+- `at/nskey` is the value-level provider you see on stored CK records. The **same X-Wing sealing**
+  also conveys nskey *privates* in Layer 1, but those ride the secret-sharing substrate as
+  transport and are **not** value-level `at/nskey` records (decision (ii)).
+- `at/symmetric/AES/GCM` names the **algorithm** deliberately — that is the layer needing
+  crypto-agility (a future `at/symmetric/AES/SIV` coexists; old values keep their tag). `at/nskey`
+  names the **role** — the nskey system is stable; its KEM (X-Wing) is versioned by the key's kid,
+  not the providerId.
+- **Legacy interop.** A value with **no** `appMetadata.providerId` defaults to `legacy`
+  (pre-convention data). `legacy`, `at/nskey`, and `at/symmetric/AES/GCM` values coexist within a
+  namespace and the seam routes per value. A writer emits the nskey data path's providers once the namespace
+  has an nskey (else cold-start, section [4](#4-the-uniform-data-flow)); legacy data is read in
+  place and re-encrypted only if rewritten.
+
+# 4. The uniform data flow
+
+One pattern, **identical for self (Alice→self) and cross-atSign (Bob→Alice)** — only the target
+nskey differs:
+
+**Write** (sender = whoever owns the data):
+1. Choose/cut a symmetric **CK** (cadence is the sender's policy).
+2. **Convey the CK once** (`at/nskey`): `X-Wing-seal(CK)` to the recipient's nskey — Alice's
+   **self** nskey when writing self data; the recipient's **public** nskey when writing to a peer
+   — and write it as a `<ckKid>.__ck.<ns>@<owner>` record. (Skip if the CK is already conveyed.)
+3. **Write data** (`at/symmetric/AES/GCM`): AES-256-GCM under the CK; stamp `ckKid` (+ iv) in
+   `appMetadata`.
+
+**Read** (recipient = an authorised client):
+1. On syncing a `…__ck…` record, the `at/nskey` provider **decapsulates the CK** with the matching
+   nskey private and caches it by `kid`.
+2. On a data value, the `at/symmetric/AES/GCM` provider **resolves the CK by `ckKid`** (from cache)
+   and AES-GCM-decrypts.
+
+The CK private-half conveyance for *new clients* (Layer 1) is the substrate's job and happens out
+of band (section [5.5](#55-bootstrap-a-new-apkam-keypair-joins-the-substrate-beneath-the-seam)).
+
+**Resolution & ordering.** Sync is not ordered, so a Layer-3 data value can arrive **before** (or
+without) its CK conveyance. On a `ckKid` cache miss the `at/symmetric/AES/GCM` reader (a)
+decapsulates the local `<ckKid>.__ck.<ns>@<owner>` record on demand if it is present, else (b)
+yields a `Stream.error` / deferred state and re-attempts when the conveyance syncs — mirroring
+`getItemsAsStream`'s per-key decode-failure convention. A value whose CK was deleted for forward
+secrecy stays undecryptable, by design.
+
+**Cold-start — no namespace public nskey yet.** When a sender has no
+`public:nskey.<ns>@<recipient>` to seal to (namespace uninitialised / first contact), it falls
+back to encapsulating the **CK** to the recipient's atSign-level `public:pqpublickey@<recipient>`
+(root) as a bootstrap recipient (`recipientKind: "root-pqpublickey"`). **Only the CK is sealed to
+the root key — application data is never encrypted directly to it**, so the nskey-never-encrypts-
+data invariant holds (`pqpublickey` is just another KEM target for the CK). Once the namespace
+publishes its public nskey, new CKs target the nskey; the root-keyed conveyance is the transient
+cold-start bridge. (This is the roadmap's cold-start fallback, expressed in the CK→nskey model.)
+
+# 5. Worked examples (given / when / then)
+
+Cast: `@alice` with clients on APKAM keypairs `K1` (this writer) and `K2` (another client), both
+authorised for `app_1.my_apps` and holding both nskey privates. `@bob` likewise for his namespace.
+
+## 5.1 Self put
+
+- **Given:** Alice (`K1`) wants to store a private note in `app_1.my_apps`; no current CK yet.
+- **When:** `K1` writes the note.
+- **Then:**
+  - `K1` cuts CK `ck7`, writes the conveyance once:
+    `ck7.__ck.app_1.my_apps@alice` — value = `X-Wing-seal(ck7)` to the **self nskey**;
+    `appMetadata = { providerId: "at/nskey", recipientKind: "self-nskey", ckKid: "ck7" }`.
+  - `K1` writes the data: `note1.app_1.my_apps@alice` — value = `AES-256-GCM(note1)` under `ck7`;
+    `appMetadata = { providerId: "at/symmetric/AES/GCM", ckKid: "ck7", iv: … }`.
+  - The data value contains **no** sealed key — only the `ck7` reference (decision (a)).
+
+## 5.2 Self read (second client)
+
+- **Given:** `K2` is online, holds the self-nskey private, has not yet seen `ck7`.
+- **When:** `K2` syncs `ck7.__ck…` and `note1`.
+- **Then:**
+  - `at/nskey` decapsulates `ck7` from the conveyance record with the self-nskey private; caches
+    `ck7` by kid.
+  - `at/symmetric/AES/GCM` resolves `ck7` by `ckKid` and AES-GCM-decrypts `note1`.
+  - A later `note2.app_1.my_apps@alice` under `ck7` needs **no** new conveyance — `K2` already
+    holds `ck7`.
+
+## 5.3 Cross-atSign put + read
+
+- **Given:** `@bob` (client `Kb`) shares data with `@alice` in `app_1.my_apps`; Bob holds Alice's
+  published `public:nskey.app_1.my_apps@alice`.
+- **When:** Bob writes a shared value, then Alice reads it.
+- **Then:**
+  - Bob cuts CK `ckB3`, conveys it once: `@alice:ckB3.__ck.app_1.my_apps@bob` — value =
+    `X-Wing-seal(ckB3)` to **Alice's published public nskey**;
+    `appMetadata = { providerId: "at/nskey", recipientKind: "public-nskey", ckKid: "ckB3" }`. (Owned
+    by `@bob`; Alice gets a cached replica.)
+  - Bob writes data `@alice:msg1.app_1.my_apps@bob` — `AES-256-GCM(msg1)` under `ckB3`;
+    `providerId: "at/symmetric/AES/GCM", ckKid: "ckB3"`.
+  - Alice's clients sync both; `at/nskey` decapsulates `ckB3` with the **public-nskey private**;
+    `at/symmetric/AES/GCM` decrypts `msg1`. **Byte-identical structure to the self path** — only
+    the nskey targeted (public vs self) and the value owner (`@bob` vs `@alice`) differ.
+
+## 5.4 CK rotation = coarse forward secrecy
+
+- **Given:** Alice wants to forward-secure her `app_1.my_apps` self data; current CK is `ck7`.
+- **When:** Alice rotates the content key.
+- **Then:**
+  - `K1` cuts `ck8`, writes `ck8.__ck.app_1.my_apps@alice` (sealed to the self nskey); new data
+    uses `ck8`. Conveying `ck8` is **O(1)** — one record, every client unwraps with the shared
+    self-nskey private.
+  - **For FS:** delete the `ck7.__ck…` conveyance record **and** every client evicts cached `ck7`.
+    `ck7`-era data is now undecryptable — the nskey private cannot help, because no sealed `ck7`
+    survives (decision (a) is what makes this possible: the CK was never embedded in the data
+    values). Retaining `ck7` instead = history access, no FS. This is the per-namespace retention
+    knob.
+  - **Not** to be confused with rotating the **nskey keypair** — that is the heavier per-APKAM
+    *revocation* lever (exclude a keypair from the successor nskey), not the routine FS lever.
+
+## 5.5 Bootstrap: a new APKAM keypair joins (the substrate, beneath the seam)
+
+- **Given:** Alice approves a new client on APKAM keypair `K3` (key package `kp3`) for
+  `app_1.my_apps`; `K3` holds neither nskey private yet.
+- **When:** `K3` is approved / comes online.
+- **Then:**
+  - The secret-sharing **substrate** conveys the namespace's nskey **privates** to `kp3`:
+    `pqSeal(nskey privates)` written to `<msgId>.kp3.__ssenv.app_1.my_apps@alice` (per-APKAM, via
+    approval-time push / `enroll:listfornamespace` / pull backstop). **This is Layer-1 plumbing —
+    not an `at/nskey` value-level record** (decision (ii)).
+  - Once `K3` holds the nskey privates, it reads all current and future CK conveyances (Layer 2,
+    O(1) sync) and decrypts data (Layer 3) — no per-APKAM step per CK.
+
+# 6. Forward secrecy
+
+- **The FS lever is CK rotation** (section [5.4](#54-ck-rotation--coarse-forward-secrecy)): rotate
+  the symmetric content key and **delete** the old CK's `at/nskey` conveyance record + evict it
+  from client caches. Decision (a) is what enables this — because the CK is a discrete deletable
+  artifact, not embedded in every data value.
+- **It is coarse**, bounded by the **stable nskey private** remaining a standing decapsulation
+  capability for any CK conveyance that *persists*. Deletion discipline is the FS trusted-computing
+  base; rotation cadence sets the granularity.
+- **CK-conveyance lifecycle (the retention knob).** Default: **retain** — `__ck` records are
+  permanent (no ttl), so a late-joining APKAM keypair can read history (legacy-like; no FS).
+  FS-mode: **delete** the `__ck` record, and clients **evict the cached CK when they observe that
+  record's deletion via sync** — that is the eviction trigger that makes section
+  [5.4](#54-ck-rotation--coarse-forward-secrecy)'s FS claim implementable. An offline /
+  never-resynced client that retains a cached CK is the residual: coarse FS is bounded by eviction
+  *reachability*, not only by record deletion.
+- **Cross-atSign FS is bilateral.** For self data Alice is both endpoints — she cuts the CK, owns
+  the authoritative conveyance + cache, so she forward-secures unilaterally. For inbound, Bob cuts
+  the CK on **his** cadence and the authoritative conveyance is **owned by `@bob` on bob's
+  atServer**; Alice holds only a cached replica keyed to her stable public-nskey private. Alice can
+  purge her cache but cannot delete Bob's authoritative copy — so closing inbound FS depends on
+  Bob's cooperation (or the heavier public-nskey **keypair** rotation lever — the per-APKAM
+  revocation lever of section [5.4](#54-ck-rotation--coarse-forward-secrecy), distinct from CK
+  rotation). This is normal for any FS system
+  (FS across two parties is bilateral), not an nskey deficiency.
+- **What's out of scope (D2):** robust/per-message FS via ratcheted leaves (no standing master
+  key), O(log n) large-group scale, and groups whose membership is decoupled from namespace
+  authorisation. See ADR 0002.
+
+# 7. Implementation notes
+
+**`appMetadata` encoding.**
+- On an `at/nskey` CK-conveyance record:
+  `{ providerId: "at/nskey", recipientKind: "self-nskey" | "public-nskey" | "root-pqpublickey", ckKid }`.
+  The record's `@<owner>` + key name identify *whose* nskey the CK was sealed to; `recipientKind`
+  selects *which* of that owner's keys — and hence which private the reader decapsulates with. The
+  `<ckKid>` in the key name equals `appMetadata.ckKid`.
+- On an `at/symmetric/AES/GCM` data value:
+  `{ providerId: "at/symmetric/AES/GCM", ckKid, iv }`. `iv` is the base64 12-byte GCM nonce, per
+  value. No sealed key is present (decision (a)).
+- **`ckKid`** is the content key's id — a SHA-256 prefix of the CK (deterministic; dedupes
+  identical keys) or a random id. It must be unique within `(owner, namespace)` and is the CK
+  cache key alongside them.
+
+**Key discovery.** A sender obtains a recipient's `public:nskey.<ns>@<recipient>` via an ordinary
+public-key `plookup`, and re-fetches on a decapsulation-failure / rotation signal (the recipient
+may have rotated the public-nskey keypair). The self nskey is never looked up — Alice's clients
+hold it from the substrate (section [5.5](#55-bootstrap-a-new-apkam-keypair-joins-the-substrate-beneath-the-seam)).
+
+# 8. Relationship to the rest of the design
+
+- **Decision:** [ADR 0002](adr/0002-d1-single-tier-nskey.md) — D1 is single-tier `nskey`; this doc
+  is its data-encryption realisation.
+- **Layer 1 conveyance:** [`pq-secret-push.md`](pq-secret-push.md) (proactive per-APKAM push +
+  `enroll:listfornamespace`) and [`pq-atsign-key-distribution.md`](pq-atsign-key-distribution.md)
+  (the `requestSecret` pull backstop) deliver the nskey privates that make Layer 2 work.
+- **Supersedes the framing in:** `crypto-roadmap.md` ("encrypt to the namespace keypair"),
+  `pq-flows-detailed.md` / `pq-use-case-catalogue.md` (the one-keypair legends and
+  `providerId ∈ {legacy, nskey, group}`). That follow-up sweep has been applied;
+  `crypto_impl_plan.md` task B2 now implements this model — a decoupled content key (the
+  `<ckKid>.__ck` record cited by `ckKid`), not an inline per-value `env` envelope. This doc remains
+  **authoritative** for D1 data encryption.

--- a/docs/pq-flows-detailed.md
+++ b/docs/pq-flows-detailed.md
@@ -12,23 +12,39 @@ atServer) unless stated.
 Key objects used throughout:
 - `public:pqpublickey@alice` — atSign-level PQ encryption pubkey (X-Wing; root, no
   namespace; **immutable** once written). Private half = the root secret `pqid:<kid>`.
-- **PQ APKAM** keypair — ML-DSA signing key for auth; minted **per (host, keyfile)**;
-  public half published as an **immutable per-host record** (working name
-  `<enrollmentId>.<hostId>.pqapkam.__manage@alice`).
-- **Namespace key** (`nskey`) — a per-`(atSign, namespace)` X-Wing keypair. With namespace
-  `app_1.my_apps` (key name `nskey`, namespace `app_1.my_apps` — namespaces read right-to-left,
-  DNS-style: app `app_1` under org `my_apps`), three at-key shapes recur — keep them distinct:
-  - `nskey.app_1.my_apps@alice` — @alice's namespace **keypair** (self); alice's clients hold
-    the **private** half (decrypts both her self data and inbound shares).
-  - `public:nskey.app_1.my_apps@alice` — its **public** half, **published world-readable**;
-    **any** atSign (a peer, or alice for self data) encapsulates to it to send to @alice.
-  - `nskey.app_1.my_apps@bob` / `public:nskey.app_1.my_apps@bob` — @bob's keypair + published
-    public half, symmetric.
-  The private half is distributed via `requestSecret`, held only by the owning atSign's own
-  clients; the `public:` form is the one published key anyone encapsulates to — there is **no**
-  per-recipient key shape.
-- `ClientKeyPackage` (CKP) — per-client X-Wing pubkey for receiving sealed secrets.
-- `appMetadata.providerId ∈ {legacy, nskey, group}` — routes the reader to a provider.
+- **PQ APKAM** keypair — ML-DSA signing key for auth; minted **per APKAM keypair**
+  (one per keyfile/install, multiple per enrollment); public half registered in the
+  **per-APKAM enrollment record** (working name
+  `<enrollmentId>.<apkamId>.pqapkam.__manage@alice`, immutable per APKAM keypair).
+- **Namespace key** (`nskey`) — **two** per-`(atSign, namespace)` X-Wing KEM keypairs (a **self
+  nskey** and a **public nskey**). nskey is asymmetric and only ever **wraps symmetric content
+  keys (CKs)** — it never encrypts application data directly; its private **decapsulates CKs**. With
+  namespace `app_1.my_apps` (key name `nskey`, namespace `app_1.my_apps` — namespaces read
+  right-to-left, DNS-style: app `app_1` under org `my_apps`), the at-key shapes recur — keep them
+  distinct:
+  - **self nskey** (`nskey.app_1.my_apps@alice`, public half **not** published) — alice encapsulates
+    **her own** CKs to it; alice's clients hold the **private** half (decapsulates her own CKs).
+  - `public:nskey.app_1.my_apps@alice` — the **public nskey** public half, **published
+    world-readable**; **external senders** encapsulate CKs to it to send to @alice; alice's clients
+    hold its private (decapsulates CKs inbound senders sent her).
+  - `@bob`'s self nskey + `public:nskey.app_1.my_apps@bob`, symmetric.
+  The private halves are conveyed **per-APKAM** by the secret-sharing substrate (PUSH at
+  mint/approve/rotate via the gated `enroll:listfornamespace` verb + the `__ssenv` envelope;
+  `requestSecret` PULL as the offline backstop), held only by the owning atSign's own APKAM
+  keypairs. There are **two** nskeys per namespace (self + public): self data uses the unpublished
+  self nskey; cross-atSign uses the recipient's published public nskey.
+- **X-Wing key package** — the per-APKAM X-Wing recipient keypair a sender `pqSeal`s to (its
+  `kpid` = the kid of its X-Wing public half). Generated locally with each APKAM keypair;
+  **registered in the per-APKAM enrollment record** (`<enrollmentId>.<apkamId>.pqapkam.__manage@alice`)
+  alongside the ML-DSA APKAM pubkey — **never published**, never a client-published at-key,
+  discovered only via the gated `enroll:listfornamespace` verb. Its **private half never leaves
+  the keyfile**.
+- `appMetadata.providerId ∈ {legacy, at/nskey, at/symmetric/AES/GCM}` — routes the reader to a
+  provider; a value with **no** `providerId` defaults to **legacy**. `at/nskey` tags a
+  CK-conveyance record (a CK X-Wing-sealed to an nskey); `at/symmetric/AES/GCM` tags application
+  data AES-256-GCM under a CK, cited by `ckKid`. (`at/nskey` only **conveys** the CK — it never
+  encrypts application data; the umbrella for `at/nskey` + `at/symmetric/AES/GCM` is the **nskey
+  data path**.)
 
 ---
 
@@ -47,7 +63,7 @@ Key objects used throughout:
   - [2.4 Legacy APKAM deletion & lockout — UC-B2.1 / B2.2](#24-legacy-apkam-deletion--lockout--uc-b21--b22)
 - [3. E2EE within one atSign (self) — puts & notifications](#3-e2ee-within-one-atsign-self--puts--notifications)
   - [3.1 Self put, namespace key exists — UC-A3.1](#31-self-put-namespace-key-exists--uc-a31)
-  - [3.2 First self put in a namespace mints + distributes `nskey.app_1.my_apps@alice` — UC-A3.2](#32-first-self-put-in-a-namespace-mints--distributes-nskeyapp_1my_appsalice--uc-a32)
+  - [3.2 First self put in a namespace mints + distributes both `nskey.app_1.my_apps@alice` keypairs — UC-A3.2](#32-first-self-put-in-a-namespace-mints--distributes-both-nskeyapp_1my_appsalice-keypairs--uc-a32)
   - [3.3 Self put falls back to `pqpublickey` (no namespace key) — UC-A3.3](#33-self-put-falls-back-to-pqpublickey-no-namespace-key--uc-a33)
   - [3.4 Self notification — NEW](#34-self-notification--new)
   - [3.5 Mixed — upgraded `alice1`, un-upgraded `alice2` — UC-B3.1](#35-mixed--upgraded-alice1-un-upgraded-alice2--uc-b31)
@@ -67,12 +83,14 @@ Key objects used throughout:
 - **When:** `alice1` runs onboarding.
 - **Steps:**
   1. CRAM-authenticate with the activation secret.
-  2. Mint **PQ APKAM** keypair (ML-DSA); publish its public half as an immutable per-host
+  2. Mint **PQ APKAM** keypair (ML-DSA); register its public half in the per-APKAM enrollment
      record; set it as this enrollment's (E1) APKAM key.
   3. Mint the atSign-level **X-Wing** keypair; **immutable-create** `public:pqpublickey@alice`;
      keep the private half locally and seed it as `pqid:<kid>`.
-  4. Mint the client's **CKP** (X-Wing) and publish it.
-  5. Persist AtKeys (PQ APKAM private + `pqpublickey@alice⁻¹` + CKP private) to keyfile/keychain.
+  4. Mint this APKAM keypair's **X-Wing key package** and register it in the per-APKAM enrollment
+     record (private half stays in the keyfile; **not** published).
+  5. Persist AtKeys (PQ APKAM private + `pqpublickey@alice⁻¹` + X-Wing key package private half)
+     to the per-APKAM keyfile/keychain.
   6. **Verify**: re-authenticate using the PQ APKAM key (proves the server accepts PQ auth).
   7. Legacy interop (config flag, **default off**): publish `public:publickey@alice` (RSA)
      **only if enabled**, for legacy-peer inbound; default is PQ-only (omit it).
@@ -80,8 +98,11 @@ Key objects used throughout:
   - `alice1` authenticates with PQ APKAM; no RSA APKAM key is required for auth.
   - `public:pqpublickey@alice` exists, is immutable (a second create attempt is rejected),
     and `alice1` holds its private half.
-  - `alice1.CKP` is published and fetchable by peers.
-  - No `selfEncryptionKey` is minted (self data will use `nskey`/`pqpublickey`).
+  - `alice1`'s X-Wing key package is registered in its per-APKAM enrollment record (not
+    published; discoverable only via `enroll:listfornamespace`).
+  - No `selfEncryptionKey` is minted (self data will use the **nskey data path** — `at/nskey`
+    conveys the CK, `at/symmetric/AES/GCM` encrypts the data; cold-start seals the CK to
+    `pqpublickey`).
   - readiness may be `ready` (no legacy clients exist).
   - *(Legacy-interop flag on)* `public:publickey@alice` is present; **default (flag off)** it is
     absent and a legacy peer's send is unsupported (UC-B4.2).
@@ -96,14 +117,20 @@ Key objects used throughout:
      RSA — and sends `enroll:request` with its PQ APKAM public half + requested namespaces.
   3. `alice1` (approver) decapsulates `apkamSymmetricKey` with `pqpublickey@alice⁻¹`; approves E2;
      registers `alice2`'s PQ APKAM pubkey for E2 (multiple-per-enrollment).
-  4. `alice1` conveys to `alice2`, AEAD-wrapped under `apkamSymmetricKey`: the
-     **`pqpublickey@alice⁻¹`** (root) and the **`nskey.app_1.my_apps@alice⁻¹`** (authorised namespace only).
-  5. `alice2` fetches + decrypts the conveyed bundle; publishes its **CKP**; persists AtKeys.
+  4. `alice1` conveys the secrets `alice2` is authorised for:
+     - the **`pqpublickey@alice⁻¹`** (root) rides the approval response bundle (wrapped under
+       `apkamSymmetricKey`);
+     - the **`nskey.app_1.my_apps@alice⁻¹`** (authorised namespace only) is delivered by the
+       **substrate push** — `alice1` `pqSeal`s it to `alice2`'s X-Wing key package and `put`s it
+       to `<msgId>.<kpid>.__ssenv.app_1.my_apps@alice` (this is
+       `shareAllSecretsWithEnrollment(E2, approvedNamespaces)`, re-keyed to APKAM-level).
+  5. `alice2` consumes the substrate envelope + approval bundle, decapsulates, verifies; registers
+     its **X-Wing key package** in its per-APKAM enrollment record; persists AtKeys.
   6. `alice2` verifies PQ APKAM auth.
 - **Then:**
   - Nothing in the conveyance path is RSA-wrapped (`apkamSymmetricKey` rode X-Wing) — the
     enrollment harvest-now hole is closed.
-  - `alice2.APKAM = pq`, `pqpk⁻¹ = ✓`, `nskey.app_1.my_apps@alice⁻¹ = ✓`, `nskey.app_2.my_apps@alice⁻¹ = ✗`, `CKP = ✓`.
+  - `alice2.APKAM = pq`, `pqpk⁻¹ = ✓`, `nskey.app_1.my_apps@alice⁻¹ = ✓`, `nskey.app_2.my_apps@alice⁻¹ = ✗`, X-Wing key package registered.
   - `alice2` can authenticate PQ and decrypt `@alice`'s `app_1.my_apps` self data; a `app_2.my_apps` key request
     is refused.
   - E2's APKAM key is a distinct, individually-revocable record.
@@ -114,19 +141,19 @@ Key objects used throughout:
 - **When:** `alice1b` first runs.
 - **Steps:**
   1. `alice1b` authenticates (it has E1's existing APKAM private from the copied keyfile).
-  2. Host-local mint-once: the copied keyfile may already carry a PQ APKAM key (then reuse) or
-     not (then mint a **new** PQ APKAM keypair for this host and publish an immutable per-host
-     record under E1).
+  2. Mint-once per APKAM keypair: the copied keyfile may already carry a PQ APKAM keypair (then
+     reuse) or not (then mint a **new** PQ APKAM keypair and register an immutable per-APKAM
+     enrollment record under E1).
   3. Obtain `pqpublickey@alice⁻¹` — present in the copied keyfile, else `requestSecret`.
-  4. Publish `alice1b`'s CKP.
+  4. Register `alice1b`'s X-Wing key package in its per-APKAM enrollment record (not published).
 - **Then:**
-  - If the second host minted its own (the keyfile copy predated alice1's upgrade), E1 now has
-    **two** PQ APKAM keys (individually revocable); if it inherited the key from the copied
-    keyfile, E1 has **one** shared across both hosts.
+  - If the second host minted its own APKAM keypair (the keyfile copy predated alice1's upgrade),
+    E1 now has **two** PQ APKAM keypairs (individually revocable); if it inherited the keypair from
+    the copied keyfile, E1 has **one** shared across both hosts.
   - Both hosts share `pqpublickey@alice⁻¹` and E1's namespace authorisations.
   - **Decision (PQ APKAM placement):** the PQ APKAM private lives in the **copyable keyfile**
     section, so a copy made *after* upgrade inherits/shares it — revocation is per-keyfile-key,
-    not strictly per-device. Device-local/keychain is optional hardening for true per-host
+    not strictly per-device. Device-local/keychain is optional hardening for true host
     binding.
 
 ## 1.4 Namespace-restricted enrollment — UC-A2.3
@@ -159,10 +186,12 @@ no `pqpublickey`.
 - **When:** `alice1` runs the upgrade.
 - **Steps:**
   1. Authenticate legacy (RSA APKAM).
-  2. **Mint-once per host** a PQ APKAM keypair; publish its immutable per-host record for E1.
+  2. **Mint-once per APKAM keypair** a PQ APKAM keypair; register its immutable per-APKAM
+     enrollment record for E1.
   3. **Verify** PQ APKAM auth succeeds.
   4. **Delete** the legacy RSA APKAM pubkey for E1 (only after step 3).
-  5. Persist AtKeys; publish CKP.
+  5. Persist AtKeys; register this APKAM keypair's X-Wing key package in its per-APKAM enrollment
+     record (not published).
   6. **Immutable-create** `public:pqpublickey@alice` → **wins** → generate X-Wing keypair, hold
      `pqpublickey@alice⁻¹`, seed `pqid:<kid>`, serve on request.
   7. When the roster holds the key, flip readiness (or leave `n-r` until siblings upgrade).
@@ -175,11 +204,12 @@ no `pqpublickey`.
 
 - **Given:** after 2.1; `pqpublickey` exists; `alice2` on E1 (RSA APKAM).
 - **When:** `alice2` runs the upgrade.
-- **Steps:** 1–5 as 2.1 (mints its **own** PQ APKAM, publishes, verifies, deletes *its* legacy
-  view if applicable, persists, publishes CKP). Step 6: **immutable-create rejected (exists)**
-  → `requestSecret(pqid:<kid>)` → verify public/private correspondence → store.
+- **Steps:** 1–5 as 2.1 (mints its **own** PQ APKAM, registers its per-APKAM record, verifies,
+  deletes *its* legacy view if applicable, persists, registers its X-Wing key package in its
+  per-APKAM enrollment record). Step 6: **immutable-create rejected (exists)** →
+  `requestSecret(pqid:<kid>)` → verify public/private correspondence → store.
 - **Then:** `alice2.APKAM = pq`, `pqpk⁻¹ = ✓`; it never created or overwrote `pqpublickey`; E1
-  now has two PQ APKAM keys.
+  now has two PQ APKAM keypairs.
 
 ## 2.3 Third client, different enrollment — UC-B1.3
 
@@ -208,39 +238,55 @@ no `pqpublickey`.
 - **Given:** `@alice` pq-native; `public:nskey.app_1.my_apps@alice` published; `alice1`, `alice2` hold `nskey.app_1.my_apps@alice⁻¹`.
 - **When:** `alice1` does `put <k>.app_1.my_apps@alice` (shouldEncrypt).
 - **Steps:**
-  1. Generate a random data key; encrypt the value with it (AES-256-GCM).
-  2. **Encapsulate** the data key to @alice's own published public key
-     `public:nskey.app_1.my_apps@alice` (X-Wing); store the encapsulation in `appMetadata.additional`.
-  3. Stamp `appMetadata.providerId = nskey`, `isEncrypted = true`; write the key; sync.
+  1. Cut a symmetric **content key (CK)**; encrypt the value with it (AES-256-GCM under the CK).
+  2. **Convey the CK once** (`at/nskey`): X-Wing-seal the CK to @alice's **self nskey** (the
+     unpublished one) and write it as its own CK-conveyance record, cited by `ckKid`. (Skip if the
+     CK is already conveyed.)
+  3. Write the **data** value (`at/symmetric/AES/GCM`): stamp `appMetadata.providerId =
+     at/symmetric/AES/GCM`, `ckKid`, `iv`; the value carries **no** inline sealed CK. Write; sync.
 - **Then:**
-  - `alice2` syncs the key, routes by `providerId = nskey`, decapsulates the data key with
-    `nskey.app_1.my_apps@alice⁻¹`, decrypts the value.
+  - `alice2` syncs both records: the `at/nskey` provider decapsulates the CK with the self-nskey
+    private and caches it by `ckKid`; the `at/symmetric/AES/GCM` provider resolves the CK by `ckKid`
+    and AES-GCM-decrypts the value.
   - No legacy provider, no `selfEncryptionKey` used.
-  - Acceptance test: round-trip equals plaintext; `providerId = nskey`; a client lacking
-    `nskey.app_1.my_apps@alice⁻¹` cannot read.
+  - Acceptance test: round-trip equals plaintext; data value `providerId = at/symmetric/AES/GCM`
+    citing `ckKid`; a client lacking the self-nskey private cannot decapsulate the CK and so cannot
+    read.
 
-## 3.2 First self put in a namespace mints + distributes `nskey.app_1.my_apps@alice` — UC-A3.2
+## 3.2 First self put in a namespace mints + distributes both `nskey.app_1.my_apps@alice` keypairs — UC-A3.2
 
-- **Given:** `@alice` pq-native; **no** `public:nskey.app_1.my_apps@alice` yet; `alice1`, `alice2` PQ, both have CKP.
+- **Given:** `@alice` pq-native; **no** `nskey.app_1.my_apps@alice` yet; `alice1`, `alice2` PQ, both
+  with registered X-Wing key packages.
 - **When:** `alice1` does the first `put <k>.app_1.my_apps@alice`.
 - **Steps:**
-  1. `alice1` mints the `app_1.my_apps` X-Wing keypair `nskey.app_1.my_apps@alice`; **immutable-create**
-     `public:nskey.app_1.my_apps@alice`; seed `nskey.app_1.my_apps@alice⁻¹` as an **`app_1.my_apps`-namespaced**
-     secret (`__nsk.app_1.my_apps.<epoch>`, working name).
-  2. Encrypt the value to the new namespace key (as 3.1).
-  3. `alice2` `requestSecret` in `app_1.my_apps` (authorised), receives `nskey.app_1.my_apps@alice⁻¹` pqSealed to its CKP,
-     verifies correspondence, stores.
+  1. `alice1` mints **both** `app_1.my_apps` nskey X-Wing keypairs: the **self nskey** (the
+     unpublished `nskey.app_1.my_apps@alice`, to which alice encapsulates her own CKs) **and** the
+     **public nskey** (**immutable-create** `public:nskey.app_1.my_apps@alice`, to which external
+     senders encapsulate). `alice1` holds both privates and seeds each as
+     `Secret(namespace: app_1.my_apps, name: nskey:<kid>, value: <private>)` for substrate delivery
+     (working names; the canonical delivery shape is `<msgId>.<kpid>.__ssenv.app_1.my_apps@alice`).
+  2. Convey the CK once via the **nskey data path** (as 3.1): cut a CK, seal it to the self nskey
+     in an `at/nskey` record, write the data under `at/symmetric/AES/GCM`.
+  3. The two nskey privates are **pushed** per-APKAM to every authorised member: `alice1` calls
+     `enroll:listfornamespace:app_1.my_apps`, then `pqSeal`s each private to `alice2`'s X-Wing key
+     package (addressed by `kpid`) and delivers on `<msgId>.<kpid>.__ssenv.app_1.my_apps@alice`.
+     `alice2` verifies correspondence against `public:nskey.app_1.my_apps@alice` and `putIfNewer`s.
+     (`requestSecret` is the offline pull backstop if `alice2` missed the push.)
 - **Then:**
-  - `public:nskey.app_1.my_apps@alice` published once (immutable); `alice2` obtains the private and can read.
-  - An `app_2.my_apps`-only client is refused `nskey.app_1.my_apps@alice⁻¹`.
+  - `public:nskey.app_1.my_apps@alice` published once (immutable); the self nskey stays unpublished;
+    `alice2` obtains **both** privates and can read.
+  - An `app_2.my_apps`-only client is refused the `app_1.my_apps` nskey privates (namespace = authz
+    boundary, server-gated on the `__ssenv` channel).
 
 ## 3.3 Self put falls back to `pqpublickey` (no namespace key) — UC-A3.3
 
 - **Given:** `@alice` pq-native; no `public:nskey.app_1.my_apps@alice`; "seal-and-hold" **not** selected (send-now is the default; seal-and-hold is the per-namespace opt-in).
 - **When:** `alice1` writes self data before any namespace key exists.
-- **Then:** data key encapsulated to `public:pqpublickey@alice` (root); any `@alice` client decrypts;
-  `providerId = nskey` with a root-key marker (or a dedicated marker — to spec). Self-heals to
-  the namespace key on the first namespaced write.
+- **Then:** the **CK** is X-Wing-sealed to `public:pqpublickey@alice` (root) via an `at/nskey`
+  conveyance record (`recipientKind: root-pqpublickey`) — data is **never** encrypted directly to
+  the root key; the data value stays `at/symmetric/AES/GCM` citing `ckKid`. Any `@alice` client
+  decapsulates the CK with the root private and decrypts. Self-heals to the namespace's public/self
+  nskey on the first namespaced write.
 
 ## 3.4 Self notification — NEW
 
@@ -248,7 +294,9 @@ no `pqpublickey`.
 - **When:** `alice1` does `notify` to `@alice` (self) carrying an encrypted value (e.g. an
   `update`/`delete` notification with `value` + shouldEncrypt).
 - **Steps:**
-  1. Encrypt the notification value exactly as a self put (data key → namespace/`pqpublickey`).
+  1. Encrypt the notification value exactly as a self put: AES-256-GCM under a CK
+     (`at/symmetric/AES/GCM`, cited by `ckKid`); the CK is conveyed once via an `at/nskey` record
+     sealed to the **self nskey** (or `pqpublickey` cold-start).
   2. Stamp `appMetadata.providerId` on the **notification** payload; send `notify:`.
   3. atServer queues/delivers; `alice2`'s monitor receives the notification frame.
   4. `alice2` reads `providerId` from the notification, decapsulates, decrypts the value.
@@ -266,8 +314,8 @@ no `pqpublickey`.
 - **When:** `alice1` puts/notifies self data both must read.
 - **Then:** `alice1` writes/notifies **legacy** (the scheme `alice2` can read) until readiness
   flips; `alice2` reads via the legacy provider; no self data is unreadable by `alice2`. After
-  all `@alice` clients are PQ and readiness flips `ready`, new self puts/notifications go
-  `nskey` (UC-B3.2).
+  all `@alice` clients are PQ and readiness flips `ready`, new self puts/notifications use the
+  **nskey data path** (UC-B3.2).
 
 ---
 
@@ -279,15 +327,19 @@ no `pqpublickey`.
   `nskey.app_1.my_apps@bob⁻¹`; `@bob` readiness `ready`.
 - **When:** `alice1` does `put @bob:<k>.app_1.my_apps@alice` (shouldEncrypt).
 - **Steps:**
-  1. Generate a data key; encrypt the value.
-  2. **Encapsulate** the data key to **bob's** published public key `public:nskey.app_1.my_apps@bob`
-     (fetched from `@bob`).
-  3. Stamp `providerId = nskey`; write the shared key; sync (delivered to `@bob`).
-  4. Write the **self-copy** for alice's own clients (encapsulated to **alice's** own published public key
-     `public:nskey.app_1.my_apps@alice`).
+  1. Cut a symmetric **CK**; encrypt the value with it (AES-256-GCM under the CK).
+  2. **Convey the CK once** (`at/nskey`): X-Wing-seal the CK to **bob's** published public nskey
+     `public:nskey.app_1.my_apps@bob` (fetched from `@bob`), as a discrete CK-conveyance record
+     cited by `ckKid`.
+  3. Write the **data** value (`at/symmetric/AES/GCM`, citing `ckKid`); sync (delivered to `@bob`).
+  4. Write the **self-copy** for alice's own clients: convey the CK once via an `at/nskey` record
+     sealed to **alice's self nskey** (the unpublished one, **not** her published public nskey),
+     plus the data value under `at/symmetric/AES/GCM`.
 - **Then:**
-  - `bob1` and `bob2` decapsulate with `nskey.app_1.my_apps@bob⁻¹` and read; `alice`'s clients read the self-copy.
-  - PQ end to end; `providerId = nskey`; no RSA on any path.
+  - `bob1` and `bob2` decapsulate the CK with their **public-nskey private** and read; `alice`'s
+    clients decapsulate the self-copy's CK with the **self-nskey private** and read.
+  - PQ end to end; data values `providerId = at/symmetric/AES/GCM`, CK conveyances `at/nskey`; no
+    RSA on any path.
   - Acceptance: every authorised reader on both atSigns decrypts; an unauthorised `@bob`
     enrollment cannot fetch the ciphertext (server-gated) nor decrypt.
 
@@ -295,8 +347,9 @@ no `pqpublickey`.
 
 - **Given:** `@alice`, `@bob` pq-native; `@bob` has `public:pqpublickey@bob` but **no** `public:nskey.app_1.my_apps@bob`.
 - **When:** `alice1` shares `@bob:<k>.app_1.my_apps@alice`.
-- **Steps:** as 4.1 but encapsulate the data key to **bob's `public:pqpublickey@bob`** (root fallback);
-  mark the fallback in `appMetadata`.
+- **Steps:** as 4.1 but X-Wing-seal the **CK** to **bob's `public:pqpublickey@bob`** (root fallback)
+  in the `at/nskey` conveyance record (`recipientKind: root-pqpublickey`) — only the CK is sealed
+  to the root; the data value stays `at/symmetric/AES/GCM`. Mark the fallback in `appMetadata`.
 - **Then:** every bob client reads instantly (all hold `pqpublickey@bob⁻¹`); when a bob `app_1.my_apps` client
   later publishes `public:nskey.app_1.my_apps@bob`, subsequent writes **upgrade** to the namespace key. (High-security
   `app_1.my_apps` may instead seal-and-hold — the per-namespace opt-in.)
@@ -307,8 +360,10 @@ no `pqpublickey`.
   `@bob` readiness `ready`; `bob1` running a monitor.
 - **When:** `alice1` `notify`s `@bob` with an encrypted value (e.g. share a key + notify).
 - **Steps:**
-  1. Encrypt the notification value to bob's `public:nskey.app_1.my_apps@bob` (or `public:pqpublickey@bob`) — same
-     encapsulation as 4.1/4.2.
+  1. Encrypt the notification value under a CK (`at/symmetric/AES/GCM`, cited by `ckKid`); convey
+     the CK once via an `at/nskey` record X-Wing-sealed to bob's published public nskey
+     `public:nskey.app_1.my_apps@bob` (or `public:pqpublickey@bob` cold-start) — same CK→nskey
+     conveyance as 4.1/4.2.
   2. Stamp `appMetadata.providerId` on the notification; `notify:@bob…`.
   3. `bobS` queues; on `bob1` reconnect the monitor delivers the notification frame.
   4. `bob1` routes by `providerId`, decapsulates, decrypts; `bob2` likewise on its monitor.
@@ -326,14 +381,16 @@ no `pqpublickey`.
 ## 4.4 Mixed PQ/legacy across atSigns — UC-B4.1 / B4.3 / B4.4
 
 - **B4.1 — `@alice` PQ-ready, `@bob` legacy.** `alice1` shares/notifies `@bob`: writes **legacy**
-  RSA to bob's `publickey` (bob's readiness `n-r` gates it); alice's self-copy may be PQ
-  independently. **Then:** no write/notification bob can't read; alice's own clients still get a
-  PQ self-copy if all alice clients are PQ.
+  (RSA-wrapped CK + AES) to bob's `publickey` (bob's readiness `n-r` gates it); alice's self-copy
+  may take the **nskey data path** independently. **Then:** no write/notification bob can't read;
+  alice's own clients still get an nskey-data-path self-copy if all alice clients are PQ.
 - **B4.3 — partially-upgraded `@alice` (alice1 PQ, alice2 legacy) → `@bob` PQ-ready.** The write
-  to `@bob` may be PQ (bob ready), but alice's **self-copy** is legacy (alice2 can't read PQ)
-  until `@alice` readiness flips. **Then:** two directions, two schemes, one `put`/`notify`.
+  to `@bob` may take the **nskey data path** (bob ready), but alice's **self-copy** is legacy
+  (alice2 can't read PQ) until `@alice` readiness flips. **Then:** two directions, two schemes,
+  one `put`/`notify`.
 - **B4.4 — `@bob` finishes upgrading.** Once all bob clients PQ and bob readiness `ready`,
-  alice's next share/notify to `@bob` goes PQ. **Then:** legacy path no longer used toward bob.
+  alice's next share/notify to `@bob` takes the **nskey data path**. **Then:** legacy path no
+  longer used toward bob.
 
 ---
 

--- a/docs/pq-flows-detailed.md
+++ b/docs/pq-flows-detailed.md
@@ -28,9 +28,11 @@ Key objects used throughout:
     world-readable**; **external senders** encapsulate CKs to it to send to @alice; alice's clients
     hold its private (decapsulates CKs inbound senders sent her).
   - `@bob`'s self nskey + `public:nskey.app_1.my_apps@bob`, symmetric.
-  The private halves are conveyed **per-APKAM** by the secret-sharing substrate (PUSH at
-  mint/approve/rotate via the gated `enroll:listfornamespace` verb + the `__ssenv` envelope;
-  `requestSecret` PULL as the offline backstop), held only by the owning atSign's own APKAM
+  The private halves are conveyed **per-APKAM** by the secret-sharing substrate over the `__ssenv`
+  envelope (PUSH at **mint/rotate** via the gated `enroll:listfornamespace` verb to enumerate
+  authorised members; at enrollment **approve** the approver seals directly to the new enrollment's
+  just-registered key package — no verb needed; `requestSecret` PULL as the offline backstop), held
+  only by the owning atSign's own APKAM
   keypairs. There are **two** nskeys per namespace (self + public): self data uses the unpublished
   self nskey; cross-atSign uses the recipient's published public nskey.
 - **X-Wing key package** — the per-APKAM X-Wing recipient keypair a sender `pqSeal`s to (its
@@ -381,7 +383,8 @@ no `pqpublickey`.
 ## 4.4 Mixed PQ/legacy across atSigns — UC-B4.1 / B4.3 / B4.4
 
 - **B4.1 — `@alice` PQ-ready, `@bob` legacy.** `alice1` shares/notifies `@bob`: writes **legacy**
-  (RSA-wrapped CK + AES) to bob's `publickey` (bob's readiness `n-r` gates it); alice's self-copy
+  (a per-value symmetric key RSA-wrapped inline onto the data, AES-256 under it — the monolithic
+  legacy model) to bob's `publickey` (bob's readiness `n-r` gates it); alice's self-copy
   may take the **nskey data path** independently. **Then:** no write/notification bob can't read;
   alice's own clients still get an nskey-data-path self-copy if all alice clients are PQ.
 - **B4.3 — partially-upgraded `@alice` (alice1 PQ, alice2 legacy) → `@bob` PQ-ready.** The write

--- a/docs/pq-secret-push.md
+++ b/docs/pq-secret-push.md
@@ -1,0 +1,374 @@
+# PQ crypto — proactive secret push
+
+**Status:** working planning doc (not plan-of-record). Lives in `docs/`.
+**Companion to** `pq-atsign-key-distribution.md` (the **pull** primitive `requestSecret`)
+— this is its **push** dual: how a holder *proactively* conveys a namespaced secret to the
+enrollments authorised for it, so the secret is already on-device before a client needs it.
+Push exists to make the common cases never feel slow: with secrets pre-delivered, a read in a
+namespace doesn't pay a discover→request→wake→serve round-trip at the moment the user is
+waiting.
+
+**Conventions.** Notation per `pq-use-case-catalogue.md`. Each worked example gives
+**Given** (state), **When** (trigger), **Steps** (protocol sequence with concrete at-keys),
+**Then** (testable acceptance). "Working name" marks an at-key/verb name not yet finalised.
+`aS = pq` (PQ-capable atServer) unless stated. Key names are shown **complete** — with the
+`@<owner>` suffix.
+
+**Two settled decisions shape everything below:**
+- **Sharing is per-APKAM, not per-client.** The recipient unit is an **APKAM keypair** (one
+  per keyfile/install — see `pq-atsign-key-distribution.md`, *APKAM cardinality*), not an
+  individual client process. Each APKAM keypair is paired with **one X-Wing key package** (the
+  encryption key a sender seals to). One enrollment may hold **several** APKAM keypairs, hence
+  several key packages. A secret sealed to an APKAM keypair's key package is openable by every
+  client sharing that keyfile — so per-client sealing would only be redundant.
+- **Discovery is a gated atServer verb, and key packages are enrollment state.** A new verb
+  **`enroll:listfornamespace:<ns>`** (working name) returns the enrollments authorised for
+  `<ns>` *and each one's per-APKAM key packages*, gated on the requester holding ≥`r` on `<ns>`.
+  Key packages are carried in the per-APKAM enrollment record — **never public**, never a
+  client-published at-key.
+
+## Table of contents
+
+- [1. The shift from pull to push](#1-the-shift-from-pull-to-push)
+- [2. Discovery — the namespace-to-enrollment verb](#2-discovery--the-namespace-to-enrollment-verb)
+- [3. Recipient granularity — APKAM-level, not per-client](#3-recipient-granularity--apkam-level-not-per-client)
+- [4. Key shapes](#4-key-shapes)
+- [5. Authorization & safety](#5-authorization--safety)
+- [6. Worked examples (given / when / then)](#6-worked-examples-given--when--then)
+  - [6.1 An enrollment registers its key packages](#61-an-enrollment-registers-its-key-packages)
+  - [6.2 Newly minted nskey pushed to all members (req 1)](#62-newly-minted-nskey-pushed-to-all-members-req-1)
+  - [6.3 Approval conveys nskey secrets for granted namespaces (req 2)](#63-approval-conveys-nskey-secrets-for-granted-namespaces-req-2)
+  - [6.4 Rotation pushes the successor, excluding the revoked (req 3)](#64-rotation-pushes-the-successor-excluding-the-revoked-req-3)
+  - [6.5 A read-only enrollment receives by push](#65-a-read-only-enrollment-receives-by-push)
+- [7. Mapping to the substrate](#7-mapping-to-the-substrate)
+- [8. Open atServer decisions](#8-open-atserver-decisions)
+- [9. D1 secret inventory — what's shared and at what granularity](#9-d1-secret-inventory--whats-shared-and-at-what-granularity)
+- [10. Relationship to the plan](#10-relationship-to-the-plan)
+
+# 1. The shift from pull to push
+
+`pq-atsign-key-distribution.md` builds a **pull** primitive: a client that *needs* a named
+secret discovers the namespace's clients, fans out a sealed request, and a holder serves it.
+The three goals here are the **push** dual — a holder converges the roster proactively:
+
+1. **Newly-minted `nskey` secrets are pushed to all enrollments with `r` or `rw` on that
+   namespace** — no one has to ask.
+2. **Approval conveys all `nskey` secrets** for the namespaces a new enrollment was granted.
+3. **The push generalises to every namespace-bound shared secret** (rotated nskey keypairs, app
+   secrets, and — once it lands — the `at/pqmls` (D2) provider's keying material), not just `nskey`.
+
+Push and pull are complementary, and pull remains the **correctness backstop** — a push
+failure is never fatal because pull still serves an offline/missed client later. They compose
+because arrival is idempotent (`SecretStore.putIfNewer` keeps the newest). The reason to add
+push on top of a complete pull is **latency and availability**: clients are frequently
+offline, so a pull at point-of-need can stall on "no holder online right now," and even a
+successful pull adds a round-trip exactly when the user is waiting on a read. Push moves that
+work to when holders *are* online, so the secret is already local.
+
+For push to deliver on "never slow," it must be **complete** — every authorised enrollment,
+read-only included, or the missed ones silently fall back to the slow pull. That completeness
+is what the verb in section [2](#2-discovery--the-namespace-to-enrollment-verb) guarantees.
+
+# 2. Discovery — the namespace-to-enrollment verb
+
+A pusher needs two facts: **who** is authorised for the namespace, and **what key** to seal to
+for each. One gated verb returns both:
+
+> **`enroll:listfornamespace:<ns>`** (working name) — returns every enrollment authorised for
+> `<ns>`, with its access level and its **per-APKAM key packages**. **Gated:** the requester
+> must hold ≥`r` on `<ns>`.
+
+- **Definitive, server-sourced.** The authorisation comes from the atServer's enrollment
+  records — not a client self-claim — so the member list is complete and trustworthy,
+  including **read-only** enrollments (which cannot self-advertise into a namespace they can't
+  write).
+- **Self-contained (decision B).** The X-Wing key package travels in the per-APKAM enrollment
+  record alongside the PQ APKAM (ML-DSA) public key; the verb returns it. So one gated call
+  yields *authorisation + every encapsulation key* — no separate key-package fetch, no
+  public records, no cross-enrollment read rule.
+- **Multiple key packages per enrollment.** An enrollment with two APKAM keypairs (e.g. a
+  keyfile on two installs) has two key packages; the verb returns both, and the pusher seals
+  once per key package (section [3](#3-recipient-granularity--apkam-level-not-per-client)).
+- **Gate scope.** ≥`r` is the right bar: any pusher (the `rw` minter, a rotator) clears it, and
+  a read-only co-member learning the roster of a namespace it already belongs to is not a leak.
+
+This replaces every discovery workaround considered earlier — the hidden-public canonical key
+package, the `rw`-only `__sskbns.<namespace>` self-advertise copies, and the per-enrollment
+"inbox". None are needed: the verb is the single discovery path, and delivery rides the
+existing namespace-gated channel.
+
+**Approval (req 2) doesn't even need the verb:** the approver already holds the new
+enrollment's id and its granted namespaces, and it reads the new enrollment's key packages
+from the same per-APKAM records (it has the enrollment in hand). The verb is for the
+*enumerate-all-members* cases — mint (req 1) and rotation (req 3).
+
+# 3. Recipient granularity — APKAM-level, not per-client
+
+The unit a secret is sealed to is an **APKAM keypair**, identified by its key package id
+(`kpid` = the kid of its X-Wing public key). Rationale:
+
+- **One keyfile, one recipient.** All client processes that share a keyfile/keychain share
+  that keyfile's APKAM keypair *and* its X-Wing key package private half. Sealing once per
+  key package reaches all of them; per-client sealing would duplicate work for processes that
+  already share storage.
+- **It matches the revocation granularity.** Revocation in the retrofit design is per
+  enrollment or per APKAM keypair (`pq-atsign-key-distribution.md`, *what revocation means*) —
+  never per process — so the recipient unit is the APKAM keypair.
+- **The key package is paired with the APKAM keypair.** Generated locally with each APKAM
+  keypair at enrolment/upgrade (its **private half never leaves the keyfile**), registered in
+  the per-APKAM enrollment record next to the ML-DSA APKAM public key. "Every APKAM keypair is
+  accompanied by a key package" is literal.
+
+**Nothing in D1 forces per-client sealing** (the full inventory is in section
+[9](#9-d1-secret-inventory--whats-shared-and-at-what-granularity)). Every shared D1 secret
+decrypts data scoped at atSign / namespace / group level (not per process); the only genuinely
+per-APKAM artefacts (the PQ APKAM signing keypair, the X-Wing key package private half) are
+**minted locally and never shared**. So there is a clean split: *shared ⇒ ≥ namespace scope ⇒
+APKAM-level delivery is correct; per-APKAM ⇒ locally generated ⇒ never on the wire.*
+
+This is a shift from the spike substrate, which keys by a per-client `clientId`. The migration
+is: generate the X-Wing keypair with each APKAM keypair, register its public half in the
+per-APKAM enrollment record, and address envelopes by `kpid` rather than `clientId`.
+
+# 4. Key shapes
+
+Concrete, with `@alice` as owner. Enrollments `E1/E2/E3/E4`; APKAM keypairs `K1…K4`; key
+packages `KP1…KP4` with ids `kp1…kp4`; namespace `app_1.my_apps` (reads right-to-left,
+DNS-style). Working names marked.
+
+| Purpose | At-key / record | Kind | Notes |
+|---|---|---|---|
+| **Per-APKAM enrollment record** *(working)* | `<E>.<apkamId>.pqapkam.__manage@alice` | enrollment state (immutable per APKAM keypair) | carries the ML-DSA APKAM pubkey **and** the X-Wing **key package**; one per APKAM keypair |
+| **Namespace→enrollment query** *(working)* | verb `enroll:listfornamespace:app_1.my_apps` | gated read (≥`r`) | returns `[{enrollmentId, access, apkam:[{apkamId, apkamPubKey, keyPackage}]}]` |
+| **Delivery envelope** | `<msgId>.<kpid>.__ssenv.app_1.my_apps@alice` | self, `shouldEncrypt=false` | sealed (`pqSeal`) to key package `<kpid>`; the atServer **gates delivery by namespace** |
+| **Self nskey — private (the secret)** | `nskey.app_1.my_apps@alice` (self nskey, **not** published) | self | held by authorised APKAM keypairs; the value pushed. X-Wing KEM private — Alice encapsulates **her own** content keys (CKs) to the self nskey's public half |
+| **Public nskey — public (encapsulate-to)** | `public:nskey.app_1.my_apps@alice` | public | world-readable; **external senders** encapsulate CKs to it. Its private half is also held by authorised APKAM keypairs and pushed the same way |
+| **Root PQ key — public** | `public:pqpublickey@alice` | public (immutable) | atSign-level fallback; private half conveyed by **pull** (root, no namespace) + **push** at approval; onboarding generates it locally |
+| **Per-enrollment signing key** (existing) | `public:_apsk.<E>.a.__e@alice` | public (single-`_`, unscannable) | verify an enrollment's envelope signatures |
+
+The delivery envelope is the substrate's existing channel, only re-addressed by `kpid`
+(per-APKAM) instead of `clientId` (per-process). No inbox, no ack, no namespace-copy.
+
+# 5. Authorization & safety
+
+**Discovery is authoritative; the channel enforces.** The verb returns exactly the authorised
+members, so over-delivery isn't a concern. And delivery is itself the enforcement: the envelope
+`<msgId>.<kpid>.__ssenv.<N>@alice` is a self key *in namespace `N`*, which the atServer delivers
+only to enrollments with ≥`r` on `N`. So even if a pusher sealed to the wrong key package, the
+server would not deliver it — **discovery/sealing mistakes cannot leak.** Read-only enrollments
+*receive* fine here: they hold `r` on `N`, so they can read the envelope.
+
+**The seal is the confidentiality boundary.** The envelope value is raw `pqSeal` bytes
+(`shouldEncrypt=false`) sealed to one key package; the namespace gate only governs who may fetch
+the ciphertext, which is useless without that keyfile's X-Wing private half. Gate = defence in
+depth; seal = boundary.
+
+**Sender authenticity:** the envelope is APKAM-signed and verified before decrypt (substrate
+`_consume`), proving a genuine Alice client wrote it. For a keypair secret (`nskey`,
+`pqpublickey`) the receiver also checks public/private correspondence against the published
+public half — so a wrong key can't be injected.
+
+**Cross-tier property to state in commits:** push delivery is safe *only because* the atServer
+refuses to deliver an `…__ssenv.<N>` key to an enrollment lacking `r` on `N`, and the verb's
+member list is authoritative. Both are atServer guarantees the client relies on.
+
+**Read-only cleanup wrinkle (unchanged):** a read-only recipient can read but not delete the
+consumed envelope (no write in `N`), so it lingers to `envelopeTtl`; re-consumption is
+idempotent (`putIfNewer`). Acceptable; TTL is the cleanup.
+
+# 6. Worked examples (given / when / then)
+
+Cast: `@alice`, `aS = pq`. `E1` (rw on `app_1.my_apps`, APKAM keypair `K1`, key package
+`KP1/kp1`), `E2` (rw, `K2`, `KP2/kp2`), `E3` (**read-only `r`**, `K3`, `KP3/kp3`). Each
+registered its per-APKAM record; each runs the substrate listener.
+
+## 6.1 An enrollment registers its key packages
+
+- **Given:** `E3` is read-only (`r`) on `app_1.my_apps`; it can write nothing in that namespace.
+- **When:** `E3` completes PQ enrolment/upgrade.
+- **Steps:**
+  1. `E3` mints its **PQ APKAM** keypair `K3` (ML-DSA) **and** its **X-Wing key package** `KP3`;
+     both private halves stay in `E3`'s keyfile.
+  2. `E3` registers the per-APKAM record `E3.K3.pqapkam.__manage@alice` carrying the APKAM
+     pubkey and `KP3` (immutable per APKAM keypair). This is enrolment state — no
+     application-namespace write is involved, so `E3`'s read-only status is irrelevant to it.
+- **Then:**
+  - `E3`'s key package is registered even though `E3` can't write any application namespace.
+  - `enroll:listfornamespace:app_1.my_apps` (called by any ≥`r` member) returns `E3` with
+    `KP3` among the results.
+  - Nothing is public; `KP3` is enrollment-internal.
+
+## 6.2 Newly minted nskey pushed to all members (req 1)
+
+- **Given:** no `nskey` exists for `app_1.my_apps`; `E1` is about to write the first self datum
+  in it. Members: `E1` (rw), `E2` (rw), `E3` (r), all with registered key packages.
+- **When:** `E1` mints `nskey.app_1.my_apps@alice`.
+- **Steps:**
+  1. `E1` **mints the namespace's nskeys**, establishing **both** the **self nskey** (the
+     unpublished `nskey.app_1.my_apps@alice`, to which Alice encapsulates her own CKs) and the
+     **public nskey** (immutable-creates `public:nskey.app_1.my_apps@alice`, to which external
+     senders encapsulate). Each is an X-Wing keypair; `E1` holds both privates and seeds each as
+     `Secret(namespace: app_1.my_apps, name: nskey:<kid>, value: <private>)`. The push conveys
+     these nskey **privates**; the symmetric content keys (CKs) the nskeys wrap are cut and
+     conveyed separately as `at/nskey` records on ordinary sync (see `pq-data-encryption.md`).
+  2. **Discover:** `enroll:listfornamespace:app_1.my_apps` → `[{E1,rw,[KP1]}, {E2,rw,[KP2]},
+     {E3,r,[KP3]}]`. `E1` drops itself.
+  3. **Seal + deliver**, once per key package: `pqSeal` the secret to `KP2`, `put`
+     `<msgId>.kp2.__ssenv.app_1.my_apps@alice`; likewise `<msgId>.kp3.__ssenv.app_1.my_apps@alice`
+     for `KP3`. Fire the wake-up notify.
+- **Then:**
+  - `E2` and `E3` receive, verify (APKAM signature + public/private correspondence against
+    `public:nskey.app_1.my_apps@alice`), and `putIfNewer` the private half.
+  - **Read-only `E3` receives it** — it holds `r` on the namespace, so the atServer delivers
+    the envelope. The first read of `app_1.my_apps` data on `E3` is instant (key already local).
+  - An APKAM keypair that was offline during the push still gets it via the **pull** backstop.
+  - If `E2` also had a second APKAM keypair `K2'` (a second keyfile) with key package `KP2'`,
+    the verb returns both and step 3 seals to each — APKAM-level, one seal per APKAM keypair.
+
+## 6.3 Approval conveys nskey secrets for granted namespaces (req 2)
+
+- **Given:** `E1` is approving new enrollment **`E4`** (APKAM keypair `K4`, key package `KP4`)
+  requesting `[app_1.my_apps (rw), app_2.my_apps (r)]`. `nskey` secrets exist for both
+  namespaces; `E1` holds their private halves.
+- **When:** `E1` approves `E4`.
+- **Steps:**
+  1. Approve `E4` over the **PQ enrollment key** (WP10), granting
+     `{app_1.my_apps: rw, app_2.my_apps: r}`. `E4` registers its per-APKAM record with `KP4`.
+  2. `E1` (holding `approvedNamespaces` and `E4`'s key packages from the records it just
+     handled) seals each held secret whose namespace `E4` was granted, to `KP4`, and delivers:
+     `nskey.app_1.my_apps@alice` on `<m1>.kp4.__ssenv.app_1.my_apps@alice` **and**
+     `nskey.app_2.my_apps@alice` on `<m2>.kp4.__ssenv.app_2.my_apps@alice`.
+- **Then:**
+  - `E4` receives exactly the `nskey` secrets for the two namespaces it was granted — nothing
+    else.
+  - `r`-only on `app_2.my_apps` suffices to **receive** that nskey (read access is the bar to
+    receive a namespace secret).
+  - No verb call is needed — the approver already had the target and the grant. This is
+    `shareAllSecretsWithEnrollment(E4, approvedNamespaces)`, re-keyed to APKAM-level.
+
+## 6.4 Rotation pushes the successor, excluding the revoked (req 3)
+
+- **Given:** `app_1.my_apps`'s `nskey` is compromised on `E3`; `E1` rotates the nskey **keypair**
+  (the per-APKAM revocation lever — distinct from routine CK rotation). The mechanism is identical
+  for *any* namespaced secret (an app secret, and — once it lands — the `at/pqmls` (D2) provider's
+  keying material).
+- **When:** `E1` mints the successor `nskey.app_1.my_apps@alice` (new `kid`).
+- **Steps:**
+  1. Mint the successor; supersede `public:nskey.app_1.my_apps@alice`.
+  2. **Discover + exclude:** `enroll:listfornamespace:app_1.my_apps`, then drop `E3` (revoked)
+     and self `E1` → `{E2,[KP2]}`.
+  3. Seal the successor to `KP2`, deliver `<msgId>.kp2.__ssenv.app_1.my_apps@alice`.
+- **Then:**
+  - `E2` holds the new key; `E3` does not — excluded at discovery **and** unable to read the
+    envelope even if included.
+  - The generic push call — *"seal this `Secret` to every authorised member of its namespace,
+    minus excludes"* — is byte-for-byte the same as [6.2](#62-newly-minted-nskey-pushed-to-all-members-req-1);
+    only the `Secret` and exclude-set differ. That sameness *is* requirement 3.
+
+## 6.5 A read-only enrollment receives by push
+
+This isolates the property that made read-only the hard case, now resolved by the verb +
+APKAM-level delivery.
+
+- **Given:** `E3` is read-only on `app_1.my_apps` and was offline during the original mint
+  push ([6.2](#62-newly-minted-nskey-pushed-to-all-members-req-1)); it now comes online.
+- **When:** `E3` comes online; a holder (`E1`) is running.
+- **Steps:**
+  1. `E3` **cannot** initiate a pull — a request is a write of `…__ssenv.<N>` *in* `app_1.my_apps`,
+     which read-only access forbids. So `E3` waits to be pushed to.
+  2. On its periodic push (or on the next mint/rotation), `E1` calls the verb, sees `E3` (with
+     `KP3`) is still an authorised member, and re-delivers the current `nskey` to
+     `<msgId>.kp3.__ssenv.app_1.my_apps@alice`.
+  3. `E3` reads, verifies, `putIfNewer`.
+- **Then:**
+  - `E3` ends up with the key **without ever writing the namespace** — push is its only route,
+    and the verb guarantees it is never forgotten (so it doesn't go stale across rotations).
+  - This is why "pull is sufficient for read-only" is **false** and push is required for them:
+    read-only can't write a pull request, but it *can* read a pushed envelope.
+
+# 7. Mapping to the substrate
+
+| Need | Status | Where |
+|---|---|---|
+| Per-recipient seal / open | **built** | `pqSeal`/`pqOpen` (`SecretEnvelope`, `pairwise_secret_sharing.dart`) |
+| Serve one secret to one recipient | **built** | `shareSecretWith(keyPackage, Secret)` — re-key recipient to `kpid` |
+| Approval conveyance (req 2) | **built** | `shareAllSecretsWithEnrollment(E, approvedNamespaces)` — wire into approve; re-key to APKAM-level |
+| Namespace-gated delivery + wake-up | **built** | `…__ssenv.<namespace>` channel + wake-up notify |
+| Idempotent merge (push ∥ pull) | **built** | `SecretStore.putIfNewer` |
+| Revocation guard | **built** | `excludeEnrollmentIds` on discovery/serve |
+| **Push to all members (req 1, 3)** | **new** | `pushSecretToNamespaceMembers(Secret, {exclude})` = verb → seal per key package |
+| **`enroll:listfornamespace:<ns>` verb** | **new (atServer)** | gated read; returns enrollments + per-APKAM key packages |
+| **Key package in per-APKAM enrollment record** | **new (atServer + client)** | register X-Wing key package with the PQ APKAM record; drop the public/at-key key package |
+| **APKAM-level addressing** | **new (client)** | address envelopes by `kpid` (per-APKAM), not `clientId`; one X-Wing keypair per APKAM keypair |
+
+Requirements 1 and 3 collapse to one push method over the verb; requirement 2 is an existing
+method wired into approve. The structural new work is the **verb + key-package-in-enrollment-record**
+(atServer) and the **per-client → per-APKAM re-keying** (client).
+
+# 8. Open atServer decisions
+
+1. **Verb response shape** — confirm `enroll:listfornamespace:<ns>` returns, per enrollment:
+   `enrollmentId`, `access` (`r`/`rw`), and `apkam: [{apkamId, apkamPubKey, keyPackage}]`
+   (multiple per enrollment). Access level is returned even though delivery treats `r` and `rw`
+   identically — it lets push apply policy and is near-free.
+2. **Key package in the per-APKAM record** — confirm the X-Wing key package is registered with
+   the PQ APKAM record (immutable per APKAM keypair) and updatable on key-package rotation.
+3. **Verb gate** — ≥`r` on `<ns>` (a co-member may enumerate the roster). Confirm acceptable.
+4. **Eviction interplay** — the per-APKAM record (APKAM key + key package) is subject to the
+   TTL/usage eviction already planned for APKAM keys (`pq-atsign-key-distribution.md`,
+   section 8), so abandoned APKAM keypairs drop out of the verb's results automatically.
+5. **Root key stays pull** — `pqpublickey` is root (no namespace), so there is no
+   `enroll:listfornamespace` for it; it keeps the pull/onboarding/approval paths of the
+   distribution doc. Push here is namespaced only.
+
+# 9. D1 secret inventory — what's shared and at what granularity
+
+Every secret D1 conveys, why, how often, and the granularity it is shared at. This is the
+evidence for section [3](#3-recipient-granularity--apkam-level-not-per-client)'s claim that
+APKAM-level delivery is correct for all of D1.
+
+**Shared secrets** (sealed with `pqSeal` and sent between APKAM keypairs):
+
+| Secret | Purpose | Holder scope | Frequency | Conveyance |
+|---|---|---|---|---|
+| `pqpublickey` **private** half | atSign-level fallback encryption key — decrypt when no `nskey` applies; replaces the legacy default encryption private key | per **atSign** (root, no namespace) | once per atSign; rare rotation | **pull** (retrofit) + **push** at approval; onboarding generates it locally |
+| `nskey.<ns>` **private** half (self + public nskey) | namespace KEM private — **decapsulates** the content keys (CKs) that decrypt self data + inbound shares in `<ns>` (it never decrypts data directly) | per **(atSign, namespace)** | once on first use of `<ns>`; occasional rotation | **push** to ≥`r` members on mint/rotate (req 1/3) + **pull** backstop + approval (req 2) |
+| Symmetric **content key (CK)** rotation | D1's coarse forward-secrecy lever in the single-tier nskey data path (`at/nskey` + `at/symmetric/AES/GCM`) — rotate the CK + delete the old `at/nskey` conveyance | per **(atSign, namespace)**, per CK epoch | **highest** — per CK-rotation cadence | conveyed as an `at/nskey` record on ordinary sync (see `pq-data-encryption.md`), **not** via the substrate push |
+| `apkamSymmetricKey` | wraps the enrolment response so the approver can convey material | per **enrollment**, transient | once per enrolment | enrolling APKAM keypair → approver, encapsulated to `pqpublickey` (PQ-safe) |
+| *(retrofit only)* legacy `defaultEncryptionPrivateKey` (RSA) + `selfEncryptionKey` | read **legacy-encrypted history** (not new data) | per **atSign** | once per enrolment; being phased out | existing enrolment conveyance |
+| *(conditional)* root PQ **seed** | only if the "derive-don't-distribute" variant (`pq-atsign-key-distribution.md` section 4) is adopted | per **atSign** (wide blast radius) | once | same path as `pqpublickey` private; **not** used to derive per-namespace keys |
+
+**Never shared — minted locally per APKAM keypair, never on the wire:**
+
+- **PQ APKAM signing keypair** (ML-DSA) — minting-own is deliberate, to keep signing keys off
+  the conveyance path.
+- **X-Wing key package private half** — the recipient/leaf key; only its *public* half is
+  registered (in the per-APKAM enrollment record), the private half stays in the keyfile.
+
+**Which must be per-client? None.** Every *shared* D1 secret decrypts data scoped at atSign /
+namespace / group level — none binds to a single process, so APKAM-level delivery is the
+correct granularity, not a compromise. The only key that is inherently **unique per
+recipient** is the **key package / leaf keypair itself** — which is exactly the one we *don't*
+share, and whose granularity is set to per-APKAM. So even the strongest per-identity case (a
+D2 (`at/pqmls`) MLS-style group leaf) lands at per-APKAM: two clients sharing one keyfile
+already share the APKAM keypair and trust boundary, so a per-process leaf would buy nothing.
+
+Two caveats: the `at/pqmls` provider (D2) keying specifics (rotation cadence, exactly what is
+sealed per member) ride on the ratcheted/TreeKEM group design (WP-GP), a separate D2 piece — if it
+ends up MLS-strict the per-member *leaf* is still per-APKAM, but re-check when that firms up.
+And `apkamSymmetricKey` is the one per-*enrollment* item, but it is transient
+enrolment-handshake material, not a steady-state shared secret.
+
+# 10. Relationship to the plan
+
+- **Extends WP-SS** (the secret-sharing substrate): adds the push method and re-keys the
+  recipient unit from client to APKAM keypair.
+- **Dual of `pq-atsign-key-distribution.md`** (pull): push is the steady-state convergence that
+  keeps reads fast; pull is the offline/edge backstop and the correctness guarantee.
+- **Feeds WP10** (enroll/approve): requirement 2 is the approve-time conveyance, prototyped as
+  `shareAllSecretsWithEnrollment`.
+- **Reuses WP9** (rotation/revocation): requirement 3's push + `excludeEnrollmentIds` is the
+  redistribute-on-rotation path.
+- **New atServer capability** (beyond the PQ-APKAM set in `pq-atsign-key-distribution.md`,
+  section 8): the **`enroll:listfornamespace:<ns>`** verb and the **X-Wing key package in the
+  per-APKAM enrollment record**.

--- a/docs/pq-use-case-catalogue.md
+++ b/docs/pq-use-case-catalogue.md
@@ -11,7 +11,7 @@
 - [Notation & state model](#notation--state-model)
 - [Part A — The new world (PQ-native, PQ-capable atServer)](#part-a--the-new-world-pq-native-pq-capable-atserver)
   - [A1 · Onboard a new atSign](#a1--onboard-a-new-atsign)
-  - [A2 · Enrollments (a new client joins)](#a2--enrollments-a-new-client-joins)
+  - [A2 · Enrollments (a new APKAM keypair joins)](#a2--enrollments-a-new-apkam-keypair-joins)
   - [A3 · E2EE within one atSign (self data)](#a3--e2ee-within-one-atsign-self-data)
   - [A4 · E2EE across atSigns (shared data)](#a4--e2ee-across-atsigns-shared-data)
   - [A5 · Rotation & revocation (new world)](#a5--rotation--revocation-new-world)
@@ -19,7 +19,7 @@
   - [B0 · Prerequisite — atServer upgrade](#b0--prerequisite--atserver-upgrade)
   - [B1 · Upgrade an existing (pre-PQ) atSign — the three scenarios](#b1--upgrade-an-existing-pre-pq-atsign--the-three-scenarios)
   - [B2 · Legacy APKAM deletion consequences](#b2--legacy-apkam-deletion-consequences)
-  - [B3 · Mixed-PQ within one atSign (some clients upgraded)](#b3--mixed-pq-within-one-atsign-some-clients-upgraded)
+  - [B3 · Mixed-PQ within one atSign (some APKAM keypairs upgraded)](#b3--mixed-pq-within-one-atsign-some-apkam-keypairs-upgraded)
   - [B4 · Mixed-PQ across atSigns](#b4--mixed-pq-across-atsigns)
   - [B5 · Retrofit edge cases](#b5--retrofit-edge-cases)
 - [Decisions](#decisions)
@@ -27,19 +27,24 @@
 
 ## Notation & state model
 
-**Actors.** `@alice`, `@bob` are atSigns. `alice1`, `alice2`, `alice3` are *clients*
-(a client = one running instance bound to one keyfile/keychain on one host) of `@alice`;
-likewise `bob1`, `bob2`. `aliceS` / `bobS` are their atServers.
+**Actors.** `@alice`, `@bob` are atSigns. `alice1`, `alice2`, `alice3` are *APKAM keypairs*
+of `@alice` — the recipient/identity unit is the **APKAM keypair** (one per keyfile/install),
+not a running client process: every process that shares a keyfile/keychain shares that one
+APKAM keypair. One enrollment may hold **several** APKAM keypairs. Likewise `bob1`, `bob2`.
+`aliceS` / `bobS` are the atServers. (Per `pq-secret-push.md` section
+[3](pq-secret-push.md#3-recipient-granularity--apkam-level-not-per-client) and ADR 0002:
+sharing, revocation, eviction and readiness all key on the APKAM keypair.)
 
-**Per-client state** (table columns):
+**Per-APKAM state** — the row unit is an APKAM keypair (per keyfile/install), not a client
+process:
 
 | Col | Meaning |
 |---|---|
-| `enr` | enrollment the client is on (`E1`, `E2`, …) |
+| `enr` | enrollment the APKAM keypair is on (`E1`, `E2`, …) |
 | `APKAM` | auth keypair held: `rsa` (legacy) · `pq` (ML-DSA) · `both` |
 | `pqpk⁻¹` | holds the atSign-level `pqpublickey` **private** half? |
-| `nskey⁻¹` | holds its **own** atSign's namespace keypair **private** half, per namespace (an `@alice` client holds `nskey.<ns>@alice`'s private) — see *Namespace key shapes* |
-| `CKP` | has published its `ClientKeyPackage` (X-Wing, for receiving sealed secrets)? |
+| `nskey⁻¹` | holds **both** nskey **privates** for the namespace — the **self-nskey** private and the **public-nskey** private, per namespace (an `@alice` APKAM keypair holds both for `<ns>@alice`); these **decapsulate content keys (CKs)**, they do not decrypt application data — see *Namespace key shapes* |
+| `KP` | its X-Wing **key package** (`kid` = `kpid`, for receiving sealed secrets) is registered in the per-APKAM enrollment record? (one key package per APKAM keypair, never published) |
 
 **Per-atSign / server state:**
 
@@ -59,19 +64,25 @@ them distinct:
 
 | Shape | Meaning |
 |---|---|
-| `nskey.app_1.my_apps@alice` | @alice's namespace **keypair** (self) — alice's own clients hold the **private** half, decrypting both her self data and inbound shares |
-| `public:nskey.app_1.my_apps@alice` | its **public** half, **published world-readable** — **any** atSign (a peer, or alice for her own self data) encapsulates to it to send to @alice |
-| `nskey.app_1.my_apps@bob` | @bob's namespace keypair (self) — symmetric; bob's clients hold its private half |
-| `public:nskey.app_1.my_apps@bob` | @bob's **published public** half — any atSign (incl. @alice) encapsulates to it to send to @bob |
+| `nskey.app_1.my_apps@alice` (self nskey) | @alice's **self nskey** — **not published**; alice's own authorised APKAM keypairs hold its **private** half and encapsulate her **own** CKs to it; the private **decapsulates** those CKs (it does not decrypt data) |
+| `public:nskey.app_1.my_apps@alice` | the **public nskey**'s public half, **published world-readable** — **external senders** (a peer) encapsulate CKs to it to send to @alice; @alice's own self data uses the **self nskey**, not this one |
+| `nskey.app_1.my_apps@bob` (self nskey) | @bob's **self nskey** — not published; bob's authorised APKAM keypairs hold its private half and encapsulate bob's own CKs to it |
+| `public:nskey.app_1.my_apps@bob` | @bob's **published public** half — external senders (incl. @alice) encapsulate CKs to it to send to @bob |
 
-The private half is held only by the owning atSign's own clients (the `nskey⁻¹` column); the
-`public:` form is the one published key anyone encapsulates to — there is **no** per-recipient
-key shape.
+There are **two** nskeys per `(atSign, namespace)`: the **self nskey** (not published; the owner
+encapsulates her own CKs to it) and the **public nskey** (published; external senders encapsulate
+CKs to it). Both nskey privates are held only by the owning atSign's own authorised APKAM
+keypairs (the `nskey⁻¹` column). Both nskeys are asymmetric KEMs (X-Wing) that only ever **wrap symmetric content keys** —
+they never encrypt application data directly.
 
 **atServer PQ capabilities** (Part A and B both assume `aS = pq` unless stated): the
 **existing** immutable write (`Metadata.immutable`) for mint-once, plus the **new** verbs —
 multiple APKAM keys per enrollment + auth-against-any · PQ (ML-DSA) APKAM auth · delete a
-specific pubkey · TTL/usage eviction of APKAM keys.
+specific pubkey · TTL/usage eviction of APKAM keys · **`enroll:listfornamespace:<ns>`** (the
+gated discovery verb that returns the enrollments authorised for `<ns>` and each one's
+per-APKAM key packages — the steady-state push primitive, gated on the requester holding
+≥`r` on `<ns>`; see `pq-secret-push.md` section
+[2](pq-secret-push.md#2-discovery--the-namespace-to-enrollment-verb)).
 
 ---
 
@@ -79,65 +90,87 @@ specific pubkey · TTL/usage eviction of APKAM keys.
 
 ## A1 · Onboard a new atSign
 
-**UC-A1.1 — First-client CRAM onboard is PQ-native**
+**UC-A1.1 — First-APKAM-keypair CRAM onboard is PQ-native**
 - **Given:** `@alice` unactivated; `aliceS = pq`; no keys exist.
 - **When:** `alice1` runs CRAM onboarding.
 - **Then:** `alice1.APKAM = pq` and it authenticates via PQ APKAM; `public:pqpublickey@alice`
-  is published (immutable) and `alice1.pqpk⁻¹ = ✓`; `alice1.CKP = ✓`; readiness can be
-  `ready` (no legacy clients exist). **Legacy interop is a config flag (default off):** by
+  is published (immutable) and `alice1.pqpk⁻¹ = ✓`; `alice1.KP = ✓`; readiness can be
+  `ready` (no legacy APKAM keypairs exist). **Legacy interop is a config flag (default off):** by
   default a PQ-native atSign is PQ-only — no RSA `public:publickey@alice`; enable the flag to
   publish it for legacy-peer inbound (see UC-B4.2).
 
-| client | enr | APKAM | pqpk⁻¹ | nskey⁻¹ | CKP |
+| APKAM | enr | APKAM-kind | pqpk⁻¹ | nskey⁻¹ | KP |
 |---|---|---|---|---|---|
 | alice1 | E1 | pq | ✓ | — | ✓ |
 
-## A2 · Enrollments (a new client joins)
+## A2 · Enrollments (a new APKAM keypair joins)
 
-**UC-A2.1 — New enrollment, approved by an online client (PQ-safe enroll/approve)**
+**UC-A2.1 — New enrollment, approved by an online APKAM keypair (PQ-safe enroll/approve)**
 - **Given:** `@alice` pq-native; `pqpublickey` published; `alice1` enrolled (E1) & online.
 - **When:** `alice2` requests enrollment (E2); `alice1` approves.
-- **Then:** `alice2.APKAM = pq` (its own); `alice2.pqpk⁻¹ = ✓` (pushed by approver over the
-  **PQ** enrollment-conveyance key, *not* RSA-wrapped); `alice2.CKP = ✓`; `alice2` can
-  authenticate PQ and decrypt `@alice`'s PQ self data within its authorised namespaces.
+- **Then:** `alice2.APKAM = pq` (its own); `alice2.pqpk⁻¹ = ✓` — the approver conveys the
+  nskey/`pqpublickey` privates **per-APKAM** by sealing (`pqSeal`) to `alice2`'s X-Wing key
+  package and writing a `<msgId>.<kpid>.__ssenv.<ns>@alice` delivery envelope
+  (`shareAllSecretsWithEnrollment`, `pq-secret-push.md` section
+  [6.3](pq-secret-push.md#63-approval-conveys-nskey-secrets-for-granted-namespaces-req-2));
+  *not* RSA-wrapped. `alice2.KP = ✓`; `alice2` can authenticate PQ and decrypt `@alice`'s PQ
+  self data within its authorised namespaces.
 
-**UC-A2.2 — Second host on the *same* enrollment (copied keyfile, E1)**
-- **Given:** `@alice` pq-native; `alice1` on E1; `alice2` is a second host using E1's keyfile.
-- **When:** `alice2` first runs.
-- **Then:** per the *multiple-APKAM-per-enrollment* rule, `alice2` mints its **own** PQ APKAM
-  keypair (host-local), publishes it as a distinct per-host record; obtains `pqpublickey@alice⁻¹`
-  (already in the copied keyfile, or pulled). One enrollment now has **two** PQ APKAM keys,
-  individually revocable.
+**UC-A2.2 — Second host using the *same* keyfile (copied keyfile, E1)**
+- **Given:** `@alice` pq-native; `alice1` on E1; a second host runs against a *copy* of E1's keyfile.
+- **When:** the copy first runs.
+- **Then:** a copied keyfile **shares** its APKAM keypair (and the key package's private half) —
+  it does **not** mint its own (Decisions §3; `pq-secret-push.md` section
+  [3](pq-secret-push.md#3-recipient-granularity--apkam-level-not-per-client)). The two hosts are
+  the **same** APKAM keypair = one recipient; secrets already sealed to that keypair's key
+  package are openable on both. Multiple-APKAM-per-enrollment arises from separate
+  installs/enrolment-time mints, not from copying a keyfile. Revocation is per-keyfile-key (per
+  APKAM keypair), so revoking that keypair cuts every host sharing the copy at once.
 
 **UC-A2.3 — Namespace-restricted enrollment**
 - **Given:** `@alice` pq-native; `alice1` (E1, `*`) approves `alice3` for namespace `app_1.my_apps` only (E3).
 - **When:** `alice3` enrolls.
-- **Then:** `alice3` gets `pqpublickey@alice⁻¹` (root — universal) but only `nskey⁻¹` for `app_1.my_apps`; a
-  request for `app_2.my_apps`'s key is refused (namespace = authz boundary).
+- **Then:** `alice3` gets `pqpublickey@alice⁻¹` (root — universal) and, by **approval-time push**
+  (sealed per-APKAM to `alice3`'s key package via `__ssenv`), only `nskey⁻¹` for the granted
+  `app_1.my_apps`; the `app_2.my_apps` nskey is never delivered. The boundary is enforced at the
+  atServer `__ssenv` namespace delivery gate (it will not deliver an `…__ssenv.app_2.my_apps` key
+  to an enrollment lacking `r` on it; `pq-secret-push.md` section
+  [5](pq-secret-push.md#5-authorization--safety)), not by a client-side refusal alone.
 
 ## A3 · E2EE within one atSign (self data)
 
 **UC-A3.1 — Self write/read, namespace key already exists**
-- **Given:** `@alice` pq-native; `public:nskey.app_1.my_apps@alice` published; alice1 & alice2 hold `nskey.app_1.my_apps@alice⁻¹`.
+- **Given:** `@alice` pq-native; the **self nskey** for `app_1.my_apps@alice` exists; alice1 & alice2 (both APKAM keypairs) hold both nskey privates.
 - **When:** `alice1` puts self key `<k>.app_1.my_apps@alice`.
-- **Then:** value encapsulated to @alice's own published public key `public:nskey.app_1.my_apps@alice`; `providerId = nskey`;
-  `alice2` decrypts with `nskey.app_1.my_apps@alice⁻¹`; no legacy provider used.
+- **Then:** via the **nskey data path** — `alice1` cuts a symmetric **CK**, conveys it **once** as
+  an `at/nskey` record (the CK X-Wing-sealed to @alice's **self nskey**); the data value is
+  `at/symmetric/AES/GCM` (AES-256-GCM under the CK) and cites the CK by `kid` — no inline sealed
+  key. `alice2` syncs the conveyance, **decapsulates** the CK with the self-nskey private, then
+  AES-GCM-decrypts the value; no legacy provider used.
 
 **UC-A3.2 — First self write in a namespace mints + distributes `nskey.app_1.my_apps@alice`**
 - **Given:** `@alice` pq-native; no `public:nskey.app_1.my_apps@alice` yet; alice1 & alice2 PQ.
 - **When:** `alice1` puts the first `app_1.my_apps` self key.
-- **Then:** `alice1` mints the `app_1.my_apps` namespace keypair `nskey.app_1.my_apps@alice`, publishes `public:nskey.app_1.my_apps@alice` (immutable),
-  seeds `nskey.app_1.my_apps@alice⁻¹` as an `app_1.my_apps`-namespaced secret; `alice2` obtains it via `requestSecret`
-  (authorised for `app_1.my_apps`), verifies correspondence, stores; both can read.
+- **Then:** `alice1` mints the `app_1.my_apps` namespace keypairs — **both** the self nskey
+  `nskey.app_1.my_apps@alice` and the public nskey `public:nskey.app_1.my_apps@alice` (immutable),
+  holding both privates — then **pushes** both privates to every ≥`r` member **per-APKAM**: it
+  calls `enroll:listfornamespace:app_1.my_apps`, seals each private to each member's key package,
+  and writes `<msgId>.<kpid>.__ssenv.app_1.my_apps@alice` (`pq-secret-push.md` section
+  [6.2](pq-secret-push.md#62-newly-minted-nskey-pushed-to-all-members-req-1)). `alice2` receives
+  the push, verifies correspondence, `putIfNewer` stores; both can read. `requestSecret` is the
+  pull backstop for an APKAM keypair offline during the push.
 
 **UC-A3.3 — Self fallback to the atSign-level PQ key (no namespace key)**
 - **Given:** `@alice` pq-native; alice1 wants to write self data but no `nskey.app_1.my_apps@alice` minted and
   "seal-and-hold" not chosen.
 - **When:** `alice1` puts self data.
-- **Then:** encapsulated to `public:pqpublickey@alice` (root fallback); any `@alice` client decrypts;
-  self-heals to `nskey` on first namespaced write.
+- **Then:** still the **nskey data path**, with the **CK** sealed to `public:pqpublickey@alice`
+  (root cold-start target) instead of an nskey; the data value is `at/symmetric/AES/GCM` under
+  that CK — application data is never encapsulated directly to `pqpublickey`. Any authorised
+  `@alice` APKAM keypair decapsulates the CK and decrypts; self-heals to the namespace's nskey on
+  the first namespaced write.
 
-| client | enr | APKAM | pqpk⁻¹ | nskey⁻¹ | CKP |
+| APKAM | enr | APKAM-kind | pqpk⁻¹ | nskey⁻¹ | KP |
 |---|---|---|---|---|---|
 | alice1 | E1 | pq | ✓ | ✓ | ✓ |
 | alice2 | E2 | pq | ✓ | ✓ | ✓ |
@@ -145,24 +178,31 @@ specific pubkey · TTL/usage eviction of APKAM keys.
 ## A4 · E2EE across atSigns (shared data)
 
 **UC-A4.1 — alice → bob, both PQ-native, bob has the namespace key**
-- **Given:** `@alice`, `@bob` pq-native; `@bob` published `public:nskey.app_1.my_apps@bob`; bob1/bob2 hold `nskey.app_1.my_apps@bob⁻¹`.
+- **Given:** `@alice`, `@bob` pq-native; `@bob` published `public:nskey.app_1.my_apps@bob`; bob1/bob2 (APKAM keypairs) hold `nskey.app_1.my_apps@bob⁻¹`.
 - **When:** `alice1` shares `@bob:<k>.app_1.my_apps@alice`.
-- **Then:** data key encapsulated to **bob's** published public key `public:nskey.app_1.my_apps@bob`; `providerId = nskey`;
-  bob1 & bob2 both decrypt; PQ-safe end to end; alice keeps a self-copy readable by her clients.
+- **Then:** via the **nskey data path** — alice1 cuts a CK and conveys it **once** as a discrete
+  `at/nskey` record (the CK X-Wing-sealed to **bob's published public nskey**
+  `public:nskey.app_1.my_apps@bob`); the data value is `at/symmetric/AES/GCM` under that CK,
+  citing it by `kid`. bob1 & bob2 sync the conveyance, decapsulate the CK with bob's public-nskey
+  private, and AES-GCM-decrypt; PQ-safe end to end; alice keeps a self-copy readable by her
+  authorised APKAM keypairs (CK conveyed to her self nskey).
 
 **UC-A4.2 — alice → bob cold-start (bob has no `app_1.my_apps` key) → pqpublickey fallback**
 - **Given:** `@alice`, `@bob` pq-native; `@bob` has `public:pqpublickey@bob` but **no** `public:nskey.app_1.my_apps@bob`.
 - **When:** `alice1` shares `@bob:<k>.app_1.my_apps@alice`.
-- **Then:** encapsulated to bob's `public:pqpublickey@bob` (every bob client can read); upgrades to
-  `public:nskey.app_1.my_apps@bob` once a bob `app_1.my_apps` client publishes it. (Or seal-and-hold for high-security `app_1.my_apps`.)
+- **Then:** still the **nskey data path**, with the **CK** sealed to bob's `public:pqpublickey@bob`
+  (root cold-start target — application data is never encapsulated directly to it); every
+  authorised bob APKAM keypair decapsulates the CK and reads. Upgrades to
+  `public:nskey.app_1.my_apps@bob` once a bob `app_1.my_apps` APKAM keypair publishes it. (Or
+  seal-and-hold for high-security `app_1.my_apps`.)
 
-**UC-A4.3 — Multi-client both ends**
-- **Given:** alice1/alice2 and bob1/bob2 all PQ; bob has `public:nskey.app_1.my_apps@bob`.
+**UC-A4.3 — Multi-APKAM both ends**
+- **Given:** alice1/alice2 and bob1/bob2 all PQ APKAM keypairs; bob has `public:nskey.app_1.my_apps@bob`.
 - **When:** `alice2` shares with `@bob`.
-- **Then:** all of bob's authorised clients read; all of alice's authorised clients read the
-  self-copy; no client is left unable to decrypt.
+- **Then:** all of bob's authorised APKAM keypairs read; all of alice's authorised APKAM keypairs
+  read the self-copy; no authorised APKAM keypair is left unable to decrypt.
 
-| client | enr | APKAM | pqpk⁻¹ | nskey⁻¹ | CKP |
+| APKAM | enr | APKAM-kind | pqpk⁻¹ | nskey⁻¹ | KP |
 |---|---|---|---|---|---|
 | alice1 | aE1 | pq | ✓ | ✓ | ✓ |
 | alice2 | aE2 | pq | ✓ | ✓ | ✓ |
@@ -172,23 +212,38 @@ specific pubkey · TTL/usage eviction of APKAM keys.
 ## A5 · Rotation & revocation (new world)
 
 **UC-A5.1 — Rotate a namespace key (post-compromise)**
-- **Given:** `nskey.app_1.my_apps@alice` exists; alice1 wants to rotate.
-- **When:** `alice1` mints `nskey.app_1.my_apps@alice` epoch+1, publishes the new `public:nskey.app_1.my_apps@alice`, distributes the new
-  private excluding nobody.
-- **Then:** new writes use epoch+1; clients retain old private to read old data (no FS);
-  peers re-encapsulate to the new pubkey.
+- **Given:** the `app_1.my_apps@alice` nskeys exist; alice1 wants to rotate. Two distinct levers,
+  do not conflate them.
+- **When (a) — coarse forward secrecy = rotate the symmetric CK:** `alice1` cuts a new CK, conveys
+  it once (sealed to the self nskey), and points new writes at it. For FS it then **deletes the old
+  CK's `at/nskey` conveyance record** and every APKAM keypair evicts the cached old CK. This is the
+  cheap, O(1) coarse-FS lever.
+- **Then (a):** old-CK-era data becomes undecryptable (the nskey private cannot help — no sealed
+  copy of the old CK survives). Retaining the old conveyance instead = history access. This is the
+  per-namespace FS retention knob.
+- **When (b) — revocation + PCS = rotate the nskey *keypair*:** `alice1` mints the next nskey
+  keypair excluding a compromised APKAM keypair, publishes the new
+  `public:nskey.app_1.my_apps@alice`, and pushes the successor private to the surviving APKAM
+  keypairs **per-APKAM** — seal to each surviving keypair's key package via `__ssenv`, dropping the
+  revoked one (`pq-secret-push.md` section
+  [6.4](pq-secret-push.md#64-rotation-pushes-the-successor-excluding-the-revoked-req-3)).
+- **Then (b):** new CKs are sealed to the successor nskey; peers re-fetch and encapsulate to the
+  new public nskey. This is the heavier, O(n)-per-APKAM revocation + post-compromise-security
+  lever — **not cheap**, and **distinct** from CK rotation.
 
-**UC-A5.2 — Per-host auth revocation**
-- **Given:** `@alice` pq-native; alice2's host is lost; legacy APKAM already deleted.
+**UC-A5.2 — Per-APKAM auth revocation**
+- **Given:** `@alice` pq-native; the keyfile holding alice2's APKAM keypair is lost; legacy APKAM already deleted.
 - **When:** operator revokes `alice2`'s PQ APKAM public key (delete it on aliceS).
-- **Then:** `alice2` can no longer authenticate; `alice1` unaffected; alice2 gets no new
-  secrets (excluded from future `requestSecret` serves).
+- **Then:** `alice2` (that APKAM keypair) can no longer authenticate; `alice1` unaffected; alice2
+  gets no new secrets — excluded at **both** discovery+push (`excludeEnrollmentIds` on
+  `enroll:listfornamespace`/serve) **and** the `requestSecret` pull serve (`pq-secret-push.md`
+  section [7](pq-secret-push.md#7-mapping-to-the-substrate), Revocation guard).
 
 **UC-A5.3 — Enrollment revocation**
-- **Given:** enrollment E2 compromised (may span hosts).
+- **Given:** enrollment E2 compromised (may hold several APKAM keypairs).
 - **When:** operator revokes E2.
-- **Then:** every host of E2 is cut at auth; pair with `nskey` rotation excluding E2 to deny
-  new-data keys.
+- **Then:** every APKAM keypair under E2 is cut at auth; pair with `nskey` keypair rotation
+  excluding E2 to deny new-data keys.
 
 ---
 
@@ -196,7 +251,7 @@ specific pubkey · TTL/usage eviction of APKAM keys.
 
 ## B0 · Prerequisite — atServer upgrade
 
-**UC-B0.1 — Client cannot PQ-upgrade against a legacy atServer**
+**UC-B0.1 — A PQ-capable APKAM keypair cannot PQ-upgrade against a legacy atServer**
 - **Given:** `aliceS = legacy` (no PQ verbs); `alice1` is a PQ-capable build.
 - **When:** `alice1` attempts the upgrade sequence.
 - **Then:** the new PQ verbs (PQ-APKAM auth / multiple-APKAM / delete-pubkey / eviction) are unavailable → `alice1`
@@ -207,65 +262,76 @@ specific pubkey · TTL/usage eviction of APKAM keys.
 
 Start state for B1: `@alice = legacy`, `aliceS = pq`, no `pqpublickey` yet.
 
-| client | enr | APKAM | pqpk⁻¹ | CKP | note |
+| APKAM | enr | APKAM-kind | pqpk⁻¹ | KP | note |
 |---|---|---|---|---|---|
 | alice1 | E1 | rsa | — | — | first to upgrade |
-| alice2 | E1 | rsa | — | — | same enrollment (B1.2) |
+| alice2 | E1 | rsa | — | — | second install on same enrollment (B1.2) |
 | alice3 | E2 | rsa | — | — | different enrollment (B1.3) |
 
-**UC-B1.1 — First client to upgrade (`alice1`)**
+**UC-B1.1 — First APKAM keypair to upgrade (`alice1`)**
 - **Given:** above; `pqpublickey` absent.
 - **When:** `alice1` runs the upgrade sequence.
-- **Then:** mints PQ APKAM (host-local), publishes it (immutable per-host); verifies PQ auth;
-  **deletes the legacy RSA APKAM pubkey**; **wins** the immutable create of `pqpublickey`,
-  generates + holds + seeds its private; publishes CKP. End: `alice1.APKAM = pq`,
-  `pqpk⁻¹ = ✓`, `pqpublickey` published.
+- **Then:** mints its PQ APKAM keypair + X-Wing key package locally (both privates stay in the
+  keyfile), registers it in the per-APKAM enrollment record (immutable per APKAM keypair);
+  verifies PQ auth; **deletes the legacy RSA APKAM pubkey**; **wins** the immutable create of
+  `pqpublickey`, generates + holds + seeds its private; its key package `KP = ✓`. End:
+  `alice1.APKAM = pq`, `pqpk⁻¹ = ✓`, `pqpublickey` published.
 
-**UC-B1.2 — Second client, same enrollment (`alice2`, E1)**
-- **Given:** after B1.1; `pqpublickey` exists.
+**UC-B1.2 — Second install, same enrollment (`alice2`, E1)**
+- **Given:** after B1.1; `pqpublickey` exists. `alice2` is a **separate install** on E1 (its own
+  enrolment-time mint, *not* a copied keyfile — a copy would share alice1's keypair, see UC-A2.2).
 - **When:** `alice2` runs the sequence.
-- **Then:** mints its **own** PQ APKAM (multiple-per-enrollment), publishes it; verifies PQ
-  auth; **requests** `pqpublickey@alice⁻¹` (exists → does not create), verifies correspondence,
-  stores. Identical to B1.1 except step 6 is *request*, not *create*.
+- **Then:** mints its **own** PQ APKAM keypair + key package (so E1 now holds **two** APKAM
+  keypairs, two key packages — multiple-per-enrollment), registers it; verifies PQ auth;
+  **requests** `pqpublickey@alice⁻¹` (exists → does not create), verifies correspondence, stores.
+  Identical to B1.1 except step 6 is *request*, not *create*.
 
-**UC-B1.3 — Third client, different enrollment (`alice3`, E2)**
+**UC-B1.3 — Third APKAM keypair, different enrollment (`alice3`, E2)**
 - **Given:** after B1.1; `pqpublickey` exists.
 - **When:** `alice3` runs the sequence.
-- **Then:** identical to B1.2 for this bootstrap (mints own PQ APKAM, requests root
-  `pqpublickey@alice⁻¹`). Distinction appears only for **namespaced** secrets — a restricted E2
-  receives a subset of `nskey` keys.
+- **Then:** identical to B1.2 for this bootstrap (mints own PQ APKAM keypair + key package,
+  requests root `pqpublickey@alice⁻¹`). Distinction appears only for **namespaced** secrets — a
+  restricted E2 receives a subset of `nskey` keys.
 
 ## B2 · Legacy APKAM deletion consequences
 
 **UC-B2.1 — Un-upgraded copy is locked out after deletion**
-- **Given:** E1's keyfile was copied to a second host `alice1b` (against advice); `alice1`
-  upgraded and deleted the legacy APKAM pubkey; `alice1b` has not upgraded.
+- **Given:** E1's keyfile was copied to a second host `alice1b` (against advice) — the **same**
+  legacy APKAM keypair on two hosts; `alice1` upgraded (minting a *new* PQ APKAM keypair) and
+  deleted the shared legacy APKAM pubkey; `alice1b` has not upgraded.
 - **When:** `alice1b` tries to authenticate (legacy).
-- **Then:** auth **fails** (legacy pubkey gone); `alice1b` must re-enroll. Acceptance: this is
-  the intended enforcement of "one enrollment key per keyfile."
+- **Then:** auth **fails** (the shared legacy pubkey is gone, and `alice1b` never minted its own PQ
+  keypair); `alice1b` must re-enroll. Acceptance: this is the intended enforcement of "one APKAM
+  keypair per keyfile" — revocation is per-keyfile-key (per APKAM keypair), so deleting the shared
+  legacy keypair cuts the un-upgraded copy.
 
 **UC-B2.2 — Grace-period variant**
 - **Given:** deployment opted into a grace period.
 - **When:** `alice1` upgrades.
 - **Then:** legacy auth survives N days then auto-deletes; `alice1b` can upgrade within the
-  window; after it, UC-B2.1 applies. (Bypass open during the window — explicit trade-off.)
+  window (minting its own PQ APKAM keypair); after it, UC-B2.1 applies. (Bypass open during the
+  window — explicit trade-off.)
 
-## B3 · Mixed-PQ within one atSign (some clients upgraded)
+## B3 · Mixed-PQ within one atSign (some APKAM keypairs upgraded)
 
-**UC-B3.1 — Upgraded client must still write legacy for an un-upgraded sibling**
-- **Given:** `alice1.APKAM/enc = pq`, `alice2` still legacy-only; `@alice` readiness `n-r`.
+**UC-B3.1 — Upgraded APKAM keypair must still write legacy for an un-upgraded sibling**
+- **Given:** `alice1` is PQ (`APKAM = pq`, holds the nskey/`pqpublickey` privates), `alice2` still
+  legacy-only; `@alice` readiness `n-r`.
 - **When:** `alice1` writes a self key both must read.
 - **Then:** `alice1` writes **legacy** (the scheme alice2 can read) — migration invariant
   "write only what every reader supports"; no data is unreadable by alice2.
 
-**UC-B3.2 — Readiness flips once all `@alice` clients are upgraded**
-- **Given:** all `@alice` clients now PQ; operator (or auto-detect) flips readiness `ready`.
+**UC-B3.2 — Readiness flips once all `@alice` APKAM keypairs are upgraded**
+- **Given:** all `@alice` APKAM keypairs now PQ; operator (or auto-detect) flips readiness `ready`.
 - **When:** `alice1` writes self data.
-- **Then:** self data goes `nskey`/`pqpublickey` (PQ); no `@alice` client loses access.
+- **Then:** self data goes via the **nskey data path** — `at/nskey` conveys the CK (sealed to the
+  self nskey, or to `public:pqpublickey@alice` as the cold-start CK target) and
+  `at/symmetric/AES/GCM` encrypts the data; the data is never encapsulated directly to the
+  nskey/`pqpublickey`. No `@alice` APKAM keypair loses access.
 
-| client | enr | APKAM | enc-reads | enc-writes |
+| APKAM | enr | APKAM-kind | data-reads | data-writes |
 |---|---|---|---|---|
-| alice1 | E1 | pq | legacy+pq | legacy (until ready) → pq |
+| alice1 | E1 | pq | legacy + nskey data path | legacy (until ready) → nskey data path |
 | alice2 | E1 | rsa | legacy | legacy |
 
 ## B4 · Mixed-PQ across atSigns
@@ -273,8 +339,9 @@ Start state for B1: `@alice = legacy`, `aliceS = pq`, no `pqpublickey` yet.
 **UC-B4.1 — PQ-ready `@alice` shares with legacy `@bob`**
 - **Given:** `@alice` PQ-ready; `@bob` legacy (only `publickey` RSA), bob readiness `n-r`.
 - **When:** `alice1` shares `@bob:<k>.app_1.my_apps@alice`.
-- **Then:** alice writes **legacy** to bob (gated by bob's readiness); PQ self-copy for alice's
-  own clients is allowed independently. No write bob can't read.
+- **Then:** alice writes **legacy** to bob (gated by bob's readiness); a PQ self-copy via the
+  nskey data path for alice's own authorised APKAM keypairs is allowed independently. No write bob
+  can't read.
 
 **UC-B4.2 — Legacy `@alice` receives from PQ `@bob` (and the interop question)**
 - **Given:** `@alice` legacy (no `pqpublickey`); `@bob` PQ-native.
@@ -287,22 +354,27 @@ Start state for B1: `@alice = legacy`, `aliceS = pq`, no `pqpublickey` yet.
 **UC-B4.3 — Partially-upgraded `@alice` (alice1 PQ, alice2 legacy) shares with `@bob`**
 - **Given:** `@alice` mixed; `@bob` PQ-ready.
 - **When:** `alice1` shares with `@bob`.
-- **Then:** to `@bob` the write may be PQ (bob is ready); but alice's **self-copy** must be
-  legacy (alice2 can't read PQ) until `@alice` readiness flips. Two directions, two schemes,
-  same `put`.
+- **Then:** to `@bob` the write may be PQ via the nskey data path (bob is ready); but alice's
+  **self-copy** must be legacy (alice2 can't read PQ) until `@alice` readiness flips. Two
+  directions, two schemes, same `put`.
 
 **UC-B4.4 — `@bob` finishes upgrading → shared flips to PQ**
-- **Given:** `@bob` was legacy; now all bob clients PQ and bob readiness `ready`.
+- **Given:** `@bob` was legacy; now all bob APKAM keypairs PQ and bob readiness `ready`.
 - **When:** `alice1` next shares with `@bob`.
-- **Then:** alice writes `nskey`/`pqpublickey` PQ to bob; legacy path no longer needed for bob.
+- **Then:** alice writes via the **nskey data path** to bob (`at/nskey` conveys the CK sealed to
+  bob's public nskey, or `public:pqpublickey@bob` cold-start; `at/symmetric/AES/GCM` encrypts the
+  data); legacy path no longer needed for bob.
 
 ## B5 · Retrofit edge cases
 
-**UC-B5.1 — Offline client pulls `pqpublickey` later**
-- **Given:** `alice2` was offline during the upgrade wave; `pqpublickey` created by `alice1`.
+**UC-B5.1 — Offline APKAM keypair pulls `pqpublickey` later**
+- **Given:** `alice2` (an APKAM keypair) was offline during the upgrade wave; `pqpublickey` created by `alice1`.
 - **When:** `alice2` next comes online and upgrades.
-- **Then:** its `requestSecret` for `pqpublickey@alice⁻¹` is answered by any online holder; persists
-  if none online until one answers.
+- **Then:** `pqpublickey` is root (no namespace), so it has no `enroll:listfornamespace` push —
+  its `requestSecret` for `pqpublickey@alice⁻¹` is answered by any online holder (pull is its
+  steady-state path; persists if none online until one answers). Namespaced `nskey` privates that
+  `alice2` missed during its offline window arrive by the **push** primary path once a holder is
+  online (`enroll:listfornamespace` + `__ssenv`), with `requestSecret` as the backstop.
 
 **UC-B5.2 — Reading legacy history after upgrade**
 - **Given:** `alice1` upgraded; legacy *encryption* key retained (only legacy APKAM deleted).
@@ -310,7 +382,7 @@ Start state for B1: `@alice = legacy`, `aliceS = pq`, no `pqpublickey` yet.
 - **Then:** decrypts via the legacy provider (reads are universal); `providerId` routes per
   value. PQ upgrade never makes old data unreadable.
 
-**UC-B5.3 — Two clients race to create `pqpublickey`**
+**UC-B5.3 — Two APKAM keypairs race to create `pqpublickey`**
 - **Given:** `alice1` and `alice3` both reach the create step with `pqpublickey` absent.
 - **When:** both attempt the immutable create.
 - **Then:** exactly one wins; the other gets "already exists" and falls through to *request*.
@@ -328,13 +400,18 @@ Resolved 2026-06-24:
    the flag is on.
 2. **Readiness granularity** (B3/B4): **per (atSign, namespace)**, plus an atSign-level marker
    for the root `pqpublickey` fallback — enabling independent per-namespace rollout.
-3. **PQ APKAM placement**: **copyable keyfile** section (like the legacy APKAM). A copy made
-   *after* upgrade shares the key (revocation is per-keyfile-key, not strictly per-device); a
-   copy made *before* upgrade mints its own. Device-local/keychain is an optional hardening for
-   deployments wanting true per-host binding.
-4. **`nskey` to a new enrollment**: **push at approve + pull fallback** — the approver conveys
-   the authorised-namespace `nskey` privates in the enroll/approve bundle; `requestSecret` is
-   the backstop. (Derive-from-seed rejected — over-grants restricted enrollments.)
+3. **PQ APKAM placement**: **copyable keyfile** section (like the legacy APKAM). The recipient
+   unit is the **APKAM keypair**, one per keyfile: a copy made *after* upgrade **shares** the
+   keypair (and its key package private half) — revocation is per-keyfile-key (per APKAM keypair),
+   not strictly per-device; a copy made *before* upgrade mints its own. (This is the source of
+   truth UC-A2.2 / UC-B2.1 align to.) Device-local/keychain is an optional hardening for
+   deployments wanting true host binding.
+4. **`nskey` to a new enrollment**: **push at approve + pull backstop** — the approver conveys the
+   authorised-namespace `nskey` privates **per-APKAM** via the `__ssenv` substrate (seal to each
+   granted-namespace key package, `shareAllSecretsWithEnrollment`); `requestSecret` is the
+   backstop. The push generalises beyond approval: steady-state mint/rotation pushes use the
+   `enroll:listfornamespace` verb to enumerate ≥`r` members (`pq-secret-push.md` reqs 1/3).
+   (Derive-from-seed rejected — over-grants restricted enrollments.)
 5. **Seal-and-hold vs send-now** (A3.3, A4.2): **send-now via the `pqpublickey` fallback by
    default; seal-and-hold a per-namespace opt-in** for high-security namespaces.
 


### PR DESCRIPTION
## What I did

Reframes the post-quantum crypto **design docs** around two decisions taken since ADR 0001 (docs-only — no code).

- **ADR 0002 supersedes ADR 0001.** D1 is single-tier: the **nskey data path** — `at/nskey` conveys the symmetric content key, `at/symmetric/AES/GCM` encrypts the data — plus `legacy`. The two-tier (nskey vs group) split is dissolved. Forward secrecy is a rotation **policy** of the one data path (coarse FS via content-key rotation; post-compromise security via nskey-keypair rotation), not a separate tier. `at/pqmls` (MLS) is **D2**.
- **Per-client → per-APKAM throughout.** The recipient/identity unit is the APKAM keypair. KeyPackages are enrollment-internal (stored as self keys, **never published**) and discovered via the gated `enroll:listfornamespace:<ns>` verb. Per-APKAM **push** (+ pull backstop) pre-delivers secrets.

**New docs**
- `docs/adr/0002-d1-single-tier-nskey.md` — the decision.
- `docs/pq-data-encryption.md` — the D1 data-encryption source of truth (three layers; the two nskeys; the three providers; decoupled content key; cold-start; CK lifecycle).
- `docs/pq-secret-push.md` — per-APKAM push + the `enroll:listfornamespace` verb design.

**Updated**
- `docs/crypto-roadmap.md` — phases renumbered to a 0–6 backbone; milestones **M0–M3 = D1, M4–M6 = D2**.
- `docs/crypto_impl_plan.md`, `docs/crypto-walkthroughs.md` (Walkthroughs A & C rewritten on the nskey data path), `docs/pq-atsign-key-distribution.md`, `docs/pq-use-case-catalogue.md`, `docs/pq-flows-detailed.md`.
- `docs/adr/0001-d1-simplicity-tiers.md` — marked **superseded** (body retained for history).
- The group provider id is renamed `at/pqmls` (provider id only; engine Dart symbols such as `SecureGroup` are unchanged).

## How I did it

Authored ADR 0002 + the two new design docs, then ran a consistency cascade across all 11 design docs. Final verification: **444 intra-repo links resolve (0 broken)**; per-client → per-APKAM swept (loose "per-host" granularity → per-APKAM, genuine hardware "host binding" kept); `ClientKeyPackage` aligned to the canonical `KeyPackage` in target prose; milestone↔deliverable mapping reconciled with the renumbered phases.

## How to verify it

- Start at `docs/adr/0002-d1-single-tier-nskey.md`; `docs/pq-data-encryption.md` is the data-encryption source of truth.
- All cross-document heading-anchor links resolve.
- No code paths touched — nothing to build or test.

## Description for the changelog

N/A — design documentation only; no published-package change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
