### PR TITLE
feat(at_commons): the _apsk value reaches the wire, bare or array

### DIFF
--- a/packages/at_auth/lib/src/at_auth_impl.dart
+++ b/packages/at_auth/lib/src/at_auth_impl.dart
@@ -188,7 +188,7 @@ class AtAuthImpl implements AtAuth {
       atOnboardingRequest.atKeys = await atOnboardingRequest.atKeysIo?.read(
         atOnboardingRequest.atSign,
       );
-    } catch (e, _) {
+    } catch (e) {
       _logger.info(
         'Failed to read keys for atSign: ${atOnboardingRequest.atSign} | Cause: $e',
       ); //swallow the error, we just want to know if keys exist or not

--- a/packages/at_chops/test/at_chops_compatibility_test.dart
+++ b/packages/at_chops/test/at_chops_compatibility_test.dart
@@ -551,7 +551,7 @@ void main() {
           DefaultSigningAlgo(null, signingInput.hashingAlgoType);
       try {
         atChops.sign(signingInput);
-      } catch (e, _) {
+      } catch (e) {
         assert(e is AtSigningException);
         expect(e.toString(),
             'Exception: encryption key pair not set for rsa signing algo');
@@ -568,7 +568,7 @@ void main() {
           DefaultSigningAlgo(encryptionKeypair, signingInput.hashingAlgoType);
       try {
         atChops.sign(signingInput);
-      } catch (e, _) {
+      } catch (e) {
         assert(e is InvalidDataException);
         expect(e.toString(), 'Exception: Unrecognized type of data: 213456777');
       }

--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 5.15.0
+
+- feat: add `EnrollVerbBuilder.apsk`, threading the existing
+  `EnrollParams.apsk` through to the built command. The field had no route to
+  the wire, so nothing could send the value the atServer publishes verbatim.
+- feat: add `EnrollParams.apskLegacy` and the matching `EnrollVerbBuilder`
+  field, carrying the **bare** RSA `_apsk` string an enrollment publishes
+  verbatim. Every deployed `_apsk` consumer base64-decodes the value as an RSA
+  key, so a plain-legacy enrollment must be able to publish that shape through
+  the same verb every other enrollment uses. A separate field rather than
+  widening `apsk` to two types, which would have been source-breaking on a
+  published field. The atServer writes it as-is — **not** JSON-encoded, since a
+  quoted string is not what a bare-RSA parser reads — and refuses a request
+  carrying both fields, which would disagree about one record with no basis for
+  choosing between them.
+- fix: `EnrollParams.apsk`'s entry `status` is `active` or **`retired`**, not
+  `verifyOnly` as 5.14.0 documented, and the entry carries a `kid` like every
+  other key entry in the protocol. `retired` is use-neutral — "retained, not
+  for new operations" — because `use` already names the operation a key serves:
+  a retired signing key still verifies old envelopes, and a retired
+  encapsulation key still opens records already sealed to it. Documentation
+  only; the atServer stores the value verbatim, so no record carries either
+  spelling.
+
 ## 5.14.0
 
 - feat: add `EnrollParams.apsk` — the value a client composes for its own

--- a/packages/at_commons/lib/src/verb/enroll_params.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.dart
@@ -30,35 +30,56 @@ class EnrollParams {
   /// and again whenever an `enroll:update` carries a new one. The contents are
   /// the client's alone, so a shape added later needs no server release.
   ///
-  /// The form the client composes today is a versioned array of signing keys,
+  /// The form the client composes is a versioned array of signing keys,
   /// spelled as `KeyPackage`'s keys are so that one vocabulary covers every
   /// "list of keys with algorithms" in the protocol:
   ///
   /// ```json
   /// {"v": 1, "keys": [
-  ///   {"use": "sign", "alg": "mldsa65", "pub": "…", "status": "active"},
-  ///   {"use": "sign", "alg": "rsa2048", "pub": "…", "status": "verifyOnly"}
+  ///   {"kid": "…", "use": "sign", "alg": "mldsa65", "pub": "…"}
   /// ]}
   /// ```
   ///
-  /// `status` absent reads as `active`. An entry is retained after it stops
-  /// signing — envelopes are stored durably and re-verified later, so removing
-  /// a key would retroactively unverify everything ever signed with it.
+  /// An array from the outset even though an enrollment holds one signing key
+  /// today: a second algorithm's key is added beside the first rather than
+  /// replacing it, because envelopes are stored durably and verified later, so
+  /// a key that stops being used must still verify what it already signed. A
+  /// reader skips entries whose `use` or `alg` it does not know, which is what
+  /// lets an enrollment advertise a new algorithm without breaking readers
+  /// that predate it.
   ///
-  /// A map rather than a string, matching [metadata]: the bare RSA spelling
-  /// `_apsk` has always carried is the *legacy* form, and a client old enough
-  /// to publish it does not send this field at all.
+  /// A per-entry `status` (`active` | `retired`, absent reading as `active`)
+  /// arrives with the retired-key path; nothing composes or reads it yet.
   ///
-  /// Absent means **no `_apsk` is published**. The atServer never composes one
-  /// from [apkamPublicKey] and [signingAlgo]: PKAM verification reads the
-  /// enrollment record, so the server has no use for this key and no business
-  /// knowing how a signing key is spelled. An enrollment that sends nothing
-  /// here publishes its own signing key from its own connection, or goes
-  /// without.
+  /// A map rather than a string, because this is the structured form. The bare
+  /// RSA spelling `_apsk` has always carried travels on [apskLegacy] instead —
+  /// two fields rather than one field of two types, so neither the wire type
+  /// nor the atServer's handling has to be widened later.
+  ///
+  /// Absent means **no `_apsk` is published** from this field. The atServer
+  /// never composes one from [apkamPublicKey] and [signingAlgo]: PKAM
+  /// verification reads the enrollment record, so the server has no use for
+  /// this key and no business knowing how a signing key is spelled.
   ///
   /// Capped by the atServer at 20KB **encoded**; a longer value is refused
   /// rather than truncated.
   Map<String, dynamic>? apsk;
+
+  /// The **bare** `_apsk` value — an RSA public key string, exactly as the
+  /// record has always carried it — to publish verbatim at
+  /// `public:_apsk.<enrollmentId>.a.__e@<atSign>`.
+  ///
+  /// This exists because every deployed `_apsk` consumer base64-decodes the
+  /// value as an RSA key, so a JSON one fails their parse. That is fail-closed
+  /// but service-breaking for anything already running, which is why a
+  /// plain-legacy enrollment must be able to publish the shape they expect
+  /// through the same verb every other enrollment uses.
+  ///
+  /// Written verbatim, **not** JSON-encoded: a quoted string is not what a
+  /// bare-RSA parser reads. Sending this together with [apsk] is a client
+  /// error and the atServer refuses it — the two would disagree about one
+  /// record, and the server has no basis for choosing between them.
+  String? apskLegacy;
 
   /// Proof that the sender holds the private half of the [apkamPublicKey] it
   /// is asking the atServer to install — base64 of a signature by that **new**

--- a/packages/at_commons/lib/src/verb/enroll_params.g.dart
+++ b/packages/at_commons/lib/src/verb/enroll_params.g.dart
@@ -26,6 +26,7 @@ EnrollParams _$EnrollParamsFromJson(Map<String, dynamic> json) => EnrollParams()
   ..apkamPublicKey = json['apkamPublicKey'] as String?
   ..signingAlgo = json['signingAlgo'] as String?
   ..apsk = json['apsk'] as Map<String, dynamic>?
+  ..apskLegacy = json['apskLegacy'] as String?
   ..apkamPublicKeySignature = json['apkamPublicKeySignature'] as String?
   ..metadata = json['metadata'] as Map<String, dynamic>?
   ..enrollmentStatusFilter = (json['enrollmentStatusFilter'] as List<dynamic>?)
@@ -52,6 +53,7 @@ Map<String, dynamic> _$EnrollParamsToJson(EnrollParams instance) =>
       'apkamPublicKey': instance.apkamPublicKey,
       'signingAlgo': instance.signingAlgo,
       'apsk': instance.apsk,
+      'apskLegacy': instance.apskLegacy,
       'apkamPublicKeySignature': instance.apkamPublicKeySignature,
       'metadata': instance.metadata,
       'enrollmentStatusFilter': instance.enrollmentStatusFilter

--- a/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
+++ b/packages/at_commons/lib/src/verb/enroll_verb_builder.dart
@@ -51,6 +51,18 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
   /// package (`metadata.keyPackage`) for the secret-sharing substrate.
   Map<String, dynamic>? metadata;
 
+  /// The value to publish as this enrollment's `_apsk` signing key. See
+  /// [EnrollParams.apsk] for the shape and why the atServer composes nothing.
+  ///
+  /// An enrollment that sends neither this nor [apskLegacy] gets no `_apsk`
+  /// published, and an approver then has no key to verify its advertised key
+  /// package against.
+  Map<String, dynamic>? apsk;
+
+  /// The bare RSA `_apsk` string, published verbatim. See
+  /// [EnrollParams.apskLegacy]. Mutually exclusive with [apsk].
+  String? apskLegacy;
+
   /// Used to force revoke the enrollment request.
   bool force = false;
 
@@ -84,6 +96,8 @@ class EnrollVerbBuilder extends AbstractVerbBuilder {
       ..selfEncKeyIV = selfEncKeyIV
       ..encryptedAPKAMSymmetricKey = encryptedAPKAMSymmetricKey
       ..signingAlgo = signingAlgo
+      ..apsk = apsk
+      ..apskLegacy = apskLegacy
       ..metadata = metadata
       ..enrollmentStatusFilter = enrollmentStatusFilter
       ..apkamKeysExpiryDuration = apkamKeysExpiryDuration;

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.14.0
+version: 5.15.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_commons/test/enroll_params_test.dart
+++ b/packages/at_commons/test/enroll_params_test.dart
@@ -204,6 +204,24 @@ void main() {
       expect(parsed.apsk, apsk);
     });
 
+    test('the bare form rides apskLegacy, verbatim and unquoted', () {
+      // A plain-legacy enrollment publishes the RSA key string itself, which
+      // is what every deployed consumer base64-decodes. It travels on its own
+      // field rather than sharing `apsk`, so neither the wire type nor the
+      // atServer's handling of `apsk` has to be widened to two types.
+      const bare = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A';
+
+      final json = (EnrollParams()..apskLegacy = bare).toJson();
+      expect(json['apskLegacy'], bare);
+      expect(json['apsk'], isNull);
+
+      final parsed = EnrollParams.fromJson(
+          jsonDecode(jsonEncode(json)) as Map<String, dynamic>);
+      expect(parsed.apskLegacy, bare,
+          reason: 'the value is published as-is; a JSON-encoded (quoted) '
+              'string is not what a bare-RSA parser reads');
+    });
+
     test('an absent apsk stays absent rather than becoming an empty map', () {
       // The atServer publishes no `_apsk` at all for an enrollment that sends
       // none, so null and {} must not collapse into each other: an empty map

--- a/packages/at_commons/test/enroll_verb_builder_test.dart
+++ b/packages/at_commons/test/enroll_verb_builder_test.dart
@@ -22,6 +22,49 @@ void main() {
           'enroll:request:{"enrollmentId":"1234","appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw","__manage":"r"},"encryptedDefaultEncryptionPrivateKey":"dummy_encrypted_private_key","encryptedDefaultSelfEncryptionKey":"dummy_self_encryption_key","encryptedAPKAMSymmetricKey":"dummy_pkam_sym_key","apkamPublicKey":"abcd1234","apkamKeysExpiryInMillis":60000}\n');
     });
 
+    // Both of these assert against a RAW LITERAL rather than against the
+    // builder's own fields, because the point of the pin is the wire: `apsk`
+    // existed on EnrollParams with no route to the built command, so a test
+    // that read the field back would have passed the whole time the value
+    // could not be sent.
+    test('a request carries its apsk array to the wire', () {
+      var enrollVerbBuilder = EnrollVerbBuilder()
+        ..operation = EnrollOperationEnum.request
+        ..appName = 'wavi'
+        ..deviceName = 'pixel'
+        ..namespaces = {'wavi': 'rw'}
+        ..apkamPublicKey = 'abcd1234'
+        ..signingAlgo = 'mldsa65'
+        ..apsk = {
+          'v': 1,
+          'keys': [
+            {
+              'kid': '0123456789abcdef',
+              'use': 'sign',
+              'alg': 'mldsa65',
+              'pub': 'PUBKEY'
+            }
+          ]
+        };
+      var command = enrollVerbBuilder.buildCommand();
+      expect(command,
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"abcd1234","signingAlgo":"mldsa65","apsk":{"v":1,"keys":[{"kid":"0123456789abcdef","use":"sign","alg":"mldsa65","pub":"PUBKEY"}]}}\n');
+    });
+
+    test('a request carries its bare apskLegacy to the wire, unquoted-as-JSON',
+        () {
+      var enrollVerbBuilder = EnrollVerbBuilder()
+        ..operation = EnrollOperationEnum.request
+        ..appName = 'wavi'
+        ..deviceName = 'pixel'
+        ..namespaces = {'wavi': 'rw'}
+        ..apkamPublicKey = 'abcd1234'
+        ..apskLegacy = 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A';
+      var command = enrollVerbBuilder.buildCommand();
+      expect(command,
+          'enroll:request:{"appName":"wavi","deviceName":"pixel","namespaces":{"wavi":"rw"},"apkamPublicKey":"abcd1234","apskLegacy":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A"}\n');
+    });
+
     test('A test to verify enroll approve operation', () {
       var enrollVerbBuilder = EnrollVerbBuilder()
         ..operation = EnrollOperationEnum.approve


### PR DESCRIPTION
**- What I did**

- `EnrollVerbBuilder` gains `apsk`. `EnrollParams.apsk` shipped in 5.14.0 with no route to the wire, so nothing could send the value the atServer stores verbatim and publishes at approval.
- Adds `EnrollParams.apskLegacy` + the matching builder field: the **bare** RSA `_apsk` string, published verbatim.
  - Every deployed `_apsk` consumer base64-decodes the value as an RSA key, so a JSON one fails their parse — fail-closed, but service-breaking for anything already running. A plain-legacy enrollment needs to publish the shape they expect, through the same verb every other enrollment uses.
  - Two fields rather than one field of two types: `apsk` is published, so widening its type would be source-breaking, and neither the wire type nor the atServer's handling has to be widened later.
- Corrects the `apsk` entry dartdoc — `status` is `retired`, not the `verifyOnly` 5.14.0 documented, and an entry carries a `kid` like every other key entry in the protocol. Documentation only; the atServer stores the value verbatim.
- Version 5.14.0 → 5.15.0 (5.14.0 is published).

**Owed on the atServer side**, not in this PR: write `apskLegacy` as-is — *not* JSON-encoded, since a quoted string is not what a bare-RSA parser reads — and refuse a request carrying both fields.

**- How I did it**

See commit & diffs.

**- How to verify it**

Tests pass. The two new pins assert raw literals against the **built command** rather than reading the builder's own fields — a field-read test would have passed the entire time `apsk` could not be sent. Removing the two `..apsk = apsk` / `..apskLegacy = apskLegacy` lines turns exactly those two red.

**- Description for the changelog**

`EnrollVerbBuilder.apsk` threads the existing `EnrollParams.apsk` to the wire, and `EnrollParams.apskLegacy` carries the bare RSA `_apsk` string a plain-legacy enrollment publishes verbatim.