### PR TITLE
feat(at_client): AtClientPreference.networkTimeout + flutter auth timeout (network-timeout stage 3)

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 3.13.0
+- feat: add `AtClientPreference.networkTimeout` — when set on the preference used
+  to create an `AtClient`, it becomes the process-wide network-timeout default
+  (`AtNetworkTimeouts.defaultTimeout`, capped at 60s), bounding every atServer
+  connect / atDirectory lookup / operation so a dead network can't hang the SDK.
+  Supersedes the misnamed `outboundConnectionTimeout` (a socket idle time).
+  Requires `at_commons ^5.13.0` (#1923).
 - refactor: migrate the local keystore to `at_persistence_secondary_server`
   5.0.0 — the client is now commit-log-free. The client no longer maintains a
   local commit log or runs commit-log compaction; sync tracks its progress

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -351,6 +351,14 @@ class AtClientImpl implements AtClient {
     _logger = AtSignLogger('AtClientImpl ($_atSign)');
     _preference = preference;
     _preference?.namespace ??= namespace;
+    // If the app configured a process-wide network timeout, apply it as the
+    // single default that bounds every atServer connect / atDirectory lookup /
+    // operation. Only mutates the global when explicitly set, so the built-in
+    // default otherwise stands.
+    if (preference.networkTimeout != null) {
+      AtNetworkTimeouts.defaultTimeout =
+          AtNetworkTimeouts.cap(preference.networkTimeout!);
+    }
     _localSecondaryKeyStore = localSecondaryKeyStore;
 
     if (_localSecondaryKeyStore != null && !_preference!.isLocalStoreRequired) {

--- a/packages/at_client/lib/src/preference/at_client_preference.dart
+++ b/packages/at_client/lib/src/preference/at_client_preference.dart
@@ -48,6 +48,16 @@ class AtClientPreference {
   /// Idle time in milliseconds of connection to secondary server. Default to 10 minutes.
   int outboundConnectionTimeout = 600000;
 
+  /// The process-wide default network timeout: the maximum wall-clock the SDK
+  /// will spend reaching/using the atServer (connect + retries + waiting for a
+  /// response) before giving up. When set on the `AtClientPreference` used to
+  /// create an `AtClient`, it becomes `AtNetworkTimeouts.defaultTimeout` for the
+  /// whole process (capped at `AtNetworkTimeouts.maxAllowed`, 60s). When null,
+  /// the existing default (30s) applies. This supersedes the misleadingly-named
+  /// [outboundConnectionTimeout], which is a socket idle time, not an
+  /// operation/connect timeout, and does not bound onboarding/auth.
+  Duration? networkTimeout;
+
   /// The maximum size of the value that a secondary server can store.
   /// [BufferOverFlowException] is thrown when size of the value exceeds the [maxDataSize]
   int maxDataSize = 10230000;

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   internet_connection_checker: ^1.0.0+1
   async: ^2.9.0
   at_base2e15: ^1.0.0
-  at_commons: ^5.9.0
+  at_commons: ^5.13.0
   at_utils: ^3.2.0
   at_chops: ^3.0.0
   at_lookup: ^3.1.0

--- a/packages/at_client_flutter/CHANGELOG.md
+++ b/packages/at_client_flutter/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 1.1.4
+
+- feat: `AuthService.onboard` / `authenticate` accept an optional `timeout` that
+  bounds the whole onboarding/auth attempt (sets `RetryOptions.overallTimeout`;
+  otherwise the process-wide `AtNetworkTimeouts` default applies). Requires
+  `at_auth ^3.2.0` (#1923).
+- fix: `FlutterEnrollmentService.enroll` no longer leaks the `AtLookupImpl`
+  connection when the enrollment submit fails — it now closes in a `finally`.
+
 ## 1.1.3
 
 - fix: force uppercase on OTP/CRAM input fields so lowercase or pasted alphanumeric codes no longer fail validation

--- a/packages/at_client_flutter/README.md
+++ b/packages/at_client_flutter/README.md
@@ -99,6 +99,60 @@ Full design, query-time aggregation semantics, and the seed-DB
 workflow for cross-window chart development are in
 [`examples/dockerstats/README.md`](examples/dockerstats/README.md).
 
+## Onboarding, provisioning & timeouts
+
+Registering a brand-new atSign and having its atServer **provisioned** are two
+separate steps — provisioning can lag registration by anything from seconds to a
+few minutes. The SDK handles that wait for you: `AuthService.onboard` polls for
+the atServer to come up for **5 minutes** by default
+(`AtNetworkTimeouts.defaultOnboardingTimeout`), retrying every `retryDelay` with
+each individual network probe capped at 60s. Returning-user sign-in
+(`authenticate`) instead **fails fast** at 30s, because an existing atSign is
+already provisioned and a dead network there should surface quickly.
+
+What a Flutter app should do:
+
+1. **Call `onboard()` with no `timeout`.** The 5-minute provisioning poll is
+   built in — don't wrap your own retry loop around it (that just re-stacks the
+   retries this design removed).
+
+2. **Show progress from `AuthService.progressStream`, not a blind spinner.** A
+   multi-minute wait behind an indeterminate spinner reads as "hung." Subscribe
+   *before* calling `onboard` — it's a broadcast stream and won't replay events
+   you missed:
+
+   ```dart
+   final sub = authService.progressStream.listen((e) {
+     setState(() => _status = e.msg); // e.type: info / success / warning / error
+   });
+   try {
+     await authService.onboard(request, cramSecret); // no timeout → full 5-min poll
+   } on AtTimeoutException {
+     // provisioning still not ready after 5 minutes — offer Retry (step 3)
+   } finally {
+     await sub.cancel();
+   }
+   ```
+
+3. **On `AtTimeoutException`, offer *Retry* rather than a longer timeout.** In the
+   rare case provisioning runs past 5 minutes, a "Still setting up your atSign —
+   tap to keep waiting" button that re-calls `onboard()` (a fresh 5-minute poll)
+   beats baking in a 15-minute single timeout that makes every genuine failure
+   feel broken.
+
+4. **Override `timeout` only to *widen* the window, and only when you know the
+   provisioner is slow** — e.g. a self-hosted atServer or custom atDirectory.
+   Never pass a *short* `timeout` to `onboard()` for a new atSign; it truncates
+   the very wait you need.
+
+5. **Returning users go through `authenticate()`** and keep the 30s fail-fast —
+   don't borrow onboarding's patience for routine sign-in.
+
+> **Note:** `onboard()` has no cancellation token, so the 5-minute poll runs to
+> completion or timeout even if the user navigates away — a "Cancel" button can
+> only change the UI, not abort the in-flight poll. True cancellation is tracked
+> in [#2075](https://github.com/atsign-foundation/at_client_sdk/issues/2075).
+
 ## Post-authentication initialization
 
 Every auth flow ends the same way: create an `AtClientPreference`, then

--- a/packages/at_client_flutter/lib/src/services/auth_service.dart
+++ b/packages/at_client_flutter/lib/src/services/auth_service.dart
@@ -22,11 +22,19 @@ class AuthService {
   /// Returns [AtOnboardingResponse] which contains keys and status of onboarding
   Future<AtOnboardingResponse> onboard(
     AtOnboardingRequest request,
-    String cramSecret,
-  ) async {
+    String cramSecret, {
+    Duration? timeout,
+  }) async {
     AtOnboardingResponse? atOnboardingResponse;
     try {
       request.atKeysIo ??= KeychainAtKeysIo();
+      if (timeout != null) {
+        request.retryOptions = RetryOptions(
+          maxRetries: request.retryOptions.maxRetries,
+          retryDelay: request.retryOptions.retryDelay,
+          overallTimeout: timeout,
+        );
+      }
       atOnboardingResponse = await _atAuth.onboard(request, cramSecret);
     } catch (e) {
       rethrow;
@@ -44,9 +52,17 @@ class AuthService {
   Future<AtAuthResponse> authenticate(
     AtAuthRequest atAuthRequest, {
     List<WrittenAtKeysIo>? backupKeys,
+    Duration? timeout,
   }) async {
     AtAuthResponse? atAuthResponse;
     try {
+      if (timeout != null) {
+        atAuthRequest.retryOptions = RetryOptions(
+          maxRetries: atAuthRequest.retryOptions.maxRetries,
+          retryDelay: atAuthRequest.retryOptions.retryDelay,
+          overallTimeout: timeout,
+        );
+      }
       atAuthResponse = await _atAuth.authenticate(atAuthRequest);
       if (backupKeys != null &&
           atAuthResponse.atAuthKeys != null &&

--- a/packages/at_client_flutter/lib/src/services/auth_service.dart
+++ b/packages/at_client_flutter/lib/src/services/auth_service.dart
@@ -19,6 +19,16 @@ class AuthService {
   ///
   ///   [cramSecret] - Cram secret
   ///
+  ///   [timeout] - Overall wall-clock budget for the whole onboarding attempt,
+  ///   including the poll that waits for a newly-registered atSign to be
+  ///   provisioned. **Leave this null** to keep the default provisioning poll
+  ///   (`AtNetworkTimeouts.defaultOnboardingTimeout`, 5 minutes) — a new atSign
+  ///   can take minutes to provision, and a short value here truncates that
+  ///   wait, so onboarding may time out before the atServer comes up. Pass a
+  ///   value only to deliberately widen the window (e.g. an unusually slow
+  ///   provisioner) or narrow it. It bounds the overall poll, not each probe:
+  ///   individual network calls stay capped at 60s regardless.
+  ///
   /// Returns [AtOnboardingResponse] which contains keys and status of onboarding
   Future<AtOnboardingResponse> onboard(
     AtOnboardingRequest request,
@@ -47,6 +57,13 @@ class AuthService {
   ///   [atAuthRequest] - AtAuthRequest containing atSign, AtRootDomain, AtKeysIo.
   ///
   ///		[backupKeys] - Optional Parameter allowing for your keys to be backed up via provided WrittenAtKeysIo implementations
+  ///
+  ///   [timeout] - Overall wall-clock budget for the authentication attempt.
+  ///   Leave null to use the default (`AtNetworkTimeouts.effectiveDefault`,
+  ///   30s), which fails fast when the atServer is unreachable. Unlike
+  ///   [onboard], this path authenticates an *existing* atSign, so there is no
+  ///   provisioning wait to accommodate — override only to tune the fail-fast
+  ///   window.
   ///
   /// Returns [AtAuthResponse] which contains keys and status of authentication
   Future<AtAuthResponse> authenticate(

--- a/packages/at_client_flutter/lib/src/services/enrollment_service.dart
+++ b/packages/at_client_flutter/lib/src/services/enrollment_service.dart
@@ -58,8 +58,11 @@ class FlutterEnrollmentService {
       atEnrollmentResponse = await _atEnrollment.submit(request, atLookup);
     } catch (e, s) {
       throw Exception('Enrollment failed: $e \n $s');
+    } finally {
+      // Always close the connection, including when submit() throws (a timeout
+      // or a network failure) — otherwise the AtLookupImpl connection leaks.
+      await atLookup.close();
     }
-    await atLookup.close();
 
     if (atEnrollmentResponse.atAuthKeys != null) {
       EnrollmentData enrollmentData = EnrollmentData(

--- a/packages/at_client_flutter/pubspec.yaml
+++ b/packages/at_client_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_client_flutter
 description: A Flutter extension to the at_client library which adds support for mobile, desktop and IoT devices.
-version: 1.1.3
+version: 1.1.4
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_client_flutter
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -19,7 +19,7 @@ dependencies:
   at_utils: ^3.4.0
   at_chops: ^3.0.0
   at_lookup: ^3.5.0
-  at_auth: ^3.0.1
+  at_auth: ^3.2.0
   at_client: ^3.11.0
   encrypt: ^5.0.3
   intl: ^0.20.2


### PR DESCRIPTION
## What I did

**Stage 3 (final) of the network-timeout fix** (#1923), on top of Stage 1 (#2072, merged) and Stage 2 (#2073, merged). The foundation (per-op timeouts) and the at_auth deadline are in; this stage exposes the app-facing knobs, fixes a connection leak, and documents the onboarding-vs-auth timeout distinction for app authors.

## How I did it

**at_client (3.13.0):**
- `AtClientPreference.networkTimeout` — when set on the preference used to create an `AtClient`, it becomes the process-wide `AtNetworkTimeouts.defaultTimeout` (capped 60s), bounding every atServer connect / atDirectory lookup / operation. Supersedes the misnamed `outboundConnectionTimeout` (a socket idle time, not an operation timeout).

**at_client_flutter (1.1.4):**
- `AuthService.onboard` / `authenticate` accept an optional `timeout` that bounds the whole onboarding/auth attempt (sets `RetryOptions.overallTimeout`; otherwise the process-wide `AtNetworkTimeouts` policy applies — auth 30s, onboarding 5 min).
- `FlutterEnrollmentService.enroll` now closes the `AtLookupImpl` connection in a `finally`, fixing a leak when the enrollment submit throws (a timeout or a network failure).
- **Docs:** an "Onboarding, provisioning & timeouts" section in the README, and expanded `onboard`/`authenticate` dartdocs, so app authors know to leave `timeout` null for the 5-minute provisioning poll (and that a short value truncates it). See [Additional context](#additional-context) below.

**Follow-up filed:** the provisioning poll is not cancellable in-flight — `onboard()` has no cancellation token, so its `Future` runs to completion/timeout even if the user navigates away. Tracked as a feature request in #2075 (referenced from the README note).

## How to verify it

    cd packages/at_client
    dart analyze lib test
    dart test --concurrency=1 test/at_client_impl_test.dart
    cd ../at_client_flutter
    dart analyze lib test
    flutter test --concurrency=1

All 20 at_client construction tests and 14 at_client_flutter tests (incl. `auth_service_test`) pass; both analyze clean.

## Description for the changelog

- feat(at_client): `AtClientPreference.networkTimeout` — a single knob to set the process-wide network timeout.
- feat(at_client_flutter): optional `timeout` on `AuthService.onboard`/`authenticate`; fix a connection leak in `FlutterEnrollmentService.enroll`.

---

**Stage 3 of 3 (final).** Builds on #2072 + #2073 (merged) — completes the #1923 network-timeout fix. Refs #1905, #1909. Opens follow-up #2075 (cancellation).

Note: at_client folds under the in-progress 3.13.0; at_client_flutter → **1.1.4** (additive minor). ⚠️ **#2070 (the dialog fix) also targets 1.1.4 and is still open** — whichever of these two merges *second* will need to bump to 1.1.5.

## Additional context

This stage documents a distinction that surfaced in review and isn't obvious from the API alone: **registering a new atSign and having its atServer *provisioned* are two separate steps**, and provisioning can lag registration by anything from seconds to a few minutes. So the two auth entry points get deliberately opposite budgets:

- **`onboard`** (new atSign) polls for the atServer to come up for **5 minutes** by default (`AtNetworkTimeouts.defaultOnboardingTimeout`), retrying every `retryDelay` with each individual network probe capped at 60s. The 5 minutes is a *retry* budget, not a single wait.
- **`authenticate`** (existing atSign) **fails fast at 30s** — it's already provisioned, so a dead network should surface quickly.

Setting `AtClientPreference.networkTimeout` does **not** shrink the provisioning wait: it writes `AtNetworkTimeouts.defaultTimeout` (the per-op / auth default), never `defaultOnboardingTimeout`. The one crossover is `AuthService.onboard(timeout:)` — an explicit value overrides the 5-minute default, so a short value there truncates the provisioning poll (the footgun the new dartdoc calls out).

Guidance added to the at_client_flutter README for app authors — call `onboard()` with no `timeout`, drive the UI from `AuthService.progressStream`, and use an app-level Retry on `AtTimeoutException` rather than a giant single timeout:

```dart
final sub = authService.progressStream.listen((e) {
  setState(() => _status = e.msg); // e.type: info / success / warning / error
});
try {
  await authService.onboard(request, cramSecret); // no timeout → full 5-min poll
} on AtTimeoutException {
  // provisioning still not ready after 5 minutes — offer Retry
} finally {
  await sub.cancel();
}
```

Because `onboard()` can't be cancelled mid-poll today, the README flags it and points at #2075 for true cancellation.
