### PR TITLE
chore(at_sync_ui_flutter): move at_client_mobile dependency

### DIFF
--- a/packages/at_sync_ui_flutter/pubspec.yaml
+++ b/packages/at_sync_ui_flutter/pubspec.yaml
@@ -12,12 +12,12 @@ environment:
 
 dependencies:
   at_client: ^3.7.0
+  at_client_mobile: ^3.3.0
   flutter:
     sdk: flutter
 
 dev_dependencies:
   at_common_flutter: ^2.1.0
-  at_client_mobile: ^3.3.0
   flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## What

- move at_client_mobile dependency so that I can publish at_sync_ui_flutter 1.2.0
- #1898 

## How



## How to verify

## Skills impact

If this PR changes a public API in `at_client`, `at_client_flutter`, or `at_auth`,
consider whether `packages/at_client_skills/` needs a follow-up release.

- [x] No public API change — skill unaffected
- [ ] Public API changed — I have opened or will open an `at_client_skills` PR to reflect this
