### PR TITLE
fix(at_chops): review fixes for RsaSignatureAlgo

### DIFF
--- a/packages/at_chops/CHANGELOG.md
+++ b/packages/at_chops/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.5.0
-- feat: add `RsaSignatureAlgorithm`, deprecating the old RsaSigningAlgorithm which implements the deprecated signing type.
+- feat: add `RsaSignatureAlgo`, a stateless `AtSignatureAlgorithm` implementation for RSA-2048 and RSA-4096 signing, with key material passed per call
+- deprecate: `RsaSigningAlgo`, which implements the deprecated `AtSigningAlgorithm` interface — use `RsaSignatureAlgo` instead. The two produce byte-identical signatures, so the swap is transparent on the wire
+- deprecate: redirect the `DefaultSigningAlgo` and `PkamSigningAlgo` deprecation notices at `RsaSignatureAlgo`; they previously pointed at `RsaSigningAlgo`, which is now itself deprecated
 
 ## 3.4.1
 - fix: export `Argon2idHashingAlgo` and `Md5HashingAlgo` from the main `at_chops.dart` barrel so callers can use all supported hashing algorithms through the public package import.

--- a/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/default_signing_algo.dart
@@ -3,7 +3,7 @@ import 'package:at_chops/src/algorithm/signing/rsa.dart';
 import 'package:at_chops/src/key/keys.dart';
 
 @Deprecated(
-    'Use RsaSigningAlgo instead. This compatibility wrapper will be removed '
+    'Use RsaSignatureAlgo instead. This compatibility wrapper will be removed '
     'in the next major release.')
 class DefaultSigningAlgo extends RsaSigningAlgo {
   // Cannot use super parameters here because the superclass constructor

--- a/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/pkam_signing_algo.dart
@@ -8,7 +8,7 @@ import 'package:crypton/crypton.dart';
 
 /// Data signing and verification for Public Key Authentication Mechanism - Pkam
 @Deprecated(
-    'Use RsaSigningAlgo with the appropriate key material instead. This '
+    'Use RsaSignatureAlgo with the appropriate key material instead. This '
     'compatibility API will be removed in the next major release.')
 class PkamSigningAlgo implements AtSigningAlgorithm {
   final AtPkamKeyPair? _pkamKeyPair;

--- a/packages/at_chops/lib/src/algorithm/signing/rsa.dart
+++ b/packages/at_chops/lib/src/algorithm/signing/rsa.dart
@@ -32,9 +32,11 @@ import 'package:crypton/crypton.dart';
 /// [RsaSignatureAlgo.rsa4096] instance is usable for data and envelope
 /// signing, but not for PKAM authentication.
 ///
-/// [generateKeyPair] runs RSA key generation on the calling isolate and takes
-/// appreciable wall-clock time, seconds for 4096 bits. Prefer generating once
-/// and persisting over generating per operation.
+/// [generateKeyPair] runs RSA key generation on the calling isolate, so it
+/// blocks the event loop while it runs. It is a probabilistic prime search with
+/// a long tail — usually well under a second at 4096 bits, but occasionally
+/// much longer. Prefer generating once and persisting over generating per
+/// operation, and run it off the UI isolate.
 final class RsaSignatureAlgo implements AtSignatureAlgorithm {
   final SigningAlgoType signingAlgoType;
   String get name => signingAlgoType.name;
@@ -126,9 +128,10 @@ final class RsaSignatureAlgo implements AtSignatureAlgorithm {
     }
     final int bits = key.asPointyCastle.n!.bitLength;
     if (bits != _modulusBits) {
-      throw AtSigningException('Key is $bits-bit but this algorithm reports '
-          '${signingAlgoType.name}; construct RsaSignatureAlgo for the '
-          'matching modulus size');
+      throw AtSigningException('Cannot sign with a $bits-bit key using '
+          'RsaSignatureAlgo.${signingAlgoType.name} — the signature would go '
+          'on the wire labelled ${signingAlgoType.name}. Construct the '
+          'RsaSignatureAlgo whose name matches the key you hold.');
     }
     return key;
   }
@@ -144,19 +147,21 @@ final class RsaSignatureAlgo implements AtSignatureAlgorithm {
     final int bits = key.asPointyCastle.modulus!.bitLength;
     if (bits != _modulusBits) {
       throw AtSigningVerificationException(
-          'Key is $bits-bit but this algorithm reports '
-          '${signingAlgoType.name}; construct RsaSignatureAlgo for the '
-          'matching modulus size');
+          'Cannot verify with a $bits-bit key using '
+          'RsaSignatureAlgo.${signingAlgoType.name} — a key of another size '
+          'was not produced by the algorithm this instance claims to be. '
+          'Construct the RsaSignatureAlgo whose name matches the key you '
+          'hold.');
     }
     return key;
   }
 }
 
-@Deprecated(
-    'Use RsaSignatureAlgo, this uses the deprecated AtSigningAlgo as the base class')
-
 /// Data signing and verification using atsign encryption keypair
 /// Allowed algorithms are listed in [SigningAlgoType] and [HashingAlgoType]
+@Deprecated('Use RsaSignatureAlgo instead. This implements the deprecated '
+    'AtSigningAlgorithm interface and will be removed in the next major '
+    'release.')
 class RsaSigningAlgo implements AtSigningAlgorithm {
   final AsymmetricKeyPair? _encryptionKeyPair;
   final HashingAlgoType _hashingAlgoType;

--- a/packages/at_chops/test/rsa_signature_algo_test.dart
+++ b/packages/at_chops/test/rsa_signature_algo_test.dart
@@ -172,4 +172,114 @@ void main() {
               e.toString().contains('X.509 RSA public key'))));
     });
   });
+
+  group(
+      'RsaSignatureAlgo — interoperability with the deprecated RsaSigningAlgo',
+      () {
+    // The migration from RsaSigningAlgo to RsaSignatureAlgo is only safe if the
+    // two produce the same bytes. RSASSA-PKCS1-v1_5 is deterministic, so this
+    // asserts identity rather than merely that each signature is independently
+    // valid — anything weaker would pass even if the two diverged on the wire.
+    test('the two produce byte-identical signatures and verify each other',
+        () async {
+      final pair = RsaKeyPair.generate();
+      // ignore: deprecated_member_use_from_same_package
+      final legacy = RsaSigningAlgo(pair, HashingAlgoType.sha256);
+      final modern = RsaSignatureAlgo.rsa2048();
+
+      final legacySig = legacy.sign(message);
+      final modernSig = await modern.signBytes(message,
+          secretKey: base64Decode(pair.atPrivateKey.privateKey));
+
+      expect(modernSig, equals(legacySig));
+      expect(legacy.verify(message, modernSig), isTrue);
+      expect(
+          await modern.verifyBytes(message,
+              signature: legacySig,
+              publicKey: base64Decode(pair.atPublicKey.publicKey)),
+          isTrue);
+    });
+  });
+
+  group('RsaSignatureAlgo — known-answer vectors', () {
+    // Every other test here signs and verifies with itself, so all of them
+    // would stay green if the construction changed underneath (PKCS#1 v1.5 to
+    // PSS, say) — the round trip would still close while the wire changed.
+    // These raw literals pin the actual output. They were captured from this
+    // implementation and are frozen: an intended change to the signature format
+    // edits them in the same commit, and that edit is the review.
+    //
+    // Test-only key pair, generated for this file and used nowhere else.
+    const String secretKeyB64 =
+        'MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQCjbdPCKkrVFg6Y'
+        'TWQmml2kB3ZFIMC2kQZpRYdnRbkw99ss4I8FyZ68qmuwE6+GAlz/2MTsQ5gXWNd4'
+        'W2ltseiJfsyJfI+pS3ptf//EDu/ArDk6BGA1YDFqa0u+nwNS7pSfai/e0BWtRZ4m'
+        'yY/64zz4DwglxXqWeM+fFI9sJ3srw2xZ9QvsT/hb0VcU5f/pPNhCf8mPpOdVxPBz'
+        'lScbGqChsxILY/y2nSHVDcI1dXqm9RiII3jN4XOEaSd74Q4p7CLHyO/qiFq+QCLB'
+        '2jMlGYrqjLDDmUH6Qv57Io7gMXv7HBWwvCao6/ES2FYlg0qb0KhN+H+g4M7UonYY'
+        'D2E6sGhhAgMBAAECggEBAIYTZjTXCYmDjPm6FD3vSn91d7wCwNeGZyIaXpmFBAd+'
+        'cBuDJxLyc/4IOky7+bYRXkavie7jDXWp9yvQos/RsxqKIjdxL1MOjyQibKxmLJ9/'
+        'K3vDd0KS5jeOSxfZ0JpLDTczoI5FXGNIyBS+LBcCMlS30FFcj9O+zWaPMZLjWRNu'
+        '7SKvoFIo4MEFPeKckn9zAvczr89y/ePMTv6SnFJEzmyk9W/Y2PqyK3grPZHYJ9B+'
+        'Vpdxvxg+yc7kGCsCsSsZUu8MlMEkieesIRAC2i2OOwkFQ+9auE8u9K9vgdzpyyrs'
+        'SFSCt20HAVKbTD57MOszfIVXChunYjvbNEi+XRTrQ3kCgYEA9C0YcJtR6kUzvg8I'
+        '0ITx1IKWL+uuD0qsQECNT3ALYXPuOwaADr37Bvgz6GEzhHpXU4NemTMWPeoMfirO'
+        'E1xNcpgsP+qFkh7QHaWhqD9+Kf59OmTKoN/MNODOD3bMEygIwiRMcO40P4o2N/Td'
+        'PCL+tH2j4OoP0QbtlpdW7ZLg9SMCgYEAq1fCElBKofLR02EF6JvtYCD5iVKWqtXJ'
+        'gyvttTERW4fWhfUoTIjGCJFhPK36P1gO7slTkbpJO7CFmDpFyF8pxv2+ZiInPcVH'
+        '4zpGapMjVQDRjOrRJRk/pFQ2kjBFU7McOWLE9TMfAQzuCerK39PiXIWgbuWpQ1ee'
+        'HO8uaS8UTqsCgYEAgJV+2U3xxTzMEro4GhbogtCB5ppl/weDzhIwWDTYyWkTe2Hg'
+        '7eJ93x21uBn31zvV4NS9bE/K1q/6BDbmbquc3UvlgYMu89PmJLakesV02wh5Sdbq'
+        'He28y9vWp64Xqb7bXeFfn9jRCuTtyGnaV2DWYJYJRtf7nEfZtgPccx9196ECgYEA'
+        'gmEz9xWLxPHtgkhI47iLB2PwHfNvXK1zOlIZ/o9I4vpZXfOv55UIBAsED9VfIAZU'
+        'zpT592DmSvpGnhBxe0gWlSoOUM9aRuGwkxKL9Jrj/tGxouYnoXA2AkhmghUjG86m'
+        'AnDK6L4usHDzTS6Rk4I6tCambtxpUSoB0YibK0S80iMCgYAk31wvq9OL0oR8uhto'
+        'rpobw34wj3lynO680R2gbCI1c8svMucwgVBrsKWi+gTNNq3m9ds82Y8oNSd2ouPE'
+        'Y4DHjtHk6CBcBtKxyCteNyiq7DtcOG/o0w1SQ1LR+iJu52+DhFFMZ/W2C6vHtkhd'
+        '3J63N7YEEduoVUgi/jbY+PjFIA==';
+    const String publicKeyB64 =
+        'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAo23TwipK1RYOmE1kJppd'
+        'pAd2RSDAtpEGaUWHZ0W5MPfbLOCPBcmevKprsBOvhgJc/9jE7EOYF1jXeFtpbbHo'
+        'iX7MiXyPqUt6bX//xA7vwKw5OgRgNWAxamtLvp8DUu6Un2ov3tAVrUWeJsmP+uM8'
+        '+A8IJcV6lnjPnxSPbCd7K8NsWfUL7E/4W9FXFOX/6TzYQn/Jj6TnVcTwc5UnGxqg'
+        'obMSC2P8tp0h1Q3CNXV6pvUYiCN4zeFzhGkne+EOKewix8jv6ohavkAiwdozJRmK'
+        '6oyww5lB+kL+eyKO4DF7+xwVsLwmqOvxEthWJYNKm9CoTfh/oODO1KJ2GA9hOrBo'
+        'YQIDAQAB';
+    const String sha256SignatureB64 =
+        'mwqQA8F5H6E3WcqUzCXnEP2qchwhT5RxC1vY1R78qKKE68Ow4T064j7cmVq9UVqh'
+        'JBTZQuq+4h3MkSVdbAbHYoGdw+ApPXRkFIf7MQKOfmfJi/eHfkg6Vz4/ILrNWsec'
+        'gNGsED+YrLqtmnrqsH9X/GuL49qh3P1z+hmQOM4nuNUYHUzJD/5eJX72tF3K1AiX'
+        'C1/ndYsDjww3boBd+24YkCKwoIJam1PJru78D0dMlb/dWUY7x5lTISUF2YuzCHv8'
+        'etDtyj0zN9kDk6ZeB536GN+99mEplocSyzaJ4aUfo2KYyKYbRzeth3H6RbwJGFf0'
+        'oBz62HH6Sf+WTl1ekqZILg==';
+    const String sha512SignatureB64 =
+        'Mn3a49qeM10gWYynWxa7s4zri6A2i8KrmULM71cGyNriapAzCOKNm3psLJn3OaZa'
+        '1i7nqxPwPMQ3wrml0P+Pd+Kp/0vc5gRxkHTesnusg8ABRm7e8SULgvGjORlfUcpm'
+        'NfwezpUezKklv+jp5uTha28rTUftDYboA0z7Vmsvrrdre8KrGKOopXkekOHGj3/i'
+        'n6KZQFouAZNMzmJOKIIkOvheaCR7k2/A6l7G11rdXonFVTFQqz3Xt6hykdP9wWkM'
+        'bSF1kIKV/mtYCkf9XVH6dDvcAwynyePHBjAhK7aEeq/8F94gkMeryHx4ImcB7zSH'
+        'mqWDMekGOb8nGAUtsI1JSg==';
+
+    test('rsa2048 + sha256 reproduces the pinned signature', () async {
+      final sig = await RsaSignatureAlgo.rsa2048()
+          .signBytes(message, secretKey: base64Decode(secretKeyB64));
+      expect(base64Encode(sig), equals(sha256SignatureB64));
+    });
+
+    test('rsa2048 + sha512 reproduces the pinned signature', () async {
+      final sig =
+          await RsaSignatureAlgo.rsa2048(hashing: HashingAlgoType.sha512)
+              .signBytes(message, secretKey: base64Decode(secretKeyB64));
+      expect(base64Encode(sig), equals(sha512SignatureB64));
+    });
+
+    test('the pinned signature verifies against the pinned public key',
+        () async {
+      expect(
+          await RsaSignatureAlgo.rsa2048().verifyBytes(message,
+              signature: base64Decode(sha256SignatureB64),
+              publicKey: base64Decode(publicKeyB64)),
+          isTrue);
+    });
+  });
 }


### PR DESCRIPTION
**- What I did**

Review fixes for #2114, based against that branch so it can be merged straight in.

- CHANGELOG named `RsaSignatureAlgorithm`/`RsaSigningAlgorithm` — neither class exists.
- The `RsaSigningAlgo` deprecation notice named `AtSigningAlgo`; the interface is `AtSigningAlgorithm`, and that string is the IDE tooltip consumers see.
- `DefaultSigningAlgo` and `PkamSigningAlgo` both pointed callers at `RsaSigningAlgo`, which #2114 deprecates — redirected to `RsaSignatureAlgo`. at_lookup has three live `PkamSigningAlgo` call sites that would have followed that advice.
- Moved `@Deprecated` below the doc comment. It applied either way, but above a blank line and the `///` block it reads as a dangling library annotation.
- Key-size mismatch errors now say what to do.
- Doc claimed 4096-bit keygen takes "seconds"; measured 560ms (2048-bit: 42ms).
- Added a legacy/new interop test — PKCS#1 v1.5 is deterministic, so the two must emit identical bytes, and that identity is what makes the swap transparent on the wire.
- Added known-answer vectors — every other test signs and verifies with itself, so all would stay green if the construction changed underneath.

Not addressed here, left for you as they are design calls rather than fixes: whether `verifyBytes` should throw or return false for bad key material (RSA throws, ML-DSA returns false, the interface documents neither); putting `signingAlgoType` on `AtSignatureAlgorithm`; wiring the class into `AtChopsImpl`. I also left the `## 3.5.0` heading alone since the version is yours to pick — but note pubspec.yaml is still on 3.4.1 and #2115 has to slot 3.4.2 in underneath it.

**- How I did it**

See commit & diffs.

**- How to verify it**

Tests pass. at_chops 192/192; analyze and format clean; at_lookup, at_client, at_auth and at_onboarding_cli clean under `--fatal-warnings`. Both new assertions were mutation-checked red before being trusted.

**- Description for the changelog**

fix(at_chops): review fixes for RsaSignatureAlgo