### PR TITLE
docs(pq): planning-day reconciliation — re-key epic, fold P-2 into 3.4.0, add IS-1 track

### DIFF
--- a/docs/projects/pq/decisions.md
+++ b/docs/projects/pq/decisions.md
@@ -495,8 +495,11 @@ Execution rulings from the plan-vs-code review (post-review); each is binding.
   library is present, at_chops' `AtPqc` auto-resolver selects the FFI backend as
   the default (faster on mobile/desktop); the pure-Dart backend is the fallback and
   the forced choice under WASM. PRs #2030 (`at_chops_ffi` barrel + auto-resolver)
-  and #2039 (AES-GCM FFI) are IN D1 scope, landing in the coordinated at_chops 3.4.0
-  slot alongside P-2. (Scope note → the 2026-07-03 rulings below: auto-resolve
+  and #2039 (AES-GCM FFI) are IN D1 scope on the at_chops 3.4.0 slot alongside P-2.
+  **Status (2026-07-06):** #2030 **merged to trunk 2026-07-03** (+ #2046 review-fixes),
+  bumping at_chops to 3.4.0 assembled-but-unpublished; #2039 is still **draft**; and
+  **P-2's `mldsa65` verify branch folds into this same unpublished 3.4.0 before it
+  publishes** (decision 2026-07-06 — not a fresh minor). (Scope note → the 2026-07-03 rulings below: auto-resolve
   applies to the `AtPqc` accessors; key generation through the web-safe barrel's
   key pair classes is pure-Dart by construction.)
 - **`_apsk` is a pinned cross-tier property — present and write-restricted.** Envelope
@@ -522,8 +525,8 @@ Execution rulings from the plan-vs-code review (post-review); each is binding.
 ### Rulings — 2026-07-03 (PR #2030 review)
 
 Rulings from the two-pass review of PR #2030 (`at_chops_ffi` barrel + `AtPqc`);
-each is binding. The code-side alignment lands in the review-fixes PR stacked on
-#2030's branch.
+each is binding. The code-side alignment landed via #2046 (merged 2026-07-03 into
+#2030's `st/at_chops_ffi` branch, then folded to trunk when #2030 merged).
 
 - **`AtPqc` supersedes the `PqcFfi` working name.** The auto-resolver ships as
   `abstract final class AtPqc`, exported from `at_chops_ffi.dart`; the PR's
@@ -589,6 +592,7 @@ Chronological, **oldest-first**. Each entry gives the one-line *why*.
 | **2026-07-02** | **Advertised-key signing + `_apsk` always-present** ([section 12](#12-advertised-recipient-keys-are-signed-against-_apsk-2026-07-02)). Advertised recipient keys (key package, `nskey` public, `pqpublickey`) are APKAM-signed by the generating enrollment and verified against its `_apsk` — same path same-atSign and cross-atSign; the atServer keeps `_apsk` present (populated from the record) as well as write-restricted. Supersedes "atServer vouches". Also: the key package is a **singular signed `metadata.keyPackage`** (no format-keyed map). | Authenticates the encapsulation target against a rogue *insider* enrollment under an honest server (not server-asserted); reuses the existing `wrapAndSign`/`_apsk` machinery. Does **not** remove a malicious atServer *operator* from the TCB — the operator is the `_apsk` anchor (see section 12 + design.md *Trust boundary*). The format-map was redundant with in-package `keys[].alg` + `v` agility. |
 
 | **2026-07-03** | **PR #2030 review rulings** (five, → [section 6](#6-resolved--open-execution-decisions-af)): `AtPqc` supersedes the `PqcFfi` working name; `AtSignatureAlgorithm` recorded with a **staged** `AtSigningAlgorithm` deprecation (stays implemented through D1 — P-2 and the section-12 `wrapAndSign` path are typed against it; removal deferred past the D1 ladder); at_chops 3.4.0 stays a minor under a recorded one-time semver exemption for the barrel-split breaks; #2030/#2039 conformance-covered under P-2's coordinated slot; auto-resolve scoped to the `AtPqc` accessors (web-safe-barrel keygen is pure-Dart by construction). | The two-pass review of #2030 found the PR shipping designs the record didn't yet name (`AtPqc`, `AtSignatureAlgorithm`) and removals the ladder didn't authorize; these rulings plus the stacked review-fixes PR align code and record. |
+| **2026-07-06** | **Planning-day reconciliation rulings** (two): (1) **inter-server PQ authentication is IN D1 scope** as new project **IS-1** ([implementation-plan.md §13](implementation-plan.md)) — the atServer FROM/POL X-Wing+ML-DSA-65 handshake (PR #2683), off the D1 GA critical path, gated on publishing the at_chops PQ-API surface (`XWingCert`/`resolveXWing`/`resolveMlDsa65`). (2) **P-2's `mldsa65` verify branch folds into the existing unpublished at_chops 3.4.0** (bumped on trunk by #2030) before it publishes — not a fresh minor. | Planning-day reconciliation of #1889 vs the plan vs merged/open PRs across at_client_sdk + at_server surfaced a whole untracked inter-server workstream and an at_chops 3.4.0 slot already opened on trunk; these two rulings place both in the record. |
 
 **Cross-refs:** the Wave-0 "already landed" detail and the project that follows
 each decision are in `implementation-plan.md`; the phase trajectory this timeline

--- a/docs/projects/pq/decisions.md
+++ b/docs/projects/pq/decisions.md
@@ -449,7 +449,8 @@ timeline rows).
   `AtChops.verify` path only if a high-level caller needs it; (4) re-confirm the
   at_commons version floor at SS-1a (pub.dev / last release tag is authoritative,
   not in-tree precedent); plus the at_auth version question in S-1 (publish 3.1.1
-  first vs fold `WritableAtKeys` under the unshipped slot). (The WP-SS "where does
+  first vs fold the `AtKeys`/`AtKeysIo` extend-in-place change under the unshipped
+  slot). (The WP-SS "where does
   `register()` get called?" decision is resolved by #B above.)
 - **#E — S-2 scope / SoT conflict.** `crypto_impl_plan` §3-S5 ("migrate legacy to
   `context.keys`") vs §7-WP3 ("legacy unchanged for now") conflict. This plan
@@ -570,6 +571,27 @@ each is binding. The code-side alignment landed via #2046 (merged 2026-07-03 int
   breaks for web consumers. Both backends stay wire-compatible (pinned by
   cross-backend interop tests), so keys generated pure-Dart are usable by the
   FFI backends and vice versa.
+
+### Rulings — 2026-07-06 (planning day)
+
+- **AtKeys: extend in place, deprecate legacy — supersedes the `WritableAtKeys`
+  holder** ([#2045](https://github.com/atsign-foundation/at_client_sdk/issues/2045)).
+  Keep the existing `AtKeys` class hierarchy **as-is** and extend it
+  **additively** with PQ-safe methods; **deprecate** the legacy key
+  fields/methods (they stay for back-compat, so call sites migrate to the
+  PQ-safe methods over time). `AtKeysIo` is extended with **runtime
+  persistence** (`append()`, `save()`, …) and remains the single contact point
+  that keeps runtime `AtKeys` objects and the persisted keyfile in-line.
+  Providers are injected **(`AtClient`, `AtKeysIo`, `AtChops`)**. There is
+  **no** new `WritableAtKeys` holder class and **no** separate `WrittenAtKeysIo`
+  widening — `AtKeysIo` itself is widened. *Rationale:* much simpler migration —
+  the code contract stays the same (deprecated fields/methods remain), the
+  deprecation path is clear-cut, and the churn is far smaller than carving a new
+  holder hierarchy. *Affects:* **S-1** (reframed from "new `WritableAtKeys`
+  holder" to "extend `AtKeys`/`AtKeysIo` in place"), **S-2**, **S-3**, and
+  design §4. *Open question (not decided):* whether `AtClient` needs any concept
+  of `AtKeys` outside the provider seam at all (encrypt/decrypt and auth already
+  reach keys via the injected `AtKeysIo`).
 
 ---
 

--- a/docs/projects/pq/design.md
+++ b/docs/projects/pq/design.md
@@ -16,6 +16,7 @@ companion to four sibling docs (see the orientation table in [section 0](#0-scop
 - [5. Subsystem E — worked design walkthroughs (NoPorts, at_talk)](#5-subsystem-e--worked-design-walkthroughs-noports-at_talk)
 - [6. Implementation notes & file-level pointers (consolidated)](#6-implementation-notes--file-level-pointers-consolidated)
 - [7. Trust boundary & residual threats](#7-trust-boundary--residual-threats)
+- [8. Subsystem F — inter-server PQ authentication (IS-1)](#8-subsystem-f--inter-server-pq-authentication-is-1)
 
 ---
 
@@ -1310,3 +1311,65 @@ closes the one-epoch window for the highest-assurance pairs.
   *delegated-monitor* path is the one that actually carries the guarantee — an atSign with
   no monitor (self- or delegated) gets **zero** KT protection. A real design must make
   independent delegated monitoring the default, not an opt-in.
+
+---
+
+## 8. Subsystem F — inter-server PQ authentication (IS-1)
+
+*The atServer↔atServer FROM/POL handshake, orthogonal to Subsystems A/B (which secure the
+client↔server data path). Project [IS-1](implementation-plan.md); tracking PR #2683
+(`at_server`, `pq/st/pq-interserver-comms`). Off the D1 GA critical path.*
+
+### 8.1 What it replaces
+
+Today the server-to-server FROM/POL handshake authenticates with a UUID challenge signed by
+RSA-2048 — the same Shor-vulnerable primitive #1889 exists to retire. IS-1 replaces it with a
+hybrid quantum-safe path and an automatic fallback so a mixed fleet needs no flag day:
+
+- **X-Wing KEM** (ML-KEM-768 + X25519) for key encapsulation.
+- **ML-DSA-65** for signing the inter-server certificate.
+- **Fallback to legacy UUID/RSA** for any peer that advertises no PQ cert.
+
+### 8.2 The handshake
+
+Certs and signing keys are looked up **live every handshake and never cached** (so cert rotation
+takes effect immediately):
+
+```
+Alice → Bob   from:@alice
+Bob   → Alice lookup:pq_xwing_cert@alice          (live, never cached)
+Bob   → Alice lookup:pq_signing_publickey@alice
+Bob:  ML-DSA-65.verify(cert) → xwing.encaps(cert.pk) → tag = HKDF-SHA256(ss, info = sessionID‖@alice)
+Bob   → Alice proof:sessionID@alice:pq:<ciphertext_b64>
+Alice: xwing.decaps(ciphertext) → same tag → saveCookie pq:<tag>
+Alice → Bob   pol
+Bob   → Alice lookup:sessionID@alice → tags equal ⇒ isPolAuthenticated = true
+```
+
+The raw shared secret never crosses the wire and is never persisted — only the HKDF
+key-confirmation tag is exchanged. `AT_DISABLE_PQ_AUTH=true` forces UUID; self-auth is always
+UUID; a peer with no PQ cert falls back to the UUID/RSA path.
+
+### 8.3 `PqKeyManager` (server-internal)
+
+A new `at_secondary_server` class — **not** an at_chops type — owns the ML-DSA-65 + X-Wing keypair
+lifecycle, cert generation and rotation (a 30-day grace window keeps the previous cert valid across
+a rotation), and the HKDF-SHA256 tag derivation. Its PQ secret keys join the protected-key set
+(delete/update verb protection).
+
+### 8.4 at_chops dependency (the gating prerequisite)
+
+IS-1 needs an at_chops API surface **not yet on `at_chops` trunk**: `XWingCert`, the resolver
+functions `resolveXWing` / `resolveMlDsa65`, and `at_algorithm.dart` exports.
+(`generateXWingKeyPair` / `generateMlDsa65KeyPair` already ship on trunk 3.4.0.) That surface lives
+on branch `pq/st/at-chops-pq-api` and **must be published — as part of, or after, the 3.4.0 slot
+([P-2](implementation-plan.md)) — before IS-1 can land without a workspace path override.** This is
+the single hard cross-package gate for the track.
+
+### 8.5 Threat scope
+
+IS-1 hardens the **inter-server channel** only; it is independent of the client-side `nskey` data
+path (Subsystem A) — a compromised server-to-server link and a compromised client-to-server link
+are different threats with different anchors. The pure-Dart fallback (ML-DSA resolves without
+libcrypto when `AT_CHOPS_LIBCRYPTO_PATH` is unset) keeps the track deployable on hosts without an
+OpenSSL build.

--- a/docs/projects/pq/design.md
+++ b/docs/projects/pq/design.md
@@ -12,7 +12,7 @@ companion to four sibling docs (see the orientation table in [section 0](#0-scop
 - [1. Subsystem A — D1 nskey data path](#1-subsystem-a--d1-nskey-data-path)
 - [2. Subsystem B — the secret-sharing substrate (WP-SS)](#2-subsystem-b--the-secret-sharing-substrate-wp-ss)
 - [3. Subsystem C — at_chops PQ primitives](#3-subsystem-c--at_chops-pq-primitives)
-- [4. Subsystem D — structural design (CryptoProvider seam, WritableAtKeys / key stores, WASM barrel)](#4-subsystem-d--structural-design-cryptoprovider-seam-writableatkeys--key-stores-wasm-barrel)
+- [4. Subsystem D — structural design (CryptoProvider seam, AtKeys/AtKeysIo & key stores, WASM barrel)](#4-subsystem-d--structural-design-cryptoprovider-seam-atkeysatkeysio--key-stores-wasm-barrel)
 - [5. Subsystem E — worked design walkthroughs (NoPorts, at_talk)](#5-subsystem-e--worked-design-walkthroughs-noports-at_talk)
 - [6. Implementation notes & file-level pointers (consolidated)](#6-implementation-notes--file-level-pointers-consolidated)
 - [7. Trust boundary & residual threats](#7-trust-boundary--residual-threats)
@@ -59,7 +59,7 @@ case, this doc links `acceptance.md` and does not re-narrate the Given/When/Then
 - **[Subsystem A — D1 nskey data path](#1-subsystem-a--d1-nskey-data-path)** (§1) — the three layers, three providers, key shapes, CK model, cold-start, FS/rotation levers, and migration/rollout + the `disallowLegacyEncryption` flag (§1.8).
 - **[Subsystem B — the secret-sharing substrate (WP-SS)](#2-subsystem-b--the-secret-sharing-substrate-wp-ss)** (§2) — kpid addressing, `__ssenv`, push/pull, the discovery verb, the enrollment record, the self-retrofit flow.
 - **[Subsystem C — at_chops PQ primitives](#3-subsystem-c--at_chops-pq-primitives)** (§3) — X-Wing, `pqSeal`/`pqOpen`, ML-DSA verify.
-- **[Subsystem D — structural design](#4-subsystem-d--structural-design-cryptoprovider-seam-writableatkeys--key-stores-wasm-barrel)** (§4) — the CryptoProvider seam, `WritableAtKeys`/key stores, the WASM barrel split.
+- **[Subsystem D — structural design](#4-subsystem-d--structural-design-cryptoprovider-seam-atkeysatkeysio--key-stores-wasm-barrel)** (§4) — the CryptoProvider seam, `AtKeys`/`AtKeysIo` & key stores, the WASM barrel split.
 - **[Subsystem E — worked design walkthroughs](#5-subsystem-e--worked-design-walkthroughs-noports-at_talk)** (§5) — NoPorts, at_talk.
 - **[Implementation notes & file-level pointers](#6-implementation-notes--file-level-pointers-consolidated)** (§6) — the consolidated `file:line` build map.
 
@@ -134,7 +134,7 @@ Notes:
   `recipientKind: "root-pqpublickey"` ([§1.4](#14-the-nskey-and-the-pqpublickey-root)).
 
 (The seam itself — `CryptoRuntime`, `CryptoConfig`, `appMetadata.providerId`
-routing — is the structural subsystem [§4](#4-subsystem-d--structural-design-cryptoprovider-seam-writableatkeys--key-stores-wasm-barrel).)
+routing — is the structural subsystem [§4](#4-subsystem-d--structural-design-cryptoprovider-seam-atkeysatkeysio--key-stores-wasm-barrel).)
 
 ### 1.3 Keys & key shapes
 
@@ -691,7 +691,8 @@ sequence in [`acceptance.md`](acceptance.md).)
 4. The new client **registers** its key package (already carried in step 1's
    `EnrollParams.metadata` — no post-enrollment write), then **pulls** `pqpublickey`
    + the namespace nskey privates over the substrate ([§2.2](#22-secretstore-push--pull-primitives)), **verifies
-   correspondence**, and stores them in the local keystore (`WritableAtKeys`, [§4](#4-subsystem-d--structural-design-cryptoprovider-seam-writableatkeys--key-stores-wasm-barrel)).
+   correspondence**, and stores them in the local keystore (the extended `AtKeys`,
+   via its injected `AtKeysIo`, [§4](#4-subsystem-d--structural-design-cryptoprovider-seam-atkeysatkeysio--key-stores-wasm-barrel)).
 
 **Each cloned pre-PQ keyfile retrofits to its OWN distinct `enrollmentId`** (1:1:1).
 A keyfile copied onto a second host mints its own single, *different* PQ APKAM
@@ -772,7 +773,7 @@ the cold-start fallback recipient for the nskey data path — [§1.4](#14-the-ns
 
 ---
 
-## 4. Subsystem D — structural design (CryptoProvider seam, WritableAtKeys / key stores, WASM barrel)
+## 4. Subsystem D — structural design (CryptoProvider seam, AtKeys/AtKeysIo & key stores, WASM barrel)
 
 The seams every other subsystem is built on. The S-1..S-6 *project* sequencing is
 in [`implementation-plan.md`](implementation-plan.md); this section owns the *design*.
@@ -805,16 +806,21 @@ CryptoProvider { id; encrypt(CryptoContext, AtKey, String) → String; decrypt(C
 routed provider). `shouldEncrypt = false` is a true no-crypto path on write and
 read — secret-sharing envelopes and key-package copies are stored that way.
 
-### `WritableAtKeys` + key stores
+### `AtKeys`/`AtKeysIo` extend-in-place + key stores
 
-**`WritableAtKeys`** (working name; deferred — not yet wired) is a **subclass of
-at_auth's `AtKeys`** (the key-material holder) adding `add` / `remove` / `write`.
-It is the single in-memory holder of every key the client knows (per-enrollment
-*and* per-APKAM), which providers read keys from and mint/add/write through.
-*(NOT a wrapper over `AtChops` — `AtKeys` already produces one via `toAtChops()`
-and carries a `metadata` stash.)* `CryptoContext` gains a `WritableAtKeys keys`
-field — **additive** (`CryptoContext` is `{atClient}`, with no `atChops` field). Convergence (newest-wins / pull recovery)
-stays in the secret-sharing substrate; the stores are **dumb** key-value backends.
+The existing **`AtKeys`** is **extended in place** — additive PQ-safe methods
+(`add` / `remove` / `write`), with the legacy key fields/methods **deprecated** but
+retained for back-compat so call sites migrate over time (ratified 2026-07-06, #2045
+— see [`decisions.md`](decisions.md); supersedes the earlier `WritableAtKeys` holder
+working name). It stays the single in-memory holder of every key the client knows
+(per-enrollment *and* per-APKAM), which providers read keys from and mint/add/write
+through. *(NOT a wrapper over `AtChops` — `AtKeys` already produces one via
+`toAtChops()` and carries a `metadata` stash.)* The provider seam is injected an
+**`AtKeysIo`** (the key source, extended with runtime persistence — `append()` /
+`save()`) alongside `(AtClient, AtChops)`; `CryptoContext` carries the `AtKeysIo` —
+**additive** (`CryptoContext` is `{atClient}`, with no `atChops` field). Convergence
+(newest-wins / pull recovery) stays in the secret-sharing substrate; the stores are
+**dumb** key-value backends.
 
 **Key taxonomy → store routing** (explicit named stores, no magic router):
 
@@ -828,8 +834,8 @@ Store homes: `InMemoryAtKeysIo` + the interfaces in `at_auth` (main barrel);
 `FileAtKeysIo` (updatable) in `at_auth_io.dart`; `LocalKeystoreAtKeysIo` in
 `at_client` (needs at_persistence, injected down); `KeychainAtKeysIo` in
 `at_client_flutter`. `.atKeys` / keychain are made **updatable** (re-wrap the
-self-enc key on rewrite; atomic write + backup). `WritableAtKeys` is born at
-AtClient construction and immutable after.
+self-enc key on rewrite; atomic write + backup). The extended `AtKeys` (with its
+injected `AtKeysIo`) is born at AtClient construction and immutable after.
 
 ### WASM barrel split (`at_auth 4.0.0`)
 
@@ -837,8 +843,8 @@ AtClient construction and immutable after.
 authenticates via at_auth; only onboarding/setup is desktop/CLI). `dart2wasm`
 errors on any `dart:io` reachable from the entry point, so:
 
-- **`at_auth.dart`** (main barrel, WASM-safe): `AtKeys` / `WritableAtKeys`, the
-  `AtKeysIo` / `WrittenAtKeysIo` interfaces, `InMemoryAtKeysIo`, the auth core,
+- **`at_auth.dart`** (main barrel, WASM-safe): `AtKeys` (extended in place), the
+  `AtKeysIo` interfaces, `InMemoryAtKeysIo`, the auth core,
   and the registrar **on `package:http`** (no `dart:io HttpClient`, so it is WASM-safe).
 - **`at_auth_io.dart`** (new non-wasm barrel): `FileAtKeysIo` + the `dart:io`
   socket-probe default. CLI and `at_client_flutter`'s `file_picker` import it —
@@ -881,7 +887,7 @@ missing map = an old daemon) — exactly how `twinKeys` rolled out. Two new
 
 The crucial subtlety: a client must **NOT** flip its default provider for traffic
 to a daemon that can't decrypt it. `PutRequestOptions.cryptoProviderId` (the
-per-operation override from the M0 seam, [§4](#4-subsystem-d--structural-design-cryptoprovider-seam-writableatkeys--key-stores-wasm-barrel)) is the per-destination gate.
+per-operation override from the M0 seam, [§4](#4-subsystem-d--structural-design-cryptoprovider-seam-atkeysatkeysio--key-stores-wasm-barrel)) is the per-destination gate.
 
 **One session, step by step:**
 
@@ -1041,7 +1047,8 @@ public/private correspondence check is likewise missing
 (`pairwise_secret_sharing.dart:360-407`); the root `pqpublickey`
 no-namespace serve exception is missing (`grep pqpublickey` = 0); durable storage
 is deferred (in-memory `SecretStore` + a pluggable persistence hook,
-`secret_store.dart:62`; `WritableAtKeys` not wired); anti-storm is a plain rate cap
+`secret_store.dart:62`; the extended `AtKeys`/`AtKeysIo` runtime persistence not
+wired); anti-storm is a plain rate cap
 without jitter (`:539`). `pushSecretToNamespaceMembers` is untested. Finally, the
 built `VerbEnrollmentDirectory` still speaks the **retired** wire shape — it parses
 a nested `apkam[]` response and performs an `enroll:metadata` registration write —

--- a/docs/projects/pq/implementation-plan.md
+++ b/docs/projects/pq/implementation-plan.md
@@ -48,8 +48,8 @@ size, watch-outs, and a `coversD1` line tying it back to the D1 workstreams.
 - **Partition by package.** Four package-domain tracks keep concurrent PRs off each other's files:
   - **Track A — crypto primitives + providers:** `at_chops` (stateless core + HPKE) → the nskey data
     path providers (`at/nskey` + `at/symmetric/AES/GCM`), `secret_sharing/`, `crypto/group/`.
-  - **Track B — key management:** `at_auth` (`WritableAtKeys`, `AtKeysIo` widening, the WASM barrel
-    split) → the PQ enrollment-conveyance key.
+  - **Track B — key management:** `at_auth` (extend `AtKeys` in place, `AtKeysIo` runtime persistence, the
+    WASM barrel split) → the PQ enrollment-conveyance key.
   - **Track C — at_client crypto seam + migration:** `crypto.dart` / `crypto_runtime.dart` / `legacy/`,
     `AtClientPreference`; the publish ladder.
   - **Track D — storage + platform + consumers:** `LocalKeystoreAtKeysIo`, the updatable `.atKeys`
@@ -57,9 +57,9 @@ size, watch-outs, and a `coversD1` line tying it back to the D1 workstreams.
   Within `at_client/crypto/`, the file partition keeps A and C apart: **C** owns `crypto.dart`,
   `crypto_runtime.dart`, `legacy/`; **A** owns `crypto/group/`, `crypto/nskey/` (new), `secret_sharing/`.
   The nskey providers are mostly new files — low collision by construction.
-- **Land contracts first.** Merge the tiny interface PRs (the `pqSeal` signature, the `WritableAtKeys`
-  API, the `CryptoContext.keys` field) first, stubs OK, so every track compiles against stable shapes
-  and never blocks on another.
+- **Land contracts first.** Merge the tiny interface PRs (the `pqSeal` signature, the extended
+  `AtKeys`/`AtKeysIo` API, the `CryptoContext.keys` field) first, stubs OK, so every track compiles against
+  stable shapes and never blocks on another.
 - **Keep merges additive / flag-gated** so trunk stays releasable at every commit boundary.
 - **Every project needs a named owner.** Each project id (`P-1`, `SS-1a`, `B-1`, …) is assigned a single
   accountable owner before its first PR; owner names are **TBD** until assigned. The owner shepherds the
@@ -103,7 +103,7 @@ The file-partition/track detail and the `CryptoConfig`/`CryptoRuntime` mechanics
   [#1993 done]→  P-1 at_chops 3.3.0 (published)    P-2 mldsa65 verify (fold into unpublished 3.4.0)
                      │                                   │
   [#1930 done]→  S-2 CryptoContext.keys (additive)       │
-                 S-1 at_auth WritableAtKeys ─→ S-3 LocalKeystore/.atKeys updatable
+                 S-1 at_auth AtKeys/AtKeysIo extend-in-place ─→ S-3 LocalKeystore/.atKeys updatable
                                                   │
    Substrate (SS-*)                                │
    SS-0 land WP-SS substrate baseline (PR #2037, reworked to 1:1:1 / flat listns / no-write-path) ─┐
@@ -222,7 +222,9 @@ lifecycle); P-3's acceptance can only prove "published + fetchable," not cold-st
 ## 4. Phase S — Structural enablers / key management (S-1, S-2, S-3, S-5, S-6, KF-1)
 
 **Structural facts (stated once).** (1) `CryptoContext` is `{atClient}`, so the additive `keys` field has
-**nothing to deprecate**; (2) `WritableAtKeys` **subclasses** at_auth's `AtKeys` (the material holder); (3)
+**nothing to deprecate**; (2) at_auth's `AtKeys` is **extended in place** — additive PQ-safe methods with the
+legacy key fields/methods deprecated (no new holder class) — and `AtKeysIo` gains runtime persistence
+(ratified 2026-07-06, #2045 — see [decisions.md](decisions.md)); (3)
 `CryptoRuntime` resolves against the live `AtClientPreference.crypto`, and cached-client reuse adopts the
 new config (there is no `CryptoRegistry`).
 
@@ -230,27 +232,34 @@ new config (there is no `CryptoRegistry`).
 `P-1`/`pqSeal` publish gate is **already satisfied** (at_chops 3.3.0, published 2026-06-23), leaving the SS-0
 baseline (PR #2037) as its prerequisite (see [section 10](#10-cross-cutting-publish-gates-critical-path-wavesparallelism-testing)).
 
-### S-1 — at_auth: `WritableAtKeys` holder + `WrittenAtKeysIo` widening (API only); publish 3.2.0 · at_auth · M
-**Goal:** the single in-memory holder of every key (per-enrollment AND per-APKAM); interface-first.
+### S-1 — at_auth: extend `AtKeys` in place (additive PQ methods, deprecate legacy) + `AtKeysIo` runtime persistence (API only); publish 3.2.0 · at_auth · M
+**Goal:** extend the existing `AtKeys` in place so it holds every key (per-enrollment AND per-APKAM) via
+additive PQ-safe accessors while the legacy key fields deprecate; interface-first.
 **Builds on:** at_auth `AtKeys`. Additive only; gates nothing in Wave 2.
-**Deliverables → [design.md](design.md)** (structural design: WritableAtKeys/key stores): `WritableAtKeys
-extends AtKeys` (add/remove/write); widen `WrittenAtKeysIo` (plain `abstract`, externally *extended* by
-`KeychainAtKeysIo`) with add/remove/update + default impls; `InMemoryAtKeysIo`. ⚠️ `AtKeysIo` is `sealed`
-— the real break surface is `WrittenAtKeysIo`; concrete-default-on-abstract is the correct mitigation for
-its `extends`-users.
-**Acceptance → [acceptance.md](acceptance.md):** existing onboard/auth suites green; `WritableAtKeys`
-add→read→remove; `InMemoryAtKeysIo` round-trip (persistent round-trip proven once **S-3** wires the stores).
+**Deliverables → [design.md](design.md)** (structural design: extend `AtKeys`/`AtKeysIo` in place): keep the
+`AtKeys` class hierarchy as-is and extend it **additively** with PQ-safe methods, **deprecating** the legacy
+key fields/methods (they stay for back-compat so call sites migrate over time); extend `AtKeysIo` with
+**runtime persistence** (`append()`, `save()`, …) — new methods ship with default impls so existing
+implementers don't break — so it stays the single contact point keeping runtime `AtKeys` objects and the
+persisted keyfile in-line. Concrete impls (`InMemoryAtKeysIo`, the keychain/file `AtKeysIo`) remain
+`AtKeysIo` implementations. (Supersedes the earlier `WritableAtKeys` holder, #2045 — ratified 2026-07-06,
+see [decisions.md](decisions.md).)
+**Acceptance → [acceptance.md](acceptance.md):** existing onboard/auth suites green; the extended `AtKeys`
+PQ add→read→remove (legacy fields still readable via the deprecated accessors); `InMemoryAtKeysIo` round-trip
+(persistent round-trip proven once **S-3** wires the stores).
 **Effort:** M.
 **Watch-outs:** ⚠️ **version** — pub.dev latest at_auth is **3.1.0**, in-tree is **3.1.1** (unshipped).
-Publish 3.1.1 first **or** fold `WritableAtKeys` under the unshipped slot before cutting 3.2.0 (Open
-decision #D).
+Publish 3.1.1 first **or** fold the `AtKeys`/`AtKeysIo` extensions under the unshipped slot before cutting
+3.2.0 (Open decision #D).
 **coversD1:** D1-S S2.
 
 ### S-2 — at_client: `CryptoContext.keys` additive field (interface-first only) · at_client · S (≈1 PR)
 **Goal:** the tiny field the data path compiles against.
-**Builds on:** #1930 + S-1's `WritableAtKeys` type.
-**Deliverables → [design.md](design.md)** (CryptoProvider seam): add `WritableAtKeys keys` to
-`CryptoContext` (additive); `CryptoRuntime` threads it into provider calls.
+**Builds on:** #1930 + S-1's extended `AtKeys` / injected `AtKeysIo`.
+**Deliverables → [design.md](design.md)** (CryptoProvider seam): add an `AtKeysIo keys` field to
+`CryptoContext` (additive) — the provider seam is injected the `AtKeysIo` (the key source) and yields the
+extended `AtKeys`; `CryptoRuntime` threads it into provider calls (ratified 2026-07-06, #2045 — see
+[decisions.md](decisions.md)).
 **Acceptance → [acceptance.md](acceptance.md):** existing crypto/legacy round-trips green; behaviour-neutral
 (no wire/stored-value change); Mode-B regression retained.
 **Effort:** S.
@@ -264,10 +273,10 @@ Resolve where `context.keys` is sourced at construction (overlaps S-3).
 ### S-3 — at_client/at_auth: `LocalKeystoreAtKeysIo` + updatable `.atKeys`/keychain · at_client, at_auth, at_client_flutter · L
 **Goal:** durable, updatable key-storage homes (bootstrap→file/keychain, distributed/rotating→keystore,
 ephemeral→memory). Stores are **dumb** — convergence stays in the substrate.
-**Builds on:** S-1's widened update API.
+**Builds on:** S-1's extended `AtKeysIo` runtime-persistence API.
 **Deliverables → [design.md](design.md)** (key stores): `LocalKeystoreAtKeysIo` over the 5.x keystore; make
-`FileAtKeysIo` updatable (re-wrap the self-encryption key on rewrite, atomic write + backup); compose
-`WritableAtKeys` at AtClient construction.
+`FileAtKeysIo` updatable (re-wrap the self-encryption key on rewrite, atomic write + backup); compose the
+extended `AtKeys` (via its injected `AtKeysIo`) at AtClient construction.
 **Acceptance → [acceptance.md](acceptance.md):** post-onboarding key add persists + survives close/reopen;
 ephemeral stays in-memory; **migration test** on a v(N-1) `.atKeys`/store fixture (backend is **Hive**
 today, not SQLite — keep the test backend-agnostic; name any legacy box/table explicitly); a **keychain
@@ -279,7 +288,7 @@ suite at every commit boundary (resource lifecycle). Does **not** gate the subst
 
 ### S-5 — at_auth 4.0.0: WASM barrel split · at_auth · L  *(parallel, off the GA critical path)*
 **Goal:** make the at_auth core WASM-safe (the one breaking major in the program).
-**Builds on:** S-3 (so `WritableAtKeys` + updatable stores bake on 3.2.0 before the breaking cut).
+**Builds on:** S-3 (so the extended `AtKeys`/`AtKeysIo` + updatable stores bake on 3.2.0 before the breaking cut).
 **Deliverables → [design.md](design.md)** (WASM barrel): move `FileAtKeysIo` + the `dart:io` socket probe
 to a new `at_auth_io.dart` barrel; drop the `atKeysIo ??= FileAtKeysIo()` default (require injection);
 registrar on `package:http`; publish 4.0.0.
@@ -758,8 +767,8 @@ out of scope here** — see [roadmap.md](roadmap.md) for the D2 trajectory.
 
 ### (a) Publish gates
 - `at_chops` (P-1, P-2) and `at_commons` (SS-1a) publish **before** `at_server`/consumers bump pins.
-- `at_auth` is split **additive-3.2.0** (S-1) then **breaking-4.0.0** (S-5) so `WritableAtKeys` bakes before
-  the barrel cut.
+- `at_auth` is split **additive-3.2.0** (S-1) then **breaking-4.0.0** (S-5) so the `AtKeys`/`AtKeysIo`
+  extend-in-place bakes before the barrel cut.
 - `at_client` stays **minor 3.14.x** through D1 GA; the v4 flip (R-2) is the final gated cutover.
 
 **Package versions & release sequencing** (single reference — publish in dependency order; two majors —
@@ -770,7 +779,7 @@ out of scope here** — see [roadmap.md](roadmap.md) for the D2 trajectory.
 | 1  | `at_chops`          | minor `3.2.1 → 3.3.0` **(published 2026-06-23, done)** | P-1    | stateless functional core + HPKE `pqSeal`/`pqOpen`; `@Deprecated AtChopsImpl` shim |
 | 2  | `at_chops`          | minor `3.3.0 → 3.4.0` **(bumped on trunk via #2030, unpublished)** | P-2 | #2030 (`at_chops_ffi` barrel + `AtPqc` + `AtSignatureAlgorithm`) landed the 3.4.0 bump on trunk 2026-07-03 (+ #2046), assembled-but-unpublished; **P-2 folds its `mldsa65` verify branch into this same 3.4.0 before publish**; #2039 (AES-GCM FFI) still draft. Minor under the one-time semver exemption ([decisions.md](decisions.md) 2026-07-03) |
 | 3  | `at_commons`        | minor `5.11.0 → 5.12.0` **(published 2026-07-04, done)** | SS-1a | `EnrollParams.metadata` + `signingAlgo`; flattened `listns`; pkam `mldsa65` literal |
-| 4  | `at_auth`           | minor `3.1.1 → 3.2.0`         | S-1        | additive: `WritableAtKeys`; `AtKeysIo`/`WrittenAtKeysIo` widened; `InMemoryAtKeysIo` |
+| 4  | `at_auth`           | minor `3.1.1 → 3.2.0`         | S-1        | additive: extend `AtKeys` in place (deprecate legacy); `AtKeysIo` runtime persistence; `InMemoryAtKeysIo` |
 | 5  | `at_auth`           | **major `3.2.0 → 4.0.0`**     | S-5        | breaking WASM cut: `FileAtKeysIo` → `at_auth_io.dart`; default removed; registrar → `package:http` |
 | 6  | `at_client`         | minor `3.13.0 → 3.14.0`       | S-2…B-2    | `at_auth ^4.0.0`; `CryptoContext.keys`; nskey data path; rotation. **= D1 GA** ⚠️ pub.dev latest is **3.12.0**, in-tree **3.13.0** (unshipped) — publish the in-progress slot first **or** fold; decide at execution against pub.dev |
 | 7  | `at_client`         | **major `3.14.0 → 4.0.0`**    | R-2        | flip `disallowLegacyEncryption` default → true; selfEncryptionKey stop-existing; dead-code removal |
@@ -806,14 +815,14 @@ dependency, `P-1`/`pqSeal` on `at_chops` 3.3.0, **shipped to pub.dev 2026-06-23*
 | Gate item                        | Blocks the substrate? |
 |----------------------------------|-----------------------|
 | P-1 (at_chops 3.3.0 / `pqSeal`)  | No — already published (2026-06-23); substrate ungated |
-| S-1 (`WritableAtKeys` + `AtKeysIo`) | No |
+| S-1 (`AtKeys`/`AtKeysIo` extend-in-place) | No |
 | S-2 (`CryptoContext.keys`)       | No — sibling of the substrate on the critical path, not a prerequisite |
 | S-3 (`LocalKeystoreAtKeysIo`)    | No |
 
 **Merge discipline.** Per-package PRs to **trunk** in dependency order (no mega-PRs); rebase on trunk daily;
 keep PRs small + additive / flag-gated so trunk stays releasable; prove cross-package combinations with an
 **ephemeral** integration branch (or CI), not a standing one. **Interface-first** — freeze the `pqSeal`
-signature (P-1), the `WritableAtKeys` API (S-1), and the `CryptoContext.keys` field (S-2) first (stubs OK).
+signature (P-1), the extended `AtKeys`/`AtKeysIo` API (S-1), and the `CryptoContext.keys` field (S-2) first (stubs OK).
 Integration is **continuous**, not a final step: each project merges to trunk when complete and publishes as
 needed.
 
@@ -841,7 +850,7 @@ Single authoritative map of D1 items, workstreams, and use cases to projects.
 | D1 item / workstream / UC | Project(s) |
 |---|---|
 | D1-S S1 (at_chops stateless) | P-1 |
-| D1-S S2/S3 (WritableAtKeys, stores) | S-1, S-3 |
+| D1-S S2/S3 (AtKeys/AtKeysIo extend-in-place, stores) | S-1, S-3 |
 | D1-S S4 (WASM split) | S-5 |
 | D1-S S5 (CryptoContext.keys) | S-2 |
 | D1-S S6 (consumer bumps) | S-6 |

--- a/docs/projects/pq/implementation-plan.md
+++ b/docs/projects/pq/implementation-plan.md
@@ -30,6 +30,7 @@ given/when/then here.
 - [10. Cross-cutting: publish gates, critical path, waves/parallelism, testing](#10-cross-cutting-publish-gates-critical-path-wavesparallelism-testing)
 - [11. Coverage map (D1 package / UC → project)](#11-coverage-map-d1-package--uc--project)
 - [12. Open decisions pointer & verification provenance](#12-open-decisions-pointer--verification-provenance)
+- [13. Phase IS — inter-server PQ authentication (IS-1)](#13-phase-is--inter-server-pq-authentication-is-1)
 
 ---
 
@@ -99,7 +100,7 @@ The file-partition/track detail and the `CryptoConfig`/`CryptoRuntime` mechanics
 
 ```
                  ┌──────────────────────── PQ primitives ───────────────────────┐
-  [#1993 done]→  P-1 at_chops 3.3.0 (published)    P-2 mldsa65 verify (publish 3.4.0, indep root)
+  [#1993 done]→  P-1 at_chops 3.3.0 (published)    P-2 mldsa65 verify (fold into unpublished 3.4.0)
                      │                                   │
   [#1930 done]→  S-2 CryptoContext.keys (additive)       │
                  S-1 at_auth WritableAtKeys ─→ S-3 LocalKeystore/.atKeys updatable
@@ -128,6 +129,7 @@ The file-partition/track detail and the `CryptoConfig`/`CryptoRuntime` mechanics
      B-3 selfEncryptionKey retirement (phases 1-3, needs at_server)     ON-1 PQ-native onboarding + legacy-interop flag
      S-5 at_auth 4.0 WASM split → S-6 consumer bumps          D2-1 at/pqmls carve + D1-E (D2)
      KF-1 .atKeys-at-rest protection + backup/restore (builds on S-3)
+     IS-1 inter-server PQ auth (FROM/POL: X-Wing KEM + ML-DSA-65, PR #2683) — needs at_chops PQ API (XWingCert/resolvers) published
      R-2 at_client 4.0 (flip flag default true) — final, gated on the ecosystem floor
 ```
 
@@ -166,14 +168,18 @@ published 3.3.0 surface. Don't break the deprecated sync verify path.
 ### P-2 — at_chops: wire `mldsa65` into the verification branch; publish a NEW minor · at_chops · M (≈1 PR)
 **Goal:** the one missing ML-DSA verification branch (the enum member + algo classes already ship in 3.3.0).
 **Builds on:** — (independent root; parallel to P-1). ⚠️ The `_getVerificationAlgorithm` `mldsa65` branch
-**did NOT make the 3.3.0 publish** — trunk `at_chops` has no ML-DSA verify branch, so P-2 needs **its own
-at_chops minor** (**3.4.0 or later**), it cannot fold into the already-shipped P-1 3.3.0.
+**did NOT make the 3.3.0 publish** — trunk `at_chops` has no ML-DSA verify branch. The **unpublished 3.4.0**
+already on trunk (bumped by #2030, merged 2026-07-03) is the slot: **P-2 folds its `mldsa65` verify branch
+into that existing 3.4.0 before it publishes** — not a fresh new minor. (Decision 2026-07-06.)
 **Deliverables → [design.md](design.md)** (at_chops primitives, ML-DSA): add an `mldsa65` branch in
 `_getVerificationAlgorithm` returning `MlDsa65PureDartAlgo()` (no `DynamicLibrary` in `AtChopsImpl` — do
 **not** claim FFI-when-available); no new `SigningAlgoType` member, no new algo class; publish in the new
-minor. **Coordinate the slot:** two FFI PRs are **also** claiming a 3.4.0 slot — #2030 (the `at_chops_ffi`
-barrel + `AtPqc` auto-resolver) and #2039 (AES-GCM FFI) — so sequence P-2 against them into **one agreed
-3.4.0** (agreed contents), not a free slot each. Those FFI PRs realise the **FFI-auto-resolve-default** policy
+minor. **The 3.4.0 slot is already open on trunk:** #2030 (the `at_chops_ffi` barrel + `AtPqc`
+auto-resolver + `AtSignatureAlgorithm` classes) **merged to trunk 2026-07-03** (+ #2046 review-fixes) and
+bumped `at_chops` to 3.4.0, **assembled-but-unpublished** under the one-time semver exemption. P-2's
+`_getVerificationAlgorithm` `mldsa65` branch is the one remaining deliverable to add into that same 3.4.0
+before publish; #2039 (AES-GCM FFI) is still **draft** and folds into 3.4.0 too if it lands first. Those
+FFI PRs realise the **FFI-auto-resolve-default** policy
 (FFI when available, pure-Dart fallback, WASM forces pure-Dart — ruling in [decisions.md](decisions.md)); they
 are **in D1 scope**, on the at_chops track. **Scope note (2026-07-03 ruling):** auto-resolve applies to the
 `AtPqc` accessors (`AtPqc.xWing`/`AtPqc.mlDsa65`, including their keygen); key generation through the
@@ -185,8 +191,9 @@ wire-compatible, so pure-Dart-generated keys work with the FFI backends and vice
 rsa/ecc/pkam unchanged. Do **not** assert end-to-end `AtChops.verify(mldsa65)` — the deprecated sync path
 doesn't await the async ML-DSA verify.
 **Effort:** M.
-**Watch-outs:** publish the 3.4.0 minor before `at_server` bumps its pin in SS-3; agree the 3.4.0 contents
-with PR #2030/#2039 first. **ML-DSA APKAM auth is retained** — the
+**Watch-outs:** add the `mldsa65` verify branch into the existing **unpublished** 3.4.0 (already on trunk
+via #2030) and publish before `at_server` bumps its pin in SS-3; do **not** open a fresh minor. **ML-DSA
+APKAM auth is retained** — the
 1:1:1 simplification does not drop ML-DSA: the at_chops `mldsa65` verify branch (this project), the
 at_commons pkam `signingAlgo` literal (folded into SS-1a's publish), and the server `_getSigningAlgoType`
 branch reading the **record** `signingAlgo` together make it work.
@@ -366,19 +373,21 @@ on trunk. It does **not** gate on S-1/S-2/S-3.
 presuppose but that lives only on the feature branch today.
 **Builds on:** #1930 + P-1 (`pqSeal`, published 3.3.0).
 **Deliverables → [design.md](design.md)** (secret-sharing substrate): land the WP-SS substrate baseline
-(**draft PR #2037**, branch commit `6184eab12`), **reworked to the 1:1:1 / flat `listns` / no-write-path
-shape before merge** (single `apkamPublicKey` + `signingAlgo`; flat discovery roster; no
-`registerKeyPackage` / `enroll:metadata` write path). This is the `__ssenv` envelope, `SecretStore`,
+(**PR #2037**, open, non-draft, ready for review), **already reworked to the 1:1:1 / flat `listns` /
+no-write-path shape** (via #2043, merged onto the branch — single `apkamPublicKey` + `signingAlgo`; flat
+discovery roster; no `registerKeyPackage` / `enroll:metadata` write path); pending merge to trunk. This is
+the `__ssenv` envelope, `SecretStore`,
 `putIfNewer` ordering, `kpid` addressing, and the push/pull primitives the later SS projects wire up.
 **Acceptance → [acceptance.md](acceptance.md):** substrate unit suite green; the baseline compiles in the
 1:1:1 shape with no write-path residue.
 **Effort:** M.
-**Watch-outs:** PR #2037 must be reworked to the current shape (1:1:1, flat `listns`, no write path) **before**
-merge — don't land the pre-decision-#F shape. It is the prerequisite for SS-1c / SS-2 / RF-1; those projects
-cite PR #2037 as "already landed," not implied trunk state.
+**Watch-outs:** PR #2037 is already in the current shape (1:1:1, flat `listns`, no write path — the
+pre-decision-#F shape has been reworked out via #2043). It is the prerequisite for SS-1c / SS-2 / RF-1;
+those projects cite PR #2037 as "already landed," so it must merge to trunk before they can.
 **coversD1:** D1-F substrate baseline.
 
-### SS-1a — at_commons enroll grammar: `EnrollParams.metadata` + flattened `listns`; publish 5.12.0 · at_commons · M
+### SS-1a — at_commons enroll grammar: `EnrollParams.metadata` + flattened `listns`; publish 5.12.0 — **SATISFIED (at_commons 5.12.0 published 2026-07-04; grammar on trunk via #2040)** · at_commons · M
+**Status:** SATISFIED — landed on trunk via #2040 (2026-07-04, with #2044 stacked in); at_commons 5.12.0 published to pub.dev.
 **Goal:** publish the grammar the new enroll verbs need before any server can parse them.
 **Builds on:** — (root). The key package rides `EnrollParams.metadata` (no grammar change); there is no
 `enroll:metadata` op.
@@ -759,8 +768,8 @@ out of scope here** — see [roadmap.md](roadmap.md) for the D2 trajectory.
 | #  | Package             | Bump                          | Project(s) | Why |
 |----|---------------------|-------------------------------|------------|-----|
 | 1  | `at_chops`          | minor `3.2.1 → 3.3.0` **(published 2026-06-23, done)** | P-1    | stateless functional core + HPKE `pqSeal`/`pqOpen`; `@Deprecated AtChopsImpl` shim |
-| 2  | `at_chops`          | minor `3.3.0 → 3.4.0`         | P-2        | ML-DSA `mldsa65` verify branch; **coordinate the 3.4.0 slot** with PR #2030 (`at_chops_ffi` barrel + `AtPqc` auto-resolver) + PR #2039 (AES-GCM FFI) — one agreed 3.4.0, minor under the recorded one-time semver exemption ([decisions.md](decisions.md) rulings 2026-07-03) |
-| 3  | `at_commons`        | minor `5.11.0 → 5.12.0`       | SS-1a      | `EnrollParams.metadata` + `signingAlgo`; flattened `listns`; pkam `mldsa65` literal |
+| 2  | `at_chops`          | minor `3.3.0 → 3.4.0` **(bumped on trunk via #2030, unpublished)** | P-2 | #2030 (`at_chops_ffi` barrel + `AtPqc` + `AtSignatureAlgorithm`) landed the 3.4.0 bump on trunk 2026-07-03 (+ #2046), assembled-but-unpublished; **P-2 folds its `mldsa65` verify branch into this same 3.4.0 before publish**; #2039 (AES-GCM FFI) still draft. Minor under the one-time semver exemption ([decisions.md](decisions.md) 2026-07-03) |
+| 3  | `at_commons`        | minor `5.11.0 → 5.12.0` **(published 2026-07-04, done)** | SS-1a | `EnrollParams.metadata` + `signingAlgo`; flattened `listns`; pkam `mldsa65` literal |
 | 4  | `at_auth`           | minor `3.1.1 → 3.2.0`         | S-1        | additive: `WritableAtKeys`; `AtKeysIo`/`WrittenAtKeysIo` widened; `InMemoryAtKeysIo` |
 | 5  | `at_auth`           | **major `3.2.0 → 4.0.0`**     | S-5        | breaking WASM cut: `FileAtKeysIo` → `at_auth_io.dart`; default removed; registrar → `package:http` |
 | 6  | `at_client`         | minor `3.13.0 → 3.14.0`       | S-2…B-2    | `at_auth ^4.0.0`; `CryptoContext.keys`; nskey data path; rotation. **= D1 GA** ⚠️ pub.dev latest is **3.12.0**, in-tree **3.13.0** (unshipped) — publish the in-progress slot first **or** fold; decide at execution against pub.dev |
@@ -874,4 +883,48 @@ knows where the sequencing assumptions come from:
 **Verification.** This plan is verified against the live trees: the `at_client_sdk` monorepo — which
 **contains** `at_chops`, `at_auth`, and `at_commons` as workspace packages (`packages/at_chops`,
 `packages/at_auth`, `packages/at_commons`) — plus the separate `at_server` / `java_at_server` repos.
+
+---
+
+## 13. Phase IS — inter-server PQ authentication (IS-1)
+
+*Off the D1 GA critical path (server-to-server, `at_server`), but in D1 scope (ruled 2026-07-06). This is
+the atServer↔atServer handshake, orthogonal to the client-side `nskey` data path (§6) — a compromised
+inter-server channel and a compromised client channel are different threats, so this track ships on its own
+schedule and does **not** gate D1 GA.*
+
+### IS-1 — atServer FROM/POL handshake: X-Wing KEM + ML-DSA-65, RSA fallback · at_secondary_server (+ at_chops) · L
+
+**Goal:** replace the RSA-only server-to-server FROM/POL handshake with a hybrid quantum-safe path, with
+automatic fallback to legacy UUID/RSA for non-PQ peers (zero flag day, mixed-fleet safe).
+
+**Builds on:** the at_chops PQ primitives (P-1 `pqSeal`/X-Wing, P-2 ML-DSA verify) **plus a new at_chops
+API surface** — `XWingCert`, `resolveXWing` / `resolveMlDsa65`, and `at_algorithm.dart` exports — that is
+**not yet on `at_chops` trunk**. It lives on branch `pq/st/at-chops-pq-api` and **must be published (as part
+of, or after, the 3.4.0 slot — see P-2) before IS-1 can land without the workspace path override**.
+(`generateXWingKeyPair` / `generateMlDsa65KeyPair` already exist on `at_chops` trunk 3.4.0.)
+
+**Deliverables:** a `PqKeyManager` (server-internal, **not** an at_chops class) managing the ML-DSA-65 +
+X-Wing keypair lifecycle, cert generation/rotation (30-day grace window on the previous cert), and
+HKDF-SHA256 key-confirmation tag derivation — the raw shared secret never crosses the wire or is persisted.
+The handshake: `lookup:pq_xwing_cert@<peer>` + `lookup:pq_signing_publickey@<peer>` (live every handshake,
+never cached) → `ML-DSA-65.verify(cert)` → `xwing.encaps(cert.pk)` → `tag = HKDF(ss, info=sessionID‖@peer)`
+→ `proof:sessionID@<peer>:pq:<ciphertext_b64>` → decaps → matching tag ⇒ `isPolAuthenticated`. Env
+`AT_DISABLE_PQ_AUTH=true` forces UUID; self-auth always UUID; a peer with no PQ cert falls back to
+UUID/RSA.
+
+**Acceptance:** `PqKeyManager` unit suite (cert round-trip, verify valid/expired/wrong-key, KEM round-trip,
+rotate lifecycle, prev-cert expiry); FROM/POL PQ-proof + fallback paths; pure-Dart fallback (unset
+`AT_CHOPS_LIBCRYPTO_PATH`, ML-DSA resolves to pure-Dart without throwing); mixed-fleet (no-PQ-cert peer →
+UUID challenge, POL via RSA signing key). Existing delete/update verb tests still pass (protected-key count
+updated for the PQ secret keys).
+
+**Tracking:** PR **#2683** (`at_server`, `pq/st/pq-interserver-comms`, currently draft, "Phase 0") →
+sub-issue under #1889. Design detail in [design.md](design.md) (§ inter-server PQ authentication).
+
+**Watch-outs:** (1) the at_chops PQ-API dependency above is the gating prerequisite — do not merge IS-1
+against the workspace path override. (2) The PR body's "Phase 0" title vs its `diag/interserver-comms-phase1.md`
+filename disagree, and that diag file is absent on the branch — reconcile before review. (3) `pq_xwing_cert`
+/ `pq_signing_publickey` are looked up live every handshake and never cached — keep it that way (cert
+rotation depends on it).
 


### PR DESCRIPTION
## What I did

Planning-day reconciliation of the PQ doc set (`docs/projects/pq/`) against trunk reality and two decisions taken today. Docs only — no code.

- **P-2** reworked to reflect that at_chops **3.4.0 is already bumped on trunk** (via #2030, merged + #2046 review-fixes) and **unpublished** — P-2's `mldsa65` verify branch **folds into that same 3.4.0 before publish**, not a fresh minor.
- **SS-1a** marked **SATISFIED** (at_commons 5.12.0 published 2026-07-04; grammar on trunk via #2040) in the section header and the publish table.
- **SS-0 / #2037** de-staled: it is open and non-draft, and **already** reworked to the 1:1:1 / flat `listns` / no-write-path shape (via #2043) — the pinned SHA and the "must rework before merge" wording are removed.
- **New Phase IS / project IS-1**: atServer inter-server PQ authentication (FROM/POL X-Wing KEM + ML-DSA-65, PR #2683) — added to `implementation-plan.md` (§13 + the dependency graph) and `design.md` (§8 Subsystem F). Off the D1 GA critical path; gated on publishing the at_chops PQ-API surface (`XWingCert`/`resolveXWing`/`resolveMlDsa65`).
- **decisions.md**: 3.4.0-slot status updated, the 2026-07-03 ruling past-tensed (#2046 merged), and a **2026-07-06 timeline entry** recording today's two rulings.

Epic **#1889** and its sub-issues were re-keyed from the `WP*` scheme to the P/S/SS project ids in the same reconciliation (GitHub-side; includes new sub-issues #2049 IS-1 and #2050 P-2).

## How I did it

Sourced from a cross-repo reconciliation of #1889's tree vs the plan docs vs merged/open PRs and recent branches across at_client_sdk + at_server. Every status claim was verified against live PR/trunk state (e.g. #2030 merged, at_commons 5.12.0 on pub.dev, #2037/#2685 open, trunk has no `secret_sharing/` yet). All five docs pass an intra-/cross-doc anchor-resolution check.

## How to verify it

- `docs/projects/pq/` renders; the new §13 (implementation-plan) and §8 (design) TOC links resolve.
- The dependency graph mermaid in #1889 renders and matches implementation-plan §2.
- Cross-check the P-2 / 3.4.0 and SS-1a "SATISFIED" claims against pub.dev (`at_chops` latest 3.3.0 unpublished-3.4.0-on-trunk; `at_commons` 5.12.0 published) and PRs #2030/#2040.

## Description for the changelog

docs(pq): planning-day reconciliation — re-key the epic to the P/S/SS project scheme, fold P-2 into the unpublished at_chops 3.4.0, mark SS-1a satisfied, and add the IS-1 inter-server PQ authentication track.
