### PR TITLE
build(deps): raise at_lookup/at_auth floors for the network-timeout API

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -11,6 +11,9 @@
   lookup and the connectivity probe) is bounded by the remaining budget and capped
   at 60s. **`RetryOptions.maxRetries` no longer bounds this loop** (the deadline
   does) (#1923). Requires `at_commons ^5.13.0`.
+- chore(deps): `at_lookup: ^3.6.0` — `validateAtServer` passes the `timeout`
+  parameter that `SecondaryAddressFinder.findSecondary` gained in at_lookup
+  3.6.0, so this version does not compile against at_lookup ≤3.5.x.
 
 ## 3.1.1
 - refactor: route enrollment RSA (encrypt/decrypt `apkamSymmetricKey` under the default encryption keypair) through at_chops (`RsaEncryptionAlgo`) — `crypton` no longer imported in `lib` and moved to `dev_dependencies` (only the enrollment test still uses it for RSA keypair fixtures). Same framing, byte-identical by construction.

--- a/packages/at_auth/pubspec.yaml
+++ b/packages/at_auth/pubspec.yaml
@@ -12,7 +12,7 @@ resolution: workspace
 dependencies:
   at_server_status: ^1.1.0
   at_commons: ^5.13.0
-  at_lookup: ^3.4.2
+  at_lookup: ^3.6.0
   at_chops: ^3.0.0
   at_utils: ^3.0.19
   http: ^1.2.1

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -5,6 +5,9 @@
   connect / atDirectory lookup / operation so a dead network can't hang the SDK.
   Supersedes the misnamed `outboundConnectionTimeout` (a socket idle time).
   Requires `at_commons ^5.13.0` (#1923).
+- chore(deps): `at_lookup: ^3.6.0`, `at_auth: ^3.2.0` — the bounded socket
+  connects and the deadline-driven `validateAtServer` live in those versions;
+  with older ones resolved, `networkTimeout` would set a policy nothing reads.
 - refactor: migrate the local keystore to `at_persistence_secondary_server`
   5.0.0 — the client is now commit-log-free. The client no longer maintains a
   local commit log or runs commit-log compaction; sync tracks its progress

--- a/packages/at_client/example/pubspec.yaml
+++ b/packages/at_client/example/pubspec.yaml
@@ -24,6 +24,10 @@ dependency_overrides:
     path: ../../at_chops
   at_commons:
     path: ../../at_commons
+  at_lookup:
+    path: ../../at_lookup
+  at_auth:
+    path: ../../at_auth
   at_onboarding_cli:
     path: ../../at_onboarding_cli
 

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -30,8 +30,8 @@ dependencies:
   at_commons: ^5.13.0
   at_utils: ^3.2.0
   at_chops: ^3.0.0
-  at_lookup: ^3.1.0
-  at_auth: ^3.0.0
+  at_lookup: ^3.6.0
+  at_auth: ^3.2.0
   at_persistence_secondary_server: ^5.1.0
   hive: ^2.2.3
   meta: ^1.16.0

--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -6,6 +6,9 @@
 - feat: activate_cli: new `decrypt` command outputs a passphrase-decrypted version of the atKeys file
 - feat: activate_cli: version is now shown via `--version`, `--help`, and `help`
 - fix: at_onboarding_cli now subscribes to at_auth progress stream events
+- chore(deps): `at_auth: ^3.2.0`, `at_lookup: ^3.6.0` — onboarding/auth network
+  waits are time-bounded (deadline-driven `validateAtServer`, bounded
+  atDirectory lookups) only with these versions resolved.
 
 ## 1.15.0
 

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -20,11 +20,11 @@ dependencies:
   meta: ^1.16.0
   path: ^1.9.0
   zxing2: ^0.2.0
-  at_auth: ^3.0.0
+  at_auth: ^3.2.0
   at_chops: ^3.0.0
   at_client: ^3.10.0
   at_commons: ^5.6.0
-  at_lookup: ^3.4.2
+  at_lookup: ^3.6.0
   at_server_status: ^1.0.5
   at_utils: ^3.2.0
   duration: ^4.0.3


### PR DESCRIPTION
## What I did

Raised dependency floors so the network-timeout work (#2072/#2073/#2074) is correctly declared before we publish the pending versions. One of these is a **publish blocker**:

- **at_auth → `at_lookup: ^3.6.0`** (was `^3.4.2`) — **compile break**: `validateAtServer` passes the `timeout:` parameter that `SecondaryAddressFinder.findSecondary` gained in at_lookup 3.6.0. pub.dev's publish validation would not catch this (3.5.0 satisfies `^3.4.2`), so at_auth 3.2.0 would ship non-compiling for any consumer resolving at_lookup ≤3.5.x.
- **at_client → `at_lookup: ^3.6.0`, `at_auth: ^3.2.0`** (were `^3.1.0` / `^3.0.0`) — feature floors: the bounded socket connects and the deadline-driven `validateAtServer` live in those versions. With older ones resolved, `AtClientPreference.networkTimeout` sets a policy nothing reads.
- **at_onboarding_cli → `at_auth: ^3.2.0`, `at_lookup: ^3.6.0`** (were `^3.0.0` / `^3.4.2`) — feature floors: onboarding is the path where the unbounded dead-network hang manifested; these guarantee the time-bounded behaviour.

## How I did it

- Pubspec floor changes in the three packages; CHANGELOG notes folded under the existing in-progress headings (at_auth 3.2.0, at_client 3.13.0, at_onboarding_cli 1.16.0) — **no version bumps**, none is published yet.
- `packages/at_client/example/pubspec.yaml` gains `at_lookup` + `at_auth` path overrides — the example is not a workspace member, so without them it resolves the new (unpublished) floors against pub.dev and version solving fails.
- Blast-radius sweep: grepped every workspace pubspec's `at_lookup`/`at_auth`/`at_commons` constraints and every caller of the new APIs (`findSecondary(timeout:)`, `AtNetworkTimeouts`, `RetryOptions.overallTimeout`). at_client_flutter already declares `at_auth: ^3.2.0` ✓; no other package uses the new APIs; no production implementers of `SecondaryAddressFinder` outside at_lookup.

## How to verify it

    dart pub get                       # workspace + all examples resolve
    cd packages/at_auth && dart analyze lib        # 0 errors/warnings
    cd ../at_client && dart analyze lib            # 0 errors/warnings
    cd ../at_onboarding_cli && dart analyze lib    # 0 errors/warnings

Negative check (the bug this prevents): `dart pub add at_auth:3.2.0 at_lookup:3.5.0` in a scratch package after publishing without this fix would fetch a non-compiling at_auth.

## Description for the changelog

- chore(deps): at_auth requires `at_lookup ^3.6.0` (compile dependency); at_client and at_onboarding_cli require `at_lookup ^3.6.0` + `at_auth ^3.2.0` so their documented time-bounded network behaviour is guaranteed by resolution.

---

**Publish sequencing context:** this gates the pending publish run — at_commons 5.13.0 → at_lookup 3.6.0 → at_auth 3.2.0 → at_client 3.13.0 (→ frees #2037 to take 3.14.0). Note: #2070 touches the adjacent CHANGELOG lines in at_auth/at_client (the #1923→#1909 reference fix); whichever merges second may need a trivial conflict resolution.
