### PR TITLE
test(at_functional_test): derive root port from VIRTUALENV_BASE_PORT in full-enrollment round trip

### DIFF
--- a/tests/at_functional_test/test/enrollment_test.dart
+++ b/tests/at_functional_test/test/enrollment_test.dart
@@ -678,7 +678,8 @@ void main() {
       final cramAtSign = ConfigUtil.getYaml()['atSign']['apkamSecondAtSign'];
       final cramSecret = cramKeyMap[cramAtSign]!;
       String keysFilePath(String a) => 'test/testData/$a.atKeys';
-      final rootDomain = AtRootDomain('vip.ve.atsign.zone', 64);
+      final rootDomain =
+          AtRootDomain('vip.ve.atsign.zone', TestUtils.rootServerPort);
 
       // Onboarding refuses to run if a keys file already exists, so clear any
       // left over from a prior run — this test mints @sachin's keys fresh
@@ -738,7 +739,8 @@ void main() {
       // generates a fresh APKAM keypair and wraps its apkamSymmetricKey with
       // the atSign's default encryption public key.
       final random = Uuid().v4().hashCode;
-      final enrolleeLookup = AtLookupImpl(cramAtSign, 'vip.ve.atsign.zone', 64);
+      final enrolleeLookup =
+          AtLookupImpl(cramAtSign, 'vip.ve.atsign.zone', TestUtils.rootServerPort);
       final enrollResponse = await AtEnrollment.create().submit(
         AtEnrollmentRequest(
           atSign: cramAtSign,


### PR DESCRIPTION
## What I did

Made the "Full enrollment round trip on a freshly CRAM-onboarded atSign" functional test derive its root/atDirectory port from `VIRTUALENV_BASE_PORT` (via `TestUtils.rootServerPort`) instead of hardcoding `64`, so it matches every other test in the pack.

## How I did it

The test built `AtRootDomain('vip.ve.atsign.zone', 64)` and `AtLookupImpl(cramAtSign, 'vip.ve.atsign.zone', 64)` with a literal `64`. `TestUtils.rootServerPort` already reads `VIRTUALENV_BASE_PORT` and defaults to `64`, so both literals now read from it. Test-only change; no library code touched.

## How to verify it

- Against the standard VE (root on port 64): the test passes exactly as before — `rootServerPort` defaults to `64`.
- Against a base-port rig (`VIRTUALENV_BASE_PORT=<n>`): the full CRAM→OTP→enroll→approve round trip now resolves the root at `<n>` and passes, where it previously failed with `Connecting to vip.ve.atsign.zone:64 : Connection refused`.
- `cd tests/at_functional_test && dart test --concurrency=1 test/enrollment_test.dart`

## Description for the changelog

Functional test: derive the full-enrollment round-trip test's root port from `VIRTUALENV_BASE_PORT` instead of hardcoding `64`, so the pack can run against a base-port virtualenv rig.