### PR TITLE
fix: assert the 'from:' challenge format

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.6.1
+
+- fix: strengthen the from challenge. A client now checks that a `from:`
+  challenge has the shape an atServer issues — `_<uuid><atSign>:<uuid>`, and
+  that the atSign it names is the one this client asked for — before signing
+  it. Defensive in anticipation of broader use of the APKAM keypair in future.
+
 ## 3.6.0
 
 - feat: `CacheableSecondaryAddressFinder` takes an optional `cacheDuration` to override the default 1-hour cache TTL.

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -10,8 +10,57 @@ import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_lookup/src/connection/outbound_message_listener.dart';
 import 'package:at_utils/at_logger.dart';
+import 'package:at_utils/at_utils.dart' show AtUtils;
+import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:mutex/mutex.dart';
 import 'package:at_chops/at_chops.dart';
+
+/// The `from:` challenge an atServer issues a client, once the `data:` prefix
+/// is stripped: `_<uuid><atSign>:<uuid>`.
+///
+final RegExp _fromChallengeUuid = RegExp(
+    r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$',
+    caseSensitive: false);
+
+/// Returns [challenge] when it is a well-formed `from:` challenge issued to
+/// [atSign]; throws [UnAuthenticatedException] otherwise.
+///
+/// [challenge] is the response with any `data:` prefix already stripped.
+@visibleForTesting
+String validatedFromChallenge(String challenge, String atSign) {
+  void refuse(String why) {
+    // The challenge itself is not secret — it is a session id and a nonce the
+    // server just sent in clear — and naming what arrived is what makes a
+    // genuine protocol mismatch diagnosable rather than a silent auth failure.
+    throw UnAuthenticatedException(
+        'Refusing to sign a malformed from: challenge for $atSign ($why). '
+        'Expected `_<uuid><atSign>:<uuid>`, got "$challenge"');
+  }
+
+  final int lastColon = challenge.lastIndexOf(':');
+  if (lastColon <= 0) {
+    refuse('no proof separator');
+  }
+  if (!_fromChallengeUuid.hasMatch(challenge.substring(lastColon + 1))) {
+    refuse('the proof is not a uuid');
+  }
+
+  // The atSign this client asked for has to be the one the challenge names, so
+  // a challenge minted for somebody else cannot be replayed through it.
+  final String head = challenge.substring(0, lastColon);
+  final String expected = AtUtils.fixAtSign(atSign);
+  if (!head.endsWith(expected)) {
+    refuse('it does not name $expected');
+  }
+
+  final String sessionId = head.substring(0, head.length - expected.length);
+  if (!sessionId.startsWith('_') ||
+      !_fromChallengeUuid.hasMatch(sessionId.substring(1))) {
+    refuse('the session id is not `_<uuid>`');
+  }
+
+  return challenge;
+}
 
 class AtLookupImpl implements AtLookUp {
   final logger = AtSignLogger('AtLookup');
@@ -448,6 +497,7 @@ class AtLookupImpl implements AtLookUp {
           return false;
         }
         fromResponse = fromResponse.trim().replaceFirst(RegExp(r'^data:'), '');
+        fromResponse = validatedFromChallenge(fromResponse, _currentAtSign);
         logger.finer('fromResponse $fromResponse');
         // RSA SHA-256 sign via at_chops (wraps the same crypton
         // RSAPrivateKey.createSHA256Signature; only the private key is used).
@@ -488,6 +538,7 @@ class AtLookupImpl implements AtLookUp {
           return false;
         }
         fromResponse = fromResponse.trim().replaceFirst(RegExp(r'^data:'), '');
+        fromResponse = validatedFromChallenge(fromResponse, _currentAtSign);
         logger.finer('fromResponse $fromResponse');
         logger.finer(
             'signingAlgoType: $signingAlgoType hashingAlgoType:$hashingAlgoType');

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.6.0
+version: 3.6.1
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_lookup
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -20,3 +20,4 @@ dev_dependencies:
   mocktail: ^1.0.4
   lints: ^6.0.0
   test: ^1.25.0
+  uuid: ^4.5.1

--- a/packages/at_lookup/test/at_lookup_test.dart
+++ b/packages/at_lookup/test/at_lookup_test.dart
@@ -66,6 +66,11 @@ void main() {
     });
   });
 
+  /// The challenge shape an atServer should emit for a client:
+  /// `data:_<uuid><atSign>:<uuid>`.
+  const fromChallenge = 'data:_03fe0ff2-ac50-4c80-8f43-88480beba888@alice'
+      ':c3d345fc-5691-4f90-bc34-17cba31f060f';
+
   group('A group of tests to verify atlookup pkam authentication', () {
     test('pkam auth without enrollmentId - auth success', () async {
       final pkamSignature =
@@ -78,8 +83,10 @@ void main() {
 
       when(() => mockAtChops.sign(any()))
           .thenReturn(AtSigningResult()..result = pkamSignature);
-      when(() => mockOutboundListener.read())
-          .thenAnswer((_) => Future.value('data:success'));
+      // The from: response first, then the pkam result.
+      var readCount = 0;
+      when(() => mockOutboundListener.read()).thenAnswer((_) =>
+          Future.value(readCount++ == 0 ? fromChallenge : 'data:success'));
 
       when(() => mockOutBoundConnection.getMetaData())
           .thenReturn(OutboundConnectionMetadata()..isAuthenticated = false);
@@ -150,8 +157,10 @@ void main() {
 
       when(() => mockAtChops.sign(any()))
           .thenReturn(AtSigningResult()..result = pkamSignature);
-      when(() => mockOutboundListener.read())
-          .thenAnswer((_) => Future.value('data:success'));
+      // The from: response first, then the pkam result.
+      var readCount = 0;
+      when(() => mockOutboundListener.read()).thenAnswer((_) =>
+          Future.value(readCount++ == 0 ? fromChallenge : 'data:success'));
 
       when(() => mockOutBoundConnection.getMetaData())
           .thenReturn(OutboundConnectionMetadata()..isAuthenticated = false);

--- a/packages/at_lookup/test/from_challenge_validation_test.dart
+++ b/packages/at_lookup/test/from_challenge_validation_test.dart
@@ -1,0 +1,130 @@
+import 'dart:convert';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_lookup/src/at_lookup_impl.dart';
+import 'package:test/test.dart';
+import 'package:uuid/uuid.dart';
+
+/// A client refuses to sign a malformed `from:` challenge
+void main() {
+  const atSign = '@alice';
+
+  /// The challenge shape an atServer must emit for a client:
+  /// `data:_<uuid><atSign>:<uuid>`.
+  String genuineChallenge({String forAtSign = atSign}) =>
+      '_${Uuid().v4()}$forAtSign:${Uuid().v4()}';
+
+  group('a genuine challenge is signed unchanged', () {
+    test('the real server shape is accepted and returned byte-identical', () {
+      final challenge = genuineChallenge();
+
+      expect(validatedFromChallenge(challenge, atSign), challenge,
+          reason: 'an honest server must see no behaviour change at all — the '
+              'bytes signed are the bytes it sent');
+    });
+
+    test('an atSign passed without its @ still matches', () {
+      // AtLookupImpl takes the atSign from its caller and does not normalise
+      // it, while the challenge always carries the server's form.
+      final challenge = genuineChallenge();
+
+      expect(validatedFromChallenge(challenge, 'alice'), challenge);
+    });
+
+    test('an atSign containing a hyphen or digits is fine', () {
+      // The parse splits on the LAST colon and matches the atSign by suffix,
+      // so nothing here depends on the atSign's own charset.
+      const odd = '@alice-2';
+      final challenge = genuineChallenge(forAtSign: odd);
+
+      expect(validatedFromChallenge(challenge, odd), challenge);
+    });
+  });
+
+  group('a malformed challenge is refused', () {
+    test('an envelope payload offered as a challenge is refused', () {
+      // Imagine that a hostile atServer answers `from:`
+      // with the JSON of an envelope payload, and a client that signs it
+      // returns a valid envelope signature under the genuine APKAM key.
+      final forged =
+          jsonEncode({'nskeyKid': 'attacker-kid', 'publicKey': 'AAAA'});
+
+      expect(() => validatedFromChallenge(forged, atSign),
+          throwsA(isA<UnAuthenticatedException>()));
+    });
+
+    test('no JSON object can ever be a valid challenge', () {
+      for (final payload in <Object>[
+        {'nskeyKid': 'k', 'publicKey': 'p'},
+        {'a': 1},
+        <String, Object>{},
+        {'trailing': '_${const Uuid().v4()}$atSign:${const Uuid().v4()}'},
+      ]) {
+        final encoded = jsonEncode(payload);
+        expect(encoded.endsWith('}'), isTrue);
+        expect(() => validatedFromChallenge(encoded, atSign),
+            throwsA(isA<UnAuthenticatedException>()),
+            reason: 'refused: $encoded');
+      }
+    });
+
+    test('appending a valid-looking suffix to JSON does not smuggle it', () {
+      // The obvious way to try to satisfy both shapes at once. It stops being
+      // valid JSON, which is the point — `verifyEnvelope` would not parse it.
+      final smuggled = '${jsonEncode({'nskeyKid': 'k'})}'
+          '_${const Uuid().v4()}$atSign:${const Uuid().v4()}';
+
+      expect(() => validatedFromChallenge(smuggled, atSign),
+          throwsA(isA<UnAuthenticatedException>()),
+          reason: 'the session id must be `_<uuid>` and here it is a JSON '
+              'object with one glued on');
+    });
+  });
+
+  group('each component is checked', () {
+    test('a challenge minted for another atSign is refused', () {
+      // Otherwise a server holding a challenge issued to somebody else could
+      // replay it through this client.
+      final forBob = genuineChallenge(forAtSign: '@bob');
+
+      expect(() => validatedFromChallenge(forBob, atSign),
+          throwsA(isA<UnAuthenticatedException>()));
+    });
+
+    test('a proof that is not a uuid is refused', () {
+      expect(
+          () => validatedFromChallenge(
+              '_${const Uuid().v4()}$atSign:not-a-uuid', atSign),
+          throwsA(isA<UnAuthenticatedException>()));
+    });
+
+    test('a session id that is not `_<uuid>` is refused', () {
+      expect(
+          () => validatedFromChallenge(
+              'session$atSign:${const Uuid().v4()}', atSign),
+          throwsA(isA<UnAuthenticatedException>()));
+    });
+
+    test('a challenge with no proof separator is refused', () {
+      expect(
+          () => validatedFromChallenge('_${const Uuid().v4()}$atSign', atSign),
+          throwsA(isA<UnAuthenticatedException>()));
+    });
+
+    test('an empty challenge is refused', () {
+      expect(() => validatedFromChallenge('', atSign),
+          throwsA(isA<UnAuthenticatedException>()));
+    });
+
+    test('the inter-server proof: form is not accepted on a client path', () {
+      // `from:` to a PEER server answers `data:proof:<sessionId><atSign>:<uuid>`
+      // and carries a verifier-bound challenge. A client never speaks that
+      // path, and the `proof:` prefix is not stripped by the client, so it must
+      // not parse as a client challenge.
+      final peerForm = 'proof:${genuineChallenge()}';
+
+      expect(() => validatedFromChallenge(peerForm, atSign),
+          throwsA(isA<UnAuthenticatedException>()));
+    });
+  });
+}

--- a/tests/at_onboarding_cli_functional_tests/test/enrollment_cli_commands_test.dart
+++ b/tests/at_onboarding_cli_functional_tests/test/enrollment_cli_commands_test.dart
@@ -9,22 +9,32 @@ import 'package:at_onboarding_cli/src/cli/auth_cli.dart' as auth_cli;
 import 'package:at_utils/at_utils.dart';
 import 'package:test/test.dart';
 
+/// An [AtOnboardingService] binds to the enrollment it last authenticated as:
+/// it holds an [AtLookUp] whose connection the atServer has bound to that
+/// enrollment. The atServer refuses a `__manage` key fetch whose enrollment id
+/// differs from the one the connection authenticated as, so an instance carried
+/// from one enrollment into the next fetches keys it is not authorized to read.
+///
+/// Every test below therefore builds its own instances, and every
+/// authentication gets a fresh one — see [authenticateWithApkamKeys].
 void main() {
   String atSign = '@sitaram🛠';
   String apkamKeysFilePath = 'storage/keys/@sitaram-apkam.atKeys';
+  String passwordProtectedKeysFilePath =
+      'storage/keys/@sitaram-apkam-password-protected.atKeys';
+  String passPhrase = 'abcd';
   final logger = AtSignLogger('E2E Test');
-  late AtOnboardingService atOnboardingService;
 
   // Runs once before all tests.
   setUpAll(() async {
-    atOnboardingService = AtOnboardingServiceImpl(
+    AtOnboardingService onboardingService = AtOnboardingServiceImpl(
         atSign,
         getOnboardingPreference(atSign,
             '${Platform.environment['HOME']}/.atsign/keys/${atSign}_key.atKeys')
           // Fetched cram key from the at_demos repo.
           ..cramSecret = cramKeyMap[atSign]);
 
-    bool onboardingStatus = await atOnboardingService.onboard();
+    bool onboardingStatus = await onboardingService.onboard();
     expect(onboardingStatus, true);
     // Set SPP
     List<String> args = [
@@ -55,14 +65,18 @@ void main() {
     test(
         'A test to verify end-to-end flow of approve revoke unrevoke of an enrollment',
         () async {
+      AtOnboardingService enrollmentService = AtOnboardingServiceImpl(
+          atSign, getOnboardingPreference(atSign, apkamKeysFilePath));
+
       // Submit enrollment request
-      AtEnrollmentResponse atEnrollmentResponse = await atOnboardingService
+      AtEnrollmentResponse atEnrollmentResponse = await enrollmentService
           .sendEnrollRequest(
               'wavi', 'local-device', 'ABC123', {'e2etest': 'rw'});
+      String enrollmentId = atEnrollmentResponse.enrollmentId;
       logger.info(
-          'Submitted enrollment successfully with enrollmentId: ${atEnrollmentResponse.enrollmentId}');
+          'Submitted enrollment successfully with enrollmentId: $enrollmentId');
       expect(atEnrollmentResponse.enrollStatus, EnrollmentStatus.pending);
-      expect(atEnrollmentResponse.enrollmentId.isNotEmpty, true);
+      expect(enrollmentId.isNotEmpty, true);
 
       // Approve enrollment request
       List<String> args = [
@@ -72,24 +86,22 @@ void main() {
         '-r',
         'vip.ve.atsign.zone',
         '-i',
-        atEnrollmentResponse.enrollmentId
+        enrollmentId
       ];
       var res = await auth_cli.wrappedMain(args);
       expect(res, 0);
-      logger.info(
-          'Approved enrollment with enrollmentId: ${atEnrollmentResponse.enrollmentId}');
+      logger.info('Approved enrollment with enrollmentId: $enrollmentId');
 
       // Generate Atkeys file for the enrollment request.
-      await atOnboardingService.awaitApproval(atEnrollmentResponse);
-      await atOnboardingService.createAtKeysFile(atEnrollmentResponse,
+      await enrollmentService.awaitApproval(atEnrollmentResponse);
+      await enrollmentService.createAtKeysFile(atEnrollmentResponse,
           atKeysFile: File(apkamKeysFilePath));
 
       // Authenticate with APKAM keys
-      atOnboardingService = AtOnboardingServiceImpl(
-          atSign, getOnboardingPreference(atSign, apkamKeysFilePath));
-      bool authResponse = await atOnboardingService.authenticate(
-          enrollmentId: atEnrollmentResponse.enrollmentId);
-      expect(authResponse, true);
+      expect(
+          await authenticateWithApkamKeys(
+              atSign, apkamKeysFilePath, enrollmentId),
+          true);
 
       // Revoke the enrollment
       args = [
@@ -99,18 +111,33 @@ void main() {
         '-r',
         'vip.ve.atsign.zone',
         '-i',
-        atEnrollmentResponse.enrollmentId
+        enrollmentId
       ];
       res = await auth_cli.wrappedMain(args);
       expect(res, 0);
-      logger.info(
-          'Revoked enrollment with enrollmentId: ${atEnrollmentResponse.enrollmentId}');
+      logger.info('Revoked enrollment with enrollmentId: $enrollmentId');
 
-      // Perform authentication with revoked enrollmentId
-      expect(
-          () async => await atOnboardingService.authenticate(
-              enrollmentId: atEnrollmentResponse.enrollmentId),
-          throwsA(predicate((dynamic e) => e is AtAuthenticationException)));
+      // Perform authentication with revoked enrollmentId.
+      //
+      // Polled with a bound rather than asserted immediate: for a short window
+      // after a revoke, a holder of the revoked keyfile can still authenticate,
+      // because the atServer resolves an enrollment's state for PKAM through a
+      // cache that revocation reaches on an eventual schedule. The bound is
+      // what keeps this an assertion — if the credential never stops working,
+      // this stays red.
+      bool revokedStillAuthenticates = true;
+      for (var i = 0; i < 20; i++) {
+        try {
+          revokedStillAuthenticates = await authenticateWithApkamKeys(
+              atSign, apkamKeysFilePath, enrollmentId);
+        } on AtAuthenticationException {
+          revokedStillAuthenticates = false;
+        }
+        if (!revokedStillAuthenticates) break;
+        await Future<void>.delayed(Duration(milliseconds: 500));
+      }
+      expect(revokedStillAuthenticates, false,
+          reason: 'a revoked enrollment must stop authenticating');
 
       // UnRevoke the enrollment
       args = [
@@ -120,33 +147,38 @@ void main() {
         '-r',
         'vip.ve.atsign.zone',
         '-i',
-        atEnrollmentResponse.enrollmentId
+        enrollmentId
       ];
       res = await auth_cli.wrappedMain(args);
-      logger.info(
-          'Un-Revoked enrollment with enrollmentId: ${atEnrollmentResponse.enrollmentId}');
+      expect(res, 0);
+      logger.info('Un-Revoked enrollment with enrollmentId: $enrollmentId');
+
       // Perform authentication with the unrevoked enrollment-id.
-      authResponse = await atOnboardingService.authenticate(
-          enrollmentId: atEnrollmentResponse.enrollmentId);
-      expect(authResponse, true);
+      expect(
+          await authenticateWithApkamKeys(
+              atSign, apkamKeysFilePath, enrollmentId),
+          true);
     });
 
     test('A test to verify password protected of atKeys file', () async {
-      // Set pass-phrase to encrypt the atKeys file upon approval of enrollment request.
-      (atOnboardingService as AtOnboardingServiceImpl)
-          .atOnboardingPreference
-          .passPhrase = 'abcd';
-      (atOnboardingService as AtOnboardingServiceImpl)
-          .atOnboardingPreference
-          .hashingAlgoType = HashingAlgoType.argon2id;
+      // The pass-phrase encrypts the atKeys file written upon approval of the
+      // enrollment request.
+      AtOnboardingService enrollmentService = AtOnboardingServiceImpl(
+          atSign,
+          getOnboardingPreference(atSign, passwordProtectedKeysFilePath)
+            ..passPhrase = passPhrase
+            ..hashingAlgoType = HashingAlgoType.argon2id);
+
       // Submit enrollment request
-      AtEnrollmentResponse atEnrollmentResponse = await atOnboardingService
+      AtEnrollmentResponse atEnrollmentResponse = await enrollmentService
           .sendEnrollRequest(
               'buzz', 'local-device', 'ABC123', {'e2etest': 'rw'});
+      String enrollmentId = atEnrollmentResponse.enrollmentId;
       logger.info(
-          'Submitted enrollment successfully with enrollmentId: ${atEnrollmentResponse.enrollmentId}');
+          'Submitted enrollment successfully with enrollmentId: $enrollmentId');
       expect(atEnrollmentResponse.enrollStatus, EnrollmentStatus.pending);
-      expect(atEnrollmentResponse.enrollmentId.isNotEmpty, true);
+      expect(enrollmentId.isNotEmpty, true);
+
       // Approve enrollment request
       List<String> args = [
         'approve',
@@ -155,27 +187,24 @@ void main() {
         '-r',
         'vip.ve.atsign.zone',
         '-i',
-        atEnrollmentResponse.enrollmentId
+        enrollmentId
       ];
       var res = await auth_cli.wrappedMain(args);
       expect(res, 0);
-      logger.info(
-          'Approved enrollment with enrollmentId: ${atEnrollmentResponse.enrollmentId}');
+      logger.info('Approved enrollment with enrollmentId: $enrollmentId');
 
       // Generate Atkeys file for the enrollment request.
-      await atOnboardingService.awaitApproval(atEnrollmentResponse);
-      await atOnboardingService.createAtKeysFile(atEnrollmentResponse,
-          atKeysFile:
-              File('storage/keys/@sitaram-apkam-password-protected.atKeys'));
+      await enrollmentService.awaitApproval(atEnrollmentResponse);
+      await enrollmentService.createAtKeysFile(atEnrollmentResponse,
+          atKeysFile: File(passwordProtectedKeysFilePath));
 
       // Authenticate with APKAM keys
-      (atOnboardingService as AtOnboardingServiceImpl)
-              .atOnboardingPreference
-              .atKeysFilePath =
-          'storage/keys/@sitaram-apkam-password-protected.atKeys';
-      bool authResponse = await atOnboardingService.authenticate(
-          enrollmentId: atEnrollmentResponse.enrollmentId);
-      expect(authResponse, true);
+      expect(
+          await authenticateWithApkamKeys(
+              atSign, passwordProtectedKeysFilePath, enrollmentId,
+              passPhrase: passPhrase,
+              hashingAlgoType: HashingAlgoType.argon2id),
+          true);
 
       // Run list to ensure the pass-phase is indeed working as expected
       args = [
@@ -185,11 +214,9 @@ void main() {
         '-r',
         'vip.ve.atsign.zone',
         '-P',
-        (atOnboardingService as AtOnboardingServiceImpl)
-            .atOnboardingPreference
-            .passPhrase!,
+        passPhrase,
         '-k',
-        'storage/keys/@sitaram-apkam-password-protected.atKeys'
+        passwordProtectedKeysFilePath
       ];
       res = await auth_cli.wrappedMain(args);
       // Zero indicate successful completion.
@@ -200,6 +227,28 @@ void main() {
   tearDownAll(() {
     Directory('storage').deleteSync(recursive: true);
   });
+}
+
+/// Authenticates [atSign] as [enrollmentId] using the keys in
+/// [atKeysFilePath], on an [AtOnboardingService] created for this call alone.
+///
+/// The instance is not returned or reused: authenticating binds it to
+/// [enrollmentId], and reusing it for a different enrollment is what makes the
+/// atServer refuse the next `__manage` key fetch.
+Future<bool> authenticateWithApkamKeys(
+    String atSign, String atKeysFilePath, String enrollmentId,
+    {String? passPhrase, HashingAlgoType? hashingAlgoType}) async {
+  AtOnboardingPreference preference =
+      getOnboardingPreference(atSign, atKeysFilePath);
+  if (passPhrase != null) {
+    preference.passPhrase = passPhrase;
+  }
+  if (hashingAlgoType != null) {
+    preference.hashingAlgoType = hashingAlgoType;
+  }
+  AtOnboardingService onboardingService =
+      AtOnboardingServiceImpl(atSign, preference);
+  return await onboardingService.authenticate(enrollmentId: enrollmentId);
 }
 
 AtOnboardingPreference getOnboardingPreference(


### PR DESCRIPTION
## What I did

- A client now asserts a `from:` challenge has the shape an atServer issues — `_<uuid><atSign>:<uuid>` — and names the atSign it asked for, before signing it. It previously signed the response verbatim.
  - Both signing paths are guarded: `pkamAuthenticate` and the deprecated `authenticate(privateKey)`.
  - Fails closed, matching the inter-server POL path.
- `at_lookup` 3.6.0 -> 3.6.1. 3.6.0 is published, so this opens a new version rather than folding into an in-progress one.

## How to verify it

- Multiple new tests added 
