### PR TITLE
feat: configurable cache duration for CacheableSecondaryAddressFinder

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,15 +1,7 @@
 ## 3.7.0
 
-- feat: `CacheableSecondaryAddressFinder` accepts an optional `cacheDuration`
-  constructor parameter, so callers that need faster recovery from a stale
-  secondary address (e.g. after an atSign reset) can pass a shorter TTL
-  instead of the fixed 1-hour default. `defaultCacheDuration` is unchanged, so
-  existing callers see no behavior change.
-- fix(deps): `at_chops` constraint corrected to `^3.3.0` — `cramAuthenticate`
-  calls `SHA512HashingAlgo` from `package:at_chops/at_chops.dart`, which the
-  package's barrel file only exports starting at `3.3.0`; the previous
-  `^3.0.0` constraint let dependents resolve an `at_chops` that fails to
-  compile against this package.
+- feat: `CacheableSecondaryAddressFinder` takes an optional `cacheDuration` to override the default 1-hour cache TTL.
+- fix(deps): correct the `at_chops` constraint to `^3.3.0`, the actual minimum this package compiles against.
 
 ## 3.6.0
 

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 3.7.0
+
+- feat: `CacheableSecondaryAddressFinder` accepts an optional `cacheDuration`
+  constructor parameter, so callers that need faster recovery from a stale
+  secondary address (e.g. after an atSign reset) can pass a shorter TTL
+  instead of the fixed 1-hour default. `defaultCacheDuration` is unchanged, so
+  existing callers see no behavior change.
+- fix(deps): `at_chops` constraint corrected to `^3.3.0` — `cramAuthenticate`
+  calls `SHA512HashingAlgo` from `package:at_chops/at_chops.dart`, which the
+  package's barrel file only exports starting at `3.3.0`; the previous
+  `^3.0.0` constraint let dependents resolve an `at_chops` that fails to
+  compile against this package.
+
 ## 3.6.0
 
 - refactor: route PKAM/CRAM signing + hashing through at_chops

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 3.7.0
 
 - feat: `CacheableSecondaryAddressFinder` takes an optional `cacheDuration` to override the default 1-hour cache TTL.
-- fix(deps): correct the `at_chops` constraint to `^3.3.0`, the actual minimum this package compiles against.
+- fix(deps): updated the `at_chops` constraint to `^3.3.0`, the actual minimum this package compiles against.
 
 ## 3.6.0
 

--- a/packages/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
+++ b/packages/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
@@ -8,7 +8,7 @@ import 'package:at_lookup/src/util/lookup_util.dart';
 import 'package:at_utils/at_logger.dart';
 
 class CacheableSecondaryAddressFinder implements SecondaryAddressFinder {
-  static const Duration defaultCacheDuration = Duration(hours: 1);
+  static const Duration defaultCacheDuration = Duration(minutes: 1);
 
   final Map<String, SecondaryAddressCacheEntry> _map = {};
   final _logger = AtSignLogger('AtServerAddressCacheImpl');

--- a/packages/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
+++ b/packages/at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart
@@ -8,17 +8,21 @@ import 'package:at_lookup/src/util/lookup_util.dart';
 import 'package:at_utils/at_logger.dart';
 
 class CacheableSecondaryAddressFinder implements SecondaryAddressFinder {
-  static const Duration defaultCacheDuration = Duration(minutes: 1);
+  static const Duration defaultCacheDuration = Duration(hours: 1);
 
   final Map<String, SecondaryAddressCacheEntry> _map = {};
   final _logger = AtSignLogger('AtServerAddressCacheImpl');
 
   final String _rootDomain;
   final int _rootPort;
+  final Duration _cacheDuration;
   late SecondaryUrlFinder _secondaryFinder;
 
   CacheableSecondaryAddressFinder(this._rootDomain, this._rootPort,
-      {SecondaryUrlFinder? secondaryFinder, SecureSocketConfig? socketConfig}) {
+      {Duration? cacheDuration,
+      SecondaryUrlFinder? secondaryFinder,
+      SecureSocketConfig? socketConfig})
+      : _cacheDuration = cacheDuration ?? defaultCacheDuration {
     _secondaryFinder = secondaryFinder ??
         SecondaryUrlFinder(_rootDomain, _rootPort, socketConfig: socketConfig);
   }
@@ -49,7 +53,7 @@ class CacheableSecondaryAddressFinder implements SecondaryAddressFinder {
 
     if (_cacheIsEmptyOrExpired(atSign)) {
       // _updateCache will either populate the cache, or throw an exception
-      await _updateCache(atSign, defaultCacheDuration, deadline);
+      await _updateCache(atSign, _cacheDuration, deadline);
     }
     if (_map.containsKey(atSign)) {
       // should always be true, since _updateCache will throw an exception if it fails

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.6.0
+version: 3.7.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_lookup
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -14,7 +14,7 @@ dependencies:
   at_commons: ^5.13.0
   mutex: ^3.0.0
   meta: ^1.16.0
-  at_chops: ^3.0.0
+  at_chops: ^3.3.0
 
 dev_dependencies:
   mocktail: ^1.0.4

--- a/packages/at_lookup/test/secondary_address_cache_test.dart
+++ b/packages/at_lookup/test/secondary_address_cache_test.dart
@@ -115,6 +115,22 @@ void main() async {
       expect((approxExpiry - cache.getCacheExpiryTime(atSign)!) < 100, true);
     });
 
+    test('test expiry time - custom cache expiry passed to constructor',
+        () async {
+      var atSign = 'registeredAtSign1';
+      final customCache = CacheableSecondaryAddressFinder(
+          rootDomain, rootPort,
+          secondaryFinder: mockSecondaryFinder,
+          cacheDuration: Duration(minutes: 1));
+      await customCache.findSecondary(atSign);
+      final approxExpiry =
+          DateTime.now().add(Duration(minutes: 1)).millisecondsSinceEpoch;
+      expect(customCache.getCacheExpiryTime(atSign), isNotNull);
+      expect(
+          (approxExpiry - customCache.getCacheExpiryTime(atSign)!) < 100,
+          true);
+    });
+
     // TODO Why are these tests commented out?
 //    test('test expiry time  - custom cache expiry for registeredAtSign1',
 //        () async {


### PR DESCRIPTION
## What
- Make cache duration configurable for CacheableSecondaryAddressFinder.

<!-- What does this PR do? Describe the change and the problem it solves. -->

## How
- Add an optional param `cacheDuration` to `CacheableSecondaryAddressFinder`'s constructor.
<!-- How was this implemented? Include any key decisions or trade-offs. -->

## How to verify

<!-- Steps to verify the change works as expected. -->

1. Tests pass
2. Cache should respect the configured duration.

## Skills impact

If this PR changes a public API in `at_client`, `at_client_flutter`, or `at_auth`,
consider whether `packages/at_client_skills/` needs a follow-up release.

- [x] No public API change — skill unaffected
- [ ] Public API changed — I have opened or will open an `at_client_skills` PR to reflect this
