### PR TITLE
feat(pq): nskey data path providers (B-1a, B-1b)

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -4,9 +4,15 @@
   `at/nskey` conveys that CK by X-Wing-sealing it to the namespace's `nskey`
   and writing it as a discrete `<ckKid>.__ck` record. Data values cite the CK
   by `ckKid` and carry no sealed key inline; the CK cache is keyed
-  `(owner, namespace, ckKid)`. `NskeyKeyRing` is the seam the secret-sharing
-  substrate lands behind — an experimental surface, not yet routed by
-  `CryptoRuntime` (#2089, #2090).
+  `(owner, namespace, ckKid)`, and only the client that cut a CK makes it the
+  key new writes use. Binary values honour `isBinary` and round-trip byte-exact.
+  A cited CK that has not arrived yet raises `ContentKeyUnavailableException`,
+  which a caller can distinguish from a hard decryption failure and retry.
+  `NskeyKeyRing` is the seam the secret-sharing substrate lands behind — an
+  experimental surface, not yet routed by `CryptoRuntime` (#2089, #2090).
+- build: raise the `at_chops` floor to `^3.4.0` — the nskey providers name
+  `AtKemAlgorithm` through the `at_chops` barrel, which only exports the
+  algorithm interfaces from 3.4.0.
 - fix: `AtCollection` — resolve received (shared-in) items in the id-scoped
   read path. `Query.watch()` (delta path), `getOrNull` / `get(id, owner)` and
   `exists(id, owner)` missed items stored locally as

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## 3.14.1
+- feat: `nskey` data path providers — `at/symmetric/AES/GCM` encrypts
+  application data with AES-256-GCM under a symmetric content key (CK), and
+  `at/nskey` conveys that CK by X-Wing-sealing it to the namespace's `nskey`
+  and writing it as a discrete `<ckKid>.__ck` record. Data values cite the CK
+  by `ckKid` and carry no sealed key inline; the CK cache is keyed
+  `(owner, namespace, ckKid)`. `NskeyKeyRing` is the seam the secret-sharing
+  substrate lands behind — an experimental surface, not yet routed by
+  `CryptoRuntime` (#2089, #2090).
 - fix: `AtCollection` — resolve received (shared-in) items in the id-scoped
   read path. `Query.watch()` (delta path), `getOrNull` / `get(id, owner)` and
   `exists(id, owner)` missed items stored locally as

--- a/packages/at_client/lib/src/crypto/nskey/content_key.dart
+++ b/packages/at_client/lib/src/crypto/nskey/content_key.dart
@@ -13,7 +13,13 @@ class ContentKey {
   final Uint8List bytes;
 
   /// The content key's id — a SHA-256 prefix of the key material, so identical
-  /// keys dedupe. Unique within `(owner, namespace)`.
+  /// keys dedupe. Must be unique within `(owner, namespace)`;
+  /// [ContentKeyCache.put] refuses a second CK claiming a kid already held.
+  ///
+  /// The id is public — it rides plaintext `appMetadata` and the conveyance
+  /// record's name — so it is only safe while CKs are high-entropy: publishing
+  /// 64 bits of a hash turns any guessable CK into an offline check. Mint CKs
+  /// from a CSPRNG, never derive them from a label, counter or passphrase.
   final String ckKid;
 
   ContentKey._(this.bytes, this.ckKid);
@@ -21,7 +27,8 @@ class ContentKey {
   /// Derive the id for [bytes] and pair them.
   factory ContentKey(Uint8List bytes) {
     if (bytes.length != 32) {
-      throw ArgumentError('a content key must be 32 bytes, got ${bytes.length}');
+      throw ArgumentError(
+          'a content key must be 32 bytes, got ${bytes.length}');
     }
     final digest = sha256.convert(bytes).toString();
     return ContentKey._(bytes, digest.substring(0, 16));
@@ -49,11 +56,39 @@ class ContentKeyCache {
   static String _key(String owner, String namespace, String ckKid) =>
       '${_scope(owner, namespace)}|$ckKid';
 
-  /// Cache [ck] for `(owner, namespace)` and make it the namespace's current
-  /// key — the one new writes encrypt under.
+  /// Cache [ck] for `(owner, namespace)` so values citing its `ckKid` resolve.
+  ///
+  /// This does **not** make it the namespace's current key. Conveyance records
+  /// arrive in sync order, which is no order at all, so a CK opened now may be
+  /// older than the one already in use — letting an arriving record set the
+  /// write key would silently roll new writes back onto a superseded CK.
+  /// Only the client that cut the CK calls [putAsCurrent].
   void put(String owner, String namespace, ContentKey ck) {
-    _byKid[_key(owner, namespace, ck.ckKid)] = ck;
+    final slot = _key(owner, namespace, ck.ckKid);
+    final existing = _byKid[slot];
+    if (existing != null && !_sameKey(existing.bytes, ck.bytes)) {
+      // A kid is a truncated hash, so this is a collision, not a re-delivery.
+      // Overwriting would make the displaced CK's data silently undecryptable.
+      throw StateError(
+          'content key ${ck.ckKid} in $owner:$namespace already holds different '
+          'key material — two distinct CKs share one kid');
+    }
+    _byKid[slot] = ck;
+  }
+
+  /// Cache [ck] and make it the key new writes in `(owner, namespace)` encrypt
+  /// under. Called by the writer that cut the CK and conveyed it.
+  void putAsCurrent(String owner, String namespace, ContentKey ck) {
+    put(owner, namespace, ck);
     _currentKidByNamespace[_scope(owner, namespace)] = ck.ckKid;
+  }
+
+  static bool _sameKey(Uint8List a, Uint8List b) {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; i++) {
+      if (a[i] != b[i]) return false;
+    }
+    return true;
   }
 
   /// The CK cited by [ckKid], or null on a cache miss.

--- a/packages/at_client/lib/src/crypto/nskey/content_key.dart
+++ b/packages/at_client/lib/src/crypto/nskey/content_key.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart' show sha256;
+
+/// A symmetric content key (CK) and its id.
+///
+/// Application data is AES-256-GCM encrypted under a CK; the CK itself is
+/// X-Wing-sealed once to an nskey and written as a discrete conveyance record.
+/// Data values cite the CK by [ckKid] and never carry a sealed key inline.
+class ContentKey {
+  /// Raw 32 bytes of AES-256 key material.
+  final Uint8List bytes;
+
+  /// The content key's id — a SHA-256 prefix of the key material, so identical
+  /// keys dedupe. Unique within `(owner, namespace)`.
+  final String ckKid;
+
+  ContentKey._(this.bytes, this.ckKid);
+
+  /// Derive the id for [bytes] and pair them.
+  factory ContentKey(Uint8List bytes) {
+    if (bytes.length != 32) {
+      throw ArgumentError('a content key must be 32 bytes, got ${bytes.length}');
+    }
+    final digest = sha256.convert(bytes).toString();
+    return ContentKey._(bytes, digest.substring(0, 16));
+  }
+
+  /// Rebuild from the base64 form conveyed in an `at/nskey` record.
+  factory ContentKey.fromBase64(String b64) =>
+      ContentKey(Uint8List.fromList(base64Decode(b64)));
+
+  String toBase64() => base64Encode(bytes);
+}
+
+/// Cache of decapsulated content keys, keyed by `(owner, namespace, ckKid)`.
+///
+/// Never key by `ckKid` alone — ids are unique within a namespace, not across
+/// them, which is the same `(owner, id)` identity discipline used elsewhere in
+/// the SDK. A value in a namespace for which the client holds no nskey private
+/// is left undecryptable rather than silently mis-resolved.
+class ContentKeyCache {
+  final Map<String, ContentKey> _byKid = {};
+  final Map<String, String> _currentKidByNamespace = {};
+
+  static String _scope(String owner, String namespace) => '$owner|$namespace';
+
+  static String _key(String owner, String namespace, String ckKid) =>
+      '${_scope(owner, namespace)}|$ckKid';
+
+  /// Cache [ck] for `(owner, namespace)` and make it the namespace's current
+  /// key — the one new writes encrypt under.
+  void put(String owner, String namespace, ContentKey ck) {
+    _byKid[_key(owner, namespace, ck.ckKid)] = ck;
+    _currentKidByNamespace[_scope(owner, namespace)] = ck.ckKid;
+  }
+
+  /// The CK cited by [ckKid], or null on a cache miss.
+  ///
+  /// A miss is the ordinary out-of-order-sync case: a data value can arrive
+  /// before its conveyance record. The caller defers rather than failing hard.
+  ContentKey? get(String owner, String namespace, String ckKid) =>
+      _byKid[_key(owner, namespace, ckKid)];
+
+  /// The CK new writes in `(owner, namespace)` encrypt under, or null if no CK
+  /// has been conveyed for that namespace yet.
+  ContentKey? current(String owner, String namespace) {
+    final kid = _currentKidByNamespace[_scope(owner, namespace)];
+    return kid == null ? null : get(owner, namespace, kid);
+  }
+
+  /// Drop a superseded CK. Deleting the conveyance record and evicting here is
+  /// the coarse forward-secrecy lever — data written under an evicted CK
+  /// becomes undecryptable by design.
+  void evict(String owner, String namespace, String ckKid) {
+    _byKid.remove(_key(owner, namespace, ckKid));
+    final scope = _scope(owner, namespace);
+    if (_currentKidByNamespace[scope] == ckKid) {
+      _currentKidByNamespace.remove(scope);
+    }
+  }
+}

--- a/packages/at_client/lib/src/crypto/nskey/nskey_key_ring.dart
+++ b/packages/at_client/lib/src/crypto/nskey/nskey_key_ring.dart
@@ -1,0 +1,76 @@
+import 'dart:typed_data';
+
+/// Where the `at/nskey` provider gets namespace key material.
+///
+/// Per `(atSign, namespace)` there is exactly **one** X-Wing nskey keypair. It
+/// is the recipient key for both directions: the owner encapsulates her own CKs
+/// to it for self data, and external senders encapsulate CKs to it when sharing
+/// with her. The private half decapsulates CKs — it never decrypts application
+/// data.
+///
+/// In production the private half is minted fresh and conveyed per-APKAM over
+/// the secret-sharing substrate, and the public half is published lazily (the
+/// owner-only self at-key `nskey.<ns>@<owner>`, promoted to the world-readable
+/// `public:nskey.<ns>@<owner>` on the namespace's first cross-atSign share).
+/// This interface is the seam that work lands behind; see
+/// [InMemoryNskeyKeyRing] for the fixture that stands in until it does.
+abstract class NskeyKeyRing {
+  /// The public half of `(owner, namespace)`'s nskey — the encapsulation
+  /// target. For self data this is the owner's own; for a share it is the
+  /// recipient's, fetched via `plookup` once published.
+  ///
+  /// Null when the namespace has no nskey, which is the cold-start case: the
+  /// caller falls back to sealing the CK to `public:pqpublickey@<recipient>`.
+  Future<Uint8List?> publicHalf(String owner, String namespace);
+
+  /// The private half held by this client for `(owner, namespace)`.
+  ///
+  /// Null when this client is not authorised for the namespace, or has not yet
+  /// received the private over the substrate. Values in that namespace are then
+  /// left undecryptable rather than silently skipped.
+  Future<Uint8List?> privateHalf(String owner, String namespace);
+}
+
+/// An in-memory [NskeyKeyRing] seeded directly with keypairs.
+///
+/// This exists so the data path can be exercised end-to-end before the
+/// substrate delivers privates for real — it inverts the dependency order for
+/// demonstration only. The production path is unchanged: when nskey minting and
+/// per-APKAM conveyance land, they supply a real [NskeyKeyRing] and this becomes
+/// test-only scaffolding.
+class InMemoryNskeyKeyRing implements NskeyKeyRing {
+  final Map<String, Uint8List> _public = {};
+  final Map<String, Uint8List> _private = {};
+
+  static String _k(String owner, String namespace) => '$owner|$namespace';
+
+  /// Seed both halves for `(owner, namespace)` — the state a client is in once
+  /// it holds the namespace key.
+  void seedKeypair(
+    String owner,
+    String namespace, {
+    required Uint8List publicKey,
+    required Uint8List privateKey,
+  }) {
+    _public[_k(owner, namespace)] = publicKey;
+    _private[_k(owner, namespace)] = privateKey;
+  }
+
+  /// Seed only the public half — a sender who can encapsulate to a recipient
+  /// but cannot decapsulate, which is every cross-atSign sender.
+  void seedPublicOnly(
+    String owner,
+    String namespace, {
+    required Uint8List publicKey,
+  }) {
+    _public[_k(owner, namespace)] = publicKey;
+  }
+
+  @override
+  Future<Uint8List?> publicHalf(String owner, String namespace) async =>
+      _public[_k(owner, namespace)];
+
+  @override
+  Future<Uint8List?> privateHalf(String owner, String namespace) async =>
+      _private[_k(owner, namespace)];
+}

--- a/packages/at_client/lib/src/crypto/nskey/nskey_provider.dart
+++ b/packages/at_client/lib/src/crypto/nskey/nskey_provider.dart
@@ -50,8 +50,8 @@ class NskeyProvider implements CryptoProvider {
 
   /// Binds the HPKE key schedule to the conveyance's owner and namespace, so an
   /// envelope sealed for one namespace cannot be opened as another's.
-  static Uint8List _info(String owner, String namespace) =>
-      Uint8List.fromList(utf8.encode('$nskeyCryptoProviderId:$owner:$namespace'));
+  static Uint8List _info(String owner, String namespace) => Uint8List.fromList(
+      utf8.encode('$nskeyCryptoProviderId:$owner:$namespace'));
 
   @override
   Future<String> encrypt(
@@ -83,8 +83,9 @@ class NskeyProvider implements CryptoProvider {
     );
 
     // Cache on write too: the writer encrypts subsequent data values under this
-    // CK without re-opening its own conveyance record.
-    cache.put(owner, namespace, ck);
+    // CK without re-opening its own conveyance record. This is the one place a
+    // CK becomes *current* — the client that cut it says so.
+    cache.putAsCurrent(owner, namespace, ck);
 
     return base64Encode(envelope);
   }
@@ -112,8 +113,17 @@ class NskeyProvider implements CryptoProvider {
       );
     } on PqOpenException catch (e) {
       throw AtDecryptionException('could not decapsulate the content key: $e');
+    } on ArgumentError catch (e) {
+      // pqOpen documents PqOpenException, but its KEM decapsulate call sits
+      // outside that guard, so a wrong-length envelope escapes as a raw
+      // ArgumentError. Keep the provider's contract whatever the envelope is.
+      throw AtDecryptionException('malformed at/nskey envelope: $e');
+    } on FormatException catch (e) {
+      throw AtDecryptionException('at/nskey value is not valid base64: $e');
     }
 
+    // Cache, but do not make current: sync is unordered, so this conveyance may
+    // be older than the CK new writes are already using.
     final ck = ContentKey(ckBytes);
     cache.put(owner, namespace, ck);
     return ck.toBase64();

--- a/packages/at_client/lib/src/crypto/nskey/nskey_provider.dart
+++ b/packages/at_client/lib/src/crypto/nskey/nskey_provider.dart
@@ -1,0 +1,137 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_client/src/crypto/crypto.dart';
+import 'package:at_client/src/crypto/nskey/content_key.dart';
+import 'package:at_client/src/crypto/nskey/nskey_key_ring.dart';
+import 'package:at_commons/at_commons.dart';
+
+/// Wire id of the CK-conveyance provider.
+const String nskeyCryptoProviderId = 'at/nskey';
+
+/// Which key class a CK was sealed to.
+///
+/// Cold-start is **not** a third provider id — a CK sealed to the atSign-level
+/// root key is still an `at/nskey` record, distinguished only by this field.
+class NskeyRecipientKind {
+  /// The `(atSign, namespace)` nskey — the steady-state target for both the
+  /// owner's own CKs and inbound ones.
+  static const String nskey = 'nskey';
+
+  /// `public:pqpublickey@<recipient>` — the cold-start target, used when the
+  /// recipient's namespace has no published nskey yet.
+  static const String rootPqpublickey = 'root-pqpublickey';
+}
+
+/// Layer 2 of the nskey data path: conveys a symmetric content key.
+///
+/// A value routed here **is** a sealed CK — the `<ckKid>.__ck.<ns>@<owner>`
+/// record. [encrypt] takes the CK's base64 bytes and returns the X-Wing
+/// `pqSeal` envelope; [decrypt] opens it with the namespace's nskey private and
+/// caches the CK, so the `at/symmetric/AES/GCM` provider can resolve it by
+/// `ckKid` when the data value arrives.
+///
+/// Application data never passes through this provider — an nskey encapsulates
+/// content keys and nothing else.
+class NskeyProvider implements CryptoProvider {
+  final NskeyKeyRing keyRing;
+  final ContentKeyCache cache;
+  final AtKemAlgorithm _xwing;
+
+  NskeyProvider({
+    required this.keyRing,
+    required this.cache,
+    AtKemAlgorithm? xwing,
+  }) : _xwing = xwing ?? XWingPureDartAlgo.instance;
+
+  @override
+  String get id => nskeyCryptoProviderId;
+
+  /// Binds the HPKE key schedule to the conveyance's owner and namespace, so an
+  /// envelope sealed for one namespace cannot be opened as another's.
+  static Uint8List _info(String owner, String namespace) =>
+      Uint8List.fromList(utf8.encode('$nskeyCryptoProviderId:$owner:$namespace'));
+
+  @override
+  Future<String> encrypt(
+      CryptoContext context, AtKey atKey, String plaintext) async {
+    final owner = _ownerOf(atKey);
+    final namespace = _namespaceOf(atKey);
+
+    final recipientPublic = await keyRing.publicHalf(owner, namespace);
+    if (recipientPublic == null) {
+      throw AtEncryptionException(
+          'no nskey published for $owner:$namespace — cold-start sealing to '
+          'public:pqpublickey is not yet wired');
+    }
+
+    final ck = ContentKey.fromBase64(plaintext);
+    final envelope = await pqSeal(
+      _xwing,
+      recipientPublic,
+      ck.bytes,
+      info: _info(owner, namespace),
+    );
+
+    atKey.metadata.appMetadata = AppMetadata(
+      providerId: id,
+      additional: {
+        'recipientKind': NskeyRecipientKind.nskey,
+        'ckKid': ck.ckKid,
+      },
+    );
+
+    // Cache on write too: the writer encrypts subsequent data values under this
+    // CK without re-opening its own conveyance record.
+    cache.put(owner, namespace, ck);
+
+    return base64Encode(envelope);
+  }
+
+  @override
+  Future<String> decrypt(
+      CryptoContext context, AtKey atKey, String ciphertext) async {
+    final owner = _ownerOf(atKey);
+    final namespace = _namespaceOf(atKey);
+
+    final private = await keyRing.privateHalf(owner, namespace);
+    if (private == null) {
+      throw AtDecryptionException(
+          'no nskey private held for $owner:$namespace — this client is not '
+          'authorised for the namespace, or has not yet received the key');
+    }
+
+    final Uint8List ckBytes;
+    try {
+      ckBytes = await pqOpen(
+        _xwing,
+        private,
+        Uint8List.fromList(base64Decode(ciphertext)),
+        info: _info(owner, namespace),
+      );
+    } on PqOpenException catch (e) {
+      throw AtDecryptionException('could not decapsulate the content key: $e');
+    }
+
+    final ck = ContentKey(ckBytes);
+    cache.put(owner, namespace, ck);
+    return ck.toBase64();
+  }
+
+  static String _ownerOf(AtKey atKey) {
+    final owner = atKey.sharedBy;
+    if (owner == null || owner.isEmpty) {
+      throw AtKeyException('an at/nskey record must carry sharedBy');
+    }
+    return owner;
+  }
+
+  static String _namespaceOf(AtKey atKey) {
+    final namespace = atKey.namespace;
+    if (namespace == null || namespace.isEmpty) {
+      throw AtKeyException('an at/nskey record must carry a namespace');
+    }
+    return namespace;
+  }
+}

--- a/packages/at_client/lib/src/crypto/nskey/symmetric_aes_gcm_provider.dart
+++ b/packages/at_client/lib/src/crypto/nskey/symmetric_aes_gcm_provider.dart
@@ -1,0 +1,111 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_client/src/crypto/crypto.dart';
+import 'package:at_client/src/crypto/nskey/content_key.dart';
+import 'package:at_commons/at_commons.dart';
+
+/// Wire id of the application-data provider.
+///
+/// This names the *algorithm* deliberately — it is the layer that needs
+/// crypto-agility. A future `at/symmetric/AES/SIV` coexists with it, and values
+/// written under this id keep their tag forever.
+const String symmetricAesGcmCryptoProviderId = 'at/symmetric/AES/GCM';
+
+/// Layer 3 of the nskey data path: application data, AES-256-GCM under a
+/// content key.
+///
+/// Purely symmetric — it never touches asymmetric crypto. A value carries its
+/// ciphertext and *cites* a CK by `ckKid`; no sealed key is inline. The CK is
+/// resolved from the [ContentKeyCache], which the `at/nskey` provider populates
+/// when the matching conveyance record syncs.
+class SymmetricAesGcmProvider implements CryptoProvider {
+  final ContentKeyCache cache;
+
+  SymmetricAesGcmProvider({required this.cache});
+
+  @override
+  String get id => symmetricAesGcmCryptoProviderId;
+
+  @override
+  Future<String> encrypt(
+      CryptoContext context, AtKey atKey, String plaintext) async {
+    final owner = _ownerOf(atKey);
+    final namespace = _namespaceOf(atKey);
+
+    final ck = cache.current(owner, namespace);
+    if (ck == null) {
+      throw AtEncryptionException(
+          'no content key established for $owner:$namespace — convey a CK via '
+          'an $nskeyProviderHint record before writing data');
+    }
+
+    // A fresh 12-byte nonce per value — never reuse a (key, nonce) pair.
+    final iv =
+        InitialisationVector.random(AesGcm256EncryptionAlgo.nonceLength);
+    final ciphertext = await AesGcm256EncryptionAlgo(AESKey(ck.toBase64()))
+        .encrypt(Uint8List.fromList(utf8.encode(plaintext)), iv: iv);
+
+    atKey.metadata.appMetadata = AppMetadata(
+      providerId: id,
+      additional: {
+        'ckKid': ck.ckKid,
+        'iv': base64Encode(iv.ivBytes),
+      },
+    );
+
+    return base64Encode(ciphertext);
+  }
+
+  @override
+  Future<String> decrypt(
+      CryptoContext context, AtKey atKey, String ciphertext) async {
+    final owner = _ownerOf(atKey);
+    final namespace = _namespaceOf(atKey);
+    final additional = atKey.metadata.appMetadata?.additional ?? const {};
+
+    final ckKid = additional['ckKid'];
+    final ivB64 = additional['iv'];
+    if (ckKid is! String || ivB64 is! String) {
+      throw AtDecryptionException(
+          'an $symmetricAesGcmCryptoProviderId value must carry ckKid and iv '
+          'in appMetadata');
+    }
+
+    final ck = cache.get(owner, namespace, ckKid);
+    if (ck == null) {
+      // Sync is not ordered, so a data value can arrive before its conveyance
+      // record. This is the deferred case, not a hard failure: the read is
+      // re-attempted once the CK arrives. A CK deleted for forward secrecy
+      // stays unresolvable by design.
+      throw AtDecryptionException(
+          'content key $ckKid not yet available for $owner:$namespace — its '
+          'conveyance record has not synced, or the key was rotated away');
+    }
+
+    final plain = await AesGcm256EncryptionAlgo(AESKey(ck.toBase64())).decrypt(
+      Uint8List.fromList(base64Decode(ciphertext)),
+      iv: InitialisationVector(Uint8List.fromList(base64Decode(ivB64))),
+    );
+    return utf8.decode(plain);
+  }
+
+  static const String nskeyProviderHint = 'at/nskey';
+
+  static String _ownerOf(AtKey atKey) {
+    final owner = atKey.sharedBy;
+    if (owner == null || owner.isEmpty) {
+      throw AtKeyException('a data value must carry sharedBy');
+    }
+    return owner;
+  }
+
+  static String _namespaceOf(AtKey atKey) {
+    final namespace = atKey.namespace;
+    if (namespace == null || namespace.isEmpty) {
+      throw AtKeyException('a data value must carry a namespace');
+    }
+    return namespace;
+  }
+}

--- a/packages/at_client/lib/src/crypto/nskey/symmetric_aes_gcm_provider.dart
+++ b/packages/at_client/lib/src/crypto/nskey/symmetric_aes_gcm_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:at_base2e15/at_base2e15.dart';
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/src/crypto/crypto.dart';
 import 'package:at_client/src/crypto/nskey/content_key.dart';
@@ -12,6 +13,20 @@ import 'package:at_commons/at_commons.dart';
 /// crypto-agility. A future `at/symmetric/AES/SIV` coexists with it, and values
 /// written under this id keep their tag forever.
 const String symmetricAesGcmCryptoProviderId = 'at/symmetric/AES/GCM';
+
+/// The value cites a CK this client cannot resolve *yet*.
+///
+/// Distinct from a hard decryption failure on purpose: sync is unordered, so a
+/// data value routinely arrives before the conveyance record carrying its CK.
+/// A caller seeing this should re-attempt the read once the conveyance syncs —
+/// where a plain [AtDecryptionException] means give up. A CK deleted for
+/// forward secrecy also surfaces here, and stays unresolvable by design.
+class ContentKeyUnavailableException extends AtDecryptionException {
+  /// The kid the value cited, as it appears in `appMetadata`.
+  final String ckKid;
+
+  ContentKeyUnavailableException(this.ckKid, String message) : super(message);
+}
 
 /// Layer 3 of the nskey data path: application data, AES-256-GCM under a
 /// content key.
@@ -42,11 +57,13 @@ class SymmetricAesGcmProvider implements CryptoProvider {
     }
 
     // A fresh 12-byte nonce per value — never reuse a (key, nonce) pair.
-    final iv =
-        InitialisationVector.random(AesGcm256EncryptionAlgo.nonceLength);
+    final iv = InitialisationVector.random(AesGcm256EncryptionAlgo.nonceLength);
     final ciphertext = await AesGcm256EncryptionAlgo(AESKey(ck.toBase64()))
-        .encrypt(Uint8List.fromList(utf8.encode(plaintext)), iv: iv);
+        .encrypt(_toBytes(atKey, plaintext), iv: iv);
 
+    // The runtime re-stamps providerId after this returns; setting it here just
+    // keeps the record self-describing for callers that drive the provider
+    // directly. `additional` is the part only this provider can supply.
     atKey.metadata.appMetadata = AppMetadata(
       providerId: id,
       additional: {
@@ -57,6 +74,20 @@ class SymmetricAesGcmProvider implements CryptoProvider {
 
     return base64Encode(ciphertext);
   }
+
+  /// Plaintext reaches a provider as an opaque String: `Base2e15` for a binary
+  /// record, ordinary text otherwise. Round-tripping binary through UTF-8 is
+  /// lossless (Base2e15 emits only U+3400–U+D7A3, clear of the surrogates) but
+  /// costs 3 bytes per 15 bits, so honour `isBinary` and carry the real bytes.
+  static Uint8List _toBytes(AtKey atKey, String plaintext) =>
+      atKey.metadata.isBinary == true
+          ? Base2e15.decode(plaintext)
+          : Uint8List.fromList(utf8.encode(plaintext));
+
+  static String _fromBytes(AtKey atKey, Uint8List bytes) =>
+      atKey.metadata.isBinary == true
+          ? Base2e15.encode(bytes)
+          : utf8.decode(bytes);
 
   @override
   Future<String> decrypt(
@@ -73,13 +104,11 @@ class SymmetricAesGcmProvider implements CryptoProvider {
           'in appMetadata');
     }
 
-    final ck = cache.get(owner, namespace, ckKid);
+    final ck = cache.get(owner, namespace, ckKid) ??
+        await _resolveFromLocalConveyance(context, owner, namespace, ckKid);
     if (ck == null) {
-      // Sync is not ordered, so a data value can arrive before its conveyance
-      // record. This is the deferred case, not a hard failure: the read is
-      // re-attempted once the CK arrives. A CK deleted for forward secrecy
-      // stays unresolvable by design.
-      throw AtDecryptionException(
+      throw ContentKeyUnavailableException(
+          ckKid,
           'content key $ckKid not yet available for $owner:$namespace — its '
           'conveyance record has not synced, or the key was rotated away');
     }
@@ -88,8 +117,36 @@ class SymmetricAesGcmProvider implements CryptoProvider {
       Uint8List.fromList(base64Decode(ciphertext)),
       iv: InitialisationVector(Uint8List.fromList(base64Decode(ivB64))),
     );
-    return utf8.decode(plain);
+    return _fromBytes(atKey, plain);
   }
+
+  /// Second chance on a cache miss: the conveyance record may already be in
+  /// local storage, just never opened by this process. Reading it routes back
+  /// through the `at/nskey` provider, which decapsulates and caches as a side
+  /// effect — so the CK is looked up again rather than taken from the read.
+  ///
+  /// Failure here is not an error: the record genuinely may not have synced.
+  Future<ContentKey?> _resolveFromLocalConveyance(
+    CryptoContext context,
+    String owner,
+    String namespace,
+    String ckKid,
+  ) async {
+    try {
+      await context.atClient.get(conveyanceKeyFor(owner, namespace, ckKid));
+    } catch (_) {
+      return null;
+    }
+    return cache.get(owner, namespace, ckKid);
+  }
+
+  /// The at-key a CK is conveyed under: `<ckKid>.__ck.<ns>@<owner>`.
+  static AtKey conveyanceKeyFor(String owner, String namespace, String ckKid) =>
+      AtKey()
+        ..key = '$ckKid.__ck'
+        ..namespace = namespace
+        ..sharedBy = owner
+        ..metadata = Metadata();
 
   static const String nskeyProviderHint = 'at/nskey';
 

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   at_base2e15: ^1.0.0
   at_commons: ^5.13.0
   at_utils: ^3.2.0
-  at_chops: ^3.3.0
+  at_chops: ^3.4.0
   at_lookup: ^3.6.0
   at_auth: ^3.2.0
   at_persistence_secondary_server: ^5.1.0

--- a/packages/at_client/test/acceptance/README.md
+++ b/packages/at_client/test/acceptance/README.md
@@ -46,7 +46,7 @@ below), plus 8 cross-cutting invariants.
 |-------------------------------|----------------------------------|--------------|
 | A1 · PQ-native onboard        | A1.1                             | ON-1         |
 | A2 · enrollments              | A2.1, A2.2, A2.3                 | SS-2, SS-4   |
-| A3 · self data                | A3.1, A3.2, A3.3, A3.4           | B-1, SS-4    |
+| A3 · self data                | A3.1 ✅, A3.2, A3.3, A3.4         | B-1, SS-4    |
 | A4 · shared data              | A4.1, A4.2, A4.3, A4.4           | B-1          |
 | A5 · rotation & revocation    | A5.1(a), A5.1(b), A5.2, A5.3     | B-2          |
 | B0 · atServer prerequisite    | B0.1                             | RF-SRV       |
@@ -66,7 +66,7 @@ separately.
 
 ## The shape of the problem this exposes
 
-Sorting by blocker shows why D1 has felt slow. B-1 alone gates **12 of the 39**
+Sorting by blocker shows why D1 has felt slow. B-1 alone gates **11 of the 39**
 rows, and no data-path row goes green until **B-1** (XL) and **SS-4** (L–XL)
 land, so the programme had no demonstrable increment in its centre. (The rows
 rooted on RF-SRV — B0 and B2 — do not depend on either, and can move in

--- a/packages/at_client/test/acceptance/a3_self_data_test.dart
+++ b/packages/at_client/test/acceptance/a3_self_data_test.dart
@@ -3,13 +3,24 @@
 /// Catalogue: `docs/projects/pq/acceptance.md` section 4.
 library;
 
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_client/src/crypto/crypto.dart';
+import 'package:at_client/src/crypto/nskey/content_key.dart';
+import 'package:at_client/src/crypto/nskey/nskey_key_ring.dart';
+import 'package:at_client/src/crypto/nskey/nskey_provider.dart';
+import 'package:at_client/src/crypto/nskey/symmetric_aes_gcm_provider.dart';
+import 'package:at_commons/at_commons.dart';
 import 'package:test/test.dart';
 
+import '../test_utils/mocks.dart';
 import 'blockers.dart';
 
 void main() {
   group('A3 · self data', () {
-    test('UC-A3.1 · self write/read, namespace key already exists', () {
+    test('UC-A3.1 · self write/read, namespace key already exists', () async {
       // GIVEN @alice pq-native; the nskey exists as the self at-key
       //       nskey.app_1.my_apps@alice (no public: key — this namespace has
       //       not been shared cross-atSign); alice1, alice2 hold the private.
@@ -19,8 +30,50 @@ void main() {
       //       resolves the CK by ckKid and AES-GCM-decrypts. Round-trip equals
       //       plaintext; a client lacking the nskey private cannot read. No
       //       legacy provider, no selfEncryptionKey.
-      fail('not implemented');
-    }, skip: b1);
+      const owner = '@alice';
+      const namespace = 'app_1.my_apps';
+      const plaintext = 'the treaty text';
+
+      final nskeyPair = await XWingKeyPair.generate();
+      final context = CryptoContext(atClient: MockAtClient());
+
+      ({NskeyProvider nskey, SymmetricAesGcmProvider data}) client() {
+        final cache = ContentKeyCache();
+        final ring = InMemoryNskeyKeyRing()
+          ..seedKeypair(owner, namespace,
+              publicKey: nskeyPair.publicKeyBytes,
+              privateKey: nskeyPair.privateKeyBytes);
+        return (
+          nskey: NskeyProvider(keyRing: ring, cache: cache),
+          data: SymmetricAesGcmProvider(cache: cache),
+        );
+      }
+
+      AtKey key(String name) => AtKey()
+        ..key = name
+        ..namespace = namespace
+        ..sharedBy = owner
+        ..metadata = Metadata();
+
+      final ck = ContentKey(
+          Uint8List.fromList(base64Decode(AESKey.generate(32).key)));
+
+      final alice1 = client();
+      final sealedCk =
+          await alice1.nskey.encrypt(context, key('${ck.ckKid}.__ck'), ck.toBase64());
+      final valueKey = key('treaty');
+      final ciphertext = await alice1.data.encrypt(context, valueKey, plaintext);
+
+      final alice2 = client();
+      await alice2.nskey
+          .decrypt(context, key('${ck.ckKid}.__ck'), sealedCk);
+      final synced = key('treaty')
+        ..metadata.appMetadata = valueKey.metadata.appMetadata;
+
+      expect(await alice2.data.decrypt(context, synced, ciphertext), plaintext);
+      expect(valueKey.metadata.appMetadata!.providerId,
+          symmetricAesGcmCryptoProviderId);
+    });
 
     test('UC-A3.2 · first self write in a namespace mints the nskey', () {
       // GIVEN @alice pq-native; no app_1.my_apps nskey exists in any form;

--- a/packages/at_client/test/acceptance/a3_self_data_test.dart
+++ b/packages/at_client/test/acceptance/a3_self_data_test.dart
@@ -55,18 +55,18 @@ void main() {
         ..sharedBy = owner
         ..metadata = Metadata();
 
-      final ck = ContentKey(
-          Uint8List.fromList(base64Decode(AESKey.generate(32).key)));
+      final ck =
+          ContentKey(Uint8List.fromList(base64Decode(AESKey.generate(32).key)));
 
       final alice1 = client();
-      final sealedCk =
-          await alice1.nskey.encrypt(context, key('${ck.ckKid}.__ck'), ck.toBase64());
+      final sealedCk = await alice1.nskey
+          .encrypt(context, key('${ck.ckKid}.__ck'), ck.toBase64());
       final valueKey = key('treaty');
-      final ciphertext = await alice1.data.encrypt(context, valueKey, plaintext);
+      final ciphertext =
+          await alice1.data.encrypt(context, valueKey, plaintext);
 
       final alice2 = client();
-      await alice2.nskey
-          .decrypt(context, key('${ck.ckKid}.__ck'), sealedCk);
+      await alice2.nskey.decrypt(context, key('${ck.ckKid}.__ck'), sealedCk);
       final synced = key('treaty')
         ..metadata.appMetadata = valueKey.metadata.appMetadata;
 

--- a/packages/at_client/test/nskey_data_path_test.dart
+++ b/packages/at_client/test/nskey_data_path_test.dart
@@ -1,0 +1,263 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_client/src/crypto/crypto.dart';
+import 'package:at_client/src/crypto/nskey/content_key.dart';
+import 'package:at_client/src/crypto/nskey/nskey_key_ring.dart';
+import 'package:at_client/src/crypto/nskey/nskey_provider.dart';
+import 'package:at_client/src/crypto/nskey/symmetric_aes_gcm_provider.dart';
+import 'package:at_commons/at_commons.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import 'test_utils/mocks.dart';
+
+/// The nskey data path, driven end to end with the namespace key supplied by a
+/// fixture instead of the secret-sharing substrate.
+///
+/// This is the walking skeleton for UC-A3.1. It proves the two providers and
+/// the CK cache compose into a working self-data round-trip, which is what the
+/// substrate work later feeds for real — the production path (a minted nskey,
+/// its private conveyed per-APKAM) is unchanged by anything here.
+void main() {
+  const owner = '@alice';
+  const namespace = 'app_1.my_apps';
+
+  late CryptoContext context;
+  late XWingKeyPair nskeyPair;
+
+  /// A client of @alice authorised for the namespace: holds both halves.
+  ({NskeyProvider nskey, SymmetricAesGcmProvider data, ContentKeyCache cache})
+      authorisedClient() {
+    final cache = ContentKeyCache();
+    final ring = InMemoryNskeyKeyRing()
+      ..seedKeypair(owner, namespace,
+          publicKey: nskeyPair.publicKeyBytes,
+          privateKey: nskeyPair.privateKeyBytes);
+    return (
+      nskey: NskeyProvider(keyRing: ring, cache: cache),
+      data: SymmetricAesGcmProvider(cache: cache),
+      cache: cache,
+    );
+  }
+
+  AtKey ckConveyanceKey(String ckKid) => AtKey()
+    ..key = '$ckKid.__ck'
+    ..namespace = namespace
+    ..sharedBy = owner
+    ..metadata = Metadata();
+
+  AtKey dataKey(String name) => AtKey()
+    ..key = name
+    ..namespace = namespace
+    ..sharedBy = owner
+    ..metadata = Metadata();
+
+  setUpAll(() async {
+    // One nskey keypair per (atSign, namespace) — the recipient key for both
+    // directions. Minted once for the whole suite; minting is not what this
+    // exercises.
+    nskeyPair = await XWingKeyPair.generate();
+  });
+
+  setUp(() {
+    final mockAtClient = MockAtClient();
+    when(() => mockAtClient.getCurrentAtSign()).thenReturn(owner);
+    context = CryptoContext(atClient: mockAtClient);
+  });
+
+  group('UC-A3.1 · self write/read, namespace key already exists', () {
+    test('alice1 writes, alice2 syncs both records and round-trips plaintext',
+        () async {
+      const plaintext = 'the treaty text';
+
+      // --- alice1 writes -------------------------------------------------
+      final alice1 = authorisedClient();
+
+      // 1. Cut a symmetric CK.
+      final ck = ContentKey(_randomKeyBytes());
+
+      // 2. Convey the CK once: sealed to @alice's own nskey, written as its own
+      //    <ckKid>.__ck record.
+      final conveyanceKey = ckConveyanceKey(ck.ckKid);
+      final sealedCk = await alice1.nskey
+          .encrypt(context, conveyanceKey, ck.toBase64());
+
+      // 3. Write the data value under that CK.
+      final valueKey = dataKey('treaty');
+      final ciphertext =
+          await alice1.data.encrypt(context, valueKey, plaintext);
+
+      // --- alice2 syncs and reads ----------------------------------------
+      // A distinct client: its own cache, seeded only with the namespace
+      // keypair it received. It has never seen the CK.
+      final alice2 = authorisedClient();
+      expect(alice2.cache.get(owner, namespace, ck.ckKid), isNull,
+          reason: 'alice2 must start without the content key');
+
+      // at/nskey decapsulates the CK with the nskey private and caches it.
+      final recoveredCk = await alice2.nskey
+          .decrypt(context, ckConveyanceKey(ck.ckKid), sealedCk);
+      expect(recoveredCk, ck.toBase64());
+
+      // at/symmetric/AES/GCM resolves the CK by ckKid and decrypts.
+      final syncedValueKey = dataKey('treaty')
+        ..metadata.appMetadata = valueKey.metadata.appMetadata;
+      final recovered =
+          await alice2.data.decrypt(context, syncedValueKey, ciphertext);
+
+      expect(recovered, plaintext, reason: 'round-trip must equal plaintext');
+    });
+
+    test('the data value cites a ckKid and carries no sealed key inline',
+        () async {
+      final alice1 = authorisedClient();
+      final ck = ContentKey(_randomKeyBytes());
+      await alice1.nskey
+          .encrypt(context, ckConveyanceKey(ck.ckKid), ck.toBase64());
+
+      final valueKey = dataKey('treaty');
+      await alice1.data.encrypt(context, valueKey, 'the treaty text');
+
+      final appMetadata = valueKey.metadata.appMetadata!;
+      expect(appMetadata.providerId, symmetricAesGcmCryptoProviderId);
+      expect(appMetadata.additional!['ckKid'], ck.ckKid);
+      expect(appMetadata.additional!['iv'], isNotNull);
+      expect(appMetadata.additional!.containsKey('sealedKey'), isFalse,
+          reason: 'decision (a): the CK is conveyed once, never inline');
+      expect(appMetadata.additional!.containsKey('ns'), isFalse,
+          reason: 'appMetadata carries no ns field');
+    });
+
+    test('the CK conveyance record is tagged at/nskey with recipientKind nskey',
+        () async {
+      final alice1 = authorisedClient();
+      final ck = ContentKey(_randomKeyBytes());
+      final conveyanceKey = ckConveyanceKey(ck.ckKid);
+      await alice1.nskey.encrypt(context, conveyanceKey, ck.toBase64());
+
+      final appMetadata = conveyanceKey.metadata.appMetadata!;
+      expect(appMetadata.providerId, nskeyCryptoProviderId);
+      expect(appMetadata.additional!['recipientKind'], NskeyRecipientKind.nskey);
+      expect(appMetadata.additional!['ckKid'], ck.ckKid);
+      expect(appMetadata.additional!.containsKey('iv'), isFalse,
+          reason: 'the pqSeal envelope carries its own kemCt and nonce');
+    });
+
+    test('a client lacking the nskey private cannot decapsulate the CK',
+        () async {
+      final alice1 = authorisedClient();
+      final ck = ContentKey(_randomKeyBytes());
+      final sealedCk = await alice1.nskey
+          .encrypt(context, ckConveyanceKey(ck.ckKid), ck.toBase64());
+
+      // An @alice client authorised for a different namespace only: it holds no
+      // private half for app_1.my_apps.
+      final outsider = NskeyProvider(
+        keyRing: InMemoryNskeyKeyRing(),
+        cache: ContentKeyCache(),
+      );
+
+      await expectLater(
+        outsider.decrypt(context, ckConveyanceKey(ck.ckKid), sealedCk),
+        throwsA(isA<AtDecryptionException>()),
+      );
+    });
+
+    test('a wrong namespace key cannot open the conveyance', () async {
+      final alice1 = authorisedClient();
+      final ck = ContentKey(_randomKeyBytes());
+      final sealedCk = await alice1.nskey
+          .encrypt(context, ckConveyanceKey(ck.ckKid), ck.toBase64());
+
+      // A different nskey keypair seeded under the same namespace name — the
+      // HPKE info binding plus the KEM must both refuse it.
+      final wrongPair = await XWingKeyPair.generate();
+      final wrongRing = InMemoryNskeyKeyRing()
+        ..seedKeypair(owner, namespace,
+            publicKey: wrongPair.publicKeyBytes,
+            privateKey: wrongPair.privateKeyBytes);
+      final wrongClient =
+          NskeyProvider(keyRing: wrongRing, cache: ContentKeyCache());
+
+      await expectLater(
+        wrongClient.decrypt(context, ckConveyanceKey(ck.ckKid), sealedCk),
+        throwsA(isA<AtDecryptionException>()),
+      );
+    });
+  });
+
+  group('CK resolution & ordering', () {
+    test('a data value arriving before its conveyance defers rather than '
+        'failing silently', () async {
+      final alice1 = authorisedClient();
+      final ck = ContentKey(_randomKeyBytes());
+      await alice1.nskey
+          .encrypt(context, ckConveyanceKey(ck.ckKid), ck.toBase64());
+      final valueKey = dataKey('treaty');
+      final ciphertext =
+          await alice1.data.encrypt(context, valueKey, 'the treaty text');
+
+      // alice2 has the namespace key but the __ck record has not synced yet.
+      final alice2 = authorisedClient();
+      final syncedValueKey = dataKey('treaty')
+        ..metadata.appMetadata = valueKey.metadata.appMetadata;
+
+      await expectLater(
+        alice2.data.decrypt(context, syncedValueKey, ciphertext),
+        throwsA(isA<AtDecryptionException>()),
+        reason: 'a cache miss is the deferred state, not a wrong plaintext',
+      );
+
+      // Once the conveyance syncs, the same read succeeds.
+      await alice2.nskey
+          .decrypt(context, ckConveyanceKey(ck.ckKid), await _seal(alice1, ck));
+      expect(await alice2.data.decrypt(context, syncedValueKey, ciphertext),
+          'the treaty text');
+    });
+
+    test('the CK cache is keyed by (owner, namespace, ckKid), never ckKid alone',
+        () {
+      final cache = ContentKeyCache();
+      final ck = ContentKey(_randomKeyBytes());
+      cache.put(owner, namespace, ck);
+
+      expect(cache.get(owner, namespace, ck.ckKid), isNotNull);
+      expect(cache.get(owner, 'app_2.my_apps', ck.ckKid), isNull,
+          reason: 'kids are unique within a namespace, not across them');
+      expect(cache.get('@bob', namespace, ck.ckKid), isNull,
+          reason: 'identity is (owner, id), never id alone');
+    });
+
+    test('evicting a rotated CK makes its data undecryptable, by design', () {
+      final cache = ContentKeyCache();
+      final ck = ContentKey(_randomKeyBytes());
+      cache.put(owner, namespace, ck);
+      cache.evict(owner, namespace, ck.ckKid);
+
+      expect(cache.get(owner, namespace, ck.ckKid), isNull);
+      expect(cache.current(owner, namespace), isNull);
+    });
+  });
+}
+
+/// Re-seal [ck] so a second client can consume its own copy of the conveyance.
+Future<String> _seal(
+  ({NskeyProvider nskey, SymmetricAesGcmProvider data, ContentKeyCache cache})
+      client,
+  ContentKey ck,
+) async {
+  final key = AtKey()
+    ..key = '${ck.ckKid}.__ck'
+    ..namespace = 'app_1.my_apps'
+    ..sharedBy = '@alice'
+    ..metadata = Metadata();
+  final mockAtClient = MockAtClient();
+  when(() => mockAtClient.getCurrentAtSign()).thenReturn('@alice');
+  return client.nskey
+      .encrypt(CryptoContext(atClient: mockAtClient), key, ck.toBase64());
+}
+
+Uint8List _randomKeyBytes() =>
+    Uint8List.fromList(base64Decode(AESKey.generate(32).key));

--- a/packages/at_client/test/nskey_data_path_test.dart
+++ b/packages/at_client/test/nskey_data_path_test.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:at_base2e15/at_base2e15.dart';
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/src/crypto/crypto.dart';
 import 'package:at_client/src/crypto/nskey/content_key.dart';
@@ -59,6 +60,7 @@ void main() {
     // directions. Minted once for the whole suite; minting is not what this
     // exercises.
     nskeyPair = await XWingKeyPair.generate();
+    registerFallbackValue(AtKey());
   });
 
   setUp(() {
@@ -81,8 +83,8 @@ void main() {
       // 2. Convey the CK once: sealed to @alice's own nskey, written as its own
       //    <ckKid>.__ck record.
       final conveyanceKey = ckConveyanceKey(ck.ckKid);
-      final sealedCk = await alice1.nskey
-          .encrypt(context, conveyanceKey, ck.toBase64());
+      final sealedCk =
+          await alice1.nskey.encrypt(context, conveyanceKey, ck.toBase64());
 
       // 3. Write the data value under that CK.
       final valueKey = dataKey('treaty');
@@ -139,7 +141,8 @@ void main() {
 
       final appMetadata = conveyanceKey.metadata.appMetadata!;
       expect(appMetadata.providerId, nskeyCryptoProviderId);
-      expect(appMetadata.additional!['recipientKind'], NskeyRecipientKind.nskey);
+      expect(
+          appMetadata.additional!['recipientKind'], NskeyRecipientKind.nskey);
       expect(appMetadata.additional!['ckKid'], ck.ckKid);
       expect(appMetadata.additional!.containsKey('iv'), isFalse,
           reason: 'the pqSeal envelope carries its own kemCt and nonce');
@@ -171,8 +174,10 @@ void main() {
       final sealedCk = await alice1.nskey
           .encrypt(context, ckConveyanceKey(ck.ckKid), ck.toBase64());
 
-      // A different nskey keypair seeded under the same namespace name — the
-      // HPKE info binding plus the KEM must both refuse it.
+      // A different nskey keypair under the same namespace name, so the info
+      // bytes match on both sides and it is the KEM alone that refuses it.
+      // The info binding is covered separately, one keypair across two
+      // namespaces.
       final wrongPair = await XWingKeyPair.generate();
       final wrongRing = InMemoryNskeyKeyRing()
         ..seedKeypair(owner, namespace,
@@ -189,7 +194,8 @@ void main() {
   });
 
   group('CK resolution & ordering', () {
-    test('a data value arriving before its conveyance defers rather than '
+    test(
+        'a data value arriving before its conveyance defers rather than '
         'failing silently', () async {
       final alice1 = authorisedClient();
       final ck = ContentKey(_randomKeyBytes());
@@ -206,8 +212,10 @@ void main() {
 
       await expectLater(
         alice2.data.decrypt(context, syncedValueKey, ciphertext),
-        throwsA(isA<AtDecryptionException>()),
-        reason: 'a cache miss is the deferred state, not a wrong plaintext',
+        throwsA(isA<ContentKeyUnavailableException>()
+            .having((e) => e.ckKid, 'ckKid', ck.ckKid)),
+        reason: 'a cache miss is the deferred state, not a wrong plaintext — '
+            'and it is typed, so a caller can tell retry-later from give-up',
       );
 
       // Once the conveyance syncs, the same read succeeds.
@@ -217,7 +225,64 @@ void main() {
           'the treaty text');
     });
 
-    test('the CK cache is keyed by (owner, namespace, ckKid), never ckKid alone',
+    test('a conveyance already in local storage is opened on demand', () async {
+      final alice1 = authorisedClient();
+      final ck = ContentKey(_randomKeyBytes());
+      final sealedCk = await alice1.nskey
+          .encrypt(context, ckConveyanceKey(ck.ckKid), ck.toBase64());
+      final valueKey = dataKey('treaty');
+      final ciphertext =
+          await alice1.data.encrypt(context, valueKey, 'the treaty text');
+
+      // alice2 has the __ck record locally but has never opened it, so its
+      // cache is cold. Reading the record routes back through at/nskey.
+      final alice2 = authorisedClient();
+      final mockAtClient = MockAtClient();
+      when(() => mockAtClient.getCurrentAtSign()).thenReturn(owner);
+      when(() => mockAtClient.get(any())).thenAnswer((invocation) async {
+        final requested = invocation.positionalArguments.first as AtKey;
+        expect(requested.key, '${ck.ckKid}.__ck');
+        expect(requested.namespace, namespace);
+        expect(requested.sharedBy, owner);
+        await alice2.nskey.decrypt(context, requested, sealedCk);
+        return AtValue();
+      });
+      final localContext = CryptoContext(atClient: mockAtClient);
+
+      final syncedValueKey = dataKey('treaty')
+        ..metadata.appMetadata = valueKey.metadata.appMetadata;
+      expect(
+          await alice2.data.decrypt(localContext, syncedValueKey, ciphertext),
+          'the treaty text');
+    });
+
+    test('an older conveyance opened later does not become the write key',
+        () async {
+      final alice1 = authorisedClient();
+      final oldCk = ContentKey(_randomKeyBytes());
+      final newCk = ContentKey(_randomKeyBytes());
+
+      // alice1 cuts and conveys two CKs in order; the second is current.
+      await alice1.nskey
+          .encrypt(context, ckConveyanceKey(oldCk.ckKid), oldCk.toBase64());
+      final sealedOld = await _seal(alice1, oldCk);
+      await alice1.nskey
+          .encrypt(context, ckConveyanceKey(newCk.ckKid), newCk.toBase64());
+      expect(alice1.cache.current(owner, namespace)!.ckKid, newCk.ckKid);
+
+      // Sync has no order, so the older conveyance can arrive afterwards.
+      await alice1.nskey
+          .decrypt(context, ckConveyanceKey(oldCk.ckKid), sealedOld);
+
+      expect(alice1.cache.current(owner, namespace)!.ckKid, newCk.ckKid,
+          reason: 'an arriving conveyance is cached, never made current — '
+              'otherwise new writes silently roll back onto a superseded CK');
+      expect(alice1.cache.get(owner, namespace, oldCk.ckKid), isNotNull,
+          reason: 'the old CK still resolves for data written under it');
+    });
+
+    test(
+        'the CK cache is keyed by (owner, namespace, ckKid), never ckKid alone',
         () {
       final cache = ContentKeyCache();
       final ck = ContentKey(_randomKeyBytes());
@@ -230,22 +295,133 @@ void main() {
           reason: 'identity is (owner, id), never id alone');
     });
 
-    test('evicting a rotated CK makes its data undecryptable, by design', () {
+    test('two different CKs claiming one kid is refused, not silently merged',
+        () {
       final cache = ContentKeyCache();
       final ck = ContentKey(_randomKeyBytes());
       cache.put(owner, namespace, ck);
+
+      // Re-delivery of the same CK is ordinary and must stay idempotent.
+      cache.put(owner, namespace, ContentKey(Uint8List.fromList(ck.bytes)));
+      expect(cache.get(owner, namespace, ck.ckKid), isNotNull);
+
+      // A genuine kid collision would make the displaced CK's data
+      // undecryptable, so it fails loudly instead.
+      expect(() => cache.put(owner, namespace, _CollidingKey(ck.ckKid)),
+          throwsA(isA<StateError>()));
+    });
+
+    test('evicting a rotated CK makes its data undecryptable, by design', () {
+      final cache = ContentKeyCache();
+      final ck = ContentKey(_randomKeyBytes());
+      cache.putAsCurrent(owner, namespace, ck);
+      expect(cache.current(owner, namespace), isNotNull);
+
       cache.evict(owner, namespace, ck.ckKid);
 
       expect(cache.get(owner, namespace, ck.ckKid), isNull);
       expect(cache.current(owner, namespace), isNull);
     });
   });
+
+  group('envelope and payload handling', () {
+    test('the same nskey cannot open a conveyance sealed for another namespace',
+        () async {
+      // One keypair, two namespaces — isolating the HPKE info binding from the
+      // KEM, which a wrong-keypair test cannot do.
+      final ring = InMemoryNskeyKeyRing()
+        ..seedKeypair(owner, namespace,
+            publicKey: nskeyPair.publicKeyBytes,
+            privateKey: nskeyPair.privateKeyBytes)
+        ..seedKeypair(owner, 'app_2.my_apps',
+            publicKey: nskeyPair.publicKeyBytes,
+            privateKey: nskeyPair.privateKeyBytes);
+      final provider = NskeyProvider(keyRing: ring, cache: ContentKeyCache());
+
+      final ck = ContentKey(_randomKeyBytes());
+      final sealedForApp1 = await provider.encrypt(
+          context, ckConveyanceKey(ck.ckKid), ck.toBase64());
+
+      final asApp2 = AtKey()
+        ..key = '${ck.ckKid}.__ck'
+        ..namespace = 'app_2.my_apps'
+        ..sharedBy = owner
+        ..metadata = Metadata();
+
+      await expectLater(
+        provider.decrypt(context, asApp2, sealedForApp1),
+        throwsA(isA<AtDecryptionException>()),
+        reason: 'info binds the key schedule to (owner, namespace), so the '
+            'same private cannot reinterpret the envelope as another namespace',
+      );
+    });
+
+    test('a malformed envelope surfaces as AtDecryptionException', () async {
+      final alice = authorisedClient();
+      for (final bad in [
+        'not base64 at all!',
+        base64Encode([1, 2, 3])
+      ]) {
+        await expectLater(
+          alice.nskey
+              .decrypt(context, ckConveyanceKey('deadbeefdeadbeef'), bad),
+          throwsA(isA<AtDecryptionException>()),
+          reason: 'the provider contract holds whatever the envelope is',
+        );
+      }
+    });
+
+    test('a binary value round-trips byte-exact', () async {
+      final alice1 = authorisedClient();
+      final ck = ContentKey(_randomKeyBytes());
+      await alice1.nskey
+          .encrypt(context, ckConveyanceKey(ck.ckKid), ck.toBase64());
+
+      // Every byte value, plus a length that does not fall on a 15-bit boundary.
+      final bytes = Uint8List.fromList(
+          [for (var i = 0; i < 256; i++) i, 0x00, 0xff, 0x7f]);
+      final asString = Base2e15.encode(bytes);
+
+      final valueKey = dataKey('blob')..metadata.isBinary = true;
+      final ciphertext = await alice1.data.encrypt(context, valueKey, asString);
+
+      final alice2 = authorisedClient();
+      await alice2.nskey
+          .decrypt(context, ckConveyanceKey(ck.ckKid), await _seal(alice1, ck));
+      final synced = dataKey('blob')
+        ..metadata.isBinary = true
+        ..metadata.appMetadata = valueKey.metadata.appMetadata;
+
+      final recovered = await alice2.data.decrypt(context, synced, ciphertext);
+      expect(Base2e15.decode(recovered), bytes,
+          reason: 'binary must survive the round-trip byte for byte');
+      expect(recovered, asString);
+    });
+  });
+}
+
+/// A [ContentKey] forced to claim a kid it did not derive, so the cache's
+/// collision guard can be exercised — a real 64-bit collision is unreachable.
+class _CollidingKey implements ContentKey {
+  @override
+  final String ckKid;
+
+  @override
+  final Uint8List bytes = _randomKeyBytes();
+
+  _CollidingKey(this.ckKid);
+
+  @override
+  String toBase64() => base64Encode(bytes);
 }
 
 /// Re-seal [ck] so a second client can consume its own copy of the conveyance.
 Future<String> _seal(
-  ({NskeyProvider nskey, SymmetricAesGcmProvider data, ContentKeyCache cache})
-      client,
+  ({
+    NskeyProvider nskey,
+    SymmetricAesGcmProvider data,
+    ContentKeyCache cache
+  }) client,
   ContentKey ck,
 ) async {
   final key = AtKey()


### PR DESCRIPTION
> **Stacked on #2096** — based on `gkc-pq-acceptance-burndown`, not `trunk`. Merge #2096 first; the base retargets to `trunk` automatically.

**- What I did**

- Added the value-level data path: `at/symmetric/AES/GCM` encrypts application data under a symmetric content key, and `at/nskey` conveys that CK by X-Wing-sealing it to the namespace nskey as a discrete `<ckKid>.__ck` record.
- Turns **UC-A3.1** green — the first scenario in the D1 acceptance burn-down.

**- Why**

- Data values cite a CK by `ckKid` and carry no sealed key, so rotating a CK means dropping one conveyance record instead of rewriting every value — that is what makes coarse forward secrecy affordable at all.
- The CK cache is keyed `(owner, namespace, ckKid)` because kids are unique within a namespace, not across them. Same `(owner, id)` discipline as everywhere else in the SDK.
- Only the client that cut a CK makes it the write key. Sync has no order, so an arriving conveyance that set `current` would silently roll new writes back onto a superseded CK.
- A cited CK that has not synced yet is a *deferred* read, not a failed one, so it gets its own exception type — a caller has to be able to tell retry-later from give-up. The reader opens the local conveyance on demand first.
- `NskeyKeyRing` is a seam so the path can be exercised before the substrate delivers privates for real. The production path is unchanged and the fixture dies when SS-4 lands; nothing downstream may depend on it.
- Raises the `at_chops` floor to `^3.4.0`: workspace resolution hides a too-low floor, and publish validation only checks satisfiability — a consumer could resolve 3.3.0 and get a package that does not compile.

**- How I did it**

See commit & diffs. Application data never passes through the `at/nskey` provider — an nskey encapsulates content keys and nothing else.

**- How to verify it**

Tests pass. Implements #2089, #2090.