### PR TITLE
feat(at_auth): bound validateAtServer with an overall timeout deadline (network-timeout stage 2)

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,13 +1,16 @@
 ## 3.2.0
 
 - feat: bound `AtAuthImpl.validateAtServer` with a single overall deadline so a
-  dead network can no longer hang authentication/onboarding. `RetryOptions`
-  gains an optional `overallTimeout` (defaults to the process-wide
-  `AtNetworkTimeouts.effectiveDefault`, 30s; capped at 60s). The retry loop and
-  each inner network call (the atDirectory lookup and the connectivity probe)
-  share that deadline and give up with an `AtTimeoutException` once it passes,
-  instead of running all `maxRetries` x `retryDelay` (#1923). Requires
-  `at_commons ^5.13.0`.
+  dead network can no longer hang authentication/onboarding. `RetryOptions` gains
+  an optional `overallTimeout`; when null the default depends on the request:
+  authentication uses `AtNetworkTimeouts.effectiveDefault` (30s) so a dead network
+  fails fast, while ONBOARDING uses `AtNetworkTimeouts.defaultOnboardingTimeout`
+  (5 min) because a newly-registered atSign can take minutes to be provisioned.
+  The loop is deadline-driven — it retries every `retryDelay` until the budget is
+  spent, then throws `AtTimeoutException`; each inner network call (the atDirectory
+  lookup and the connectivity probe) is bounded by the remaining budget and capped
+  at 60s. **`RetryOptions.maxRetries` no longer bounds this loop** (the deadline
+  does) (#1923). Requires `at_commons ^5.13.0`.
 
 ## 3.1.1
 - refactor: route enrollment RSA (encrypt/decrypt `apkamSymmetricKey` under the default encryption keypair) through at_chops (`RsaEncryptionAlgo`) — `crypton` no longer imported in `lib` and moved to `dev_dependencies` (only the enrollment test still uses it for RSA keypair fixtures). Same framing, byte-identical by construction.

--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 3.2.0
+
+- feat: bound `AtAuthImpl.validateAtServer` with a single overall deadline so a
+  dead network can no longer hang authentication/onboarding. `RetryOptions`
+  gains an optional `overallTimeout` (defaults to the process-wide
+  `AtNetworkTimeouts.effectiveDefault`, 30s; capped at 60s). The retry loop and
+  each inner network call (the atDirectory lookup and the connectivity probe)
+  share that deadline and give up with an `AtTimeoutException` once it passes,
+  instead of running all `maxRetries` x `retryDelay` (#1923). Requires
+  `at_commons ^5.13.0`.
+
 ## 3.1.1
 - refactor: route enrollment RSA (encrypt/decrypt `apkamSymmetricKey` under the default encryption keypair) through at_chops (`RsaEncryptionAlgo`) — `crypton` no longer imported in `lib` and moved to `dev_dependencies` (only the enrollment test still uses it for RSA keypair fixtures). Same framing, byte-identical by construction.
 - fix: `decodeAtKeys()` now reliably throws `AtDecryptionException` on an incorrect passphrase. The `jsonDecode` of the decrypted bytes now runs inside the decrypt try/catch, so wrong-passphrase garbage no longer escapes as an uncaught `FormatException` (an intermittent failure in `at_keys_io_test`).

--- a/packages/at_auth/lib/src/at_auth_impl.dart
+++ b/packages/at_auth/lib/src/at_auth_impl.dart
@@ -380,17 +380,28 @@ class AtAuthImpl implements AtAuth {
   /// This method is used internally before onboarding or authentication operations.
   @override
   Future<void> validateAtServer(AuthRequest atRequest) async {
-    final maxRetries = atRequest.retryOptions.maxRetries;
-    final retryDelay = atRequest.retryOptions.retryDelay;
-    // Bound the TOTAL wall-clock across all retries with a single deadline, so
-    // this loop cannot multiply the inner (now individually-bounded) network
-    // waits into a minutes-long hang on a dead network. Defaults to the
-    // process-wide network timeout, capped at AtNetworkTimeouts.maxAllowed.
-    final deadline = DateTime.now().add(AtNetworkTimeouts.cap(
-        atRequest.retryOptions.overallTimeout ??
-            AtNetworkTimeouts.defaultTimeout));
-    int retryCount = 0;
+    // Floor the poll interval so a zero/tiny retryDelay can't hammer the network
+    // for the whole (possibly minutes-long) onboarding budget.
+    final retryDelay =
+        atRequest.retryOptions.retryDelay < const Duration(milliseconds: 100)
+            ? const Duration(milliseconds: 100)
+            : atRequest.retryOptions.retryDelay;
+    // Bound the TOTAL wall-clock of this poll with a single overall deadline.
+    // The two paths need opposite budgets: authentication of an EXISTING atSign
+    // must fail fast on a dead network (#1923), but ONBOARDING polls for a
+    // newly-registered atSign to be provisioned, which can take minutes. So the
+    // default depends on the request type. This budget bounds the whole poll and
+    // is deliberately NOT clamped to AtNetworkTimeouts.maxAllowed (that cap is
+    // for individual network operations); the retry COUNT no longer bounds the
+    // loop — the deadline does.
+    final overallTimeout = atRequest.retryOptions.overallTimeout ??
+        (atRequest is AtOnboardingRequest
+            ? AtNetworkTimeouts.defaultOnboardingTimeout
+            : AtNetworkTimeouts.effectiveDefault);
+    final deadline = DateTime.now().add(overallTimeout);
+    int attempt = 0;
     bool validated = false;
+    Object? lastError;
 
     //support mocking
     atServerStatus ??= AtStatusImpl(
@@ -398,12 +409,12 @@ class AtAuthImpl implements AtAuth {
       rootPort: atRequest.rootDomain.rootPort,
     );
 
-    while (retryCount < maxRetries && DateTime.now().isBefore(deadline)) {
-      retryCount++;
+    while (DateTime.now().isBefore(deadline)) {
+      attempt++;
       try {
         _addProgress(
             'Find',
-            '#[$retryCount/$maxRetries] : looking up ${atRequest.atSign} in atDirectory',
+            '#[$attempt] : looking up ${atRequest.atSign} in atDirectory',
             ProgressEventType.info);
 
         // Bound each network call by the budget remaining before the deadline,
@@ -460,7 +471,7 @@ class AtAuthImpl implements AtAuth {
         // AtServer availability probing
         _addProgress(
             'Connect',
-            '#[$retryCount/$maxRetries] : Connecting to ${atRequest.atSign} atServer',
+            '#[$attempt] : Connecting to ${atRequest.atSign} atServer',
             ProgressEventType.info);
 
         secondaryAddressFinder ??= CacheableSecondaryAddressFinder(
@@ -478,26 +489,19 @@ class AtAuthImpl implements AtAuth {
 
         _addProgress(
             'Connect',
-            '#[$retryCount/$maxRetries] : Connected to ${atRequest.atSign} atServer',
+            '#[$attempt] : Connected to ${atRequest.atSign} atServer',
             ProgressEventType.success);
 
         validated = true;
         break; // Exit loop if no exception occurs
       } catch (e) {
+        lastError = e;
         if (e is SocketException) {
-          _logger.warning(
-              'Attempt #[$retryCount/$maxRetries] Probe socket failed: $e');
+          _logger.warning('Attempt #[$attempt] Probe socket failed: $e');
         } else {
-          _logger.severe('Attempt #[$retryCount/$maxRetries] failed: $e');
+          _logger.severe('Attempt #[$attempt] failed: $e');
         }
-        if (retryCount >= maxRetries) {
-          _addProgress('Connect', '#[$retryCount/$maxRetries] : $e',
-              ProgressEventType.error);
-          throw AtAuthenticationException(
-              'Max retries reached while validating atSign server. Last error: $e');
-        }
-        _addProgress('Connect', '#[$retryCount/$maxRetries] : $e',
-            ProgressEventType.error);
+        _addProgress('Connect', '#[$attempt] : $e', ProgressEventType.error);
         // Don't sleep past the overall deadline before the next attempt.
         if (!DateTime.now().add(retryDelay).isBefore(deadline)) {
           break;
@@ -506,14 +510,12 @@ class AtAuthImpl implements AtAuth {
       }
     }
     if (!validated) {
-      // We left the loop because the overall deadline passed (success and
-      // retries-exhausted both throw above), so surface a timeout.
-      final budget = AtNetworkTimeouts.cap(
-          atRequest.retryOptions.overallTimeout ??
-              AtNetworkTimeouts.defaultTimeout);
+      // We left the loop because the overall deadline passed (success breaks out
+      // above). Surface a timeout with the last error seen.
       throw AtTimeoutException(
-          'Timed out after ${budget.inSeconds}s while reaching '
-          '${atRequest.atSign} atServer');
+          'Timed out after ${overallTimeout.inSeconds}s while reaching '
+          '${atRequest.atSign} atServer'
+          '${lastError == null ? '' : ' : $lastError'}');
     }
   }
 }

--- a/packages/at_auth/lib/src/at_auth_impl.dart
+++ b/packages/at_auth/lib/src/at_auth_impl.dart
@@ -382,7 +382,15 @@ class AtAuthImpl implements AtAuth {
   Future<void> validateAtServer(AuthRequest atRequest) async {
     final maxRetries = atRequest.retryOptions.maxRetries;
     final retryDelay = atRequest.retryOptions.retryDelay;
+    // Bound the TOTAL wall-clock across all retries with a single deadline, so
+    // this loop cannot multiply the inner (now individually-bounded) network
+    // waits into a minutes-long hang on a dead network. Defaults to the
+    // process-wide network timeout, capped at AtNetworkTimeouts.maxAllowed.
+    final deadline = DateTime.now().add(AtNetworkTimeouts.cap(
+        atRequest.retryOptions.overallTimeout ??
+            AtNetworkTimeouts.defaultTimeout));
     int retryCount = 0;
+    bool validated = false;
 
     //support mocking
     atServerStatus ??= AtStatusImpl(
@@ -390,7 +398,7 @@ class AtAuthImpl implements AtAuth {
       rootPort: atRequest.rootDomain.rootPort,
     );
 
-    while (retryCount < maxRetries) {
+    while (retryCount < maxRetries && DateTime.now().isBefore(deadline)) {
       retryCount++;
       try {
         _addProgress(
@@ -398,7 +406,12 @@ class AtAuthImpl implements AtAuth {
             '#[$retryCount/$maxRetries] : looking up ${atRequest.atSign} in atDirectory',
             ProgressEventType.info);
 
-        var atStatus = await atServerStatus!.get(atRequest.atSign);
+        // Bound each network call by the budget remaining before the deadline,
+        // so no single call can overshoot the overall timeout.
+        Duration remaining =
+            AtNetworkTimeouts.cap(deadline.difference(DateTime.now()));
+        var atStatus =
+            await atServerStatus!.get(atRequest.atSign).timeout(remaining);
 
         // 3 Checks for onboarding:
         //   1. Root server should be found
@@ -454,17 +467,21 @@ class AtAuthImpl implements AtAuth {
           atRequest.rootDomain.rootDomain,
           atRequest.rootDomain.rootPort,
         );
-        SecondaryAddress secondaryAddress =
-            await secondaryAddressFinder!.findSecondary(atRequest.atSign);
+        remaining = AtNetworkTimeouts.cap(deadline.difference(DateTime.now()));
+        SecondaryAddress secondaryAddress = await secondaryAddressFinder!
+            .findSecondary(atRequest.atSign, timeout: remaining);
 
+        remaining = AtNetworkTimeouts.cap(deadline.difference(DateTime.now()));
         await (probeSocket ?? _defaultProbeSocket)(
-            secondaryAddress.host, secondaryAddress.port);
+                secondaryAddress.host, secondaryAddress.port)
+            .timeout(remaining);
 
         _addProgress(
             'Connect',
             '#[$retryCount/$maxRetries] : Connected to ${atRequest.atSign} atServer',
             ProgressEventType.success);
 
+        validated = true;
         break; // Exit loop if no exception occurs
       } catch (e) {
         if (e is SocketException) {
@@ -481,8 +498,22 @@ class AtAuthImpl implements AtAuth {
         }
         _addProgress('Connect', '#[$retryCount/$maxRetries] : $e',
             ProgressEventType.error);
+        // Don't sleep past the overall deadline before the next attempt.
+        if (!DateTime.now().add(retryDelay).isBefore(deadline)) {
+          break;
+        }
         await Future.delayed(retryDelay); // Wait before retrying
       }
+    }
+    if (!validated) {
+      // We left the loop because the overall deadline passed (success and
+      // retries-exhausted both throw above), so surface a timeout.
+      final budget = AtNetworkTimeouts.cap(
+          atRequest.retryOptions.overallTimeout ??
+              AtNetworkTimeouts.defaultTimeout);
+      throw AtTimeoutException(
+          'Timed out after ${budget.inSeconds}s while reaching '
+          '${atRequest.atSign} atServer');
     }
   }
 }

--- a/packages/at_auth/lib/src/auth/models/at_auth_requests.dart
+++ b/packages/at_auth/lib/src/auth/models/at_auth_requests.dart
@@ -98,5 +98,16 @@ class RetryOptions {
   final int maxRetries;
   final Duration retryDelay;
 
-  const RetryOptions({required this.maxRetries, required this.retryDelay});
+  /// The maximum total wall-clock to spend reaching/validating the atServer,
+  /// across all [maxRetries] attempts. When null, the process-wide default
+  /// (`AtNetworkTimeouts.effectiveDefault`, 30s) is used; the resolved value is
+  /// always capped at `AtNetworkTimeouts.maxAllowed` (60s). This is what stops
+  /// the retry loop from multiplying the inner network waits into a
+  /// minutes-long hang on a dead network.
+  final Duration? overallTimeout;
+
+  const RetryOptions(
+      {required this.maxRetries,
+      required this.retryDelay,
+      this.overallTimeout});
 }

--- a/packages/at_auth/lib/src/auth/models/at_auth_requests.dart
+++ b/packages/at_auth/lib/src/auth/models/at_auth_requests.dart
@@ -98,12 +98,16 @@ class RetryOptions {
   final int maxRetries;
   final Duration retryDelay;
 
-  /// The maximum total wall-clock to spend reaching/validating the atServer,
-  /// across all [maxRetries] attempts. When null, the process-wide default
-  /// (`AtNetworkTimeouts.effectiveDefault`, 30s) is used; the resolved value is
-  /// always capped at `AtNetworkTimeouts.maxAllowed` (60s). This is what stops
-  /// the retry loop from multiplying the inner network waits into a
-  /// minutes-long hang on a dead network.
+  /// The maximum total wall-clock to spend reaching/validating the atServer —
+  /// the whole retry/poll loop. When null, the default depends on the request:
+  /// authentication uses the short process-wide default
+  /// (`AtNetworkTimeouts.effectiveDefault`, 30s) so a dead network fails fast,
+  /// while ONBOARDING uses `AtNetworkTimeouts.defaultOnboardingTimeout` (5 min)
+  /// because a newly-registered atSign can take minutes to be provisioned. This
+  /// bounds the loop and is deliberately NOT clamped to
+  /// `AtNetworkTimeouts.maxAllowed` — that cap applies to individual network
+  /// operations. Note [maxRetries] no longer bounds this loop; this deadline
+  /// does (the loop retries every [retryDelay] until the budget is spent).
   final Duration? overallTimeout;
 
   const RetryOptions(

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_auth
 description: Package that implements common logic for onboarding/authenticating an atsign to a secondary server
-version: 3.1.1
+version: 3.2.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_auth
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -11,7 +11,7 @@ resolution: workspace
 
 dependencies:
   at_server_status: ^1.1.0
-  at_commons: ^5.9.0
+  at_commons: ^5.13.0
   at_lookup: ^3.4.2
   at_chops: ^3.0.0
   at_utils: ^3.0.19

--- a/packages/at_auth/test/at_auth_test.dart
+++ b/packages/at_auth/test/at_auth_test.dart
@@ -97,6 +97,33 @@ void main() {
       expect(response.atAuthKeys!.enrollmentId, testEnrollmentId);
     });
 
+    test(
+        'validateAtServer honours overallTimeout instead of running all retries',
+        () async {
+      atAuth.secondaryAddressFinder = fakeSecondaryAddressFinder;
+      // Every probe fails, so without a deadline validateAtServer would retry
+      // maxRetries(10) x retryDelay(2s) ~= 20s. A short overallTimeout must cut
+      // that short and surface an AtTimeoutException.
+      atAuth.probeSocket = (host, port) async {
+        throw Exception('simulated unreachable atServer');
+      };
+      final atAuthRequest = AtAuthRequest('@alice🛠', atKeysIo: fileAtKeysIo)
+        ..enrollmentId = testEnrollmentId
+        ..retryOptions = const RetryOptions(
+            maxRetries: 10,
+            retryDelay: Duration(seconds: 2),
+            overallTimeout: Duration(milliseconds: 300));
+
+      final sw = Stopwatch()..start();
+      await expectLater(
+        atAuth.validateAtServer(atAuthRequest),
+        throwsA(isA<AtTimeoutException>()),
+      );
+      sw.stop();
+      expect(sw.elapsed, lessThan(const Duration(seconds: 5)),
+          reason: 'should honour overallTimeout (300ms), not 10 x 2s retries');
+    });
+
     test('Test authenticate() false with keys file', () async {
       when(() => mockAtLookUp.pkamAuthenticate(enrollmentId: testEnrollmentId))
           .thenAnswer((_) => Future.value(false));

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## 5.13.0
 
-- feat: add `AtNetworkTimeouts` — the process-wide network-timeout policy
-  (`defaultTimeout` = 30s, `maxAllowed` = 60s hard cap, `cap()`). The single
-  place to set the default network timeout for the whole SDK; every resolved
-  timeout is passed through `cap()` so nothing can wait longer than 60 seconds
-  (#1923).
+- feat: add `AtNetworkTimeouts` — the process-wide network-timeout policy:
+  `defaultTimeout` (30s, the per-attempt default), `maxAllowed` (60s hard cap on
+  any single network operation), `defaultOnboardingTimeout` (5 min — the poll
+  budget for waiting on a newly-registered atSign to be provisioned, deliberately
+  longer than the per-op cap), and `cap()`. The single place to set the SDK's
+  network timeouts (#1923).
 - feat: add `SecureSocketConfig.connectTimeout` so a connect deadline can be
   threaded through to `SecureSocket.connect`.
 

--- a/packages/at_commons/lib/src/security/at_network_timeouts.dart
+++ b/packages/at_commons/lib/src/security/at_network_timeouts.dart
@@ -1,9 +1,10 @@
 /// Process-wide network timeout policy for the Atsign SDK.
 ///
-/// Every network operation that can block — connecting to an atServer or the
-/// atDirectory, waiting for a response, and the retry loops around them — is
-/// bounded by a deadline derived from [defaultTimeout], and no effective
-/// timeout is ever allowed to exceed [maxAllowed].
+/// Every individual network operation that can block — connecting to an atServer
+/// or the atDirectory, or waiting for a response — is bounded and capped at
+/// [maxAllowed]. Retry/poll loops that repeat such operations (e.g. the
+/// onboarding provisioning wait, [defaultOnboardingTimeout]) are bounded by their
+/// own overall budget, which may be longer than [maxAllowed].
 ///
 /// This is the single place to change the default for the whole process: set
 /// [defaultTimeout] once (e.g. at app start). Individual call sites may override
@@ -14,16 +15,24 @@
 class AtNetworkTimeouts {
   AtNetworkTimeouts._();
 
-  /// The hard ceiling on any effective network timeout. Nothing waits longer
-  /// than this, regardless of what a caller requests. Callers may request up to
-  /// this much; the [defaultTimeout] (used when no explicit timeout is given)
-  /// is shorter.
+  /// The hard ceiling on any single network operation (a connect, an atDirectory
+  /// lookup, or a response wait). Nothing waits longer than this per operation,
+  /// regardless of what a caller requests. Note this bounds *operations*, not
+  /// retry/poll loops (see [defaultOnboardingTimeout]).
   static const Duration maxAllowed = Duration(seconds: 60);
 
-  /// The process-wide default network timeout. Change this once to move the
-  /// default everywhere. Always read through [cap] / [effectiveDefault] so it
-  /// can never exceed [maxAllowed].
+  /// The process-wide default network timeout for a single reach-the-atServer
+  /// attempt (the authentication path). Change this once to move the default
+  /// everywhere. Always read through [cap] / [effectiveDefault] so it can never
+  /// exceed [maxAllowed].
   static Duration defaultTimeout = const Duration(seconds: 30);
+
+  /// The default overall budget for the ONBOARDING poll: how long to wait for a
+  /// newly-registered atSign to be provisioned before giving up. Much longer than
+  /// [defaultTimeout] because provisioning can take minutes, and NOT capped by
+  /// [maxAllowed] — that cap is for individual operations, whereas this bounds a
+  /// whole retry/poll loop. Settable to change the default.
+  static Duration defaultOnboardingTimeout = const Duration(minutes: 5);
 
   /// Returns [d] clamped to the range `[Duration.zero, maxAllowed]`.
   static Duration cap(Duration d) {

--- a/packages/at_commons/test/at_network_timeouts_test.dart
+++ b/packages/at_commons/test/at_network_timeouts_test.dart
@@ -36,5 +36,17 @@ void main() {
       expect(AtNetworkTimeouts.effectiveDefault,
           lessThanOrEqualTo(AtNetworkTimeouts.maxAllowed));
     });
+
+    test('defaultOnboardingTimeout is 5 minutes and longer than defaultTimeout',
+        () {
+      expect(AtNetworkTimeouts.defaultOnboardingTimeout,
+          const Duration(minutes: 5));
+      // The onboarding poll waits for provisioning, so it must be much longer
+      // than the per-attempt default and is intentionally above the 60s op cap.
+      expect(AtNetworkTimeouts.defaultOnboardingTimeout,
+          greaterThan(AtNetworkTimeouts.defaultTimeout));
+      expect(AtNetworkTimeouts.defaultOnboardingTimeout,
+          greaterThan(AtNetworkTimeouts.maxAllowed));
+    });
   });
 }


### PR DESCRIPTION
## What I did

**Stage 2 of the network-timeout fix** (#1923), building on Stage 1 (#2072, merged). Stage 1 bounded the lowest network layer; this stage caps the wall-clock of `at_auth`'s retry loop, which was the outer multiplier of the "SDK hangs for minutes on a dead network" hang.

`AtAuthImpl.validateAtServer`'s retry loop had no wall-clock budget, so it multiplied the (now individually-bounded) atDirectory-lookup waits into a minutes-long hang.

A key nuance surfaced in review: `validateAtServer` serves **two paths that need opposite budgets** — **authentication** of an *existing* atSign must fail fast on a dead network, while **onboarding** of a *new* atSign must **poll for provisioning**, which can legitimately take minutes.

## How I did it

**at_commons (5.13.0, in-progress on trunk):**
- `AtNetworkTimeouts.defaultOnboardingTimeout` = 5 min — the poll budget for waiting on a newly-registered atSign to be provisioned. Deliberately longer than the 60s per-operation cap (`maxAllowed`), because that cap bounds *individual network operations*, not a poll loop.

**at_auth (3.2.0):**
- `RetryOptions.overallTimeout` — optional; when null the default depends on the request type: **authentication** uses `AtNetworkTimeouts.effectiveDefault` (30s) so a dead network fails fast; **onboarding** uses `defaultOnboardingTimeout` (5 min) so a new atSign has time to provision.
- `validateAtServer` computes one absolute deadline up front and is now **deadline-driven** — it retries every `retryDelay` until the budget is spent, then throws `AtTimeoutException`. Each inner call (`atStatus.get`, `findSecondary` (Stage 1's param), the connectivity probe) is bounded by the remaining budget and capped at 60s. **`RetryOptions.maxRetries` no longer bounds this loop** (the deadline does).

## How to verify it

    cd packages/at_auth && dart analyze lib test && dart test --concurrency=1 test/at_auth_test.dart
    cd ../at_commons && dart analyze lib test && dart test --concurrency=1 test/at_network_timeouts_test.dart

New tests: at_auth's "validateAtServer honours overallTimeout instead of running all retries" (failing probe + 300ms budget → `AtTimeoutException` in <5s); at_commons' "defaultOnboardingTimeout is 5 minutes and longer than defaultTimeout". All at_auth (11) + at_commons timeout tests pass; at_client / at_onboarding_cli / at_client_flutter analyze clean.

## Description for the changelog

- feat(at_commons): `AtNetworkTimeouts.defaultOnboardingTimeout` (5 min poll budget for new-atSign provisioning).
- feat(at_auth): `validateAtServer` bounded by a single deadline — auth fails fast (30s), onboarding polls for provisioning (5 min); loop is deadline-driven (`maxRetries` no longer bounds it).

---

**Stage 2 of 3.** Builds on #2072 (merged). Next: at_client/at_client_flutter wiring. Refs #1923, #1905, #1909.

Note: bumps at_auth → **3.2.0** (additive minor); `defaultOnboardingTimeout` folds into the in-progress at_commons 5.13.0. Say the word to adjust versions or the 5-minute onboarding default.
