### PR TITLE
feat(at_lookup): bound atDirectory lookup + connect with a timeout deadline (network-timeout stage 1)

### DIFF
--- a/packages/at_auth/test/at_auth_test.dart
+++ b/packages/at_auth/test/at_auth_test.dart
@@ -34,7 +34,8 @@ class FakeEnrollmentRequest extends Fake implements EnrollmentRequest {}
 class FakeSecondaryAddressFinder extends Fake
     implements CacheableSecondaryAddressFinder {
   @override
-  Future<SecondaryAddress> findSecondary(String atSign) async {
+  Future<SecondaryAddress> findSecondary(String atSign,
+      {Duration? timeout}) async {
     return SecondaryAddress('abcd', 123);
   }
 }

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 5.13.0
+
+- feat: add `AtNetworkTimeouts` — the process-wide network-timeout policy
+  (`defaultTimeout`, `maxAllowed` = 30s hard cap, `cap()`). The single place to
+  set the default network timeout for the whole SDK; every resolved timeout is
+  passed through `cap()` so nothing can wait longer than 30 seconds (#1923).
+- feat: add `SecureSocketConfig.connectTimeout` so a connect deadline can be
+  threaded through to `SecureSocket.connect`.
+
 ## 5.12.0
 
 - feat: add the `enroll:listns:<listNamespace>` operation to the enroll verb

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## 5.13.0
 
 - feat: add `AtNetworkTimeouts` — the process-wide network-timeout policy
-  (`defaultTimeout`, `maxAllowed` = 30s hard cap, `cap()`). The single place to
-  set the default network timeout for the whole SDK; every resolved timeout is
-  passed through `cap()` so nothing can wait longer than 30 seconds (#1923).
+  (`defaultTimeout` = 30s, `maxAllowed` = 60s hard cap, `cap()`). The single
+  place to set the default network timeout for the whole SDK; every resolved
+  timeout is passed through `cap()` so nothing can wait longer than 60 seconds
+  (#1923).
 - feat: add `SecureSocketConfig.connectTimeout` so a connect deadline can be
   threaded through to `SecureSocket.connect`.
 

--- a/packages/at_commons/lib/at_commons.dart
+++ b/packages/at_commons/lib/at_commons.dart
@@ -20,6 +20,7 @@ export 'package:at_commons/src/keystore/at_key.dart';
 export 'package:at_commons/src/keystore/key_type.dart';
 export 'package:at_commons/src/shared_key_status.dart';
 export 'package:at_commons/src/security/secure_socket_config.dart';
+export 'package:at_commons/src/security/at_network_timeouts.dart';
 export 'package:at_commons/src/validators/at_key_validation.dart';
 export 'package:at_commons/src/validators/at_key_validation_impl.dart';
 export 'package:at_commons/src/verb/batch/batch_request.dart';

--- a/packages/at_commons/lib/src/security/at_network_timeouts.dart
+++ b/packages/at_commons/lib/src/security/at_network_timeouts.dart
@@ -1,0 +1,35 @@
+/// Process-wide network timeout policy for the Atsign SDK.
+///
+/// Every network operation that can block — connecting to an atServer or the
+/// atDirectory, waiting for a response, and the retry loops around them — is
+/// bounded by a deadline derived from [defaultTimeout], and no effective
+/// timeout is ever allowed to exceed [maxAllowed].
+///
+/// This is the single place to change the default for the whole process: set
+/// [defaultTimeout] once (e.g. at app start). Individual call sites may override
+/// it (`AtClientPreference.networkTimeout`, `RetryOptions.overallTimeout`,
+/// `SecureSocketConfig.connectTimeout`, or a per-call parameter), but every
+/// resolved value is passed through [cap], so nothing can ever wait longer than
+/// [maxAllowed].
+class AtNetworkTimeouts {
+  AtNetworkTimeouts._();
+
+  /// The hard ceiling on any effective network timeout. Nothing waits longer
+  /// than this, regardless of what a caller requests.
+  static const Duration maxAllowed = Duration(seconds: 30);
+
+  /// The process-wide default network timeout. Change this once to move the
+  /// default everywhere. Always read through [cap] / [effectiveDefault] so it
+  /// can never exceed [maxAllowed].
+  static Duration defaultTimeout = const Duration(seconds: 30);
+
+  /// Returns [d] clamped to the range `[Duration.zero, maxAllowed]`.
+  static Duration cap(Duration d) {
+    if (d > maxAllowed) return maxAllowed;
+    if (d < Duration.zero) return Duration.zero;
+    return d;
+  }
+
+  /// The [defaultTimeout], already capped at [maxAllowed].
+  static Duration get effectiveDefault => cap(defaultTimeout);
+}

--- a/packages/at_commons/lib/src/security/at_network_timeouts.dart
+++ b/packages/at_commons/lib/src/security/at_network_timeouts.dart
@@ -15,8 +15,10 @@ class AtNetworkTimeouts {
   AtNetworkTimeouts._();
 
   /// The hard ceiling on any effective network timeout. Nothing waits longer
-  /// than this, regardless of what a caller requests.
-  static const Duration maxAllowed = Duration(seconds: 30);
+  /// than this, regardless of what a caller requests. Callers may request up to
+  /// this much; the [defaultTimeout] (used when no explicit timeout is given)
+  /// is shorter.
+  static const Duration maxAllowed = Duration(seconds: 60);
 
   /// The process-wide default network timeout. Change this once to move the
   /// default everywhere. Always read through [cap] / [effectiveDefault] so it

--- a/packages/at_commons/lib/src/security/secure_socket_config.dart
+++ b/packages/at_commons/lib/src/security/secure_socket_config.dart
@@ -9,4 +9,9 @@ class SecureSocketConfig {
 
   ///location of where the TLS keys file will be stored.
   String? tlsKeysSavePath;
+
+  /// Maximum time to wait for the TCP + TLS connect to complete. When null,
+  /// [AtNetworkTimeouts.effectiveDefault] is used. The resolved value is always
+  /// capped at [AtNetworkTimeouts.maxAllowed].
+  Duration? connectTimeout;
 }

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.12.0
+version: 5.13.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_commons/test/at_network_timeouts_test.dart
+++ b/packages/at_commons/test/at_network_timeouts_test.dart
@@ -3,22 +3,29 @@ import 'package:test/test.dart';
 
 void main() {
   group('AtNetworkTimeouts', () {
-    test('maxAllowed is 30 seconds', () {
-      expect(AtNetworkTimeouts.maxAllowed, const Duration(seconds: 30));
+    test('maxAllowed is 60 seconds', () {
+      expect(AtNetworkTimeouts.maxAllowed, const Duration(seconds: 60));
     });
 
     test('cap clamps values above maxAllowed down to maxAllowed', () {
       expect(AtNetworkTimeouts.cap(const Duration(minutes: 5)),
           AtNetworkTimeouts.maxAllowed);
-      expect(AtNetworkTimeouts.cap(const Duration(seconds: 31)),
+      expect(AtNetworkTimeouts.cap(const Duration(seconds: 90)),
           AtNetworkTimeouts.maxAllowed);
     });
 
     test('cap passes through values within range unchanged', () {
       expect(AtNetworkTimeouts.cap(const Duration(seconds: 5)),
           const Duration(seconds: 5));
+      // 45s is above the 30s default but below the 60s ceiling.
+      expect(AtNetworkTimeouts.cap(const Duration(seconds: 45)),
+          const Duration(seconds: 45));
       expect(AtNetworkTimeouts.cap(AtNetworkTimeouts.maxAllowed),
           AtNetworkTimeouts.maxAllowed);
+    });
+
+    test('defaultTimeout is 30 seconds', () {
+      expect(AtNetworkTimeouts.defaultTimeout, const Duration(seconds: 30));
     });
 
     test('cap clamps negative values to zero', () {

--- a/packages/at_commons/test/at_network_timeouts_test.dart
+++ b/packages/at_commons/test/at_network_timeouts_test.dart
@@ -1,0 +1,33 @@
+import 'package:at_commons/at_commons.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('AtNetworkTimeouts', () {
+    test('maxAllowed is 30 seconds', () {
+      expect(AtNetworkTimeouts.maxAllowed, const Duration(seconds: 30));
+    });
+
+    test('cap clamps values above maxAllowed down to maxAllowed', () {
+      expect(AtNetworkTimeouts.cap(const Duration(minutes: 5)),
+          AtNetworkTimeouts.maxAllowed);
+      expect(AtNetworkTimeouts.cap(const Duration(seconds: 31)),
+          AtNetworkTimeouts.maxAllowed);
+    });
+
+    test('cap passes through values within range unchanged', () {
+      expect(AtNetworkTimeouts.cap(const Duration(seconds: 5)),
+          const Duration(seconds: 5));
+      expect(AtNetworkTimeouts.cap(AtNetworkTimeouts.maxAllowed),
+          AtNetworkTimeouts.maxAllowed);
+    });
+
+    test('cap clamps negative values to zero', () {
+      expect(AtNetworkTimeouts.cap(const Duration(seconds: -1)), Duration.zero);
+    });
+
+    test('effectiveDefault never exceeds maxAllowed', () {
+      expect(AtNetworkTimeouts.effectiveDefault,
+          lessThanOrEqualTo(AtNetworkTimeouts.maxAllowed));
+    });
+  });
+}

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -10,8 +10,8 @@
   `SecureSocket.connect`. `SecondaryAddressFinder.findSecondary` takes an
   optional `timeout` that bounds the entire atDirectory lookup — the retry loop
   and the previously-fixed 30-second response busy-wait — as a single deadline.
-  Both default to `AtNetworkTimeouts.effectiveDefault` and are capped at 30s
-  (#1923). Requires `at_commons ^5.13.0`.
+  Both default to `AtNetworkTimeouts.effectiveDefault` (30s) and are capped at
+  60s (#1923). Requires `at_commons ^5.13.0`.
 
 ## 3.5.0
 

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -4,6 +4,14 @@
   (`PkamSigningAlgo` / `SHA512HashingAlgo`); `crypton` and `crypto` are no
   longer imported anywhere in the package and have been dropped from
   `dependencies`. Byte-identical by construction.
+- feat: bound network operations with a timeout so a dead network cannot hang
+  the SDK. `SecureSocketUtil.createSecureSocket` now accepts an optional
+  `timeout` (and honours `SecureSocketConfig.connectTimeout`), passing it to
+  `SecureSocket.connect`. `SecondaryAddressFinder.findSecondary` takes an
+  optional `timeout` that bounds the entire atDirectory lookup — the retry loop
+  and the previously-fixed 30-second response busy-wait — as a single deadline.
+  Both default to `AtNetworkTimeouts.effectiveDefault` and are capped at 30s
+  (#1923). Requires `at_commons ^5.13.0`.
 
 ## 3.5.0
 

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -688,8 +688,10 @@ class AtLookupImpl implements AtLookUp {
 
 class AtLookupSecureSocketFactory {
   Future<SecureSocket> createSocket(
-      String host, String port, SecureSocketConfig socketConfig) async {
-    return await SecureSocketUtil.createSecureSocket(host, port, socketConfig);
+      String host, String port, SecureSocketConfig socketConfig,
+      {Duration? timeout}) async {
+    return await SecureSocketUtil.createSecureSocket(host, port, socketConfig,
+        timeout: timeout);
   }
 }
 

--- a/packages/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
+++ b/packages/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
@@ -38,12 +38,18 @@ class CacheableSecondaryAddressFinder implements SecondaryAddressFinder {
   }
 
   @override
-  Future<SecondaryAddress> findSecondary(String atSign) async {
+  Future<SecondaryAddress> findSecondary(String atSign,
+      {Duration? timeout}) async {
     atSign = stripAtSignFromAtSign(atSign);
+
+    // Convert the timeout into an absolute deadline once, then thread it down so
+    // the retry loop, the connect and the response-wait all share ONE budget.
+    final DateTime deadline = DateTime.now().add(
+        AtNetworkTimeouts.cap(timeout ?? AtNetworkTimeouts.defaultTimeout));
 
     if (_cacheIsEmptyOrExpired(atSign)) {
       // _updateCache will either populate the cache, or throw an exception
-      await _updateCache(atSign, defaultCacheDuration);
+      await _updateCache(atSign, defaultCacheDuration, deadline);
     }
     if (_map.containsKey(atSign)) {
       // should always be true, since _updateCache will throw an exception if it fails
@@ -86,9 +92,11 @@ class CacheableSecondaryAddressFinder implements SecondaryAddressFinder {
     return 'Failed attempt to lookup atServer address for $atSign';
   }
 
-  Future<void> _updateCache(String atSign, Duration cacheFor) async {
+  Future<void> _updateCache(
+      String atSign, Duration cacheFor, DateTime deadline) async {
     try {
-      String? secondaryUrl = await _secondaryFinder.findSecondaryUrl(atSign);
+      String? secondaryUrl =
+          await _secondaryFinder.findSecondaryUrl(atSign, deadline: deadline);
       if (secondaryUrl == null ||
           secondaryUrl.isEmpty ||
           secondaryUrl == 'data:null') {
@@ -149,7 +157,7 @@ class SecondaryUrlFinder {
   /// (b) the delay before each retry
   static List<int> retryDelaysMillis = [50, 100, 150, 200];
 
-  Future<String?> findSecondaryUrl(String atSign) async {
+  Future<String?> findSecondaryUrl(String atSign, {DateTime? deadline}) async {
     if (_rootDomain.startsWith("proxy:")) {
       // In order to make it easy for clients to connect to a reverse proxy
       // instead of doing a root lookup,  we adopt the convention that:
@@ -158,19 +166,30 @@ class SecondaryUrlFinder {
       // and the secondary port will be deemed to be the rootPort
       return '${_rootDomain.substring("proxy:".length)}:$_rootPort';
     }
+    deadline ??= DateTime.now().add(AtNetworkTimeouts.effectiveDefault);
     String? address;
     String lastExceptionMsg = '';
     for (int i = 0; i <= retryDelaysMillis.length; i++) {
+      // Abandon the retry loop once the overall deadline has passed, instead of
+      // always running all attempts (each of which can take seconds).
+      if (!DateTime.now().isBefore(deadline)) {
+        throw AtTimeoutException('AtLookup.findAtServer for $atSign timed out'
+            '${lastExceptionMsg.isEmpty ? '' : ' : $lastExceptionMsg'}');
+      }
       try {
-        address = await _findSecondary(atSign);
+        address = await _findSecondary(atSign, deadline);
         return address;
       } catch (e) {
         lastExceptionMsg = e.toString();
         if (i < retryDelaysMillis.length) {
-          _logger.info('AtLookup.findAtServer for $atSign failed with $e'
-              ' : will retry in ${retryDelaysMillis[i]} milliseconds');
-          await Future.delayed(Duration(milliseconds: retryDelaysMillis[i]));
-          continue;
+          final delay = Duration(milliseconds: retryDelaysMillis[i]);
+          // Only wait for the backoff if it still fits inside the deadline.
+          if (DateTime.now().add(delay).isBefore(deadline)) {
+            _logger.info('AtLookup.findAtServer for $atSign failed with $e'
+                ' : will retry in ${retryDelaysMillis[i]} milliseconds');
+            await Future.delayed(delay);
+            continue;
+          }
         }
         _logger.severe('findAtServer for $atSign : $e');
         if (e is RootServerConnectivityException) {
@@ -181,7 +200,7 @@ class SecondaryUrlFinder {
     throw AtConnectException('findAtServer for $atSign : $lastExceptionMsg');
   }
 
-  Future<String?> _findSecondary(String atsign) async {
+  Future<String?> _findSecondary(String atsign, DateTime deadline) async {
     String? response;
     SecureSocket? socket;
     try {
@@ -193,10 +212,14 @@ class SecondaryUrlFinder {
       var prompt = false;
       var once = true;
 
+      // Bound the connect by whatever budget remains before the deadline.
+      final remaining =
+          AtNetworkTimeouts.cap(deadline.difference(DateTime.now()));
       socket = await _socketFactory.createSocket(
         _rootDomain,
         '$_rootPort',
         _socketConfig,
+        timeout: remaining,
       );
       _logger.finer('findAtServerUrl: connection to atDirectory established');
       // listen to the received data event stream
@@ -222,8 +245,9 @@ class SecondaryUrlFinder {
           ans = true;
         }
       });
-      // wait 30 seconds
-      for (var i = 0; i < 6000; i++) {
+      // Wait for the atDirectory to answer, bounded by the overall deadline
+      // (previously a fixed 30-second busy-wait, ignoring any caller budget).
+      while (DateTime.now().isBefore(deadline)) {
         await Future.delayed(Duration(milliseconds: 5));
         if (ans) {
           response = secondary;

--- a/packages/at_lookup/lib/src/cache/secondary_address_finder.dart
+++ b/packages/at_lookup/lib/src/cache/secondary_address_finder.dart
@@ -3,8 +3,8 @@ abstract class SecondaryAddressFinder {
   ///
   /// [timeout] bounds the TOTAL wall-clock spent doing so (connect + the
   /// internal retries + waiting for the atDirectory response). When null, the
-  /// process-wide default (`AtNetworkTimeouts.effectiveDefault`) is used, and
-  /// the value is always capped at `AtNetworkTimeouts.maxAllowed` (30s). On
+  /// process-wide default (`AtNetworkTimeouts.effectiveDefault`, 30s) is used,
+  /// and the value is always capped at `AtNetworkTimeouts.maxAllowed` (60s). On
   /// expiry the socket is closed and an `AtTimeoutException` is thrown.
   Future<SecondaryAddress> findSecondary(String atSign, {Duration? timeout});
 }

--- a/packages/at_lookup/lib/src/cache/secondary_address_finder.dart
+++ b/packages/at_lookup/lib/src/cache/secondary_address_finder.dart
@@ -1,5 +1,12 @@
 abstract class SecondaryAddressFinder {
-  Future<SecondaryAddress> findSecondary(String atSign);
+  /// Finds the atServer address for [atSign] by looking it up in the atDirectory.
+  ///
+  /// [timeout] bounds the TOTAL wall-clock spent doing so (connect + the
+  /// internal retries + waiting for the atDirectory response). When null, the
+  /// process-wide default (`AtNetworkTimeouts.effectiveDefault`) is used, and
+  /// the value is always capped at `AtNetworkTimeouts.maxAllowed` (30s). On
+  /// expiry the socket is closed and an `AtTimeoutException` is thrown.
+  Future<SecondaryAddress> findSecondary(String atSign, {Duration? timeout});
 }
 
 class SecondaryAddress {

--- a/packages/at_lookup/lib/src/util/secure_socket_util.dart
+++ b/packages/at_lookup/lib/src/util/secure_socket_util.dart
@@ -7,8 +7,16 @@ class SecureSocketUtil {
 
   ///method that creates and returns a [SecureSocket]. If [decryptPackets] is set to true,the TLS keys are logged into a file.
   static Future<SecureSocket> createSecureSocket(
-      String host, String port, SecureSocketConfig secureSocketConfig) async {
+      String host, String port, SecureSocketConfig secureSocketConfig,
+      {Duration? timeout}) async {
     SecurityContext securityContext = SecurityContext.defaultContext;
+
+    // Bound the TCP + TLS connect so a dead/black-hole network cannot block
+    // here indefinitely. Precedence: explicit [timeout] > config.connectTimeout
+    // > process default, always capped at AtNetworkTimeouts.maxAllowed.
+    final Duration connectTimeout = AtNetworkTimeouts.cap(timeout ??
+        secureSocketConfig.connectTimeout ??
+        AtNetworkTimeouts.defaultTimeout);
 
     bool certsProvided = false;
     if (secureSocketConfig.pathToCerts != null &&
@@ -22,6 +30,7 @@ class SecureSocketUtil {
         host,
         int.parse(port),
         context: securityContext,
+        timeout: connectTimeout,
       );
       aSecureSocket.setOption(SocketOption.tcpNoDelay, true);
       return aSecureSocket;
@@ -40,6 +49,7 @@ class SecureSocketUtil {
         SecureSocket aSecureSocket = await SecureSocket.connect(
             host, int.parse(port),
             context: securityContext,
+            timeout: connectTimeout,
             keyLog: (line) =>
                 keysFile?.writeAsStringSync(line, mode: FileMode.append));
         aSecureSocket.setOption(SocketOption.tcpNoDelay, true);

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -11,7 +11,7 @@ resolution: workspace
 
 dependencies:
   at_utils: ^3.0.19
-  at_commons: ^5.7.0
+  at_commons: ^5.13.0
   mutex: ^3.0.0
   meta: ^1.16.0
   at_chops: ^3.0.0

--- a/packages/at_lookup/test/secondary_address_cache_test.dart
+++ b/packages/at_lookup/test/secondary_address_cache_test.dart
@@ -40,17 +40,19 @@ void main() async {
 
     setUp(() {
       reset(mockSecondaryFinder);
-      when(() => mockSecondaryFinder
-              .findSecondaryUrl(any(that: startsWith('registered'))))
+      when(() => mockSecondaryFinder.findSecondaryUrl(
+              any(that: startsWith('registered')),
+              deadline: any(named: 'deadline')))
           .thenAnswer((invocation) async =>
               addressFromAtSign(invocation.positionalArguments.first));
-      when(() => mockSecondaryFinder
-              .findSecondaryUrl(any(that: startsWith('notCached'))))
+      when(() => mockSecondaryFinder.findSecondaryUrl(
+              any(that: startsWith('notCached')),
+              deadline: any(named: 'deadline')))
           .thenAnswer((invocation) async =>
               addressFromAtSign(invocation.positionalArguments.first));
-      when(() => mockSecondaryFinder
-              .findSecondaryUrl(any(that: startsWith('notRegistered'))))
-          .thenAnswer((invocation) async {
+      when(() => mockSecondaryFinder.findSecondaryUrl(
+          any(that: startsWith('notRegistered')),
+          deadline: any(named: 'deadline'))).thenAnswer((invocation) async {
         throw SecondaryNotFoundException(
             CacheableSecondaryAddressFinder.getNotFoundExceptionMessage(
                 invocation.positionalArguments.first));
@@ -173,8 +175,8 @@ void main() async {
               socketFactory: mockSocketFactory));
 
       numSocketCreateCalls = 0;
-      when(() =>
-              mockSocketFactory.createSocket(mockAtDirectoryHost, '64', any()))
+      when(() => mockSocketFactory.createSocket(
+              mockAtDirectoryHost, '64', any(), timeout: any(named: 'timeout')))
           .thenAnswer((invocation) {
         print(
             'mock create socket: numFailures $numSocketCreateCalls requiredFailures $requiredFailures');
@@ -208,6 +210,28 @@ void main() async {
       SecondaryAddress sa = await cachingAtServerFinder.findSecondary(atSign);
       expect(sa.toString(), mockedAtServerAddress);
       expect(numSocketCreateCalls - 1, requiredFailures);
+    });
+
+    test(
+        'findSecondary honours its timeout budget when the atDirectory '
+        'connects but never answers (does not busy-wait for 30s)', () async {
+      requiredFailures = 0;
+      // The atDirectory accepts the connection but never returns an address,
+      // so the response-wait must be bounded by the deadline, not the old
+      // fixed 30-second busy-wait.
+      when(() => mockSocket.write('$noAtAtSign\n'))
+          .thenAnswer((invocation) async {
+        // deliberately send nothing back
+      });
+      final sw = Stopwatch()..start();
+      await expectLater(
+        cachingAtServerFinder.findSecondary(atSign,
+            timeout: const Duration(milliseconds: 300)),
+        throwsA(isA<AtException>()),
+      );
+      sw.stop();
+      expect(sw.elapsed, lessThan(const Duration(seconds: 10)),
+          reason: 'findSecondary should honour the deadline, not wait ~30s');
     });
 
     test('test lookup of @alice with mocked atDirectory and 1 failure',
@@ -324,6 +348,7 @@ void main() async {
         rootDomain,
         rootPort.toString(),
         any(),
+        timeout: any(named: 'timeout'),
       ),
     ).thenAnswer((invocation) async {
       configPassedToFactory = invocation.positionalArguments[2];


### PR DESCRIPTION
## What I did

**PR 1 (of 3) of the network-timeout fix** for the "SDK hangs for minutes on a dead network" problem (#1923, surfaced in the #2070 review). This stage bounds the *lowest* network layer; follow-up stages thread the deadline through at_auth's retry loop and expose an `AtClientPreference` knob.

The hang is a nested retry stack with no wall-clock budget: `AtAuthImpl.validateAtServer` (10× / 2s) wraps `SecondaryUrlFinder.findSecondaryUrl` (5×), whose `_findSecondary` busy-waits **30s** for the atDirectory, and the actual `SecureSocket.connect` had **no `timeout`** — worst case ~50 minutes.

PR 2 will be the at_auth deadline loop over its 10× retry, then PR 3 will be to add `AtClientPreference.networkTimeout` + do the at_client/at_client_flutter wiring

## How I did it

**at_commons (5.13.0):**
- `AtNetworkTimeouts` — the process-wide network-timeout policy: `defaultTimeout` = 30s, `maxAllowed` = 60s hard cap, `cap()`. The single place to set the default; every resolved timeout is capped at 60s (a caller may explicitly request up to 60s; the default when none is given is 30s).
- `SecureSocketConfig.connectTimeout`.

**at_lookup (3.6.0):**
- `SecureSocketUtil.createSecureSocket` now passes a `timeout` to `SecureSocket.connect` (precedence: explicit > `config.connectTimeout` > process default, all capped).
- `SecondaryAddressFinder.findSecondary` takes an optional `timeout`, converted to a single absolute deadline threaded through the 5-attempt retry loop and the 30s response busy-wait — both abandon once the budget is spent.
- Defaults to `AtNetworkTimeouts.effectiveDefault` (30s) even when no caller passes a timeout, so existing call sites are bounded now (capped at 60s).

Note: at_commons 5.12.0 is published, so this bumps at_commons to **5.13.0** (additive minor); at_lookup 3.6.0 is in progress, so am adding the changelog entry under there.

## How to verify it
Tests pass

Note New test in `secondary_address_cache_test.dart` — "findSecondary honours its timeout budget when the atDirectory connects but never answers" — proves the finder gives up in <10s instead of the old 30s busy-wait.

