### PR TITLE
chore(at_lookup): fold 3.7.0 entries back into unpublished 3.6.0

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 3.7.0
+## 3.6.0
 
 - feat: `CacheableSecondaryAddressFinder` takes an optional `cacheDuration` to override the default 1-hour cache TTL.
 - fix(deps): updated the `at_chops` constraint to `^3.3.0`, the actual minimum this package compiles against.
-
-## 3.6.0
-
 - refactor: route PKAM/CRAM signing + hashing through at_chops
   (`PkamSigningAlgo` / `SHA512HashingAlgo`); `crypton` and `crypto` are no
   longer imported anywhere in the package and have been dropped from

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.7.0
+version: 3.6.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_lookup
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
**- What I did**

- at_lookup back to **3.6.0**: pub.dev is at 3.5.0 and 3.6.0 (network timeouts) is the in-progress unpublished slot, so the `cacheDuration` / at_chops-constraint entries fold under the 3.6.0 heading instead of opening 3.7.0
- no consumer floor exceeds `^3.6.0`

**- How I did it**

See commit & diff

**- How to verify it**

CHANGELOG/pubspec-only change; CI green

**- Description for the changelog**

chore(at_lookup): fold 3.7.0 entries back into unpublished 3.6.0
