### PR TITLE
refactor(at_client): align WP-SS substrate to 1:1:1 / flat listns wire shape

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## 3.13.0
+- feat (experimental): per-APKAM same-atSign secret-sharing substrate —
+  `AtClientSecretSharing` / `PairwiseSecretSharing` (mixins `KeyPackageRegistration`,
+  `EnvelopeSigning`), `SecretStore`, `KeyPackage`, `SecretEnvelope`, and the
+  `EnrollmentDirectory` seam. Secrets travel in X-Wing-sealed (`pqSeal`),
+  APKAM-signed `__ssenv` envelopes addressed by `kpid`; key packages are
+  enrollment-internal (conveyed via `enroll:request`, discovered via the gated
+  `enroll:listns` verb) and never published. The whole surface is
+  `@experimental` — the wire shape is subject to change pending the atServer
+  verb work — and requires `at_chops ^3.3.0` (`pqSeal`/`pqOpen`).
 - refactor: migrate the local keystore to `at_persistence_secondary_server`
   5.0.0 — the client is now commit-log-free. The client no longer maintains a
   local commit log or runs commit-log compaction; sync tracks its progress

--- a/packages/at_client/lib/src/secret_sharing/algo_ids.dart
+++ b/packages/at_client/lib/src/secret_sharing/algo_ids.dart
@@ -26,13 +26,6 @@ class SecretSharingAlgos {
   /// `suite` field records which construction produced it.
   static const String xWingHpke = 'x-wing-hpke-v1';
 
-  /// The key-package **format id** this substrate writes into, and reads from,
-  /// an enrollment record's `metadata.keyPackages` map. Keying that map by
-  /// format id lets the key-package shape evolve (a new id) without the
-  /// atServer — which stores `metadata` opaquely and has no opinion on its
-  /// contents — needing any change.
-  static const String keyPackageType = 'x-wing-v1';
-
   /// Key-establishment algorithms this client supports, strongest first.
   /// A sender picks the first of these that the recipient's key package
   /// advertises.

--- a/packages/at_client/lib/src/secret_sharing/enrollment_directory.dart
+++ b/packages/at_client/lib/src/secret_sharing/enrollment_directory.dart
@@ -1,7 +1,6 @@
 import 'dart:convert' show jsonDecode;
 
 import 'package:at_client/at_client.dart' show AtClient;
-import 'package:at_client/src/secret_sharing/algo_ids.dart';
 import 'package:at_client/src/secret_sharing/key_package.dart';
 import 'package:meta/meta.dart' show experimental;
 
@@ -10,10 +9,8 @@ import 'package:meta/meta.dart' show experimental;
 /// package of its APKAM keypair.
 ///
 /// Enrollment cardinality is **1:1:1** — one enrollment has exactly one APKAM
-/// keypair and therefore exactly one key package — so [keyPackages] holds at
-/// most one element (empty if the enrollment advertised none). It is kept a
-/// list only so a sender can iterate uniformly; a sender seals once per key
-/// package, reaching the enrollment.
+/// keypair and therefore exactly one key package — so each member has exactly
+/// one [keyPackage] (null if the enrollment advertised none).
 @experimental
 class NamespaceMember {
   final String enrollmentId;
@@ -23,13 +20,14 @@ class NamespaceMember {
   /// key — reading the data requires it.
   final String access;
 
-  /// This enrollment's key package(s): 0 or 1 element under 1:1:1.
-  final List<KeyPackage> keyPackages;
+  /// This enrollment's single key package, or null if it advertised none
+  /// (1:1:1).
+  final KeyPackage? keyPackage;
 
   NamespaceMember({
     required this.enrollmentId,
     required this.access,
-    required this.keyPackages,
+    this.keyPackage,
   });
 }
 
@@ -62,13 +60,13 @@ abstract class EnrollmentDirectory {
 /// authorised for the namespace (1:1:1 — no nested `apkam[]` array). Each
 /// record carries the enrollment's access level, its single APKAM public key,
 /// and its opaque `metadata` map (stored verbatim by the server from the
-/// enrollment's `enroll:request`). Key packages live in `metadata.keyPackages`,
-/// a map keyed by key-package format id ([SecretSharingAlgos.keyPackageType])
-/// so formats can evolve without server changes:
+/// enrollment's `enroll:request`). The enrollment's single key package lives
+/// directly under `metadata.keyPackage` (the payload itself — no format-id
+/// sub-key):
 ///
 ///     enroll:listns:<ns>
 ///       -> data:[{"enrollmentId":..,"access":"rw","apkamPubKey":..,
-///                 "metadata":{"keyPackages":{"x-wing-v1":{..}}}}]
+///                 "metadata":{"keyPackage":{"v":1,"createdAt":..,"keys":[..]}}}]
 @experimental
 class VerbEnrollmentDirectory implements EnrollmentDirectory {
   final AtClient atClient;
@@ -94,31 +92,28 @@ class VerbEnrollmentDirectory implements EnrollmentDirectory {
       final access = e['access'];
       if (enrollmentId is! String || access is! String) continue;
       if (excludeEnrollmentIds.contains(enrollmentId)) continue;
-      final keyPackages = <KeyPackage>[];
+      KeyPackage? keyPackage;
       final apkamPubKey = e['apkamPubKey'];
       final metadata = e['metadata'];
       if (metadata is Map) {
-        final pkgs = metadata['keyPackages'];
-        if (pkgs is Map) {
-          final payload = pkgs[SecretSharingAlgos.keyPackageType];
-          if (payload != null) {
-            try {
-              keyPackages.add(KeyPackage.fromPayload(
-                payload,
-                enrollmentId: enrollmentId,
-                apkamId: apkamPubKey is String ? apkamPubKey : null,
-              ));
-            } catch (_) {
-              // skip a malformed/unknown-format package; a newer client may
-              // have written one this version doesn't understand
-            }
+        final pkg = metadata['keyPackage'];
+        if (pkg != null) {
+          try {
+            keyPackage = KeyPackage.fromPayload(
+              pkg,
+              enrollmentId: enrollmentId,
+              apkamId: apkamPubKey is String ? apkamPubKey : null,
+            );
+          } catch (_) {
+            // skip a malformed/unknown-format package; a newer client may
+            // have written one this version doesn't understand
           }
         }
       }
       members.add(NamespaceMember(
         enrollmentId: enrollmentId,
         access: access,
-        keyPackages: keyPackages,
+        keyPackage: keyPackage,
       ));
     }
     return members;

--- a/packages/at_client/lib/src/secret_sharing/enrollment_directory.dart
+++ b/packages/at_client/lib/src/secret_sharing/enrollment_directory.dart
@@ -1,4 +1,4 @@
-import 'dart:convert' show jsonDecode, jsonEncode;
+import 'dart:convert' show jsonDecode;
 
 import 'package:at_client/at_client.dart' show AtClient;
 import 'package:at_client/src/secret_sharing/algo_ids.dart';
@@ -7,12 +7,13 @@ import 'package:meta/meta.dart' show experimental;
 
 /// One enrollment authorised for a namespace, as returned by
 /// [EnrollmentDirectory.listForNamespace]: its access level and the key
-/// packages of every APKAM keypair it has registered.
+/// package of its APKAM keypair.
 ///
-/// An enrollment can expose several [keyPackages] — one per APKAM keypair
-/// (the keyfile copied to another device mints its own). A sender seals once
-/// per key package, so every client sharing the enrollment receives the
-/// secret.
+/// Enrollment cardinality is **1:1:1** — one enrollment has exactly one APKAM
+/// keypair and therefore exactly one key package — so [keyPackages] holds at
+/// most one element (empty if the enrollment advertised none). It is kept a
+/// list only so a sender can iterate uniformly; a sender seals once per key
+/// package, reaching the enrollment.
 @experimental
 class NamespaceMember {
   final String enrollmentId;
@@ -22,7 +23,7 @@ class NamespaceMember {
   /// key — reading the data requires it.
   final String access;
 
-  /// One [KeyPackage] per APKAM keypair of this enrollment that advertised one.
+  /// This enrollment's key package(s): 0 or 1 element under 1:1:1.
   final List<KeyPackage> keyPackages;
 
   NamespaceMember({
@@ -32,44 +33,42 @@ class NamespaceMember {
   });
 }
 
-/// The atServer-backed directory of per-APKAM key packages.
+/// The atServer-backed directory of per-enrollment key packages.
 ///
-/// Discovery and storage of key packages live behind this seam so the
-/// secret-sharing substrate above it is independent of the wire protocol and
-/// fully unit-testable with a fake. The concrete [VerbEnrollmentDirectory]
-/// talks to the gated `enroll:listfornamespace` verb and the enrollment
-/// record; tests substitute their own implementation.
+/// Discovery of key packages lives behind this seam so the secret-sharing
+/// substrate above it is independent of the wire protocol and fully
+/// unit-testable with a fake. The concrete [VerbEnrollmentDirectory] talks to
+/// the gated `enroll:listns` verb; tests substitute their own implementation.
+///
+/// There is no registration method: a key package is conveyed into its
+/// enrollment record by riding `enroll:request` as opaque
+/// `EnrollParams.metadata` at enrollment time (there is no post-enrollment
+/// metadata write, and no `enroll:metadata` verb).
 @experimental
 abstract class EnrollmentDirectory {
   /// The enrollments authorised for [namespace] (the caller's own enrollment
   /// must hold at least read access — the atServer gates the verb), each with
-  /// the per-APKAM key packages to seal to. [excludeEnrollmentIds] drops
-  /// revoked enrollments before they ever enter a roster.
+  /// the key package to seal to. [excludeEnrollmentIds] drops revoked
+  /// enrollments before they ever enter a roster.
   Future<List<NamespaceMember>> listForNamespace(
     String namespace, {
     Set<String> excludeEnrollmentIds = const {},
   });
-
-  /// Records [keyPackage] in this client's enrollment record (filed by the
-  /// atServer under whichever APKAM keypair authenticated the write), so peers
-  /// discover it via [listForNamespace]. Idempotent.
-  Future<void> registerKeyPackage(KeyPackage keyPackage);
 }
 
-/// [EnrollmentDirectory] backed by the atServer's `enroll:listfornamespace`
-/// verb and enrollment-record metadata.
+/// [EnrollmentDirectory] backed by the atServer's `enroll:listns` verb.
 ///
-/// **Wire shape (assumed):** the server stores an opaque `metadata` JSON map
-/// per APKAM keypair and returns it verbatim — it has no opinion on the
-/// contents, only on the auth info it needs to verify PKAM. Key packages live
-/// in `metadata.keyPackages`, a map keyed by key-package format id
-/// ([SecretSharingAlgos.keyPackageType]) so formats can evolve without server
-/// changes:
+/// **Wire shape:** the server returns one flat record per approved enrollment
+/// authorised for the namespace (1:1:1 — no nested `apkam[]` array). Each
+/// record carries the enrollment's access level, its single APKAM public key,
+/// and its opaque `metadata` map (stored verbatim by the server from the
+/// enrollment's `enroll:request`). Key packages live in `metadata.keyPackages`,
+/// a map keyed by key-package format id ([SecretSharingAlgos.keyPackageType])
+/// so formats can evolve without server changes:
 ///
-///     enroll:listfornamespace:<ns>
-///       -> data:[{"enrollmentId":..,"access":"rw",
-///                 "apkam":[{"apkamId":..,"apkamPubKey":..,
-///                           "metadata":{"keyPackages":{"x-wing-v1":{..}}}}]}]
+///     enroll:listns:<ns>
+///       -> data:[{"enrollmentId":..,"access":"rw","apkamPubKey":..,
+///                 "metadata":{"keyPackages":{"x-wing-v1":{..}}}}]
 @experimental
 class VerbEnrollmentDirectory implements EnrollmentDirectory {
   final AtClient atClient;
@@ -83,7 +82,7 @@ class VerbEnrollmentDirectory implements EnrollmentDirectory {
   }) async {
     final String? raw = await atClient
         .getRemoteSecondary()
-        ?.executeCommand('enroll:listfornamespace:$namespace\n', auth: true);
+        ?.executeCommand('enroll:listns:$namespace\n', auth: true);
     final decoded = _data(raw);
     if (decoded is! List) {
       return const [];
@@ -95,27 +94,24 @@ class VerbEnrollmentDirectory implements EnrollmentDirectory {
       final access = e['access'];
       if (enrollmentId is! String || access is! String) continue;
       if (excludeEnrollmentIds.contains(enrollmentId)) continue;
-      final apkams = e['apkam'];
       final keyPackages = <KeyPackage>[];
-      if (apkams is List) {
-        for (final a in apkams) {
-          if (a is! Map) continue;
-          final apkamId = a['apkamId'];
-          final metadata = a['metadata'];
-          if (metadata is! Map) continue;
-          final pkgs = metadata['keyPackages'];
-          if (pkgs is! Map) continue;
+      final apkamPubKey = e['apkamPubKey'];
+      final metadata = e['metadata'];
+      if (metadata is Map) {
+        final pkgs = metadata['keyPackages'];
+        if (pkgs is Map) {
           final payload = pkgs[SecretSharingAlgos.keyPackageType];
-          if (payload == null) continue;
-          try {
-            keyPackages.add(KeyPackage.fromPayload(
-              payload,
-              enrollmentId: enrollmentId,
-              apkamId: apkamId is String ? apkamId : null,
-            ));
-          } catch (_) {
-            // skip a malformed/unknown-format package; a newer client may
-            // have written one this version doesn't understand
+          if (payload != null) {
+            try {
+              keyPackages.add(KeyPackage.fromPayload(
+                payload,
+                enrollmentId: enrollmentId,
+                apkamId: apkamPubKey is String ? apkamPubKey : null,
+              ));
+            } catch (_) {
+              // skip a malformed/unknown-format package; a newer client may
+              // have written one this version doesn't understand
+            }
           }
         }
       }
@@ -126,18 +122,6 @@ class VerbEnrollmentDirectory implements EnrollmentDirectory {
       ));
     }
     return members;
-  }
-
-  @override
-  Future<void> registerKeyPackage(KeyPackage keyPackage) async {
-    // The server stores the metadata opaquely under the authenticating APKAM
-    // keypair; the substrate's format lives under `keyPackages.<format-id>`.
-    final metadata = jsonEncode({
-      'keyPackages': {SecretSharingAlgos.keyPackageType: keyPackage.toJson()}
-    });
-    await atClient.getRemoteSecondary()?.executeCommand(
-        'enroll:metadata:${atClient.enrollmentId}:$metadata\n',
-        auth: true);
   }
 
   /// Strips the at-protocol `data:` prefix and JSON-decodes a verb response.

--- a/packages/at_client/lib/src/secret_sharing/key_package.dart
+++ b/packages/at_client/lib/src/secret_sharing/key_package.dart
@@ -64,10 +64,13 @@ class PackageKey {
 /// record, conveyed there by riding `enroll:request` as opaque
 /// `EnrollParams.metadata` at enrollment time, and are discovered only via the
 /// gated `enroll:listns` verb (see [EnrollmentDirectory]). They are **not**
-/// published and **not** separately signed: the atServer vouches that a
-/// returned key package belongs to the enrollment it is filed under. (Message
-/// authenticity is the per-envelope APKAM signature, see EnvelopeSigning —
-/// unchanged.)
+/// published as ordinary at-keys. Per the ratified design the advertised key
+/// package is wrapped in an APKAM-signed envelope by its generating enrollment
+/// and verified against that enrollment's `_apsk` — the same path same-atSign
+/// and cross-atSign — so the encapsulation target is authenticated, not merely
+/// server-vouched. *(Signing/verifying the advertised package is not yet
+/// implemented here — today it is advertised unsigned; per-envelope `__ssenv`
+/// messages are already APKAM-signed, see EnvelopeSigning.)*
 ///
 /// The wire form is the value stored at `metadata.keyPackage`
 /// in the enrollment record ([toJson] / [fromPayload]); [enrollmentId] and

--- a/packages/at_client/lib/src/secret_sharing/key_package.dart
+++ b/packages/at_client/lib/src/secret_sharing/key_package.dart
@@ -55,18 +55,19 @@ class PackageKey {
 /// The X-Wing recipient key(s) one **APKAM keypair** advertises so that other
 /// clients of the same atSign can seal secrets to it.
 ///
-/// The recipient unit is the APKAM keypair, not a client process: a key
-/// package is identified by ([enrollmentId], [apkamId]). Several APKAM
-/// keypairs may belong to one enrollment (the keyfile copied to another
-/// device, each minting its own), so an enrollment can expose more than one.
+/// The recipient unit is the APKAM keypair, not a client process. Enrollment
+/// cardinality is **1:1:1** — one enrollment has exactly one APKAM keypair and
+/// therefore exactly one key package — so a key package is identified by its
+/// [enrollmentId] (with [apkamId] carried alongside for reference).
 ///
-/// Key packages are **enrollment-internal** — they live in the per-APKAM
-/// enrollment record (written under that APKAM keypair's authenticated write)
-/// and are discovered only via the gated `enroll:listfornamespace` verb (see
-/// [EnrollmentDirectory]). They are **not** published and **not** separately
-/// signed: the atServer vouches that a returned key package belongs to the
-/// enrollment it is filed under. (Message authenticity is the per-envelope
-/// APKAM signature, see EnvelopeSigning — unchanged.)
+/// Key packages are **enrollment-internal** — they live in the enrollment
+/// record, conveyed there by riding `enroll:request` as opaque
+/// `EnrollParams.metadata` at enrollment time, and are discovered only via the
+/// gated `enroll:listns` verb (see [EnrollmentDirectory]). They are **not**
+/// published and **not** separately signed: the atServer vouches that a
+/// returned key package belongs to the enrollment it is filed under. (Message
+/// authenticity is the per-envelope APKAM signature, see EnvelopeSigning —
+/// unchanged.)
 ///
 /// The wire form is the value stored at `metadata.keyPackages[<format-id>]`
 /// in the enrollment record ([toJson] / [fromPayload]); [enrollmentId] and
@@ -81,9 +82,9 @@ class KeyPackage {
   /// The enrollment this key package belongs to.
   final String enrollmentId;
 
-  /// The APKAM keypair this key package belongs to, as reported by the verb.
-  /// Null on a key package this client builds for its own registration — the
-  /// atServer files it under whichever APKAM keypair authenticated the write.
+  /// The APKAM keypair this key package belongs to, as reported by the verb
+  /// (the enrollment's `apkamPubKey`). Null on a key package this client builds
+  /// for its own enrollment — identity is carried by the enclosing enrollment.
   final String? apkamId;
 
   final DateTime createdAt;

--- a/packages/at_client/lib/src/secret_sharing/key_package.dart
+++ b/packages/at_client/lib/src/secret_sharing/key_package.dart
@@ -69,7 +69,7 @@ class PackageKey {
 /// authenticity is the per-envelope APKAM signature, see EnvelopeSigning —
 /// unchanged.)
 ///
-/// The wire form is the value stored at `metadata.keyPackages[<format-id>]`
+/// The wire form is the value stored at `metadata.keyPackage`
 /// in the enrollment record ([toJson] / [fromPayload]); [enrollmentId] and
 /// [apkamId] are carried by the enclosing verb structure, not duplicated in
 /// the payload.
@@ -118,7 +118,7 @@ class KeyPackage {
     return null;
   }
 
-  /// The value stored at `metadata.keyPackages[<format-id>]` — the payload
+  /// The value stored at `metadata.keyPackage` — the payload
   /// only. [enrollmentId] / [apkamId] are carried by the enclosing verb
   /// structure (the enrollment and its APKAM-keypair entry), not repeated here.
   Map<String, Object?> toJson() => {
@@ -127,7 +127,7 @@ class KeyPackage {
         'keys': keys.map((k) => k.toJson()).toList(),
       };
 
-  /// Parses a stored key-package [payload] (from `metadata.keyPackages`),
+  /// Parses a stored key-package [payload] (from `metadata.keyPackage`),
   /// injecting the [enrollmentId] / [apkamId] the enclosing verb structure
   /// carried. Skips malformed entries in `keys` rather than throwing — a
   /// payload written by a newer client may carry key entries (or extra fields)

--- a/packages/at_client/lib/src/secret_sharing/key_package_registration.dart
+++ b/packages/at_client/lib/src/secret_sharing/key_package_registration.dart
@@ -26,12 +26,13 @@ class PersistedApkamKeys {
 
 /// Maintains this APKAM keypair's [KeyPackage] for same-atSign secret sharing.
 ///
-/// The recipient unit is the **APKAM keypair**: this client holds one X-Wing
-/// enc keypair (its [kpid] is the SHA-256 prefix of the public key), registers
-/// it via the [EnrollmentDirectory] into its enrollment record, and publishes
-/// its APKAM signing key so peers can verify the envelopes it sends. Key
-/// packages are enrollment-internal — never published, discovered only via the
-/// gated `enroll:listfornamespace` verb.
+/// The recipient unit is the **APKAM keypair** (1:1:1 — one enrollment, one
+/// APKAM keypair, one key package): this client holds one X-Wing enc keypair
+/// (its [kpid] is the SHA-256 prefix of the public key) and publishes its APKAM
+/// signing key so peers can verify the envelopes it sends. Its key package is
+/// conveyed into the enrollment record by riding `enroll:request` as opaque
+/// `EnrollParams.metadata` at enrollment time (there is no post-enrollment
+/// write); peers discover it via the gated `enroll:listns` verb.
 ///
 /// By default the enc keypair is generated fresh and held in memory; apps that
 /// want it stable across restarts supply [loadApkamKeys] / [saveApkamKeys]
@@ -98,9 +99,13 @@ mixin KeyPackageRegistration on ApkamSigning, EnvelopeSigning {
       );
 
   /// Generates (or loads, via [loadApkamKeys]) this APKAM keypair's X-Wing enc
-  /// keypair, publishes its APKAM signing key (so peers can verify its
-  /// envelopes), and registers its key package in the enrollment record so
-  /// peers can discover it. Idempotent.
+  /// keypair and publishes its APKAM signing key (so peers can verify its
+  /// envelopes), then returns this client's [KeyPackage]. Idempotent.
+  ///
+  /// The returned key package is conveyed into the enrollment record by riding
+  /// `enroll:request` as opaque `EnrollParams.metadata` at enrollment time — it
+  /// is never written by a post-enrollment directory call. Peers then discover
+  /// it via the gated `enroll:listns` verb.
   Future<KeyPackage> register() async {
     if (_xWingSeed == null) {
       final loaded = await loadApkamKeys?.call();
@@ -118,11 +123,9 @@ mixin KeyPackageRegistration on ApkamSigning, EnvelopeSigning {
       }
     }
     await publishPublicSigningKey();
-    final keyPackage = myKeyPackage;
-    await directory.registerKeyPackage(keyPackage);
     _registered = true;
-    logger.info('Registered key package for enrollment $enrollmentId '
+    logger.info('Prepared key package for enrollment $enrollmentId '
         '(kpid $kpid)');
-    return keyPackage;
+    return myKeyPackage;
   }
 }

--- a/packages/at_client/lib/src/secret_sharing/pairwise_secret_sharing.dart
+++ b/packages/at_client/lib/src/secret_sharing/pairwise_secret_sharing.dart
@@ -461,8 +461,8 @@ mixin PairwiseSecretSharing on KeyPackageRegistration {
         excludeEnrollmentIds: excludeEnrollmentIds);
     int sent = 0;
     for (final member in members) {
-      for (final to in member.keyPackages) {
-        if (to.kpid == kpid) continue; // skip ourselves
+      final to = member.keyPackage;
+      if (to != null && to.kpid != kpid) {
         await sendEnvelope(to, namespace, {
           'kind': secretRequestKind,
           if (names != null) 'want': names,
@@ -510,11 +510,9 @@ mixin PairwiseSecretSharing on KeyPackageRegistration {
       if (member.enrollmentId != received.fromEnrollmentId) {
         continue;
       }
-      for (final kp in member.keyPackages) {
-        if (kp.kpid == received.fromKpid) {
-          requester = kp;
-          break;
-        }
+      final kp = member.keyPackage;
+      if (kp != null && kp.kpid == received.fromKpid) {
+        requester = kp;
       }
       if (requester != null) break;
     }
@@ -667,8 +665,8 @@ mixin PairwiseSecretSharing on KeyPackageRegistration {
         excludeEnrollmentIds: excludeEnrollmentIds);
     int pushed = 0;
     for (final member in members) {
-      for (final to in member.keyPackages) {
-        if (to.kpid == kpid) continue; // skip ourselves
+      final to = member.keyPackage;
+      if (to != null && to.kpid != kpid) {
         await shareSecretWith(to, secret);
         pushed++;
       }
@@ -699,7 +697,8 @@ mixin PairwiseSecretSharing on KeyPackageRegistration {
       if (ns == '*') continue; // a wildcard isn't a queryable namespace
       for (final member in await directory.listForNamespace(ns)) {
         if (member.enrollmentId != enrollmentId) continue;
-        for (final kp in member.keyPackages) {
+        final kp = member.keyPackage;
+        if (kp != null) {
           final id = kp.kpid;
           if (id != null) byKpid[id] = kp;
         }

--- a/packages/at_client/lib/src/secret_sharing/secret_sharing.dart
+++ b/packages/at_client/lib/src/secret_sharing/secret_sharing.dart
@@ -3,12 +3,12 @@
 /// Multiple atClients frequently authenticate as the same atSign — on
 /// different APKAM enrollments, or as several APKAM keypairs of one
 /// enrollment. This library lets them share secrets such that only the target
-/// **APKAM keypair** can read them: each APKAM keypair registers a [KeyPackage]
-/// (per [KeyPackageRegistration]) into its enrollment record, and secrets
-/// travel in signed, encrypted [SecretEnvelope]s addressed by `kpid` and scoped
-/// by application namespace (per [PairwiseSecretSharing]). Key packages are
-/// discovered via the gated `enroll:listfornamespace` verb behind
-/// [EnrollmentDirectory] — never published.
+/// **APKAM keypair** can read them: each APKAM keypair holds a [KeyPackage]
+/// (per [KeyPackageRegistration]) conveyed into its enrollment record via
+/// `enroll:request`, and secrets travel in signed, encrypted [SecretEnvelope]s
+/// addressed by `kpid` and scoped by application namespace (per
+/// [PairwiseSecretSharing]). Key packages are discovered via the gated
+/// `enroll:listns` verb behind [EnrollmentDirectory] — never published.
 ///
 /// [AtClientSecretSharing] is the ready-made entry point; the mixins are
 /// exported for apps that prefer composing them into their own classes.

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   at_base2e15: ^1.0.0
   at_commons: ^5.9.0
   at_utils: ^3.2.0
-  at_chops: ^3.0.0
+  at_chops: ^3.3.0
   at_lookup: ^3.1.0
   at_auth: ^3.0.0
   at_persistence_secondary_server: ^5.1.0

--- a/packages/at_client/test/fake_enrollment_directory.dart
+++ b/packages/at_client/test/fake_enrollment_directory.dart
@@ -2,22 +2,25 @@ import 'package:at_client/at_client_mixins.dart';
 
 /// In-memory [EnrollmentDirectory] for tests.
 ///
-/// Holds registered key packages by enrollmentId, and a namespace ->
+/// Holds one key package per enrollment (1:1:1) and a namespace ->
 /// {enrollmentId: access} map that models the atServer's namespace
 /// authorization (only authorized enrollments are discoverable for a
 /// namespace). One instance is shared across the test's sharers, so a key
-/// package one registers another can discover.
+/// package [seed]ed for one enrollment another can discover.
+///
+/// In production a key package reaches the enrollment record by riding
+/// `enroll:request`; tests model that with [seed] — there is no registration
+/// verb on the directory seam.
 class FakeEnrollmentDirectory implements EnrollmentDirectory {
-  /// enrollmentId -> its registered key packages (one per APKAM keypair).
-  final Map<String, List<KeyPackage>> registered = {};
+  /// enrollmentId -> its single key package (1:1:1).
+  final Map<String, KeyPackage> registered = {};
 
   final Map<String, Map<String, String>> _nsAccess = {};
 
-  @override
-  Future<void> registerKeyPackage(KeyPackage keyPackage) async {
-    final list = registered.putIfAbsent(keyPackage.enrollmentId, () => []);
-    list.removeWhere((e) => e.kpid == keyPackage.kpid);
-    list.add(keyPackage);
+  /// Records [keyPackage] as [enrollmentId]'s single key package (1:1:1),
+  /// modelling the package the enrollment carried on `enroll:request`.
+  void seed(String enrollmentId, KeyPackage keyPackage) {
+    registered[enrollmentId] = keyPackage;
   }
 
   @override
@@ -29,10 +32,11 @@ class FakeEnrollmentDirectory implements EnrollmentDirectory {
     final members = <NamespaceMember>[];
     access.forEach((enrollmentId, acc) {
       if (excludeEnrollmentIds.contains(enrollmentId)) return;
+      final kp = registered[enrollmentId];
       members.add(NamespaceMember(
         enrollmentId: enrollmentId,
         access: acc,
-        keyPackages: List.of(registered[enrollmentId] ?? const []),
+        keyPackages: kp == null ? const [] : [kp],
       ));
     });
     return members;

--- a/packages/at_client/test/fake_enrollment_directory.dart
+++ b/packages/at_client/test/fake_enrollment_directory.dart
@@ -36,7 +36,7 @@ class FakeEnrollmentDirectory implements EnrollmentDirectory {
       members.add(NamespaceMember(
         enrollmentId: enrollmentId,
         access: acc,
-        keyPackages: kp == null ? const [] : [kp],
+        keyPackage: kp,
       ));
     });
     return members;

--- a/packages/at_client/test/key_package_registration_test.dart
+++ b/packages/at_client/test/key_package_registration_test.dart
@@ -99,10 +99,10 @@ void main() {
 
   group('register', () {
     test(
-        'publishes the _apsk signing key and registers a key package with an '
+        'publishes the _apsk signing key and returns a key package with an '
         'x-wing enc key (nothing is published as an at-key)', () async {
-      final directory = FakeEnrollmentDirectory();
-      final registrant = buildRegistrant('enroll-a', directory, seed: seedA);
+      final registrant =
+          buildRegistrant('enroll-a', FakeEnrollmentDirectory(), seed: seedA);
       final keyPackage = await registrant.register();
 
       expect(keyPackage.enrollmentId, 'enroll-a');
@@ -112,10 +112,10 @@ void main() {
       expect(remoteData['public:_apsk.enroll-a.a.__e$atSign'],
           registrant.publicSigningKey);
 
-      // the key package is in the directory, NOT published as a hidden key
-      final registered = directory.registered['enroll-a']!;
-      expect(registered, hasLength(1));
-      final encKey = registered.single.bestKeyFor(SecretSharingAlgos.keyAlgos);
+      // the returned key package carries the x-wing enc key; register() does
+      // NOT write it anywhere (it rides enroll:request), and nothing is
+      // published as a hidden at-key
+      final encKey = keyPackage.bestKeyFor(SecretSharingAlgos.keyAlgos);
       expect(encKey, isNotNull);
       expect(encKey!.alg, SecretSharingAlgos.xWing);
       expect(encKey.use, SecretSharingAlgos.useEnc);
@@ -200,47 +200,34 @@ void main() {
         'exclude', () async {
       final atClient = buildMockClient('enroll-self');
       final secondary = atClient.getRemoteSecondary()!;
+      // Flat 1:1:1 shape: one record per enrollment, no nested apkam[] array;
+      // apkamPubKey + metadata sit directly on the record.
       final response = jsonEncode([
         {
           'enrollmentId': 'enroll-b',
           'access': 'rw',
-          'apkam': [
-            {
-              'apkamId': 'apkam-b1',
-              'apkamPubKey': 'pk',
-              'metadata': {
-                'keyPackages': {
-                  SecretSharingAlgos.keyPackageType: {
-                    'v': 1,
-                    'createdAt': '2026-06-11T00:00:00.000Z',
-                    'keys': [
-                      {
-                        'kid': 'kb',
-                        'use': 'enc',
-                        'alg': 'x-wing',
-                        'pub': 'pubb'
-                      }
-                    ],
-                  }
-                }
+          'apkamPubKey': 'pkb',
+          'metadata': {
+            'keyPackages': {
+              SecretSharingAlgos.keyPackageType: {
+                'v': 1,
+                'createdAt': '2026-06-11T00:00:00.000Z',
+                'keys': [
+                  {'kid': 'kb', 'use': 'enc', 'alg': 'x-wing', 'pub': 'pubb'}
+                ],
               }
             }
-          ]
+          }
         },
         {
           'enrollmentId': 'enroll-c',
           'access': 'r',
-          'apkam': [
-            {
-              'apkamId': 'apkam-c1',
-              'apkamPubKey': 'pk',
-              'metadata': {'keyPackages': {}}
-            }
-          ]
+          'apkamPubKey': 'pkc',
+          'metadata': {'keyPackages': {}}
         },
       ]);
-      when(() => secondary.executeCommand('enroll:listfornamespace:myapp\n',
-          auth: true)).thenAnswer((_) async => 'data:$response');
+      when(() => secondary.executeCommand('enroll:listns:myapp\n', auth: true))
+          .thenAnswer((_) async => 'data:$response');
 
       final directory = VerbEnrollmentDirectory(atClient);
       final members = await directory.listForNamespace('myapp');
@@ -249,7 +236,8 @@ void main() {
       final b = members.firstWhere((m) => m.enrollmentId == 'enroll-b');
       expect(b.access, 'rw');
       expect(b.keyPackages, hasLength(1));
-      expect(b.keyPackages.single.apkamId, 'apkam-b1');
+      // apkamId is populated from the record's apkamPubKey
+      expect(b.keyPackages.single.apkamId, 'pkb');
       expect(b.keyPackages.single.bestKeyFor(SecretSharingAlgos.keyAlgos)!.pub,
           'pubb');
       final c = members.firstWhere((m) => m.enrollmentId == 'enroll-c');
@@ -258,27 +246,6 @@ void main() {
       final excluded = await directory
           .listForNamespace('myapp', excludeEnrollmentIds: {'enroll-b'});
       expect(excluded.map((m) => m.enrollmentId), ['enroll-c']);
-    });
-
-    test(
-        'registerKeyPackage issues an enroll:metadata command with the package',
-        () async {
-      final atClient = buildMockClient('enroll-self');
-      final secondary = atClient.getRemoteSecondary()!;
-      String? sent;
-      when(() => secondary.executeCommand(any(), auth: any(named: 'auth')))
-          .thenAnswer((inv) async {
-        sent = inv.positionalArguments[0] as String;
-        return 'data:ok';
-      });
-      final directory = VerbEnrollmentDirectory(atClient);
-      await directory.registerKeyPackage(KeyPackage(
-          enrollmentId: 'enroll-self',
-          createdAt: DateTime.utc(2026, 6, 11),
-          keys: [PackageKey(use: 'enc', alg: 'x-wing', pub: 'p')]));
-      expect(sent, isNotNull);
-      expect(sent, startsWith('enroll:metadata:enroll-self:'));
-      expect(sent, contains(SecretSharingAlgos.keyPackageType));
     });
   });
 }

--- a/packages/at_client/test/key_package_registration_test.dart
+++ b/packages/at_client/test/key_package_registration_test.dart
@@ -208,14 +208,12 @@ void main() {
           'access': 'rw',
           'apkamPubKey': 'pkb',
           'metadata': {
-            'keyPackages': {
-              SecretSharingAlgos.keyPackageType: {
-                'v': 1,
-                'createdAt': '2026-06-11T00:00:00.000Z',
-                'keys': [
-                  {'kid': 'kb', 'use': 'enc', 'alg': 'x-wing', 'pub': 'pubb'}
-                ],
-              }
+            'keyPackage': {
+              'v': 1,
+              'createdAt': '2026-06-11T00:00:00.000Z',
+              'keys': [
+                {'kid': 'kb', 'use': 'enc', 'alg': 'x-wing', 'pub': 'pubb'}
+              ],
             }
           }
         },
@@ -223,7 +221,7 @@ void main() {
           'enrollmentId': 'enroll-c',
           'access': 'r',
           'apkamPubKey': 'pkc',
-          'metadata': {'keyPackages': {}}
+          'metadata': {}
         },
       ]);
       when(() => secondary.executeCommand('enroll:listns:myapp\n', auth: true))
@@ -235,13 +233,13 @@ void main() {
           members.map((m) => m.enrollmentId).toSet(), {'enroll-b', 'enroll-c'});
       final b = members.firstWhere((m) => m.enrollmentId == 'enroll-b');
       expect(b.access, 'rw');
-      expect(b.keyPackages, hasLength(1));
+      expect(b.keyPackage, isNotNull);
       // apkamId is populated from the record's apkamPubKey
-      expect(b.keyPackages.single.apkamId, 'pkb');
-      expect(b.keyPackages.single.bestKeyFor(SecretSharingAlgos.keyAlgos)!.pub,
-          'pubb');
+      expect(b.keyPackage!.apkamId, 'pkb');
+      expect(
+          b.keyPackage!.bestKeyFor(SecretSharingAlgos.keyAlgos)!.pub, 'pubb');
       final c = members.firstWhere((m) => m.enrollmentId == 'enroll-c');
-      expect(c.keyPackages, isEmpty);
+      expect(c.keyPackage, isNull);
 
       final excluded = await directory
           .listForNamespace('myapp', excludeEnrollmentIds: {'enroll-b'});

--- a/packages/at_client/test/pairwise_secret_sharing_test.dart
+++ b/packages/at_client/test/pairwise_secret_sharing_test.dart
@@ -187,8 +187,11 @@ void main() {
     directory = FakeEnrollmentDirectory();
     sharerA = buildSharer('enroll-a', seedA);
     sharerB = buildSharer('enroll-b', seedB);
-    await sharerA.register();
-    await sharerB.register();
+    // register() prepares each keypair + publishes its signing key; the key
+    // package reaches the directory via enroll:request in production, modelled
+    // here with seed() so peers discover each other via listForNamespace.
+    directory.seed('enroll-a', await sharerA.register());
+    directory.seed('enroll-b', await sharerB.register());
   });
 
   tearDown(() async {

--- a/packages/at_client/test/secret_sharing_approver_test.dart
+++ b/packages/at_client/test/secret_sharing_approver_test.dart
@@ -245,7 +245,9 @@ void main() {
       // Per OQ4 the new enrollment's key package is in the record from request
       // time; approval makes it discoverable for the namespace.
       final clientB = buildSharer('enroll-b', seedB);
-      await clientB.register();
+      // key package reaches the record via enroll:request (modelled by seed);
+      // authorize makes it discoverable for the namespace.
+      directory.seed('enroll-b', await clientB.register());
       directory.authorize('myapp', 'enroll-b');
 
       final shared = await approverA.shareAllSecretsWithEnrollment('enroll-b', {
@@ -269,7 +271,9 @@ void main() {
     test('honours excludeEnrollmentIds (revoked enrollment gets nothing)',
         () async {
       final clientB = buildSharer('enroll-b', seedB);
-      await clientB.register();
+      // key package reaches the record via enroll:request (modelled by seed);
+      // authorize makes it discoverable for the namespace.
+      directory.seed('enroll-b', await clientB.register());
       directory.authorize('myapp', 'enroll-b');
 
       final shared = await approverA.shareAllSecretsWithEnrollment(


### PR DESCRIPTION
Targets **`jt-wp-ss`** (PR #2037) — merge this in to bring the substrate onto the ratified wire shape before #2037 lands.

**- What I did**

Reworked the same-atSign secret-sharing substrate to the ratified per-enrollment (1:1:1) model from `docs/projects/pq/decisions.md` #F / OQ9, replacing the pre-2026-06-30 wire assumptions the carved substrate still encoded. Crypto and store semantics are unchanged; this is a wire-shape + API-surface alignment.

**- How I did it**

- **`EnrollmentDirectory.listForNamespace`** now sends `enroll:listns:<ns>` (was the `enroll:listfornamespace` working name — the ratified verb name) and parses the **flat** 1:1:1 response `[{enrollmentId, access, apkamPubKey, metadata}]` — no nested `apkam[]` array. `KeyPackage.apkamId` is populated from the record's `apkamPubKey`.
- **Removed `registerKeyPackage`** (interface + impl) and its `enroll:metadata` write path. A key package is conveyed into the enrollment record by riding `enroll:request` as opaque `EnrollParams.metadata` — there is no `enroll:metadata` verb and no post-enrollment metadata write (decision #B/#F). `register()` now prepares the X-Wing enc keypair + publishes the APKAM signing key and returns the key package; it no longer writes to the directory.
- **1:1:1 dartdoc** on `NamespaceMember` / `KeyPackage` (one enrollment → one APKAM keypair → one key package; `keyPackages` holds 0 or 1).
- **Tests** migrated off the `registerKeyPackage` seam to a `FakeEnrollmentDirectory.seed()` seam (models the package arriving via `enroll:request`); the `VerbEnrollmentDirectory` parse test uses the flat shape + `listns`; the `enroll:metadata` command test is removed.
- **CHANGELOG**: adds the previously-missing experimental substrate entry under `3.13.0`.
- **pubspec**: `at_chops` floor `^3.0.0` → `^3.3.0` (the substrate needs `pqSeal`/`pqOpen`, published in at_chops 3.3.0).

**- How to verify it**

- `dart test --concurrency=1` on the six secret-sharing test files: **52 tests pass**.
- `dart analyze` on the changed lib + tests: no errors/warnings (only pre-existing `deprecated_member_use` info for the AtChops compatibility API in tests).
- `dart format . -o none --set-exit-if-changed`: clean.
- `grep -rn 'listfornamespace\|registerKeyPackage' lib test` returns only the deliberate "no `enroll:metadata` verb" dartdoc mention.

The atServer verbs (`enroll:listns` discovery + `EnrollParams.metadata` store, DEP1/DEP2) remain the atServer's to implement; this aligns the client so the server workstream copies a correct spec. See at_server PR #2685 review + `docs/projects/pq/` (PR #2042) for the ratified rulings.

**- Description for the changelog**

feat (experimental): per-APKAM same-atSign secret-sharing substrate on the ratified 1:1:1 / flat `enroll:listns` wire shape.