### PR TITLE
feat(at_commons): complete SS-1a — EnrollParams.metadata/signingAlgo, drop enroll:metadata, pkam mldsa65

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,7 +1,15 @@
 ## 5.12.0
 
-- feat: enroll:listns
-- feat: enroll:metadata
+- feat: add the `enroll:listns:<listNamespace>` operation to the enroll verb
+  grammar (the gated per-namespace enrollment-discovery verb), ordered before
+  `list` in the operation alternation so it is not prefix-shadowed.
+- feat: add `EnrollParams.metadata` (opaque `Map<String, dynamic>`, stored
+  verbatim on the enrollment record and returned from discovery) and
+  `EnrollParams.signingAlgo` (`rsa2048` | `mldsa65`), with the matching
+  `EnrollVerbBuilder` fields; an empty `metadata` map is dropped from the
+  built command.
+- feat: widen the `pkam` verb `signingAlgo` literal to accept `mldsa65`
+  (post-quantum ML-DSA APKAM authentication).
 
 ## 5.11.0
 

--- a/packages/at_commons/lib/src/verb/enroll_params.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.dart
@@ -24,7 +24,7 @@ class EnrollParams {
 
   /// Opaque, additive metadata the server stores verbatim on the enrollment
   /// record and returns from discovery (`enroll:listns`). Carries the
-  /// enrollment's key package (`metadata.keyPackages`) for the secret-sharing
+  /// enrollment's key package (`metadata.keyPackage`) for the secret-sharing
   /// substrate; the server has no opinion on its contents.
   Map<String, dynamic>? metadata;
 

--- a/packages/at_commons/lib/src/verb/enroll_params.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.dart
@@ -16,6 +16,18 @@ class EnrollParams {
   String? selfEncKeyIV;
   String? encryptedAPKAMSymmetricKey;
   String? apkamPublicKey;
+
+  /// The signing algorithm of [apkamPublicKey] — `rsa2048` (legacy default) or
+  /// `mldsa65` (PQ). Recorded on the enrollment so PKAM verification is
+  /// record-authoritative.
+  String? signingAlgo;
+
+  /// Opaque, additive metadata the server stores verbatim on the enrollment
+  /// record and returns from discovery (`enroll:listns`). Carries the
+  /// enrollment's key package (`metadata.keyPackages`) for the secret-sharing
+  /// substrate; the server has no opinion on its contents.
+  Map<String, dynamic>? metadata;
+
   List<EnrollmentStatus>? enrollmentStatusFilter;
   Duration? apkamKeysExpiryDuration;
 

--- a/packages/at_commons/lib/src/verb/enroll_params.g.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.g.dart
@@ -24,6 +24,8 @@ EnrollParams _$EnrollParamsFromJson(Map<String, dynamic> json) => EnrollParams()
   ..selfEncKeyIV = json['selfEncKeyIV'] as String?
   ..encryptedAPKAMSymmetricKey = json['encryptedAPKAMSymmetricKey'] as String?
   ..apkamPublicKey = json['apkamPublicKey'] as String?
+  ..signingAlgo = json['signingAlgo'] as String?
+  ..metadata = json['metadata'] as Map<String, dynamic>?
   ..enrollmentStatusFilter = (json['enrollmentStatusFilter'] as List<dynamic>?)
       ?.map((e) => $enumDecode(_$EnrollmentStatusEnumMap, e))
       .toList()
@@ -46,6 +48,8 @@ Map<String, dynamic> _$EnrollParamsToJson(EnrollParams instance) =>
       'selfEncKeyIV': instance.selfEncKeyIV,
       'encryptedAPKAMSymmetricKey': instance.encryptedAPKAMSymmetricKey,
       'apkamPublicKey': instance.apkamPublicKey,
+      'signingAlgo': instance.signingAlgo,
+      'metadata': instance.metadata,
       'enrollmentStatusFilter': instance.enrollmentStatusFilter
           ?.map((e) => _$EnrollmentStatusEnumMap[e]!)
           .toList(),

--- a/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
@@ -48,7 +48,7 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
 
   /// Opaque, additive metadata stored verbatim on the enrollment record and
   /// returned from discovery (`enroll:listns`). Carries the enrollment's key
-  /// package (`metadata.keyPackages`) for the secret-sharing substrate.
+  /// package (`metadata.keyPackage`) for the secret-sharing substrate.
   Map<String, dynamic>? metadata;
 
   /// Used to force revoke the enrollment request.

--- a/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
@@ -42,6 +42,15 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
 
   String? encryptedAPKAMSymmetricKey;
 
+  /// The signing algorithm of [apkamPublicKey] — `rsa2048` or `mldsa65`.
+  /// Recorded on the enrollment so PKAM verification is record-authoritative.
+  String? signingAlgo;
+
+  /// Opaque, additive metadata stored verbatim on the enrollment record and
+  /// returned from discovery (`enroll:listns`). Carries the enrollment's key
+  /// package (`metadata.keyPackages`) for the secret-sharing substrate.
+  Map<String, dynamic>? metadata;
+
   /// Used to force revoke the enrollment request.
   bool force = false;
 
@@ -74,6 +83,8 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
       ..encryptedDefaultSelfEncryptionKey = encryptedDefaultSelfEncryptionKey
       ..selfEncKeyIV = selfEncKeyIV
       ..encryptedAPKAMSymmetricKey = encryptedAPKAMSymmetricKey
+      ..signingAlgo = signingAlgo
+      ..metadata = metadata
       ..enrollmentStatusFilter = enrollmentStatusFilter
       ..apkamKeysExpiryDuration = apkamKeysExpiryDuration;
 
@@ -95,6 +106,10 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
   /// to refrain adding the key and its value to the enroll verb command.
   bool _removeElements(String key, dynamic value) {
     if (value == null || value.toString().isEmpty) {
+      return true;
+    }
+    // Drop an empty metadata map so it never reaches the wire.
+    if (value is Map && value.isEmpty) {
       return true;
     }
     // EnrollmentStatusFilter is only applicable to EnrollOperation.list

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -7,7 +7,7 @@ class VerbSyntax {
   static const pol = r'^pol$';
   static const cram = r'^cram:(?<digest>.+$)';
   static const pkam =
-      r'^pkam:(signingAlgo:(?<signingAlgo>ecc_secp256r1|rsa2048):)?(hashingAlgo:(?<hashingAlgo>sha256|sha512):)?(enrollmentId:(?<enrollmentId>.+):)?(?<signature>.+$)';
+      r'^pkam:(signingAlgo:(?<signingAlgo>ecc_secp256r1|rsa2048|mldsa65):)?(hashingAlgo:(?<hashingAlgo>sha256|sha512):)?(enrollmentId:(?<enrollmentId>.+):)?(?<signature>.+$)';
   static const llookup = r'^llookup'
       r'(:(?<operation>meta|all))?'
       r'(:cached)?'
@@ -148,7 +148,7 @@ class VerbSyntax {
   static const notifyRemove = r'notify:remove:(?<id>[\w\d\-\_]+)';
   static const enroll =
       // The non-capturing group (?::)? matches ":" if the operation is request|approve|deny|revoke
-      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|listns|list|fetch|unrevoke|delete|metadata)))(:(?<force>force))?(:(?<namespace>[^:{\n]+))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
+      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|listns|list|fetch|unrevoke|delete)))(:(?<force>force))?(:(?<listNamespace>[^:{\n]+))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
   static const otp =
       r'^otp:(?<operation>get|put)(:(?<otp>(?<=put:)\w{6,}))?(:(?:ttl:(?<ttl>\d+)))?$';
   static const keys = r'^keys:((?<operation>put|get|delete):?)'

--- a/packages/at_commons/test/syntax_test.dart
+++ b/packages/at_commons/test/syntax_test.dart
@@ -385,16 +385,12 @@ void main() {
       final params = EnrollParams()
         ..signingAlgo = 'mldsa65'
         ..metadata = {
-          'keyPackages': {
-            'x-wing-v1': {'v': 1}
-          }
+          'keyPackage': {'v': 1}
         };
       final restored = EnrollParams.fromJson(params.toJson());
       expect(restored.signingAlgo, 'mldsa65');
       expect(restored.metadata, {
-        'keyPackages': {
-          'x-wing-v1': {'v': 1}
-        }
+        'keyPackage': {'v': 1}
       });
     });
 
@@ -418,9 +414,7 @@ void main() {
         ..otp = '123456'
         ..apkamPublicKey = 'pk'
         ..signingAlgo = 'mldsa65'
-        ..metadata = {
-          'keyPackages': {'x-wing-v1': {}}
-        };
+        ..metadata = {'keyPackage': {}};
       final command = withMeta.buildCommand();
       expect(command, contains('"metadata"'));
       expect(command, contains('"signingAlgo":"mldsa65"'));

--- a/packages/at_commons/test/syntax_test.dart
+++ b/packages/at_commons/test/syntax_test.dart
@@ -1,6 +1,7 @@
 import 'dart:collection';
 import 'dart:convert';
 
+import 'package:at_commons/at_builders.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:test/test.dart';
 
@@ -72,6 +73,15 @@ void main() {
           'pkam:signingAlgo:ecc_secp256r1:hashingAlgo:sha256:abcd1234';
       var verbParams = getVerbParams(VerbSyntax.pkam, command);
       expect(verbParams[AtConstants.atPkamSigningAlgo], 'ecc_secp256r1');
+      expect(verbParams[AtConstants.atPkamHashingAlgo], 'sha256');
+      expect(verbParams[AtConstants.atPkamSignature], 'abcd1234');
+    });
+
+    test('pkam regex with mldsa65 (PQ) signing algo and sha256 hashing algo',
+        () {
+      var command = 'pkam:signingAlgo:mldsa65:hashingAlgo:sha256:abcd1234';
+      var verbParams = getVerbParams(VerbSyntax.pkam, command);
+      expect(verbParams[AtConstants.atPkamSigningAlgo], 'mldsa65');
       expect(verbParams[AtConstants.atPkamHashingAlgo], 'sha256');
       expect(verbParams[AtConstants.atPkamSignature], 'abcd1234');
     });
@@ -345,34 +355,75 @@ void main() {
       expect(enrollmentInfo['enrollmentId'], '4567');
     });
 
-    test('A test to verify enroll:listns parses namespace', () {
+    test('A test to verify enroll:listns parses the listNamespace', () {
       String command = 'enroll:listns:wavi\n';
       var verbParams =
           VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim())!;
       expect(verbParams['operation'], 'listns');
-      expect(verbParams['namespace'], 'wavi');
+      expect(verbParams['listNamespace'], 'wavi');
     });
 
-    test(
-        'A test to verify enroll:listns without namespace parses correctly',
+    test('A test to verify enroll:listns without a namespace parses correctly',
         () {
       String command = 'enroll:listns\n';
       var verbParams =
           VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim())!;
       expect(verbParams['operation'], 'listns');
-      expect(verbParams['namespace'], isNull);
+      expect(verbParams['listNamespace'], isNull);
     });
 
-    test('A test to verify enroll:metadata parses enrollmentId and payload',
-        () {
-      const enrollmentId = 'abc123';
-      const payload = '{"kpid":"deadbeef","xWingPub":"AAAA"}';
-      String command = 'enroll:metadata:$enrollmentId:$payload\n';
+    test('A test to verify enroll:listns is matched before enroll:list', () {
+      // `listns` must be an earlier alternative than `list`, else `list`
+      // prefix-wins and the operation parses as `list` + leftover `ns:...`.
+      String command = 'enroll:listns:wavi\n';
       var verbParams =
           VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim())!;
-      expect(verbParams['operation'], 'metadata');
-      expect(verbParams['namespace'], enrollmentId);
-      expect(verbParams['enrollParams'], payload);
+      expect(verbParams['operation'], 'listns');
+    });
+
+    test('EnrollParams round-trips metadata and signingAlgo', () {
+      final params = EnrollParams()
+        ..signingAlgo = 'mldsa65'
+        ..metadata = {
+          'keyPackages': {
+            'x-wing-v1': {'v': 1}
+          }
+        };
+      final restored = EnrollParams.fromJson(params.toJson());
+      expect(restored.signingAlgo, 'mldsa65');
+      expect(restored.metadata, {
+        'keyPackages': {
+          'x-wing-v1': {'v': 1}
+        }
+      });
+    });
+
+    test('EnrollVerbBuilder drops empty metadata but keeps a populated one',
+        () {
+      final withEmpty = EnrollVerbBuilder()
+        ..operation = EnrollOperationEnum.request
+        ..appName = 'app'
+        ..deviceName = 'dev'
+        ..namespaces = {'wavi': 'rw'}
+        ..otp = '123456'
+        ..apkamPublicKey = 'pk'
+        ..metadata = {};
+      expect(withEmpty.buildCommand(), isNot(contains('metadata')));
+
+      final withMeta = EnrollVerbBuilder()
+        ..operation = EnrollOperationEnum.request
+        ..appName = 'app'
+        ..deviceName = 'dev'
+        ..namespaces = {'wavi': 'rw'}
+        ..otp = '123456'
+        ..apkamPublicKey = 'pk'
+        ..signingAlgo = 'mldsa65'
+        ..metadata = {
+          'keyPackages': {'x-wing-v1': {}}
+        };
+      final command = withMeta.buildCommand();
+      expect(command, contains('"metadata"'));
+      expect(command, contains('"signingAlgo":"mldsa65"'));
     });
   });
 


### PR DESCRIPTION
Targets **`jt-at-commons`** (PR #2040) — merge this in to bring #2040 to the ratified SS-1a scope before it lands on trunk.

**- What I did**

Reworked the interim regex-only change on `jt-at-commons` into the full SS-1a grammar from `docs/projects/pq/` (decisions.md #B/#F, ratified 2026-06-30). The prior state added `enroll:listns` + `enroll:metadata` ops to the regex but none of SS-1a's actual model changes, and it kept the retired `enroll:metadata` op.

**- How I did it**

- **enroll regex**: dropped the `metadata` operation — decision #B removed the `enroll:metadata` verb (the key package rides `EnrollParams.metadata` on `enroll:request`; there is no post-enrollment metadata write). Kept `listns` ordered **before** `list` (else `list` prefix-wins and `listns` never matches — the bug at_server PR #2685 also has). Renamed the discovery-namespace capture group `namespace` → `listNamespace` to avoid colliding with `EnrollParams.namespaces`.
- **`EnrollParams` + `EnrollVerbBuilder`**: added `metadata` (opaque `Map<String, dynamic>`, stored verbatim, carries `keyPackages`) and `signingAlgo` (`rsa2048` | `mldsa65`, record-authoritative PKAM). Empty `metadata` is dropped from the built command. `.g.dart` hand-updated for the two nullable fields (the file is manually maintained — see its header note about `apkamKeysExpiry`; there is no `build_runner` CI gate).
- **pkam regex**: widened the `signingAlgo` literal to accept `mldsa65` (PQ ML-DSA APKAM auth).
- **Tests**: `listns` asserts `listNamespace`; added a `listns`-before-`list` ordering test, an `EnrollParams` metadata/`signingAlgo` round-trip, an `EnrollVerbBuilder` empty-vs-populated metadata test, and a pkam `mldsa65` literal test; dropped the `enroll:metadata` test. CHANGELOG `5.12.0` rewritten to the actual scope.

**- How to verify it**

- `dart analyze lib test`: no issues.
- `dart test --concurrency=1 test/syntax_test.dart test/enroll_verb_builder_test.dart`: **79 tests pass**.
- `dart format . -o none --set-exit-if-changed`: clean.
- Version stays `5.12.0` (the in-progress slot; pub.dev latest is `5.11.0`).

Pairs with the WP-SS client rework (PR #2043) and the at_server review on #2685 — all three now agree on `enroll:listns` + `EnrollParams.metadata` (no `enroll:metadata`). See `docs/projects/pq/` (PR #2042) for the ratified rulings.

**- Description for the changelog**

feat: add `enroll:listns` + `EnrollParams.metadata`/`signingAlgo` and the pkam `mldsa65` literal; remove the `enroll:metadata` op.