### PR TITLE
chore(at_client): deprecate FileTransferService; drop unused cron dep

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -9,6 +9,15 @@
   are retained for source compatibility but are now no-ops (a commit-log-free
   client has no commit log to compact); they will be removed in a future
   major release.
+- deprecated: `FileTransferService` and `FileTransferObject` are now marked
+  `@Deprecated`. The SDK file-sharing API (`uploadFile` / `downloadFile` /
+  `shareFiles` / `reuploadFiles`) has moved to the app layer and will be
+  removed, along with the `archive` dependency, in the next major version
+  (#1113).
+- chore(deps): remove the unused `cron` dependency — it was only used by the
+  commit-log compaction that the `at_persistence_secondary_server` 5.0.0
+  migration removed, and nothing in the client imports it (#1378). `uuid` is
+  already on `^4.0.0`.
 
 ## 3.12.0
 

--- a/packages/at_client/lib/src/service/file_transfer_service.dart
+++ b/packages/at_client/lib/src/service/file_transfer_service.dart
@@ -5,6 +5,8 @@ import 'package:at_client/src/stream/file_transfer_object.dart';
 import 'package:at_client/src/util/constants.dart';
 import 'package:http/http.dart' as http;
 
+@Deprecated('Will be removed from the SDK in a future major release; '
+    'file sharing has moved to the app layer')
 class FileTransferService {
   Future<dynamic> uploadToFileBin(
       List<int> file, String container, String fileName) async {

--- a/packages/at_client/lib/src/stream/file_transfer_object.dart
+++ b/packages/at_client/lib/src/stream/file_transfer_object.dart
@@ -1,3 +1,5 @@
+@Deprecated('Will be removed from the SDK in a future major release; '
+    'file sharing has moved to the app layer')
 class FileTransferObject {
   final String transferId;
   final List<FileStatus> fileStatus;

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   crypto: ^3.0.5
   crypton: ^2.2.1
   encrypt: ^5.0.3
-  cron: ^0.5.1
   uuid: ^4.0.0
   archive: ^4.0.7
   http: ^1.2.1


### PR DESCRIPTION
## What I did

Two independent housekeeping fixes found during a sweep of old open issues:

- **#1378** — removed the unused `cron: ^0.5.1` dependency from `at_client`. `uuid` was already bumped to `^4.0.0`, so this clears the remaining stale pin the issue flagged.
- **#1113** — marked the `FileTransferService` and `FileTransferObject` classes `@Deprecated`. The public file-sharing methods on `AtClient` (`uploadFile` / `downloadFile` / `shareFiles` / `reuploadFiles`) were already deprecated; this completes the deprecation signal on the two classes. Removing them and the `archive` dependency is a breaking change deferred to the next major version — file sharing has moved to the app layer.

## How I did it

- Deleted the `cron` line from `packages/at_client/pubspec.yaml`. `cron` was only used by the commit-log compaction that the `at_persistence_secondary_server` 5.0.0 migration removed; there is no `package:cron` import anywhere in `lib`.
- Added `@Deprecated(...)` to the two classes. No behaviour change, and deprecated-member-use is info-level, so `dart analyze --fatal-warnings` stays green.
- CHANGELOG entries folded under the in-progress `3.13.0` heading.

## How to verify it

    cd packages/at_client
    dart analyze --fatal-warnings lib test        # 0 errors/warnings
    dart format -o none --set-exit-if-changed \
      lib/src/service/file_transfer_service.dart \
      lib/src/stream/file_transfer_object.dart    # clean
    grep -r "package:cron" lib                     # no matches

## Description for the changelog

- deprecated: `FileTransferService` / `FileTransferObject` — file sharing has moved to the app layer; the classes and the `archive` dependency will be removed in the next major version.
- chore(deps): remove the unused `cron` dependency.

---

Closes #1378. Advances #1113 (deprecation only; class + `archive` removal deferred to the next major version).
