### PR TITLE
feat(at_commons): enroll:update, and _apsk as an array of signing keys

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,48 @@
+## 5.14.0
+
+- feat: add `EnrollParams.apsk` — the value a client composes for its own
+  `public:_apsk.<enrollmentId>.a.__e@<atSign>` signing key, carried on
+  `enroll:request` and stored verbatim on the enrollment record. A
+  `Map<String, dynamic>` like `metadata`, opaque to the atServer, capped there
+  at 20KB encoded.
+
+  It exists so the atServer can stop composing that value from
+  `(apkamPublicKey, signingAlgo)`. PKAM verification is record-authoritative
+  and reads the enrollment record, so `_apsk` is a client-side artefact the
+  server has no use for and no business knowing the format of — it was
+  publishing one only because the record's rightful writer, the enrollee, does
+  not exist yet at approval. Sending the value moves the format back to the
+  side that owns it, and a new signing-key shape stops needing a server
+  release. Absent means no `_apsk` is published at all.
+
+  The form the client composes is a versioned array of signing keys —
+  `{"v":1,"keys":[{"use","alg","pub","status"}]}` — spelled as `KeyPackage`'s
+  keys are, so one vocabulary covers every "list of keys with algorithms" in
+  the protocol. An entry whose `status` is `verifyOnly` has stopped signing but
+  is retained: envelopes are stored durably and re-verified later, so removing
+  a key would retroactively unverify everything ever signed with it.
+
+- feat: add `EnrollOperationEnum.update` and the matching `enroll:update`
+  alternation in the `enroll` grammar — an approved enrollment amending its own
+  record's `apkamPublicKey`, `signingAlgo`, `apsk` and `metadata`. Self-only:
+  the connection's enrollment id must equal the target's. It never reaches
+  `namespaces` or the approval state, because an operation an enrollment can
+  invoke on itself must not be able to widen its own grant.
+
+  This is what lets an enrollment replace its APKAM authentication keypair
+  while keeping its id, rather than the replacement being a new enrollment.
+
+- feat: add `EnrollParams.apkamPublicKeySignature` — base64 of a signature by
+  the **new** APKAM private key over
+  `<enrollmentId>|<apkamPublicKey>|<signingAlgo>`, required on an
+  `enroll:update` that changes `apkamPublicKey`.
+
+  The connection proves possession of the enrollment's *current* key and
+  nothing else proves possession of the new one, so without this a
+  compromised-but-authenticated client can install a public key whose private
+  half is held by someone else — locking out the legitimate holder while the
+  record still looks valid.
+
 ## 5.13.0
 
 - feat: add `AtNetworkTimeouts` — the process-wide network-timeout policy:

--- a/packages/at_commons/lib/src/verb/enroll_params.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.dart
@@ -22,6 +22,61 @@ class EnrollParams {
   /// record-authoritative.
   String? signingAlgo;
 
+  /// The value to publish as this enrollment's APKAM public signing key at
+  /// `public:_apsk.<enrollmentId>.a.__e@<atSign>`, composed by the client.
+  ///
+  /// Opaque to the atServer, which stores it verbatim on the enrollment record
+  /// and writes its JSON encoding unaltered when the enrollment is approved,
+  /// and again whenever an `enroll:update` carries a new one. The contents are
+  /// the client's alone, so a shape added later needs no server release.
+  ///
+  /// The form the client composes today is a versioned array of signing keys,
+  /// spelled as `KeyPackage`'s keys are so that one vocabulary covers every
+  /// "list of keys with algorithms" in the protocol:
+  ///
+  /// ```json
+  /// {"v": 1, "keys": [
+  ///   {"use": "sign", "alg": "mldsa65", "pub": "…", "status": "active"},
+  ///   {"use": "sign", "alg": "rsa2048", "pub": "…", "status": "verifyOnly"}
+  /// ]}
+  /// ```
+  ///
+  /// `status` absent reads as `active`. An entry is retained after it stops
+  /// signing — envelopes are stored durably and re-verified later, so removing
+  /// a key would retroactively unverify everything ever signed with it.
+  ///
+  /// A map rather than a string, matching [metadata]: the bare RSA spelling
+  /// `_apsk` has always carried is the *legacy* form, and a client old enough
+  /// to publish it does not send this field at all.
+  ///
+  /// Absent means **no `_apsk` is published**. The atServer never composes one
+  /// from [apkamPublicKey] and [signingAlgo]: PKAM verification reads the
+  /// enrollment record, so the server has no use for this key and no business
+  /// knowing how a signing key is spelled. An enrollment that sends nothing
+  /// here publishes its own signing key from its own connection, or goes
+  /// without.
+  ///
+  /// Capped by the atServer at 20KB **encoded**; a longer value is refused
+  /// rather than truncated.
+  Map<String, dynamic>? apsk;
+
+  /// Proof that the sender holds the private half of the [apkamPublicKey] it
+  /// is asking the atServer to install — base64 of a signature by that **new**
+  /// private key over `<enrollmentId>|<apkamPublicKey>|<signingAlgo>`.
+  ///
+  /// Required on an `enroll:update` that changes [apkamPublicKey], and refused
+  /// without it. The connection proves possession of the enrollment's
+  /// *current* key; nothing else proves possession of the new one, so without
+  /// this a compromised-but-authenticated client can install a public key
+  /// whose private half is held by someone else, locking out the legitimate
+  /// holder while the enrollment record still looks valid.
+  ///
+  /// No nonce, deliberately. The operation is self-only over an authenticated
+  /// connection, and the old key stops authenticating the moment the rotation
+  /// lands, so a replayed request can only be sent by the current holder —
+  /// which makes a rollback self-harm rather than an attack.
+  String? apkamPublicKeySignature;
+
   /// Opaque, additive metadata the server stores verbatim on the enrollment
   /// record and returns from discovery (`enroll:listns`). Carries the
   /// enrollment's key package (`metadata.keyPackage`) for the secret-sharing

--- a/packages/at_commons/lib/src/verb/enroll_params.g.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.g.dart
@@ -25,6 +25,8 @@ EnrollParams _$EnrollParamsFromJson(Map<String, dynamic> json) => EnrollParams()
   ..encryptedAPKAMSymmetricKey = json['encryptedAPKAMSymmetricKey'] as String?
   ..apkamPublicKey = json['apkamPublicKey'] as String?
   ..signingAlgo = json['signingAlgo'] as String?
+  ..apsk = json['apsk'] as Map<String, dynamic>?
+  ..apkamPublicKeySignature = json['apkamPublicKeySignature'] as String?
   ..metadata = json['metadata'] as Map<String, dynamic>?
   ..enrollmentStatusFilter = (json['enrollmentStatusFilter'] as List<dynamic>?)
       ?.map((e) => $enumDecode(_$EnrollmentStatusEnumMap, e))
@@ -49,6 +51,8 @@ Map<String, dynamic> _$EnrollParamsToJson(EnrollParams instance) =>
       'encryptedAPKAMSymmetricKey': instance.encryptedAPKAMSymmetricKey,
       'apkamPublicKey': instance.apkamPublicKey,
       'signingAlgo': instance.signingAlgo,
+      'apsk': instance.apsk,
+      'apkamPublicKeySignature': instance.apkamPublicKeySignature,
       'metadata': instance.metadata,
       'enrollmentStatusFilter': instance.enrollmentStatusFilter
           ?.map((e) => _$EnrollmentStatusEnumMap[e]!)

--- a/packages/at_commons/lib/src/verb/operation_enum.dart
+++ b/packages/at_commons/lib/src/verb/operation_enum.dart
@@ -29,7 +29,14 @@ enum EnrollOperationEnum {
   list,
   fetch,
   unrevoke,
-  delete
+  delete,
+
+  /// An approved enrollment amending its own record: `apkamPublicKey`,
+  /// `signingAlgo`, `apsk` and `metadata`. Self-only — the connection's
+  /// enrollment id must equal the target's — and it never reaches
+  /// `namespaces` or the approval state, because an operation an enrollment
+  /// can invoke on itself must not be able to widen its own grant.
+  update
 }
 
 String getEnrollOperation(EnrollOperationEnum? enrollOperationEnum) =>

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -148,7 +148,7 @@ class VerbSyntax {
   static const notifyRemove = r'notify:remove:(?<id>[\w\d\-\_]+)';
   static const enroll =
       // The non-capturing group (?::)? matches ":" if the operation is request|approve|deny|revoke
-      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|listns|list|fetch|unrevoke|delete)))(:(?<force>force))?(:(?<listNamespace>[^:{\n]+))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
+      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|listns|list|fetch|unrevoke|delete|update)))(:(?<force>force))?(:(?<listNamespace>[^:{\n]+))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
   static const otp =
       r'^otp:(?<operation>get|put)(:(?<otp>(?<=put:)\w{6,}))?(:(?:ttl:(?<ttl>\d+)))?$';
   static const keys = r'^keys:((?<operation>put|get|delete):?)'

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.13.0
+version: 5.14.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_commons/test/enroll_params_test.dart
+++ b/packages/at_commons/test/enroll_params_test.dart
@@ -161,4 +161,129 @@ void main() {
           [EnrollmentStatus.approved, EnrollmentStatus.pending]);
     });
   });
+
+  group('A group of tests to verify EnrollParams.apsk', () {
+    // Raw-literal pins: `apsk` is the wire spelling the atServer reads off
+    // enroll:request, and the map is written to the enrollment's published
+    // `_apsk` record as-is. A rename on either side is a protocol break, so
+    // the name and the contents are pinned rather than asserted through the
+    // constants that produce them.
+    test('an apsk map survives a wire round trip under the name "apsk"', () {
+      // The array form, spelled as KeyPackage's keys are (use/alg/pub) so one
+      // vocabulary covers every "list of keys with algorithms" in the
+      // protocol. `status: verifyOnly` marks an entry that no longer signs but
+      // is retained so historic envelopes still verify.
+      final apsk = {
+        'v': 1,
+        'keys': [
+          {
+            'use': 'sign',
+            'alg': 'mldsa65',
+            'pub': 'ZmFrZS1tbC1kc2EtcHVibGlj',
+            'status': 'active',
+          },
+          {
+            'use': 'sign',
+            'alg': 'rsa2048',
+            'pub': 'ZmFrZS1yc2EtcHVibGlj',
+            'status': 'verifyOnly',
+          },
+        ],
+      };
+
+      final json = (EnrollParams()..apsk = apsk).toJson();
+      expect(json['apsk'], apsk);
+
+      final command = 'enroll:request:${jsonEncode(json)}';
+      expect(RegExp(VerbSyntax.enroll).hasMatch(command), true,
+          reason: 'the enroll grammar takes enrollParams as one opaque blob, '
+              'so a nested object needs no syntax change');
+
+      final parsed = EnrollParams.fromJson(
+          jsonDecode(jsonEncode(json)) as Map<String, dynamic>);
+      expect(parsed.apsk, apsk);
+    });
+
+    test('an absent apsk stays absent rather than becoming an empty map', () {
+      // The atServer publishes no `_apsk` at all for an enrollment that sends
+      // none, so null and {} must not collapse into each other: an empty map
+      // would have it publish "{}" as somebody's signing key.
+      final parsed = EnrollParams.fromJson(<String, dynamic>{
+        'appName': 'wavi',
+        'deviceName': 'pixel',
+      });
+      expect(parsed.apsk, isNull);
+      expect(parsed.toJson()['apsk'], isNull);
+    });
+  });
+
+  group('A group of tests to verify enroll:update', () {
+    // Raw-literal pins. The operation token and the field name are what the
+    // atServer matches and reads; a rename on either side is a protocol break,
+    // so both are pinned as literals rather than through the enum and the
+    // getter that produce them.
+    test('the operation token is "update"', () {
+      expect(getEnrollOperation(EnrollOperationEnum.update), 'update');
+    });
+
+    test('the enroll grammar matches an enroll:update command', () {
+      final json = (EnrollParams()
+            ..enrollmentId = 'abc-123'
+            ..apkamPublicKey = 'ZmFrZS1uZXctcHVibGlj'
+            ..signingAlgo = 'mldsa65'
+            ..apkamPublicKeySignature = 'ZmFrZS1zaWduYXR1cmU=')
+          .toJson();
+
+      final match = RegExp(VerbSyntax.enroll)
+          .firstMatch('enroll:update:${jsonEncode(json)}');
+      expect(match, isNotNull);
+      expect(match!.namedGroup('operation'), 'update');
+      expect(match.namedGroup('enrollParams'), jsonEncode(json));
+    });
+
+    test('adding "update" leaves the existing operations matching as before',
+        () {
+      // Widening an alternation can change what an earlier token matches —
+      // `listns` precedes `list` for exactly that reason — so every existing
+      // operation is re-checked rather than assumed unaffected.
+      for (final op in [
+        'request',
+        'approve',
+        'deny',
+        'revoke',
+        'listns',
+        'list',
+        'fetch',
+        'unrevoke',
+        'delete',
+      ]) {
+        final match = RegExp(VerbSyntax.enroll).firstMatch('enroll:$op:{}');
+        expect(match?.namedGroup('operation'), op,
+            reason: 'operation "$op" must still capture as itself');
+      }
+    });
+
+    test('apkamPublicKeySignature survives a wire round trip under that name',
+        () {
+      const signature = 'ZmFrZS1uZXcta2V5LXNpZ25hdHVyZQ==';
+
+      final json =
+          (EnrollParams()..apkamPublicKeySignature = signature).toJson();
+      expect(json['apkamPublicKeySignature'], signature);
+
+      final parsed = EnrollParams.fromJson(
+          jsonDecode(jsonEncode(json)) as Map<String, dynamic>);
+      expect(parsed.apkamPublicKeySignature, signature);
+    });
+
+    test('an absent apkamPublicKeySignature stays null', () {
+      // The atServer refuses an enroll:update that changes apkamPublicKey
+      // without one, so absent must be distinguishable from empty.
+      final parsed = EnrollParams.fromJson(<String, dynamic>{
+        'enrollmentId': 'abc-123',
+      });
+      expect(parsed.apkamPublicKeySignature, isNull);
+      expect(parsed.toJson()['apkamPublicKeySignature'], isNull);
+    });
+  });
 }


### PR DESCRIPTION
**- What I did**

- `EnrollParams.apsk` — the value a client composes for its own `public:_apsk.<enrollmentId>.a.__e@<atSign>` record, carried on `enroll:request` and stored verbatim by the atServer. A versioned array of signing keys, `{"v":1,"keys":[{"use","alg","pub","status"}]}`, spelled as `KeyPackage`'s keys are.
  - It exists so the atServer stops composing that value from `(apkamPublicKey, signingAlgo)`. PKAM verification is record-authoritative, so `_apsk` is a client-side artefact the server has no use for and no business knowing the format of. Absent means none is published.
- `EnrollOperationEnum.update` and the matching `enroll:update` grammar alternation — an approved enrollment amending its own `apkamPublicKey`, `signingAlgo`, `apsk` and `metadata`. Self-only, and never `namespaces` or the approval state.
  - This is what lets an enrollment replace its APKAM keypair while keeping its id, rather than the replacement being a new enrollment.
- `EnrollParams.apkamPublicKeySignature` — proof the sender holds the private half of the key it is installing. The connection proves possession of the *current* key; without this a compromised-but-authenticated client can install a key whose private half is held by someone else.

Design: `docs/projects/pq/decisions.md` section 91.

**- How I did it**

See commit & diffs.

**- How to verify it**

Tests pass. Note one deliberate addition: widening the `enroll` alternation can change what an earlier token matches (`listns` precedes `list` for exactly that reason), so a test re-checks that all nine existing operations still capture as themselves.

**- Description for the changelog**

at_commons 5.14.0 — `EnrollParams.apsk` (the client-composed `_apsk` signing-key array), `EnrollParams.apkamPublicKeySignature` (proof of possession of a new APKAM key), and `EnrollOperationEnum.update` with its `enroll:update` grammar entry.
