### PR TITLE
feat(at_lookup): 3.7.0 - AtLookUp.withSecureSocket and the muxable

### DIFF
--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -7,6 +7,15 @@
   `startNotifications` had a socket whose loss reached nothing: no `false` on
   `notificationConnectionUp`, no reconnect, and a listener silent for the rest
   of the process while still reporting itself up.
+- fix: a watermark read that throws no longer leaves the client permanently
+  deaf. `getLastNotificationTime` is caller code running inside the reconnect
+  loop, and an exception aborted the attempt AFTER it had opened and
+  authenticated a connection — which then stayed valid, so every later attempt
+  skipped the connect, re-ran only the throwing call, and backed off forever
+  with `monitor:` never sent. The only symptom was an `up` that never arrived.
+  The read is now guarded: the failure is logged at `warning` and the
+  connection starts without a watermark, which costs a replayed window rather
+  than every future notification.
 - fix: a reconnect no longer re-requests the backlog from where notifications
   first started. `startNotifications`'s `lastNotificationTime` is now
   `getLastNotificationTime`, a function the muxable calls on every connect

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,5 +1,20 @@
 ## 3.7.0
 
+- fix: a connection built before anything reads `notifications` now
+  reconnects when it drops. The stream getter installs the routing seam for
+  the case where a verb opened the connection first, but not the disconnect
+  seam — so a client that authenticated or ran a verb before calling
+  `startNotifications` had a socket whose loss reached nothing: no `false` on
+  `notificationConnectionUp`, no reconnect, and a listener silent for the rest
+  of the process while still reporting itself up.
+- fix: a subscriber applying back-pressure no longer loses its connection to
+  the heartbeat. Pausing the `notifications` stream stops the socket being
+  read, which is the documented point of it, but it also means nothing can
+  answer the `noop:0` probe — so the probe timed out and destroyed a healthy
+  connection. A pause longer than `heartbeatResponseTimeout` (10s by default)
+  was enough, which one slow `await` in an `await for` body will do. The
+  heartbeat now skips while delivery is paused, before and after the probe
+  goes out.
 - deprecated: `AtLookUp.executeVerb`'s `sync` parameter, removal in 4.0. It
   has never been read: the verb always executes on the remote atServer, and
   there is no sync behaviour for the parameter to control.

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -7,6 +7,19 @@
   `startNotifications` had a socket whose loss reached nothing: no `false` on
   `notificationConnectionUp`, no reconnect, and a listener silent for the rest
   of the process while still reporting itself up.
+- fix: a reconnect no longer re-requests the backlog from where notifications
+  first started. `startNotifications`'s `lastNotificationTime` is now
+  `getLastNotificationTime`, a function the muxable calls on every connect
+  rather than a value it remembers — restoring what the caller-owned monitor
+  loop did before the muxable took over reconnection.
+- fix: `stopNotifications` retires any reconnect loop still sleeping on a
+  backoff, and clears the `_reconnecting` flag it used to leave set. A stop
+  followed by a start inside that window let the orphaned loop wake, see
+  notifications running again, and act on the connection the restart had just
+  made — a second `monitor:` on a live socket, its heartbeat reset, and an
+  `up` with no preceding down — while the stale flag disarmed the disconnect
+  handler for up to 34 seconds. `isReconnectingNotifications` also no longer
+  reads true after a stop.
 - fix: a subscriber applying back-pressure no longer loses its connection to
   the heartbeat. Pausing the `notifications` stream stops the socket being
   read, which is the documented point of it, but it also means nothing can
@@ -99,9 +112,14 @@
 - feat: the muxable owns reconnect, reauth and heartbeat, because it owns the
   socket. Losing the notification connection re-establishes it on the
   `[1,2,3,5,8,13,21,34]`-second backoff, re-runs the authenticator, and
-  re-issues the **same** `monitor:` — a reconnect that dropped the regex would
-  start delivering everything, and one that dropped the watermark would replay
-  from the beginning. A quiet connection is probed with `noop:0`, because a
+  re-issues `monitor:` with the same regex — one that dropped it would start
+  delivering everything. The **watermark is asked for again**, not replayed
+  from the start value: `startNotifications` takes a
+  `getLastNotificationTime` function and the muxable calls it on every
+  connect, so a reconnect resumes from where the caller has actually got to.
+  This is the behaviour at_client's `Monitor` had when it owned reconnection
+  and re-read the watermark on each start; holding the number instead would
+  re-request the whole retained backlog on every reconnect. A quiet connection is probed with `noop:0`, because a
   connection that only ever reads cannot tell a quiet atServer from a dead
   socket. at_client's `Monitor` carries an identical delay list; both cannot
   own reconnection.

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,3 +1,199 @@
+## 3.7.0
+
+- deprecated: `AtLookUp.executeVerb`'s `sync` parameter, removal in 4.0. It
+  has never been read: the verb always executes on the remote atServer, and
+  there is no sync behaviour for the parameter to control.
+- fix(deps): raised the `at_chops` constraint to `^3.6.0`. The old `^3.3.0`
+  floor was never exercised — the only build evidence for this package is
+  against at_chops 3.5.0 and later, so a consumer resolving 3.3.0 or 3.4.x
+  was relying on a combination nothing had tested. Workspace resolution hides
+  that gap locally, because it always supplies the in-tree at_chops. 3.6.0 is
+  what this release is built and tested against.
+- fix(deps): raised the `at_commons` constraint to `^5.16.0`. This package now
+  reads `AtNetworkTimeouts.defaultResponseBudget`, which does not exist in
+  at_commons 5.15.0 or earlier — under the old `^5.13.0` a consumer could
+  resolve an at_commons that this package does not compile against.
+
+- fix: a request in flight when its connection closes now fails immediately
+  instead of waiting out its response budget. `AtLookupImpl` holds
+  `requestResponseMutex` across that wait, so a connection that had already gone
+  stalled the **next** request on the same instance for the whole transient
+  budget - 30 seconds by default. Stopping an atSign's client while its startup
+  work was still in flight was enough to trigger it, and the request that
+  followed read as a hang rather than as a closed connection. Every close now
+  routes through one place that fails the pending read first, and the caller
+  gets a `ConnectionInvalidException` naming what happened rather than an
+  `AtTimeoutException` pointing at the atServer. A response already parsed and
+  queued before the connection went away is still returned.
+
+- feat: `AtLookupMuxable.notificationConnectionUp` — `true` when `monitor:` is
+  accepted on a live connection, `false` when it is lost or stopped. The
+  muxable owns reconnection, so it is the only thing that knows; at_client's
+  `Monitor` re-broadcasts it as a listener state, which noports' daemon
+  subscribes to for its whole life. Broadcast, unlike `notifications`, because
+  it is a state signal whose latest value supersedes the last — a dropped
+  notification is gone, a dropped state event is re-derivable.
+
+- feat: `AtLookupMuxable` gains the members callers were reaching for through
+  a cast to the concrete class: `authenticator`, `isConnectionAvailable` and
+  `readResponse`, plus `scan(auth:)` and `lookup(metadata:)`. Those last two
+  are a defect this surfaced - `AtLookupImpl` accepted **more** than `AtLookUp`
+  declared, so a caller moving to the interface silently lost parameters. They
+  are restated on the muxable rather than added to `AtLookUp`, which is frozen:
+  adding a parameter there forces every `implements AtLookUp` to redeclare it.
+
+- feat: `AtLookUp.withSecureSocket(...)` — the entry point, returning an
+  `AtLookupMuxable`. Static, so it adds nothing to the `implements` contract
+  and breaks none of the classes that mock `AtLookUp`. It takes an
+  `AtRootDomain` rather than a `String, int` pair, requires
+  `secureSocketConfig` and `authenticator` (the latter nullable, because "this
+  connection never authenticates" is a real mode that ought to be stated), and
+  takes an `AtLookupTransport`.
+- feat: `AtLookupTransport` bundles the three connection factories
+  `AtLookupImpl` has always accepted into one value, so a caller holding only
+  the `AtLookupMuxable` interface can still say how connections are made. It
+  bundles rather than abstracts on purpose: the web-port plan records that
+  these factories are already injectable and that the blocker is their
+  **return type**, so a second abstraction here would be one more seam for that
+  work to reconcile. It is not yet sufficient for a non-socket transport, and
+  does not claim to be — `AtConnection.getSocket()` still returns a `Socket`.
+- feat: `AtLookupImpl`'s constructor is `@Deprecated` in favour of the factory.
+  The class itself is **not** deprecated and does not move: it is exported from
+  the barrel, so renaming it or making it private would remove a public class,
+  which this release is not. The warnings at each construction site are the
+  deliverable — 45 of them, `info`, so nothing breaks while they are worked
+  through.
+- feat: `MonitorClient` is `@Deprecated` with no replacement. A tree-wide
+  search finds its own declaration and nothing else, and it predates the
+  connect timeouts — it builds its socket directly rather than through
+  `SecureSocketUtil`, so it never got them. Use `withSecureSocket` and
+  `AtLookupMuxable.notifications`.
+
+- feat: the muxable owns reconnect, reauth and heartbeat, because it owns the
+  socket. Losing the notification connection re-establishes it on the
+  `[1,2,3,5,8,13,21,34]`-second backoff, re-runs the authenticator, and
+  re-issues the **same** `monitor:` — a reconnect that dropped the regex would
+  start delivering everything, and one that dropped the watermark would replay
+  from the beginning. A quiet connection is probed with `noop:0`, because a
+  connection that only ever reads cannot tell a quiet atServer from a dead
+  socket. at_client's `Monitor` carries an identical delay list; both cannot
+  own reconnection.
+- feat: `OutboundMessageListener.onDisconnect`. The listener knows the socket
+  died before anything else does and used to keep it to itself, so a
+  subscriber just stopped hearing anything, with no event separating "the
+  atServer is quiet" from "the socket is gone".
+- fix: `stopNotifications` no longer awaits the notification controller's
+  `close()`. On a single-subscription controller that future completes only
+  once a subscriber has received the done event, so starting notifications and
+  stopping them without ever listening — a legal sequence — hung forever.
+
+- feat: `AtLookupMuxable`, an `AtLookUp` that also carries the atServer's
+  asynchronous notification stream, so one class knows both of the atServer's
+  framings instead of the framing code existing twice. `AtLookupImpl`
+  implements it: `notifications` is a **single-subscription** stream whose
+  pause reaches the socket, `startNotifications` sends `monitor:` under the
+  request-response mutex, and `stopNotifications` closes both. A broadcast
+  stream was rejected — it does not buffer, ignores pause and drops anything
+  arriving before a listener attaches, and each of those is a lost
+  notification, which is indistinguishable from one the atServer never sent.
+- feat: `OutboundMessageListener` keeps the subscription `listen()` used to
+  discard, and exposes `pauseDelivery`/`resumeDelivery`. That is what makes
+  back-pressure real: pausing stops reading the socket, so TCP closes the
+  window on the atServer rather than this process buffering without bound.
+  Note that `StreamSubscription` **counts** pauses — two need two resumes.
+- fix: ⚠️ `MonitorVerbBuilder.multiplexed` does not do what it says, and
+  nothing in at_lookup sets it. Its dartdoc claims the atServer "will only send
+  notifications once there is no request currently in progress". No atServer
+  implements it: zero occurrences in `at_server` `origin/trunk`, against a
+  probe proven positive on `selfNotifications` (16). The monitor verb's syntax
+  — shared by both sides — does capture `multiplexed`, so the atServer parses
+  the flag and ignores it rather than refusing it. Until an atServer
+  implements the interlock, give the notification stream a connection of its
+  own.
+
+- feat: the six credential members are `@Deprecated` — `atChops`,
+  `signingAlgoType`, `hashingAlgoType` and `enrollmentId` on both `AtLookUp`
+  and `AtLookupImpl`, plus `privateKey` and `cramSecret` on the impl.
+  Authentication runs through an injected `AtAuthenticator`, which at_auth
+  builds from whichever credential shape a caller holds, so at_lookup no
+  longer needs key material of its own. The fallback ladder still reads these
+  fields and nothing breaks; the fields and the ladder are removed together in
+  the next major. `signingAlgoType` and `hashingAlgoType` are one setting —
+  they are read on the same lines when the PKAM signature is built — so
+  deprecating either without the other would say the survivor lives on into
+  the major, which is not true.
+- fix: `privateKey`'s deprecation message claimed "privateKey reference is no
+  longer used". That was false: the ladder in `_process` reads the field and
+  signs with it, and before the authenticator seam landed it was the leg most
+  of the traffic took. The message now names the replacement instead.
+
+- fix: `pkamAuthenticate` prefers an injected authenticator too, not only
+  `executeCommand`. at_auth reaches that method directly rather than through a
+  verb, so a seam wired into the verb path alone would have looked connected
+  while doing nothing on the one call that matters most. The enrollment id is
+  now threaded to the recording, because a caller of `pkamAuthenticate` names
+  it in the call while a verb has only the field.
+
+- feat: `validatedFromChallenge` is public API rather than
+  `@visibleForTesting`. Authentication is moving to at_auth, where the key
+  material is, and the side that signs a challenge is the side that must refuse
+  a malformed one. The alternative was a second copy of a security control,
+  and two copies drift.
+- feat: `AtCommandExecutor.sendSync` accepts the same two timeout budgets as
+  `OutboundMessageListener.read`. Authentication does not want one answer: the
+  CRAM leg of onboarding waits far less than a verb response does, and moving
+  that code out of at_lookup must not change its timing.
+
+- feat: `AtLookupImpl` accepts an injected authenticator. Two new types,
+  `AtAuthenticator` and `AtCommandExecutor`, let a caller hand over the whole
+  of authentication as one closure instead of handing at_lookup a credential
+  to store. at_lookup cannot name `AtKeys` or `AtKeysIo` - they live in
+  at_auth, which depends on at_lookup - so the keystore, the enrollment and
+  the signing algorithm stay on the caller's side of the seam. When set, the
+  authenticator is preferred over the existing
+  atChops/privateKey/cramSecret ladder; when absent, nothing changes. Both
+  routes work, and the ladder goes once every caller supplies one.
+
+- feat: `OutboundMessageListener` can route asynchronous notifications, via a
+  new `onNotification` callback. The atServer frames the two kinds of message
+  differently - a verb response ends with a newline and the ready prompt
+  `@<atSign>@`, while a notification is a reply to nothing, so no prompt
+  follows it and it ends at a bare newline. One listener now knows both. While
+  `onNotification` is null the second framing is not applied at all and parsing
+  is byte-for-byte what it was, because routing notifications to a callback
+  nobody installed would drop them.
+
+- feat: `OutboundMessageListener.read` waits on an event instead of polling.
+  It slept 10ms at a time and re-checked a queue, so every response carried up
+  to a polling interval of latency for no reason. It now sleeps until a
+  response is queued or until the nearer of its two deadlines, whichever comes
+  first.
+- feat: `read`'s two timeouts come from `AtNetworkTimeouts` and are now
+  nullable. The whole-response budget defaults to
+  `AtNetworkTimeouts.defaultResponseBudget` (90s, unchanged in value) and the
+  between-chunks budget to `AtNetworkTimeouts.effectiveDefault`, which moves
+  that default from **10s to 30s**. Ten seconds of silence is not evidence a
+  busy atServer has gone away, and the two budgets measure different things:
+  one bounds the whole response, the other restarts on every chunk. Callers
+  passing explicit values are unaffected, and a process that sets
+  `AtNetworkTimeouts.defaultTimeout` at startup now moves this too.
+
+- fix: a response carrying no colon no longer destroys the connection.
+  `OutboundMessageListener._stripPrompt` ran `substring(0, -1)` when
+  `indexOf(':')` found nothing, and the bare `@<atSign>@` that completes the
+  handshake is exactly such a response - one `_isValidResponse` accepts. The
+  RangeError was raised inside the socket's data handler, so `runZonedGuarded`
+  reported it as a socket error and closed a healthy connection, leaving the
+  caller with an `AtTimeoutException` naming the wrong cause. Guarded, as the
+  copy of this method in at_client's `Monitor` already was.
+
+- feat: a connection records the identity it authenticated as.
+  `AtConnectionMetaData` gains `authenticatedAsEnrollmentId` and
+  `authenticatedAt` beside `isAuthenticated`, set by every path in
+  `AtLookupImpl` that authenticates. `AtLookUp.enrollmentId` is what the *next*
+  PKAM will send, so it cannot answer which enrollment a socket that is already
+  up holds; this can.
+
 ## 3.6.1
 
 - fix: strengthen the from challenge. A client now checks that a `from:`

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.7.0
+## 3.7.0-rc1
 
 - fix: a connection built before anything reads `notifications` now
   reconnects when it drops. The stream getter installs the routing seam for

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -60,18 +60,30 @@
 - feat: `AtLookUp.withSecureSocket(...)` — the entry point, returning an
   `AtLookupMuxable`. Static, so it adds nothing to the `implements` contract
   and breaks none of the classes that mock `AtLookUp`. It takes an
-  `AtRootDomain` rather than a `String, int` pair, requires
-  `secureSocketConfig` and `authenticator` (the latter nullable, because "this
-  connection never authenticates" is a real mode that ought to be stated), and
-  takes an `AtLookupTransport`.
+  `AtRootDomain` rather than a `String, int` pair, and requires both
+  `authenticator` (nullable, because "this connection never authenticates" is
+  a real mode that ought to be stated) and `transport`. No socket settings
+  appear in its signature: they belong to the transport.
 - feat: `AtLookupTransport` bundles the three connection factories
   `AtLookupImpl` has always accepted into one value, so a caller holding only
   the `AtLookupMuxable` interface can still say how connections are made. It
   bundles rather than abstracts on purpose: the web-port plan records that
   these factories are already injectable and that the blocker is their
   **return type**, so a second abstraction here would be one more seam for that
-  work to reconcile. It is not yet sufficient for a non-socket transport, and
-  does not claim to be — `AtConnection.getSocket()` still returns a `Socket`.
+  work to reconcile. It also carries the `SecureSocketConfig`, because how a
+  transport reaches an atServer is a property of the transport — TLS
+  certificates and a keylog path mean nothing to one that is not TLS over TCP.
+  It is not yet sufficient for a non-socket transport, and does not claim to
+  be — `AtConnection.getSocket()` still returns a `Socket`.
+- feat: the socket transport is `secureSocketTransport(...)` in a new
+  `package:at_lookup/at_lookup_io.dart`, and `transport` has no default.
+  A default naming an implementation pulls that implementation's imports in
+  whatever the caller injects, which is how a transport swap fails silently
+  instead of failing to compile; naming the transport is therefore also what
+  selects the library carrying it. Callers import the `_io` barrel, which
+  re-exports everything in `at_lookup.dart`. This does not make a web build
+  possible on its own — `AtConnection.getSocket()` still has to go, which is a
+  major — but it means that change will not also have to remove a default.
 - feat: `AtLookupImpl`'s constructor is `@Deprecated` in favour of the factory.
   The class itself is **not** deprecated and does not move: it is exported from
   the barrel, so renaming it or making it private would remove a public class,

--- a/packages/at_lookup/CHANGELOG.md
+++ b/packages/at_lookup/CHANGELOG.md
@@ -64,9 +64,13 @@
 
 - feat: `AtLookupMuxable` gains the members callers were reaching for through
   a cast to the concrete class: `authenticator`, `isConnectionAvailable` and
-  `readResponse`, plus `scan(auth:)` and `lookup(metadata:)`. Those last two
-  are a defect this surfaced - `AtLookupImpl` accepted **more** than `AtLookUp`
-  declared, so a caller moving to the interface silently lost parameters. They
+  `readResponse`, plus `scan(auth:)`, `scan(showHiddenKeys:)` and
+  `lookup(metadata:)`. Those last three are a defect this surfaced -
+  `AtLookupImpl` accepted **more** than `AtLookUp` declared, so a caller
+  moving to the interface silently lost parameters. Dart permits an
+  implementer to add optional named parameters, so nothing goes red when the
+  restatement is incomplete: `showHiddenKeys` was missed on the first pass and
+  this entry named only two parameters until it was found. They
   are restated on the muxable rather than added to `AtLookUp`, which is frozen:
   adding a parameter there forces every `implements AtLookUp` to redeclare it.
 
@@ -219,9 +223,13 @@
   between-chunks budget to `AtNetworkTimeouts.effectiveDefault`, which moves
   that default from **10s to 30s**. Ten seconds of silence is not evidence a
   busy atServer has gone away, and the two budgets measure different things:
-  one bounds the whole response, the other restarts on every chunk. Callers
-  passing explicit values are unaffected, and a process that sets
-  `AtNetworkTimeouts.defaultTimeout` at startup now moves this too.
+  one bounds the whole response, the other restarts on every chunk. The
+  defaulting is **per parameter**: a budget you pass is used as you passed it,
+  but passing only one of the two leaves the other on the new default — so a
+  caller that set only `maxWaitMilliSeconds` moves from a 10s silence budget
+  to 30s. A process that sets `AtNetworkTimeouts.defaultTimeout` at startup
+  now moves this too, which puts the response read under the same
+  process-wide setting that already governs connect, atDirectory and auth.
 
 - fix: a response carrying no colon no longer destroys the connection.
   `OutboundMessageListener._stripPrompt` ran `substring(0, -1)` when

--- a/packages/at_lookup/README.md
+++ b/packages/at_lookup/README.md
@@ -41,14 +41,21 @@ Feel free to fork a copy of the source from the [GitHub Repo](https://github.com
 ### To get the instance of at_lookup
 
 ```dart
-AtLookUp atLookUp = AtLookupImpl(
-  '@alice',
-  'root.atsign.com',
-  64,
-  privateKey: 'privateKey',
-  cramSecret: 'cramSecret',
+final AtLookupMuxable atLookUp = AtLookUp.withSecureSocket(
+  atSign: '@alice',
+  rootDomain: AtRootDomain.atsignDomain,
+  secureSocketConfig: SecureSocketConfig(),
+  // How this connection authenticates, as one closure. at_lookup holds no key
+  // material of its own; at_auth builds an authenticator from whatever
+  // credential you have - a keystore, an AtChops, or a bare private key.
+  // Pass null for a connection that never authenticates.
+  authenticator: authenticatorFor(keysIo, '@alice'),
 );
 ```
+
+`withSecureSocket` returns an [`AtLookupMuxable`], which is an `AtLookUp` that
+also carries the atServer's notification stream, so one connection and one
+parser handle both of the atServer's framings.
 Please refer to [examples](https://github.com/atsign-foundation/at_libraries/blob/doc_at_lookup/at_lookup/example/bin/example.dart) for more details.
 
 ## Open source usage and contributions

--- a/packages/at_lookup/README.md
+++ b/packages/at_lookup/README.md
@@ -44,7 +44,7 @@ Feel free to fork a copy of the source from the [GitHub Repo](https://github.com
 final AtLookupMuxable atLookUp = AtLookUp.withSecureSocket(
   atSign: '@alice',
   rootDomain: AtRootDomain.atsignDomain,
-  secureSocketConfig: SecureSocketConfig(),
+  transport: secureSocketTransport(SecureSocketConfig()),
   // How this connection authenticates, as one closure. at_lookup holds no key
   // material of its own; at_auth builds an authenticator from whatever
   // credential you have - a keystore, an AtChops, or a bare private key.

--- a/packages/at_lookup/example/README.md
+++ b/packages/at_lookup/example/README.md
@@ -17,13 +17,13 @@ directory for usage of the at_lookup library.
 #### Initializing the atLookup Instance
 
 ```dart
-
-var atLookupImpl = AtLookupImpl(
-  '@alice',
-  'root.atsign.com',
-  64,
-  privateKey: 'privateKey',
-  cramSecret: 'cramSecret',
+final atLookUp = AtLookUp.withSecureSocket(
+  atSign: '@alice',
+  rootDomain: AtRootDomain.atsignDomain,
+  secureSocketConfig: SecureSocketConfig(),
+  // at_auth builds this from whatever credential you hold. Pass null for a
+  // connection that never authenticates.
+  authenticator: authenticatorFor(keysIo, '@alice'),
 );
 ```
 
@@ -37,9 +37,8 @@ var updateVerbBuilder = UpdateVerbBuilder()
   ..sharedWith = '@bob'
   ..value = '+1 889 886 7879';
 
-// Sends update command to secondary server
-// Set sync attribute to true sync the value to secondary server.
-var updateResult = atLookupImpl.executeVerb(updateVerbBuilder, sync: true);
+// Sends update command to the secondary server
+var updateResult = atLookupImpl.executeVerb(updateVerbBuilder);
 ```
 
 #### Get the value of the key
@@ -71,5 +70,5 @@ var deleteVerbBuilder = DeleteVerbBuilder()
     ..atKey = 'phone'
     ..sharedBy = '@alice';
 // Sends delete key to secondary server  
-var deleteResult = atLookupImpl.executeVerb(deleteVerbBuilder, sync: true);
+var deleteResult = atLookupImpl.executeVerb(deleteVerbBuilder);
 ```

--- a/packages/at_lookup/example/README.md
+++ b/packages/at_lookup/example/README.md
@@ -20,7 +20,7 @@ directory for usage of the at_lookup library.
 final atLookUp = AtLookUp.withSecureSocket(
   atSign: '@alice',
   rootDomain: AtRootDomain.atsignDomain,
-  secureSocketConfig: SecureSocketConfig(),
+  transport: secureSocketTransport(SecureSocketConfig()),
   // at_auth builds this from whatever credential you hold. Pass null for a
   // connection that never authenticates.
   authenticator: authenticatorFor(keysIo, '@alice'),

--- a/packages/at_lookup/example/bin/example.dart
+++ b/packages/at_lookup/example/bin/example.dart
@@ -1,3 +1,9 @@
+// Names AtLookupImpl directly, which is deprecated in favour of
+// AtLookUp.withSecureSocket but cannot leave the barrel before the next
+// major release.
+// TODO(4.0): rewrite against AtLookUp.withSecureSocket.
+// ignore_for_file: deprecated_member_use
+
 import 'package:at_commons/at_builders.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
@@ -22,9 +28,8 @@ void main() async {
         (AtKey.shared('phone', sharedBy: '@alice')..sharedWith('@bob')).build()
     ..value = '+1 889 886 7879';
 
-  // Sends update command to secondary server
-  // Set sync attribute to true sync the value to secondary server.
-  await atLookupImpl.executeVerb(updateVerbBuilder, sync: true);
+  // Sends update command to the secondary server
+  await atLookupImpl.executeVerb(updateVerbBuilder);
 
   /// To lookup a value of a key sharedBy a specific atSign
   var lookupVerbBuilder = LookupVerbBuilder()
@@ -47,7 +52,7 @@ void main() async {
   var deleteVerbBuilder = DeleteVerbBuilder()
     ..atKey =
         (AtKey.shared('phone', sharedBy: '@alice')..sharedWith('@bob')).build();
-  await atLookupImpl.executeVerb(deleteVerbBuilder, sync: true);
+  await atLookupImpl.executeVerb(deleteVerbBuilder);
 
   /// To retrieve keys from the secondary server
   var scanVerbBuilder = ScanVerbBuilder();

--- a/packages/at_lookup/lib/at_lookup_io.dart
+++ b/packages/at_lookup/lib/at_lookup_io.dart
@@ -1,0 +1,34 @@
+/// at_lookup on a native socket: everything in `at_lookup.dart`, plus the
+/// transport that reaches an atServer over TLS on TCP.
+///
+/// The split exists so that naming the native transport is what pulls the
+/// native imports in. A caller that imports only `at_lookup.dart` and injects
+/// its own transport does not acquire `dart:io` through a default it never
+/// asked for — which is the way a transport swap otherwise fails silently
+/// instead of failing to compile.
+///
+/// ⚠️ **Importing this library is not yet the only thing standing between
+/// at_lookup and a non-socket transport, and it does not claim to be.**
+/// `AtConnection` still exposes `Socket getSocket()`, which the message
+/// listener calls and which every `implements AtConnection` would have to
+/// drop. Until that member goes, a transport built on anything other than a
+/// socket cannot satisfy the connection type this one produces. What this
+/// split buys is that the shape is already right when that change lands,
+/// rather than the change also having to remove a default.
+library;
+
+import 'package:at_commons/at_commons.dart' show SecureSocketConfig;
+
+import 'src/at_lookup.dart' show AtLookupTransport;
+
+export 'at_lookup.dart';
+
+/// TLS over TCP — the transport to pass to `AtLookUp.withSecureSocket` unless
+/// you are supplying your own.
+///
+/// A function rather than a constant because the configuration belongs to the
+/// transport, and a caller has to state it: `secureSocketTransport(
+/// SecureSocketConfig())` says "the TLS defaults", where a constant would let
+/// a site inherit settings its neighbour set deliberately.
+AtLookupTransport secureSocketTransport(SecureSocketConfig secureSocketConfig) =>
+    AtLookupTransport(secureSocketConfig: secureSocketConfig);

--- a/packages/at_lookup/lib/src/at_lookup.dart
+++ b/packages/at_lookup/lib/src/at_lookup.dart
@@ -63,23 +63,30 @@ abstract interface class AtLookUp {
   /// request goes out unauthenticated. Requiring it forces the caller to say
   /// which it meant.
   ///
-  /// [secureSocketConfig] is required for the same reason: a caller wanting
-  /// the defaults writes `SecureSocketConfig()` and thereby states it. One
-  /// production site today omits what its neighbour sets.
+  /// [transport] is required, and deliberately has no default. A default
+  /// naming an implementation pulls that implementation's imports in whatever
+  /// the caller injects, which is what makes a transport swap fail silently
+  /// rather than loudly. The socket transport is `secureSocketTransport` in
+  /// `package:at_lookup/at_lookup_io.dart`, so naming it is also what selects
+  /// the library that carries it.
+  ///
+  /// It carries its own configuration, which is why no socket settings appear
+  /// here: a caller wanting the TLS defaults writes
+  /// `secureSocketTransport(SecureSocketConfig())` and thereby states it,
+  /// while a caller on another transport says nothing about TLS at all.
   static AtLookupMuxable withSecureSocket({
     required String atSign,
     required AtRootDomain rootDomain,
-    required SecureSocketConfig secureSocketConfig,
     required AtAuthenticator? authenticator,
+    required AtLookupTransport transport,
     Map<String, dynamic> clientConfig = const {},
     SecondaryAddressFinder? secondaryAddressFinder,
-    AtLookupTransport transport = AtLookupTransport.secureSocket,
   }) {
     return AtLookupImpl(
       atSign,
       rootDomain.rootDomain,
       rootDomain.rootPort,
-      secureSocketConfig: secureSocketConfig,
+      secureSocketConfig: transport.secureSocketConfig,
       clientConfig: clientConfig,
       secondaryAddressFinder: secondaryAddressFinder,
       secureSocketFactory: transport.socketFactory,
@@ -396,12 +403,19 @@ class AtLookupTransport {
   final AtLookupOutboundConnectionFactory connectionFactory;
   final AtLookupSecureSocketListenerFactory listenerFactory;
 
+  /// How this transport is configured to reach an atServer.
+  ///
+  /// Here rather than on [AtLookUp.withSecureSocket] because it is a property
+  /// of the transport, not of the lookup: TLS certificates, a keylog path and
+  /// a cert-check toggle mean nothing to a transport that is not TLS over TCP.
+  /// A WebSocket transport would carry its own settings in its own type and
+  /// leave the factory's signature alone.
+  final SecureSocketConfig secureSocketConfig;
+
   const AtLookupTransport({
+    required this.secureSocketConfig,
     this.socketFactory = const AtLookupSecureSocketFactory(),
     this.connectionFactory = const AtLookupOutboundConnectionFactory(),
     this.listenerFactory = const AtLookupSecureSocketListenerFactory(),
   });
-
-  /// TLS over TCP: what every caller gets unless it says otherwise.
-  static const AtLookupTransport secureSocket = AtLookupTransport();
 }

--- a/packages/at_lookup/lib/src/at_lookup.dart
+++ b/packages/at_lookup/lib/src/at_lookup.dart
@@ -3,7 +3,91 @@ import 'package:at_commons/at_commons.dart';
 import 'package:at_chops/at_chops.dart';
 import 'package:at_lookup/at_lookup.dart';
 
+/// Performs one authentication on a connection that is already open, using
+/// [executor] to speak to the atServer, and returns whether it succeeded.
+///
+/// This is the whole of authentication reduced to one value. at_lookup cannot
+/// name `AtKeys` or `AtKeysIo` - they live in at_auth, which depends on
+/// at_lookup - so the credential, the enrollment and the signing algorithm all
+/// stay on the at_auth side of this typedef and none of them reach here.
+///
+/// Implementations are invoked once per connection that needs authenticating,
+/// so a closure held for an instance's life must decide afresh each time what
+/// credential applies: an instance that CRAM-onboards and then PKAM-
+/// authenticates is one instance and two answers.
+typedef AtAuthenticator = Future<bool> Function(AtCommandExecutor executor);
+
+/// The narrow view of a connection that an [AtAuthenticator] is given: enough
+/// to run a challenge-response, and nothing else.
+abstract interface class AtCommandExecutor {
+  /// Sends [command] and returns the atServer's reply.
+  ///
+  /// "Sync" names the channel, not the Dart semantics: verb responses are the
+  /// synchronous side of the connection, the side where a reply belongs to the
+  /// command that preceded it. Notifications are the asynchronous side and
+  /// never arrive here.
+  ///
+  /// Called from inside authentication, which already holds the
+  /// request/response mutex, so this must not take it again.
+  ///
+  /// The two budgets are those of `OutboundMessageListener.read` and mean the
+  /// same things. They are here because authentication does not want one
+  /// answer: the CRAM leg of onboarding waits far less than a verb response
+  /// does, on the grounds that a secret is either accepted promptly or not at
+  /// all. Omit them and the process-wide defaults apply.
+  Future<String> sendSync(String command,
+      {int? maxWaitMilliSeconds, int? transientWaitTimeMillis});
+}
+
 abstract interface class AtLookUp {
+  /// Build a lookup that talks to an atServer over TLS.
+  ///
+  /// This is the entry point. Constructing `AtLookupImpl` directly still
+  /// works and is deprecated: it takes a `String, int` root pair rather than
+  /// an [AtRootDomain], it accepts key material this class no longer needs,
+  /// and it hands back a concrete type where callers only need an interface.
+  ///
+  /// Static, and that is deliberate — statics are not part of the `implements`
+  /// contract, so adding this breaks none of the classes that mock
+  /// [AtLookUp]. Widening the interface itself would have: `implements` erases
+  /// bodies, so a mock satisfies a new member through `noSuchMethod` and
+  /// returns null into a non-nullable type **at runtime only**, with
+  /// `dart analyze` clean.
+  ///
+  /// Named for its transport, so a differently-transported factory can join it
+  /// later rather than this one growing a mode flag.
+  ///
+  /// [authenticator] is required and nullable, which is not an oversight: null
+  /// means *this connection never authenticates*, and that is a real mode —
+  /// `at_status_impl` holds no key material at all, and an OTP enrolment
+  /// request goes out unauthenticated. Requiring it forces the caller to say
+  /// which it meant.
+  ///
+  /// [secureSocketConfig] is required for the same reason: a caller wanting
+  /// the defaults writes `SecureSocketConfig()` and thereby states it. One
+  /// production site today omits what its neighbour sets.
+  static AtLookupMuxable withSecureSocket({
+    required String atSign,
+    required AtRootDomain rootDomain,
+    required SecureSocketConfig secureSocketConfig,
+    required AtAuthenticator? authenticator,
+    Map<String, dynamic> clientConfig = const {},
+    SecondaryAddressFinder? secondaryAddressFinder,
+    AtLookupTransport transport = AtLookupTransport.secureSocket,
+  }) {
+    return AtLookupImpl(
+      atSign,
+      rootDomain.rootDomain,
+      rootDomain.rootPort,
+      secureSocketConfig: secureSocketConfig,
+      clientConfig: clientConfig,
+      secondaryAddressFinder: secondaryAddressFinder,
+      secureSocketFactory: transport.socketFactory,
+      socketListenerFactory: transport.listenerFactory,
+      outboundConnectionFactory: transport.connectionFactory,
+    )..authenticator = authenticator;
+  }
+
   /// update
   Future<bool> update(String key, String value,
       {String? sharedWith, Metadata? metadata});
@@ -24,7 +108,11 @@ abstract interface class AtLookUp {
   /// scan
   Future<List<String>> scan({String? regex, String? sharedBy});
 
-  Future<String?> executeVerb(VerbBuilder builder, {bool sync = false});
+  Future<String?> executeVerb(VerbBuilder builder,
+      {@Deprecated('Inert: nothing reads it. The verb always executes '
+          'on the remote atServer; there is no sync behaviour here '
+          'to control. Removed in 4.0.')
+      bool sync = false});
 
   Future<String?> executeCommand(String command, {bool auth = false});
 
@@ -46,10 +134,22 @@ abstract interface class AtLookUp {
   Future<void> close();
 
   /// set an instance of  [AtChops] for signing and verification operations.
+  ///
+  /// Deprecated as a *credential*. Authentication runs through an injected
+  /// [AtAuthenticator] instead, so at_lookup no longer needs to hold key
+  /// material to authenticate. Callers that read this for crypto which is not
+  /// authentication should be handed their own [AtChops] - that is what
+  /// at_auth EnrollmentApprover.approve takes an approverChops for.
+  @Deprecated('Pass an AtAuthenticator to AtLookUp.withSecureSocket '
+      'instead - at_auth builds one with authenticatorForChops(). '
+      'Removed with the credential ladder in the next major release.')
   set atChops(AtChops? atChops);
 
   OutboundConnection? get connection;
 
+  @Deprecated('Pass an AtAuthenticator to AtLookUp.withSecureSocket '
+      'instead - at_auth builds one with authenticatorForChops(). '
+      'Removed with the credential ladder in the next major release.')
   AtChops? get atChops;
 
   set secondaryAddressFinder(SecondaryAddressFinder secondaryAddressFinder);
@@ -57,17 +157,251 @@ abstract interface class AtLookUp {
   SecondaryAddressFinder get secondaryAddressFinder;
 
   /// Signing algorithm for pkam signature
+  ///
+  /// Deprecated together with [hashingAlgoType]: the two are read on the same
+  /// lines when the PKAM signature is built, so they are one setting and they
+  /// move together.
+  @Deprecated('Pass the signing algorithm to the AtAuthenticator that at_auth '
+      'builds - authenticatorForChops() takes signingAlgo and hashingAlgo. '
+      'Removed with the credential ladder in the next major release.')
   set signingAlgoType(SigningAlgoType signingAlgoType);
 
+  @Deprecated('Pass the signing algorithm to the AtAuthenticator that at_auth '
+      'builds - authenticatorForChops() takes signingAlgo and hashingAlgo. '
+      'Removed with the credential ladder in the next major release.')
   SigningAlgoType get signingAlgoType;
 
   /// Hashing algorithm for pkam signature
+  ///
+  /// Deprecated together with [signingAlgoType]; see the note there.
+  @Deprecated('Pass the hashing algorithm to the AtAuthenticator that at_auth '
+      'builds - authenticatorForChops() takes signingAlgo and hashingAlgo. '
+      'Removed with the credential ladder in the next major release.')
   set hashingAlgoType(HashingAlgoType hashingAlgoType);
 
+  @Deprecated('Pass the hashing algorithm to the AtAuthenticator that at_auth '
+      'builds - authenticatorForChops() takes signingAlgo and hashingAlgo. '
+      'Removed with the credential ladder in the next major release.')
   HashingAlgoType get hashingAlgoType;
 
   /// EnrollmentId has to be set for clients that are enrolled through APKAM.
+  ///
+  /// This is the enrollment the *next* authentication will use, which is
+  /// deliberately not [AtConnectionMetaData.authenticatedAsEnrollmentId] -
+  /// what a live socket actually authenticated as. That distinction survives
+  /// the deprecation; the two are not interchangeable.
+  @Deprecated('Pass the enrollment id to the AtAuthenticator that at_auth '
+      'builds. To ask "which enrollment am I", read your own client state - '
+      'not this field, and not '
+      'AtConnectionMetaData.authenticatedAsEnrollmentId, which is what the '
+      'live connection authenticated as rather than what the next '
+      'authentication will use. '
+      'Removed with the credential ladder in the next major release.')
   set enrollmentId(String? enrollmentId);
 
+  @Deprecated('Pass the enrollment id to the AtAuthenticator that at_auth '
+      'builds. To ask "which enrollment am I", read your own client state - '
+      'not this field, and not '
+      'AtConnectionMetaData.authenticatedAsEnrollmentId, which is what the '
+      'live connection authenticated as rather than what the next '
+      'authentication will use. '
+      'Removed with the credential ladder in the next major release.')
   String? get enrollmentId;
+}
+
+/// An [AtLookUp] that also carries the atServer's asynchronous notification
+/// stream, so one class knows both of the atServer's framings.
+///
+/// A verb response ends `\n@<atSign>@` — the newline, then the prompt saying
+/// the atServer is ready for the next command. A notification is not a reply
+/// to anything, so no prompt follows it and it ends at a bare `\n`. Everything
+/// that reads one of those framings has, until now, been written twice.
+///
+/// ## This does NOT make one connection safe for both
+///
+/// ⚠️ **Give this a connection of its own.** The notification stream and verb
+/// request-response must not share a socket today, and the flag that was
+/// supposed to make that safe does not work.
+///
+/// `MonitorVerbBuilder.multiplexed` documents itself as telling the atServer
+/// that a connection carries both, so that "the server will only send
+/// notifications once there is no request currently in progress". **No
+/// atServer implements it.** Measured against `at_server` `origin/trunk`:
+/// zero occurrences of the string in the entire repository, against a probe
+/// proven positive on `selfNotifications`, which returns 16. The monitor
+/// verb's syntax — shared by both sides, in at_commons — *does* capture
+/// `multiplexed` as a named group, so the atServer parses the flag, ignores
+/// it, and does not refuse it. Setting it buys nothing and reports success.
+///
+/// The consequence is concrete: the atServer's monitor handler subscribes to
+/// its notification stream and writes each notification to the connection as
+/// it arrives, with nothing gating that write on a request being in flight. A
+/// notification landing mid-response is appended to a buffer whose prefix is
+/// already `data:`, so the framing check — which tests that prefix — will not
+/// route it, and it is absorbed into the verb response instead. Corruption,
+/// not a dropped message, and only under concurrency.
+abstract interface class AtLookupMuxable implements AtLookUp {
+  /// Notifications from the atServer, as the raw lines it sent.
+  ///
+  /// **Single-subscription, deliberately.** A broadcast stream does not
+  /// buffer, ignores `pause()`, and drops anything arriving before a listener
+  /// attaches. Every one of those is data loss on a notification, and a
+  /// dropped notification is indistinguishable from one the atServer never
+  /// sent — so the failure gets attributed to the sender.
+  ///
+  /// Pausing this stream stops reading the socket, so back-pressure reaches
+  /// the atServer through TCP rather than being absorbed by an unbounded
+  /// buffer in this process.
+  Stream<String> get notifications;
+
+  /// Ask the atServer to start sending notifications on this connection.
+  ///
+  /// Connects and authenticates if required, then sends `monitor:`. Safe to
+  /// call when already notifying: it returns without re-sending.
+  Future<void> startNotifications({
+    String? regex,
+    int? lastNotificationTime,
+    bool selfNotificationsEnabled = true,
+  });
+
+  /// Stop notifications by dropping the connection carrying them.
+  ///
+  /// There is no verb that turns `monitor:` off — the atServer streams until
+  /// the connection goes away — so this closes it. [notifications] is closed
+  /// too, because a stream that can never produce another event should say so
+  /// rather than hang.
+  Future<void> stopNotifications();
+
+  /// Whether [startNotifications] is in force.
+  bool get isNotifying;
+
+  // The two places `AtLookupImpl` accepts more than `AtLookUp` does, restated
+  // here so a caller can hold this interface without losing anything.
+  //
+  // Found with the analyzer, not by reading: a hand-written comparison of the
+  // two signature lists missed `scan` entirely, because nested generics in
+  // `Future<List<String>>` broke its return-type pattern. A probe that calls
+  // each method through the interface reports exactly what is missing, and
+  // carries `scan(auth:)` as a control that must be reported.
+  //
+  // They go HERE rather than on `AtLookUp` because that interface is frozen:
+  // adding a parameter to one of its methods forces every `implements
+  // AtLookUp` to redeclare it, which breaks the six mocks and any external
+  // implementer at compile time. This interface is new, and `AtLookupImpl` is
+  // its only implementer.
+
+  /// As [AtLookUp.scan], and additionally [auth] - whether to scan as the
+  /// authenticated atSign. `at_server_status` scans unauthenticated.
+  @override
+  Future<List<String>> scan({String? regex, String? sharedBy, bool auth = true});
+
+  /// As [AtLookUp.lookup], and additionally [metadata].
+  @override
+  Future<String> lookup(String key, String sharedBy,
+      {bool auth = true, bool verifyData = false, bool metadata = false});
+
+  /// Takes over authentication entirely when set.
+  ///
+  /// On the interface because installing one is the whole point of the seam,
+  /// and every installer previously had to write `if (lookUp is
+  /// AtLookupImpl)` to reach it — four such casts across at_auth, at_client
+  /// and at_onboarding_cli. A cast to a concrete type in order to configure it
+  /// is the shape this project exists to remove.
+  AtAuthenticator? get authenticator;
+  set authenticator(AtAuthenticator? value);
+
+  /// Whether a usable connection is currently open.
+  ///
+  /// A caller closing down needs this to avoid closing what was never opened,
+  /// and it too was reached only by casting.
+  bool isConnectionAvailable();
+
+  /// Read one response from the connection, without sending anything first.
+  ///
+  /// For a caller that has already put bytes on the wire itself — at_client's
+  /// file-stream path writes to the socket directly and then waits for
+  /// `stream:done`. It previously reached `messageListener.read(...)` through
+  /// a cast to the concrete class.
+  ///
+  /// This is deliberately narrower than exposing the listener: that type is
+  /// not in at_lookup's barrel, and putting it on a public interface would
+  /// publish it by the back door.
+  Future<String> readResponse(
+      {int? maxWaitMilliSeconds, int? transientWaitTimeMillis});
+
+  /// Whether the connection dropped and a reconnect is in flight.
+  ///
+  /// A subscriber otherwise cannot tell a reconnecting stream from a quiet
+  /// atServer: both look like no events. at_client's `Monitor` surfaces the
+  /// same distinction as a listener state, for the same reason.
+  bool get isReconnectingNotifications;
+
+  /// `true` when `monitor:` has been accepted on a live connection, `false`
+  /// when that connection is lost or notifications are stopped.
+  ///
+  /// This exists because the muxable owns reconnection, so it is the only
+  /// thing that knows. at_client's `Monitor` re-broadcasts it as a
+  /// `NotificationListenerState`, which noports' daemon subscribes to for its
+  /// whole life; without this it could only poll [isReconnectingNotifications]
+  /// and would learn of an outage a poll interval late.
+  ///
+  /// `bool` rather than a richer state because the richer type lives in
+  /// at_client, which depends on at_lookup - naming it here would invert that.
+  ///
+  /// **Broadcast**, unlike [notifications], and the difference is deliberate:
+  /// this is a state signal whose latest value supersedes the last, so a
+  /// dropped event costs a subscriber nothing it cannot re-derive. A dropped
+  /// *notification* is gone. ⚠️ A late subscriber does not get the current
+  /// state on attach, matching what `Monitor.currentStateStream` has always
+  /// done.
+  Stream<bool> get notificationConnectionUp;
+
+  /// How often a quiet notification connection is probed, and how long the
+  /// probe waits for its answer.
+  ///
+  /// On the interface because they are the only way to make the notification
+  /// connection's liveness behaviour testable, or tunable, without naming the
+  /// implementation - which is the thing this project is removing from callers.
+  Duration get heartbeatInterval;
+  set heartbeatInterval(Duration value);
+
+  Duration get heartbeatResponseTimeout;
+  set heartbeatResponseTimeout(Duration value);
+}
+
+
+/// How an [AtLookupMuxable] makes connections: the three factories
+/// `AtLookupImpl` has always accepted, bundled into one value.
+///
+/// This exists because [AtLookUp.withSecureSocket] returns an interface, and
+/// an interface cannot be handed a socket. Without it there is no way to give
+/// a factory-built muxable a connection it did not open itself — which is
+/// invisible while the concrete constructor is still reachable, and becomes
+/// total the moment callers stop using it.
+///
+/// It bundles rather than abstracts, deliberately. These factories are
+/// **already injectable**; what blocks a web transport is their **return
+/// type** (`SecureSocket`), not their injectability. A parallel abstraction
+/// here would be a second seam for that return-type change to reconcile,
+/// where bundling leaves exactly one — and the change lands inside it without
+/// touching this signature.
+///
+/// ⚠️ **This is not yet enough for a non-socket transport, and it does not
+/// claim to be.** `AtConnection` exposes `Socket getSocket()`, which the
+/// listener calls, so a WebSocket implementation needs that member gone —
+/// a breaking change for every `implements AtConnection`, and out of scope
+/// while this ships as an additive minor.
+class AtLookupTransport {
+  final AtLookupSecureSocketFactory socketFactory;
+  final AtLookupOutboundConnectionFactory connectionFactory;
+  final AtLookupSecureSocketListenerFactory listenerFactory;
+
+  const AtLookupTransport({
+    this.socketFactory = const AtLookupSecureSocketFactory(),
+    this.connectionFactory = const AtLookupOutboundConnectionFactory(),
+    this.listenerFactory = const AtLookupSecureSocketListenerFactory(),
+  });
+
+  /// TLS over TCP: what every caller gets unless it says otherwise.
+  static const AtLookupTransport secureSocket = AtLookupTransport();
 }

--- a/packages/at_lookup/lib/src/at_lookup.dart
+++ b/packages/at_lookup/lib/src/at_lookup.dart
@@ -267,7 +267,7 @@ abstract interface class AtLookupMuxable implements AtLookUp {
   /// call when already notifying: it returns without re-sending.
   Future<void> startNotifications({
     String? regex,
-    int? lastNotificationTime,
+    Future<int?> Function()? getLastNotificationTime,
     bool selfNotificationsEnabled = true,
   });
 

--- a/packages/at_lookup/lib/src/at_lookup.dart
+++ b/packages/at_lookup/lib/src/at_lookup.dart
@@ -276,14 +276,26 @@ abstract interface class AtLookupMuxable implements AtLookUp {
   /// There is no verb that turns `monitor:` off — the atServer streams until
   /// the connection goes away — so this closes it. [notifications] is closed
   /// too, because a stream that can never produce another event should say so
-  /// rather than hang.
+  /// rather than hang, and so is [notificationConnectionUp].
+  ///
+  /// Both are replaced on the next [startNotifications], so a caller that
+  /// restarts must take fresh subscriptions: the ones it held are closed and
+  /// will report nothing about the new connection.
   Future<void> stopNotifications();
 
   /// Whether [startNotifications] is in force.
   bool get isNotifying;
 
-  // The two places `AtLookupImpl` accepts more than `AtLookUp` does, restated
-  // here so a caller can hold this interface without losing anything.
+  // Where `AtLookupImpl` accepts more than `AtLookUp` does, restated here so
+  // a caller can hold this interface without losing anything: two methods,
+  // three parameters - `scan(auth:)`, `scan(showHiddenKeys:)` and
+  // `lookup(metadata:)`.
+  //
+  // ⚠️ Dart lets an implementer ADD optional named parameters, so a gap here
+  // is invisible: the analyzer stays clean and the only symptom is a caller
+  // holding the interface unable to pass something the class accepts.
+  // `showHiddenKeys` was missed for exactly that reason, and this comment
+  // claimed the restatement was complete while it was not.
   //
   // Found with the analyzer, not by reading: a hand-written comparison of the
   // two signature lists missed `scan` entirely, because nested generics in
@@ -298,9 +310,14 @@ abstract interface class AtLookupMuxable implements AtLookUp {
   // its only implementer.
 
   /// As [AtLookUp.scan], and additionally [auth] - whether to scan as the
-  /// authenticated atSign. `at_server_status` scans unauthenticated.
+  /// authenticated atSign (`at_server_status` scans unauthenticated) - and
+  /// [showHiddenKeys], which asks the atServer to include `public:__` keys.
   @override
-  Future<List<String>> scan({String? regex, String? sharedBy, bool auth = true});
+  Future<List<String>> scan(
+      {String? regex,
+      String? sharedBy,
+      bool auth = true,
+      bool showHiddenKeys = false});
 
   /// As [AtLookUp.lookup], and additionally [metadata].
   @override
@@ -361,6 +378,12 @@ abstract interface class AtLookupMuxable implements AtLookUp {
   /// *notification* is gone. ⚠️ A late subscriber does not get the current
   /// state on attach, matching what `Monitor.currentStateStream` has always
   /// done.
+  ///
+  /// ⚠️ **[stopNotifications] closes this stream**, so a subscription does not
+  /// survive a stop: a caller that stops and starts again is holding a closed
+  /// stream and will never see the new connection come up. Read this getter
+  /// again after each [startNotifications] rather than once for the life of
+  /// the object.
   Stream<bool> get notificationConnectionUp;
 
   /// How often a quiet notification connection is probed, and how long the

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -942,11 +942,23 @@ class AtLookupImpl implements AtLookUp, AtCommandExecutor, AtLookupMuxable {
   Duration heartbeatResponseTimeout = const Duration(seconds: 10);
 
   String? _notifyRegex;
-  int? _notifyLastNotificationTime;
+  /// The caller's watermark source, asked on every (re)connect.
+  ///
+  /// A function rather than a value because the caller's position moves as it
+  /// consumes notifications, and a reconnect should resume from where it has
+  /// got to - not from where it was when notifications started.
+  Future<int?> Function()? _getLastNotificationTime;
   bool _notifySelfNotifications = true;
 
   int _reconnectIx = 0;
   bool _reconnecting = false;
+
+  /// Bumped by every start of a reconnect loop and by every
+  /// [stopNotifications], so a loop can tell whether the notification session
+  /// it belongs to is still the current one. A stop followed by a start puts
+  /// `_isNotifying` back to true, which is why that flag alone cannot answer
+  /// it.
+  int _notifyGeneration = 0;
   Timer? _heartbeatTimer;
 
   /// Whether a reconnect is in flight. Visible so a test can assert the loop
@@ -980,9 +992,16 @@ class AtLookupImpl implements AtLookUp, AtCommandExecutor, AtLookupMuxable {
   }
 
   Future<void> _reconnectNotifications() async {
+    // The generation this loop belongs to. `_isNotifying` alone is not enough
+    // to decide whether waking is safe: a stop followed by a start inside the
+    // backoff window sets it back to true, and a loop orphaned by that stop
+    // would then act on a connection somebody else established - writing a
+    // second `monitor:` on it, resetting its heartbeat and announcing an `up`
+    // that never went down.
+    final generation = ++_notifyGeneration;
     _reconnecting = true;
     try {
-      while (_isNotifying) {
+      while (_isNotifying && generation == _notifyGeneration) {
         final delay = notificationReconnectDelays[
             min(_reconnectIx, notificationReconnectDelays.length - 1)];
         _reconnectIx++;
@@ -991,8 +1010,10 @@ class AtLookupImpl implements AtLookUp, AtCommandExecutor, AtLookupMuxable {
         await Future.delayed(delay);
         // Re-checked after the delay, not only before it: stopNotifications
         // can land while this is sleeping, and reconnecting after that would
-        // resurrect a connection the caller asked to be rid of.
-        if (!_isNotifying) return;
+        // resurrect a connection the caller asked to be rid of - or, if a
+        // start followed that stop, interfere with the connection the restart
+        // just made.
+        if (!_isNotifying || generation != _notifyGeneration) return;
         try {
           await _openNotificationStream();
           logger.info('Notification connection re-established');
@@ -1005,7 +1026,9 @@ class AtLookupImpl implements AtLookUp, AtCommandExecutor, AtLookupMuxable {
         }
       }
     } finally {
-      _reconnecting = false;
+      // Only if this loop is still the current one. A superseded loop clearing
+      // the flag would disarm nothing and re-arm the live loop's guard.
+      if (generation == _notifyGeneration) _reconnecting = false;
     }
   }
 
@@ -1129,7 +1152,7 @@ class AtLookupImpl implements AtLookUp, AtCommandExecutor, AtLookupMuxable {
   @override
   Future<void> startNotifications({
     String? regex,
-    int? lastNotificationTime,
+    Future<int?> Function()? getLastNotificationTime,
     bool selfNotificationsEnabled = true,
   }) async {
     if (_isNotifying) {
@@ -1141,11 +1164,17 @@ class AtLookupImpl implements AtLookUp, AtCommandExecutor, AtLookupMuxable {
     // notifications arrive with nowhere to go.
     notifications;
 
-    // Remembered, because reconnecting has to re-issue the SAME monitor:. A
-    // reconnect that dropped the regex would start delivering everything, and
-    // one that dropped the watermark would replay from the beginning.
+    // Remembered, because reconnecting has to re-issue the same monitor:. A
+    // reconnect that dropped the regex would start delivering everything.
+    //
+    // The watermark is remembered as the CALLER'S FUNCTION, not as a value:
+    // it is asked again on every reconnect, so the command carries where the
+    // caller has actually got to rather than where it had got to when
+    // notifications first started. Freezing the value re-requests the whole
+    // retained backlog on every reconnect, which is what a caller holding a
+    // durable watermark is keeping one to avoid.
     _notifyRegex = regex;
-    _notifyLastNotificationTime = lastNotificationTime;
+    _getLastNotificationTime = getLastNotificationTime;
     _notifySelfNotifications = selfNotificationsEnabled;
 
     await _openNotificationStream();
@@ -1172,9 +1201,12 @@ class AtLookupImpl implements AtLookUp, AtCommandExecutor, AtLookupMuxable {
               'monitor requires authentication and no authenticator is set');
         }
       }
+      // Asked here rather than held from the start, so a reconnect resumes
+      // from the caller's current watermark.
+      final lastNotificationTime = await _getLastNotificationTime?.call();
       final command = (MonitorVerbBuilder()
             ..regex = _notifyRegex
-            ..lastNotificationTime = _notifyLastNotificationTime
+            ..lastNotificationTime = lastNotificationTime
             ..selfNotificationsEnabled = _notifySelfNotifications)
           .buildCommand();
       // ⚠️ `multiplexed` is deliberately NOT set. It is accepted by the shared
@@ -1194,6 +1226,12 @@ class AtLookupImpl implements AtLookUp, AtCommandExecutor, AtLookupMuxable {
     // would trip the disconnect handler into reconnecting the very connection
     // this method is tearing down.
     _isNotifying = false;
+    // Retires any reconnect loop still sleeping on a backoff, and clears the
+    // flag it would otherwise leave set: `_reconnecting` disarms
+    // [_onNotificationConnectionLost], so a stale one left true means a real
+    // loss on a later connection is ignored.
+    _notifyGeneration++;
+    _reconnecting = false;
     _stopHeartbeat();
     _emitConnectionUp(false);
     await _closeConnection();

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -3,6 +3,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:at_commons/at_builders.dart';
@@ -11,7 +12,6 @@ import 'package:at_lookup/at_lookup.dart';
 import 'package:at_lookup/src/connection/outbound_message_listener.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:at_utils/at_utils.dart' show AtUtils;
-import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:mutex/mutex.dart';
 import 'package:at_chops/at_chops.dart';
 
@@ -26,7 +26,12 @@ final RegExp _fromChallengeUuid = RegExp(
 /// [atSign]; throws [UnAuthenticatedException] otherwise.
 ///
 /// [challenge] is the response with any `data:` prefix already stripped.
-@visibleForTesting
+///
+/// Public, not `@visibleForTesting`: authentication is moving out of at_lookup
+/// and into at_auth, where the key material is, and the side that signs the
+/// challenge is the side that has to refuse a bad one. Duplicating this check
+/// there would be the worse answer - two copies of a security control drift,
+/// and the one that drifts is the one nobody is looking at.
 String validatedFromChallenge(String challenge, String atSign) {
   void refuse(String why) {
     // The challenge itself is not secret — it is a session id and a nonce the
@@ -62,7 +67,7 @@ String validatedFromChallenge(String challenge, String atSign) {
   return challenge;
 }
 
-class AtLookupImpl implements AtLookUp {
+class AtLookupImpl implements AtLookUp, AtCommandExecutor, AtLookupMuxable {
   final logger = AtSignLogger('AtLookup');
 
   /// Listener for reading verb responses from the remote server
@@ -82,10 +87,37 @@ class AtLookupImpl implements AtLookUp {
 
   late int _rootPort;
 
-  @Deprecated("privateKey reference is no longer used")
+  /// The legacy PKAM credential: a private key and nothing else.
+  ///
+  /// The message this annotation used to carry - "privateKey reference is no
+  /// longer used" - was false. The ladder in [_process] reads this field and
+  /// calls authenticate() with it, and before the authenticator seam landed
+  /// that was the leg most ladder traffic took.
+  @Deprecated('Pass an AtAuthenticator to AtLookUp.withSecureSocket '
+      'instead - at_auth builds one from a bare private key with '
+      'authenticatorForPrivateKey(). '
+      'Removed with the credential ladder in the next major release.')
   String? privateKey;
 
+  @Deprecated('Pass an AtAuthenticator to AtLookUp.withSecureSocket '
+      'instead - at_auth builds one that falls back to CRAM with '
+      'authenticatorFor(). '
+      'Removed with the credential ladder in the next major release.')
   String? cramSecret;
+
+  /// Takes over authentication entirely when set, in place of the
+  /// atChops/privateKey/cramSecret ladder below.
+  ///
+  /// The ladder asks "which credential do I hold?" in at_lookup, which is the
+  /// wrong place to ask: at_lookup cannot see an enrollment, a keystore or a
+  /// signing algorithm, so every credential it might use has to be handed to
+  /// it and stored here first. A caller that sets this hands over one closure
+  /// instead, and keeps all of that on its own side. See [AtAuthenticator].
+  ///
+  /// Both routes work while this exists. The ladder and the fields feeding it
+  /// go once every caller supplies an authenticator.
+  @override
+  AtAuthenticator? authenticator;
 
   /// Permitted number of milliseconds before connection to atServer
   /// is deemed 'idle' and will be closed. The default is usually set to
@@ -103,8 +135,26 @@ class AtLookupImpl implements AtLookUp {
   /// Represents the client configurations.
   late Map<String, dynamic> _clientConfig;
 
+  // Holds what the deprecated `atChops` accessors set. The type cannot leave
+  // while those accessors are part of this class's API, so it goes when the
+  // credential ladder does.
+  // TODO(4.0): remove with the credential ladder.
+  // ignore: deprecated_member_use
   AtChops? _atChops;
 
+  /// Prefer [AtLookUp.withSecureSocket].
+  ///
+  /// This takes a `String, int` root pair where [AtRootDomain] validates the
+  /// port and knows about proxy addresses, it accepts key material at_lookup
+  /// no longer needs, and it hands back a concrete type where a caller only
+  /// ever needs an interface.
+  ///
+  /// The warnings this raises at every construction site ARE the deliverable:
+  /// they are the mechanical list of what still has to move. `dart analyze`
+  /// reports them as `info`, so nothing breaks while the list is worked
+  /// through.
+  @Deprecated('Use AtLookUp.withSecureSocket, which returns an '
+      'AtLookupMuxable. Removed in the next major release.')
   AtLookupImpl(String atSign, String rootDomain, int rootPort,
       {this.privateKey,
       this.cramSecret,
@@ -228,6 +278,13 @@ class AtLookupImpl implements AtLookUp {
       logger.finer('value: $value dataSignature:$dataSignature');
       // RSA SHA-256 verify via at_chops (wraps the same crypton
       // RSAPublicKey.verifySHA256Signature).
+      // TODO(4.0): not part of the credential ladder, so this one outlives
+      // it. at_chops directs it to RsaSignatureAlgo — but that class pins a
+      // modulus size per instance, and this verifies a PEER's key, whose
+      // size we do not control: rsa2048() returns false for a 4096-bit key
+      // that verifies here today. Choose the instance by the key, or keep a
+      // size-agnostic verify.
+      // ignore: deprecated_member_use
       var isDataValid = PkamSigningAlgo(null, HashingAlgoType.sha256).verify(
           Uint8List.fromList(utf8.encode(value)), base64Decode(dataSignature),
           publicKey: publicKeyResult);
@@ -293,7 +350,7 @@ class AtLookupImpl implements AtLookUp {
       if (_connection != null) {
         // Clean up the connection before creating a new one
         logger.finer('Closing old connection');
-        await _connection!.close();
+        await _closeConnection();
       }
       logger.info('Creating new connection');
       //1. find secondary url for atsign from lookup library
@@ -306,6 +363,14 @@ class AtLookupImpl implements AtLookUp {
           host, port.toString(), _currentAtSign, _secureSocketConfig);
       //3. listen to server response
       messageListener = socketListenerFactory.createListener(_connection!);
+      // Re-established on every connection, because createConnection builds a
+      // fresh listener each time. Installed only when somebody has asked for
+      // the stream: with no controller there is nowhere to put a notification,
+      // and routing one into a void drops it silently.
+      if (_notificationController != null) {
+        messageListener.onNotification = _routeNotification;
+        messageListener.onDisconnect = _onNotificationConnectionLost;
+      }
       messageListener.listen();
       logger.info('New connection created OK');
     }
@@ -314,7 +379,11 @@ class AtLookupImpl implements AtLookUp {
   /// Executes the command returned by [VerbBuilder] build command on a remote secondary server.
   /// Catches any exception and throws [AtLookUpException]
   @override
-  Future<String> executeVerb(VerbBuilder builder, {sync = false}) async {
+  Future<String> executeVerb(VerbBuilder builder,
+      {@Deprecated('Inert: nothing reads it. The verb always executes '
+          'on the remote atServer; there is no sync behaviour here '
+          'to control. Removed in 4.0.')
+      sync = false}) async {
     String verbResult = '';
     try {
       if (builder is UpdateVerbBuilder) {
@@ -474,7 +543,63 @@ class AtLookupImpl implements AtLookUp {
     return _verbResponseHandler(verbResponse);
   }
 
+  /// Records on the connection the identity it has just authenticated as, so
+  /// a later caller can tell which enrollment a live socket holds rather than
+  /// which one the next authentication would use.
+  void _recordAuthentication({String? enrollmentId}) {
+    final metaData = _connection!.getMetaData()!;
+    metaData.isAuthenticated = true;
+    metaData.authenticatedAsEnrollmentId = enrollmentId;
+    metaData.authenticatedAt = DateTime.now().toUtc();
+  }
+
   final Mutex _pkamAuthenticationMutex = Mutex();
+
+  @override
+  Future<String> readResponse(
+          {int? maxWaitMilliSeconds, int? transientWaitTimeMillis}) =>
+      messageListener.read(
+          maxWaitMilliSeconds: maxWaitMilliSeconds,
+          transientWaitTimeMillis: transientWaitTimeMillis);
+
+  @override
+  Future<String> sendSync(String command,
+      {int? maxWaitMilliSeconds, int? transientWaitTimeMillis}) async {
+    await _sendCommand(command);
+    return messageListener.read(
+        maxWaitMilliSeconds: maxWaitMilliSeconds,
+        transientWaitTimeMillis: transientWaitTimeMillis);
+  }
+
+  /// Runs [authenticate] against this connection, under the same mutex the
+  /// ladder's own methods take.
+  ///
+  /// [enrollmentId] is what gets recorded on the connection. It is a parameter
+  /// rather than always this object's field because the two can differ: a
+  /// caller reaching [pkamAuthenticate] names the enrollment in that call,
+  /// while a verb going through [_process] has only the field to go on.
+  Future<void> _authenticateWith(AtAuthenticator authenticate,
+      {String? enrollmentId}) async {
+    await createConnection();
+    try {
+      await _pkamAuthenticationMutex.acquire();
+      if (_connection!.getMetaData()!.isAuthenticated) {
+        return;
+      }
+      if (!await authenticate(this)) {
+        throw UnAuthenticatedException(
+            'Failed connecting to $_currentAtSign.'
+            ' The authenticator reported failure');
+      }
+      // The enrollment id still comes from the caller or this object, because
+      // the ladder still needs the field. When the ladder goes, so does the
+      // field, and the authenticator - which is the side that knows the
+      // enrollment - becomes the only thing that can supply it.
+      _recordAuthentication(enrollmentId: enrollmentId ?? this.enrollmentId);
+    } finally {
+      _pkamAuthenticationMutex.release();
+    }
+  }
 
   /// Generates digest using from verb response and [privateKey] and performs a PKAM authentication to
   /// secondary server. This method is executed for all verbs that requires authentication.
@@ -501,8 +626,17 @@ class AtLookupImpl implements AtLookUp {
         logger.finer('fromResponse $fromResponse');
         // RSA SHA-256 sign via at_chops (wraps the same crypton
         // RSAPrivateKey.createSHA256Signature; only the private key is used).
+        // TODO(4.0): remove with the privateKey ladder credential this method
+        // exists to serve. If it outlives the ladder instead, RsaSignatureAlgo
+        // produces identical signature bytes for a 2048-bit key — but refuses
+        // any other modulus size, which this path never checked, so a
+        // caller-supplied 3072- or 4096-bit key that authenticates today
+        // would start throwing.
+        // ignore: deprecated_member_use
         var sha256signature = PkamSigningAlgo(
-                AtPkamKeyPair.create('', privateKey), HashingAlgoType.sha256)
+                // ignore: deprecated_member_use
+                AtPkamKeyPair.create('', privateKey),
+                HashingAlgoType.sha256)
             .sign(Uint8List.fromList(utf8.encode(fromResponse)));
         var signature = base64Encode(sha256signature);
         logger.finer('Sending command pkam:$signature');
@@ -510,7 +644,7 @@ class AtLookupImpl implements AtLookUp {
         var pkamResponse = await messageListener.read();
         if (pkamResponse == 'data:success') {
           logger.info('auth success');
-          _connection!.getMetaData()!.isAuthenticated = true;
+          _recordAuthentication();
         } else {
           throw UnAuthenticatedException(
               'Failed connecting to $_currentAtSign. $pkamResponse');
@@ -524,6 +658,15 @@ class AtLookupImpl implements AtLookUp {
 
   @override
   Future<bool> pkamAuthenticate({String? enrollmentId}) async {
+    // Prefer an injected authenticator here too, not only in [_process].
+    // at_auth reaches this method directly rather than through a verb, so a
+    // seam wired only into [_process] would leave the authenticate() path
+    // still running the ladder - the seam would look connected and do nothing
+    // on the one call that matters most.
+    if (authenticator != null) {
+      await _authenticateWith(authenticator!, enrollmentId: enrollmentId);
+      return _connection!.getMetaData()!.isAuthenticated;
+    }
     await createConnection();
     try {
       await _pkamAuthenticationMutex.acquire();
@@ -542,9 +685,13 @@ class AtLookupImpl implements AtLookUp {
         logger.finer('fromResponse $fromResponse');
         logger.finer(
             'signingAlgoType: $signingAlgoType hashingAlgoType:$hashingAlgoType');
+        // TODO(4.0): remove with the credential ladder; at_chops directs this
+        // to calling an AtSigningAlgorithm implementation directly.
+        // ignore: deprecated_member_use
         final atSigningInput = AtSigningInput(fromResponse)
           ..signingAlgoType = signingAlgoType
           ..hashingAlgoType = hashingAlgoType
+          // ignore: deprecated_member_use
           ..signingMode = AtSigningMode.pkam;
         var signingResult = _atChops!.sign(atSigningInput);
         var pkamBuilder = PkamVerbBuilder()
@@ -558,7 +705,7 @@ class AtLookupImpl implements AtLookUp {
         var pkamResponse = await messageListener.read();
         if (pkamResponse == 'data:success') {
           logger.info('auth success');
-          _connection!.getMetaData()!.isAuthenticated = true;
+          _recordAuthentication(enrollmentId: enrollmentId);
         } else {
           throw UnAuthenticatedException(
               'Failed connecting to $_currentAtSign. $pkamResponse');
@@ -598,7 +745,7 @@ class AtLookupImpl implements AtLookUp {
             transientWaitTimeMillis: 4000, maxWaitMilliSeconds: 10000);
         if (cramResponse == 'data:success') {
           logger.info('auth success');
-          _connection!.getMetaData()!.isAuthenticated = true;
+          _recordAuthentication();
         } else {
           throw UnAuthenticatedException('Auth failed');
         }
@@ -651,7 +798,9 @@ class AtLookupImpl implements AtLookUp {
       await requestResponseMutex.acquire();
 
       if (auth && _isAuthRequired()) {
-        if (_atChops != null) {
+        if (authenticator != null) {
+          await _authenticateWith(authenticator!);
+        } else if (_atChops != null) {
           logger.finer('calling pkam using atchops');
           await pkamAuthenticate(enrollmentId: enrollmentId);
         } else if (privateKey != null) {
@@ -699,6 +848,7 @@ class AtLookupImpl implements AtLookUp {
     return true;
   }
 
+  @override
   bool isConnectionAvailable() {
     return _connection != null && !_connection!.isInValid();
   }
@@ -709,7 +859,329 @@ class AtLookupImpl implements AtLookUp {
 
   @override
   Future<void> close() async {
-    await _connection?.close();
+    await _closeConnection();
+  }
+
+  /// Closes the connection and fails whatever was waiting on it.
+  ///
+  /// Every close goes through here rather than calling `_connection.close()`
+  /// directly, because a close leaves a request in flight with nowhere for its
+  /// response to arrive from. [OutboundMessageListener.read] cannot see that on
+  /// its own, so it waits out its transient budget - and it is holding
+  /// [requestResponseMutex] while it does, which stalls the NEXT request on
+  /// this instance for the same 30 seconds.
+  ///
+  /// That is not hypothetical: it is what made an atSign switch stall the
+  /// request that followed it, because `AtClientImpl.stop()` destroys the
+  /// outgoing client's socket while its startup work is still in flight, and
+  /// the same AtLookupImpl is handed back when that atSign is switched to
+  /// again.
+  ///
+  /// The listener aborts on `onDone` as well, and in Dart a local
+  /// `Socket.destroy()` does deliver one - measured - so the two routes
+  /// usually agree. This one is still needed, and not merely as belt and
+  /// braces: **a PAUSED subscription delivers no done event**, also measured,
+  /// and this class pauses the socket to push back-pressure at the atServer
+  /// during notification delivery. Closing while paused reaches the abort
+  /// through here and through nothing else.
+  Future<void> _closeConnection() async {
+    final connection = _connection;
+    if (connection == null) {
+      return;
+    }
+    // `messageListener` is `late` and assigned in [createConnection] - which is
+    // also where `_connection` is assigned, so a non-null connection means
+    // there is a listener to tell.
+    messageListener.abortPendingRequests();
+    await connection.close();
+  }
+
+  // ---------------------------------------------------------------------
+  // AtLookupMuxable - the second framing, on a connection of its own.
+  // See the warning on [AtLookupMuxable]: sharing one socket with verb
+  // traffic is NOT safe today, because no atServer implements the flag that
+  // was supposed to make it safe.
+  // ---------------------------------------------------------------------
+
+  /// Created on first read of [notifications], not in the constructor.
+  ///
+  /// Its existence is what tells [createConnection] to install the framing
+  /// seam, so a lookup nobody asked notifications of behaves exactly as it
+  /// always did - including leaving a stray notification in the buffer, which
+  /// is pinned by test as the behaviour the seam exists to fix.
+  StreamController<String>? _notificationController;
+
+  bool _isNotifying = false;
+
+  // --- reconnect, reauth and heartbeat -----------------------------------
+  //
+  // Owned here because this object holds the socket. at_client's Monitor
+  // carries an identical [1,2,3,5,8,13,21,34] delay list; both cannot own
+  // reconnection, and on a connection that also carries verb traffic a
+  // Monitor-owned reconnect would be healing a socket it does not own for a
+  // subsystem that is not it.
+
+  /// Delays between reconnect attempts. The last is repeated indefinitely.
+  static const List<Duration> notificationReconnectDelays = [
+    Duration(seconds: 1),
+    Duration(seconds: 2),
+    Duration(seconds: 3),
+    Duration(seconds: 5),
+    Duration(seconds: 8),
+    Duration(seconds: 13),
+    Duration(seconds: 21),
+    Duration(seconds: 34),
+  ];
+
+  /// How often a quiet notification connection is probed, and how long the
+  /// probe waits. Settable so a test does not have to wait 30 seconds.
+  @override
+  Duration heartbeatInterval = const Duration(seconds: 30);
+
+  @override
+  Duration heartbeatResponseTimeout = const Duration(seconds: 10);
+
+  String? _notifyRegex;
+  int? _notifyLastNotificationTime;
+  bool _notifySelfNotifications = true;
+
+  int _reconnectIx = 0;
+  bool _reconnecting = false;
+  Timer? _heartbeatTimer;
+
+  /// Whether a reconnect is in flight. Visible so a test can assert the loop
+  /// is running rather than inferring it from a delay.
+  @override
+  bool get isReconnectingNotifications => _reconnecting;
+
+  StreamController<bool>? _connectionUpController;
+
+  @override
+  Stream<bool> get notificationConnectionUp {
+    _connectionUpController ??= StreamController<bool>.broadcast();
+    return _connectionUpController!.stream;
+  }
+
+  void _emitConnectionUp(bool up) {
+    final controller = _connectionUpController;
+    if (controller == null || controller.isClosed) return;
+    controller.add(up);
+  }
+
+  void _onNotificationConnectionLost() {
+    if (!_isNotifying || _reconnecting) return;
+    // `warning`: the subscriber cannot see this any other way, and a silent
+    // reconnect looks identical to an atServer that has simply gone quiet.
+    logger.warning(
+        'Notification connection to $_currentAtSign lost - reconnecting');
+    _emitConnectionUp(false);
+    _stopHeartbeat();
+    unawaited(_reconnectNotifications());
+  }
+
+  Future<void> _reconnectNotifications() async {
+    _reconnecting = true;
+    try {
+      while (_isNotifying) {
+        final delay = notificationReconnectDelays[
+            min(_reconnectIx, notificationReconnectDelays.length - 1)];
+        _reconnectIx++;
+        logger.info('Reconnecting notifications in ${delay.inSeconds}s '
+            '(attempt $_reconnectIx)');
+        await Future.delayed(delay);
+        // Re-checked after the delay, not only before it: stopNotifications
+        // can land while this is sleeping, and reconnecting after that would
+        // resurrect a connection the caller asked to be rid of.
+        if (!_isNotifying) return;
+        try {
+          await _openNotificationStream();
+          logger.info('Notification connection re-established');
+          _reconnectIx = 0;
+          _startHeartbeat();
+          _emitConnectionUp(true);
+          return;
+        } catch (e) {
+          logger.warning('Reconnect attempt $_reconnectIx failed: $e');
+        }
+      }
+    } finally {
+      _reconnecting = false;
+    }
+  }
+
+  void _startHeartbeat() {
+    _stopHeartbeat();
+    _heartbeatTimer = Timer(heartbeatInterval, _heartbeat);
+  }
+
+  void _stopHeartbeat() {
+    _heartbeatTimer?.cancel();
+    _heartbeatTimer = null;
+  }
+
+  /// Probe a quiet connection with `noop:0`.
+  ///
+  /// ⚠️ This makes the notification connection carry verb traffic, which is
+  /// the arrangement [AtLookupMuxable] warns about: no atServer implements the
+  /// `multiplexed` interlock, so a notification written between this command
+  /// and its reply is absorbed into the reply rather than routed. The window
+  /// is one short round trip every [heartbeatInterval], and it is the same
+  /// exposure at_client's Monitor has had all along - this moves that
+  /// behaviour, it does not add it. It closes when an atServer implements the
+  /// flag.
+  Future<void> _heartbeat() async {
+    if (!_isNotifying) return;
+    try {
+      await requestResponseMutex.acquire();
+      try {
+        await _sendCommand('noop:0\n');
+        await messageListener.read(
+            maxWaitMilliSeconds: heartbeatResponseTimeout.inMilliseconds,
+            transientWaitTimeMillis: heartbeatResponseTimeout.inMilliseconds);
+      } finally {
+        requestResponseMutex.release();
+      }
+      _heartbeatTimer = Timer(heartbeatInterval, _heartbeat);
+    } catch (e) {
+      logger.info('Notification heartbeat failed ($e) - closing the '
+          'connection so it reconnects');
+      // Closing is what starts recovery: the socket going away drives the
+      // listener's onDone, which is wired to [_onNotificationConnectionLost].
+      await _closeConnection();
+    }
+  }
+
+  @override
+  bool get isNotifying => _isNotifying;
+
+  @override
+  Stream<String> get notifications {
+    _notificationController ??= StreamController<String>(
+      // Back-pressure that reaches the far end. A listener that stops reading
+      // stops the socket, so bytes pile up in the kernel buffer and TCP closes
+      // the window on the atServer - rather than being absorbed here without
+      // bound until the byte buffer overflows.
+      onPause: () => _setNotificationDelivery(paused: true),
+      onResume: () => _setNotificationDelivery(paused: false),
+    );
+    // A connection may already exist - `notifications` can be read after the
+    // first verb - so the seam is installed here too, not only on connect.
+    if (_connection != null) {
+      messageListener.onNotification = _routeNotification;
+    }
+    return _notificationController!.stream;
+  }
+
+  /// [messageListener] is `late` and is assigned only inside
+  /// [createConnection], immediately after `_connection`. So a null
+  /// `_connection` is exactly the case where touching it throws a
+  /// `LateInitializationError` - and the controller can be paused before
+  /// anything has connected.
+  void _setNotificationDelivery({required bool paused}) {
+    if (_connection == null) return;
+    if (paused) {
+      messageListener.pauseDelivery();
+    } else {
+      messageListener.resumeDelivery();
+    }
+  }
+
+  void _routeNotification(String notification) {
+    final controller = _notificationController;
+    if (controller == null || controller.isClosed) {
+      // `warning`, not `finer`. A silently dropped notification is
+      // indistinguishable from one the atServer never sent, so the failure
+      // gets attributed to the sender. Nothing retries this.
+      logger.warning('Notification DROPPED for $_currentAtSign - the stream is '
+          '${controller == null ? "not open" : "closed"}: $notification');
+      return;
+    }
+    controller.add(notification);
+  }
+
+  @override
+  Future<void> startNotifications({
+    String? regex,
+    int? lastNotificationTime,
+    bool selfNotificationsEnabled = true,
+  }) async {
+    if (_isNotifying) {
+      logger.info('startNotifications: already notifying, nothing sent');
+      return;
+    }
+    // Reading this getter is what creates the controller and installs the
+    // seam, so it must happen before `monitor:` goes out - otherwise the first
+    // notifications arrive with nowhere to go.
+    notifications;
+
+    // Remembered, because reconnecting has to re-issue the SAME monitor:. A
+    // reconnect that dropped the regex would start delivering everything, and
+    // one that dropped the watermark would replay from the beginning.
+    _notifyRegex = regex;
+    _notifyLastNotificationTime = lastNotificationTime;
+    _notifySelfNotifications = selfNotificationsEnabled;
+
+    await _openNotificationStream();
+    _isNotifying = true;
+    _reconnectIx = 0;
+    _startHeartbeat();
+    _emitConnectionUp(true);
+  }
+
+  /// Connect, authenticate if required, and send `monitor:`.
+  ///
+  /// Shared by [startNotifications] and the reconnect loop, so a reconnected
+  /// connection is established exactly as the first one was. Anything else and
+  /// the two paths drift, with the difference only visible after an outage.
+  Future<void> _openNotificationStream() async {
+    await requestResponseMutex.acquire();
+    try {
+      await createConnection();
+      if (_isAuthRequired()) {
+        if (authenticator != null) {
+          await _authenticateWith(authenticator!, enrollmentId: enrollmentId);
+        } else {
+          throw UnAuthenticatedException(
+              'monitor requires authentication and no authenticator is set');
+        }
+      }
+      final command = (MonitorVerbBuilder()
+            ..regex = _notifyRegex
+            ..lastNotificationTime = _notifyLastNotificationTime
+            ..selfNotificationsEnabled = _notifySelfNotifications)
+          .buildCommand();
+      // ⚠️ `multiplexed` is deliberately NOT set. It is accepted by the shared
+      // verb syntax and read by no atServer, so setting it would advertise a
+      // safety property that does not exist. See [AtLookupMuxable].
+      logger.info('SENDING: ${command.trim()}');
+      await _connection!.write(command);
+    } finally {
+      requestResponseMutex.release();
+    }
+  }
+
+  @override
+  Future<void> stopNotifications() async {
+    // First, and deliberately: this flag is what the reconnect loop reads to
+    // decide whether to keep trying. Closing the connection before clearing it
+    // would trip the disconnect handler into reconnecting the very connection
+    // this method is tearing down.
+    _isNotifying = false;
+    _stopHeartbeat();
+    _emitConnectionUp(false);
+    await _closeConnection();
+    final controller = _notificationController;
+    _notificationController = null;
+    // NOT awaited, and that is the point. `close()` on a single-subscription
+    // controller returns its `done` future, which completes only once a
+    // subscriber has received the done event - so a caller that started
+    // notifications and never listened would hang here forever. Start-then-stop
+    // with no subscriber is a legal caller, and awaiting this deadlocked four
+    // tests for thirty seconds each before it was caught.
+    unawaited(controller?.close() ?? Future<void>.value());
+    final up = _connectionUpController;
+    _connectionUpController = null;
+    unawaited(up?.close() ?? Future<void>.value());
   }
 
   Future<void> _sendCommand(String command) async {
@@ -718,26 +1190,47 @@ class AtLookupImpl implements AtLookUp {
     await _connection!.write(command);
   }
 
+  @Deprecated('Pass an AtAuthenticator to AtLookUp.withSecureSocket '
+      'instead - at_auth builds one with authenticatorForChops(). '
+      'Removed with the credential ladder in the next major release.')
   @override
   set atChops(AtChops? atChops) {
     _atChops = atChops;
   }
 
+  @Deprecated('Pass an AtAuthenticator to AtLookUp.withSecureSocket '
+      'instead - at_auth builds one with authenticatorForChops(). '
+      'Removed with the credential ladder in the next major release.')
   @override
   AtChops? get atChops => _atChops;
 
   /// To use a specific signing algorithm other than default one for pkam auth, set the [SigningAlgoType] and [HashingAlgoType]
+  @Deprecated('Pass the hashing algorithm to the AtAuthenticator that at_auth '
+      'builds - authenticatorForChops() takes signingAlgo and hashingAlgo. '
+      'Removed with the credential ladder in the next major release.')
   @override
   HashingAlgoType hashingAlgoType = HashingAlgoType.sha256;
 
+  @Deprecated('Pass the signing algorithm to the AtAuthenticator that at_auth '
+      'builds - authenticatorForChops() takes signingAlgo and hashingAlgo. '
+      'Removed with the credential ladder in the next major release.')
   @override
   SigningAlgoType signingAlgoType = SigningAlgoType.rsa2048;
 
+  @Deprecated('Pass the enrollment id to the AtAuthenticator that at_auth '
+      'builds. To ask "which enrollment am I", read your own client state - '
+      'not this field, and not '
+      'AtConnectionMetaData.authenticatedAsEnrollmentId, which is what the '
+      'live connection authenticated as rather than what the next '
+      'authentication will use. '
+      'Removed with the credential ladder in the next major release.')
   @override
   String? enrollmentId;
 }
 
 class AtLookupSecureSocketFactory {
+  const AtLookupSecureSocketFactory();
+
   Future<SecureSocket> createSocket(
       String host, String port, SecureSocketConfig socketConfig,
       {Duration? timeout}) async {
@@ -747,6 +1240,8 @@ class AtLookupSecureSocketFactory {
 }
 
 class AtLookupSecureSocketListenerFactory {
+  const AtLookupSecureSocketListenerFactory();
+
   OutboundMessageListener createListener(
       OutboundConnection outboundConnection) {
     return OutboundMessageListener(outboundConnection);
@@ -754,6 +1249,8 @@ class AtLookupSecureSocketListenerFactory {
 }
 
 class AtLookupOutboundConnectionFactory {
+  const AtLookupOutboundConnectionFactory();
+
   OutboundConnection createOutboundConnection(SecureSocket secureSocket) {
     return OutboundConnectionImpl(secureSocket);
   }

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -1031,6 +1031,17 @@ class AtLookupImpl implements AtLookUp, AtCommandExecutor, AtLookupMuxable {
   /// flag.
   Future<void> _heartbeat() async {
     if (!_isNotifying) return;
+    // A paused subscriber is not reading the socket, so nothing can fill the
+    // read queue and the probe below could never be answered - it would time
+    // out and destroy a healthy connection. Pausing is a documented feature of
+    // [notifications], not misuse, so skip this round and try again at the
+    // next interval. A connection that really has gone is still detected: the
+    // done event is buffered by the paused subscription and delivered when
+    // delivery resumes.
+    if (messageListener.isDeliveryPaused) {
+      _heartbeatTimer = Timer(heartbeatInterval, _heartbeat);
+      return;
+    }
     try {
       await requestResponseMutex.acquire();
       try {
@@ -1043,6 +1054,16 @@ class AtLookupImpl implements AtLookUp, AtCommandExecutor, AtLookupMuxable {
       }
       _heartbeatTimer = Timer(heartbeatInterval, _heartbeat);
     } catch (e) {
+      // The same pause, landing after the probe went out rather than before
+      // it: the failure is our own reader being starved, not the connection.
+      // Tearing down here would destroy a healthy socket for doing exactly
+      // what the back-pressure contract invites.
+      if (messageListener.isDeliveryPaused) {
+        logger.info('Notification heartbeat could not complete while delivery '
+            'is paused - leaving the connection alone and retrying');
+        _heartbeatTimer = Timer(heartbeatInterval, _heartbeat);
+        return;
+      }
       logger.info('Notification heartbeat failed ($e) - closing the '
           'connection so it reconnects');
       // Closing is what starts recovery: the socket going away drives the
@@ -1065,9 +1086,15 @@ class AtLookupImpl implements AtLookUp, AtCommandExecutor, AtLookupMuxable {
       onResume: () => _setNotificationDelivery(paused: false),
     );
     // A connection may already exist - `notifications` can be read after the
-    // first verb - so the seam is installed here too, not only on connect.
+    // first verb - so the seams are installed here too, not only on connect.
+    // BOTH of them: a listener given a route but no disconnect callback loses
+    // its connection silently, because `_notifyDisconnect` is the only path to
+    // `_onNotificationConnectionLost` and so the only thing that emits `false`
+    // and starts a reconnect. Installing the disconnect seam before anything
+    // is notifying is harmless - it returns immediately unless `_isNotifying`.
     if (_connection != null) {
       messageListener.onNotification = _routeNotification;
+      messageListener.onDisconnect = _onNotificationConnectionLost;
     }
     return _notificationController!.stream;
   }

--- a/packages/at_lookup/lib/src/at_lookup_impl.dart
+++ b/packages/at_lookup/lib/src/at_lookup_impl.dart
@@ -1203,7 +1203,23 @@ class AtLookupImpl implements AtLookUp, AtCommandExecutor, AtLookupMuxable {
       }
       // Asked here rather than held from the start, so a reconnect resumes
       // from the caller's current watermark.
-      final lastNotificationTime = await _getLastNotificationTime?.call();
+      //
+      // Guarded, because this is CALLER code running inside the reconnect
+      // loop. Letting it throw would abort the attempt after the connection
+      // was already opened and authenticated - and that connection stays
+      // valid, so every later attempt skips the connect, re-runs only this
+      // call, and backs off forever without ever sending `monitor:`. The
+      // client would be permanently deaf with no symptom but a missing `up`.
+      // Starting without a watermark instead costs a replayed window, which
+      // the caller can absorb.
+      int? lastNotificationTime;
+      try {
+        lastNotificationTime = await _getLastNotificationTime?.call();
+      } catch (e) {
+        logger.warning('Could not read the last-notification watermark, so '
+            'this connection starts without one and the atServer will replay '
+            'from where it last heard: $e');
+      }
       final command = (MonitorVerbBuilder()
             ..regex = _notifyRegex
             ..lastNotificationTime = lastNotificationTime

--- a/packages/at_lookup/lib/src/connection/at_connection.dart
+++ b/packages/at_lookup/lib/src/connection/at_connection.dart
@@ -25,4 +25,19 @@ abstract class AtConnectionMetaData {
   DateTime? created;
   bool isClosed = false;
   bool isStale = false;
+
+  /// The enrollment id this connection authenticated as, or null where the
+  /// authentication carried none — a CRAM authentication, or a PKAM
+  /// authentication made without one.
+  ///
+  /// This is what the connection *holds*, not what the next authentication
+  /// will ask for. `AtLookUp.enrollmentId` is the latter: setting it does not
+  /// move a socket that is already up, so a client whose enrollment changes
+  /// must re-authenticate each connection and read this field back to know it
+  /// happened.
+  String? authenticatedAsEnrollmentId;
+
+  /// When this connection last completed authentication, in UTC. Null until it
+  /// authenticates; set on the same paths as [isAuthenticated].
+  DateTime? authenticatedAt;
 }

--- a/packages/at_lookup/lib/src/connection/outbound_message_listener.dart
+++ b/packages/at_lookup/lib/src/connection/outbound_message_listener.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
@@ -13,8 +15,37 @@ class OutboundMessageListener {
   final logger = AtSignLogger('OutboundMessageListener');
   late ByteBuffer _buffer;
   final Queue _queue = Queue();
+
+  /// Completed to wake any pending [read] the moment a response is queued.
+  ///
+  /// Replaced rather than reused, because a [Completer] completes once. Null
+  /// whenever nobody is waiting, so a response arriving with no reader costs
+  /// nothing.
+  Completer<void>? _responseQueued;
+
+  /// Set once the connection this listener reads has gone away.
+  ///
+  /// Never cleared: [AtLookupImpl.createConnection] builds a fresh listener
+  /// with every connection, so a listener whose socket has died is never
+  /// reused for a live one.
+  bool _connectionGone = false;
+
   final AtConnection _connection;
   Function? syncCallback;
+
+  /// Where asynchronous `notification:` lines go, if anywhere.
+  ///
+  /// The atServer frames the two kinds of message differently. A verb response
+  /// ends `\n@<atSign>@` - the newline, then the prompt saying it is ready for
+  /// the next command. A notification is not a reply to anything, so no prompt
+  /// follows it and it ends at a bare `\n`.
+  ///
+  /// While this is null the second framing is not applied at all and the
+  /// listener behaves exactly as it did before it existed. That is deliberate:
+  /// routing notifications to a callback nobody installed would drop them, and
+  /// a dropped notification is indistinguishable from one the atServer never
+  /// sent.
+  void Function(String notification)? onNotification;
   final int newLineCodeUnit = 10;
   final int atCharCodeUnit = 64;
   late DateTime _lastReceivedTime;
@@ -23,13 +54,23 @@ class OutboundMessageListener {
     _buffer = ByteBuffer(capacity: bufferCapacity);
   }
 
+  /// The subscription to the socket, kept so delivery can be stopped.
+  ///
+  /// This used to be discarded. Keeping it is what lets back-pressure reach
+  /// the far end: pausing here stops reading the socket, so bytes accumulate
+  /// in the kernel receive buffer and TCP eventually closes the window on the
+  /// atServer. Without it a slow consumer's only option is to buffer without
+  /// bound in this process, which is not back-pressure - it is a memory leak
+  /// that ends in an overflow.
+  StreamSubscription<Uint8List>? _socketSubscription;
+
   /// Listens to the underlying connection's socket if the connection is created.
   /// @throws [AtConnectException] if the connection is not yet created
   void listen() {
     logger.finest('Calling socket.listen within runZonedGuarded block');
 
     runZonedGuarded(() {
-      _connection
+      _socketSubscription = _connection
           .getSocket()
           .listen(messageHandler, onDone: onSocketDone, onError: onSocketError);
     }, (Object error, StackTrace st) {
@@ -37,6 +78,46 @@ class OutboundMessageListener {
           'runZonedGuarded received socket error $error - calling onSocketError() to close connection');
       onSocketError(error);
     });
+  }
+
+  /// Whether delivery from the socket is currently stopped.
+  bool get isDeliveryPaused => _socketSubscription?.isPaused ?? false;
+
+  /// Stop reading the socket.
+  ///
+  /// ⚠️ Pauses are COUNTED by [StreamSubscription] - measured, not assumed:
+  /// two `pause()` calls need two `resume()` calls before delivery restarts.
+  /// So every call here needs exactly one matching [resumeDelivery]. Wiring
+  /// these to a [StreamController]'s `onPause`/`onResume` satisfies that by
+  /// construction, which is why the notification stream drives them rather
+  /// than callers doing it by hand.
+  ///
+  /// A no-op before [listen] has been called, and a no-op is right: there is
+  /// no delivery to stop.
+  void pauseDelivery() => _socketSubscription?.pause();
+
+  /// Resume reading the socket. Safe when not paused - probed, it does not
+  /// throw - so an unmatched resume costs nothing.
+  void resumeDelivery() => _socketSubscription?.resume();
+
+  /// Called after the connection has been closed because the far end went
+  /// away - either cleanly (`onDone`) or with an error (`onError`).
+  ///
+  /// The listener knows the socket died before anything else does, and until
+  /// now it kept that to itself: it closed the connection and returned, so a
+  /// subscriber waiting on notifications simply stopped hearing anything, with
+  /// no event distinguishing "the atServer is quiet" from "the socket is
+  /// gone". Whoever owns reconnection needs that difference.
+  void Function()? onDisconnect;
+
+  void _notifyDisconnect() {
+    final callback = onDisconnect;
+    if (callback == null) return;
+    try {
+      callback();
+    } catch (e, st) {
+      logger.shout('onDisconnect threw $e - reconnection may not happen\n$st');
+    }
   }
 
   /// Logs the error and closes the [OutboundConnection]
@@ -48,6 +129,7 @@ class OutboundMessageListener {
     await closeConnection();
     logger.finest(
         'outbound socket onError handler called - closeConnection complete');
+    _notifyDisconnect();
   }
 
   /// Closes the [OutboundConnection]
@@ -58,6 +140,7 @@ class OutboundMessageListener {
     await closeConnection();
     logger.finest(
         'outbound socket onDone handler called - closeConnection complete');
+    _notifyDisconnect();
   }
 
   /// Handles messages on the inbound client's connection and calls the verb executor
@@ -70,10 +153,29 @@ class OutboundMessageListener {
     // check buffer overflow
     _checkBufferOverFlow(data);
     // If the data contains a new line character, add until the new line char to buffer
+    // Everything before the LAST newline is appended without being examined
+    // for the `\n@` terminator, and that is not an optimisation - it is what
+    // makes multi-line values work. A `data:` value may itself contain `\n@`
+    // (a key name follows a newline inside the value), and inspecting those
+    // bytes would end the response early and truncate it.
+    //
+    // Notifications need the opposite: they end at a bare newline, so every
+    // newline in that skipped region IS a message boundary. Hence two passes
+    // over it - the notification check byte by byte, the `\n@` check only from
+    // the last newline on, exactly as before.
     if (data.contains(newLineCodeUnit)) {
       offset = data.lastIndexOf(newLineCodeUnit);
-      var dataSubList = data.getRange(0, offset).toList();
-      _buffer.append(dataSubList);
+      final head = data.getRange(0, offset).toList();
+      if (onNotification == null) {
+        _buffer.append(head);
+      } else {
+        for (final byte in head) {
+          _buffer.addByte(byte);
+          if (byte == newLineCodeUnit) {
+            _routeIfNotification();
+          }
+        }
+      }
     } else {
       offset = 0;
     }
@@ -93,12 +195,45 @@ class OutboundMessageListener {
         result = _stripPrompt(result);
         logger.finer('RECEIVED $result');
         _queue.add(result);
+        _wakeReaders();
         //clear the buffer after adding result to queue
         _buffer.clear();
         _buffer.addByte(data[element]);
       } else {
         _buffer.addByte(data[element]);
+        if (data[element] == newLineCodeUnit && onNotification != null) {
+          _routeIfNotification();
+        }
       }
+    }
+  }
+
+  /// Surface the buffer if it holds a complete notification.
+  ///
+  /// Called only when the buffer just gained a newline. A verb response whose
+  /// VALUE contains newlines is left alone, because the test is on the
+  /// buffer's prefix: a multi-line value still begins `data:` or `error:`,
+  /// never `notification:`.
+  void _routeIfNotification() {
+    final bytes = _buffer.getData();
+    if (bytes.isEmpty || bytes.last != newLineCodeUnit) return;
+    final body = bytes.sublist(0, bytes.length - 1);
+    if (body.isEmpty) return;
+    final String stripped;
+    try {
+      stripped = _stripPrompt(utf8.decode(body));
+    } catch (_) {
+      // Not decodable yet - more bytes are coming. Leave the buffer alone.
+      return;
+    }
+    if (!stripped.startsWith('notification:')) return;
+
+    logger.finer('NOTIFICATION $stripped');
+    _buffer.clear();
+    try {
+      onNotification!(stripped);
+    } catch (e, st) {
+      logger.shout('onNotification threw $e - notification dropped\n$st');
     }
   }
 
@@ -116,8 +251,19 @@ class OutboundMessageListener {
 
   /// The method accepts the result (server response) and trim's the prompt from the response
   /// and returns the actual response.
+  ///
+  /// A response with no colon has no prompt to strip and is returned as it
+  /// stands. The bare `@<atSign>@` that completes the handshake is exactly
+  /// that, and [_isValidResponse] accepts it, so without this guard
+  /// `substring(0, -1)` throws a RangeError from inside the socket's data
+  /// handler - which `runZonedGuarded` turns into a socket error, destroying a
+  /// healthy connection and leaving the caller with a timeout that names the
+  /// wrong cause.
   String _stripPrompt(String result) {
     var colonIndex = result.indexOf(':');
+    if (colonIndex == -1) {
+      return result;
+    }
     var responsePrefix = result.substring(0, colonIndex);
     var response = result.substring(colonIndex);
     if (responsePrefix.contains('@')) {
@@ -127,19 +273,77 @@ class OutboundMessageListener {
     return '$responsePrefix$response';
   }
 
+  void _wakeReaders() {
+    final waiter = _responseQueued;
+    _responseQueued = null;
+    if (waiter != null && !waiter.isCompleted) {
+      waiter.complete();
+    }
+  }
+
+  /// Fails anything waiting in [read], at once, because the connection is gone.
+  ///
+  /// A response can only arrive on the socket this listener reads, so once that
+  /// socket is gone a pending [read] is waiting for something that can never
+  /// come. That wait is not free: `AtLookupImpl._process` holds
+  /// `requestResponseMutex` across it, so the next request on the same
+  /// AtLookupImpl queues behind a dead one for the whole transient budget -
+  /// measured at 30 seconds, long enough to blow past a test's own timeout and
+  /// long enough that an application reads it as a hang.
+  ///
+  /// Deliberately NOT the same thing as a timeout: nothing timed out. The
+  /// caller is told the connection went away, which is both true and
+  /// actionable, where `AtTimeoutException` would send it looking at the
+  /// atServer's latency.
+  ///
+  /// A response already parsed and queued is still returned - those bytes
+  /// arrived while the connection was alive and the caller is owed them.
+  void abortPendingRequests() {
+    _connectionGone = true;
+    final waiter = _responseQueued;
+    _responseQueued = null;
+    if (waiter != null && !waiter.isCompleted) {
+      // Logged because it is otherwise invisible: the request simply fails, and
+      // a failure attributed to the atServer rather than to the connection
+      // being closed underneath it sends the reader to the wrong end.
+      logger.info('Connection closed with a request in flight - failing it now '
+          'rather than waiting out its response budget');
+      waiter.complete();
+    }
+  }
+
   /// Reads the response sent by remote socket from the queue.
-  /// If there is no message in queue after [maxWaitMilliSeconds], return null. Defaults to 90 seconds.
-  /// Whenever data is received on client socket from server, [_lastReceivedTime] will be updated to current time.
-  /// [transientWaitTimeMillis] specifies the max duration to wait between current time and [_lastReceivedTime] before timing out.Defaults to 10 seconds.
-  Future<String> read(
-      {int maxWaitMilliSeconds = 90000,
-      int transientWaitTimeMillis = 10000}) async {
+  ///
+  /// Two independent budgets bound the wait, and they measure different things:
+  ///
+  /// - [maxWaitMilliSeconds] is the whole response, from this call to the
+  ///   terminating byte. Defaults to [AtNetworkTimeouts.defaultResponseBudget].
+  /// - [transientWaitTimeMillis] is the gap between *chunks*. Every byte the
+  ///   socket delivers moves [_lastReceivedTime], so this restarts whenever the
+  ///   atServer is still sending. Defaults to
+  ///   [AtNetworkTimeouts.effectiveDefault].
+  ///
+  /// Passing null for either takes the default at the time of the call, so a
+  /// process that moves `AtNetworkTimeouts.defaultTimeout` at startup moves
+  /// this too.
+  ///
+  /// The wait is event-driven: this sleeps until a response is queued or until
+  /// the nearer of the two deadlines, whichever happens first. It does not poll,
+  /// so a response is surfaced as soon as its last byte is parsed rather than up
+  /// to a polling interval later.
+  Future<String> read({
+    int? maxWaitMilliSeconds,
+    int? transientWaitTimeMillis,
+  }) async {
+    final maxWait = maxWaitMilliSeconds ??
+        AtNetworkTimeouts.defaultResponseBudget.inMilliseconds;
+    final transientWait = transientWaitTimeMillis ??
+        AtNetworkTimeouts.effectiveDefault.inMilliseconds;
     String result;
     _lastReceivedTime = DateTime.now();
     var startTime = DateTime.now();
     while (true) {
-      var queueLength = _queue.length;
-      if (queueLength > 0) {
+      if (_queue.isNotEmpty) {
         result = _queue.removeFirst();
         // result from another secondary is either data or a @<atSign>@ denoting complete
         // of the handshake
@@ -151,25 +355,48 @@ class OutboundMessageListener {
         throw AtLookUpException('AT0014', 'Unexpected response found');
       }
 
-      // if currentTime - startTime  is greater than maxWaitMillis throw AtTimeoutException
-      if (DateTime.now().difference(startTime).inMilliseconds >
-          maxWaitMilliSeconds) {
+      // Checked after the queue and before the deadlines: a response that
+      // arrived before the connection died is still owed to the caller, and a
+      // connection that has gone will never produce another one.
+      if (_connectionGone) {
+        _buffer.clear();
+        throw ConnectionInvalidException(
+            'The connection went away before a response arrived');
+      }
+
+      // if currentTime - startTime  is greater than maxWait throw AtTimeoutException
+      final sinceStart = DateTime.now().difference(startTime).inMilliseconds;
+      if (sinceStart > maxWait) {
         _buffer.clear();
         await closeConnection();
         throw AtTimeoutException(
-            'Full response not received after $maxWaitMilliSeconds millis from remote atServer');
+            'Full response not received after $maxWait millis from remote atServer');
       }
       // if no data is received from server and if currentTime - _lastReceivedTime is greater than
-      // transientWaitTimeMillis throw AtTimeoutException
-      if (DateTime.now().difference(_lastReceivedTime).inMilliseconds >
-          transientWaitTimeMillis) {
+      // transientWait throw AtTimeoutException
+      final sinceReceived =
+          DateTime.now().difference(_lastReceivedTime).inMilliseconds;
+      if (sinceReceived > transientWait) {
         _buffer.clear();
         await closeConnection();
         throw AtTimeoutException(
-            'Waited for $transientWaitTimeMillis millis. No response after $_lastReceivedTime ');
+            'Waited for $transientWait millis. No response after $_lastReceivedTime ');
       }
-      // wait for 10 ms before attempting to read from queue again
-      await Future.delayed(Duration(milliseconds: 10));
+
+      // Sleep until a response is queued or the nearer deadline passes. The
+      // extra millisecond matters: both checks above are strict `>`, so waking
+      // exactly ON a deadline would find neither exceeded and sleep again for
+      // zero, spinning until the clock ticked over.
+      //
+      // A chunk that does not complete a response does not wake anything. It
+      // does not need to - it can only push the transient deadline further
+      // out, and the wake that was already scheduled recomputes it from
+      // _lastReceivedTime and sleeps again.
+      final untilDeadline = Duration(
+          milliseconds:
+              min(maxWait - sinceStart, transientWait - sinceReceived) + 1);
+      _responseQueued ??= Completer<void>();
+      await _responseQueued!.future.timeout(untilDeadline, onTimeout: () {});
     }
   }
 
@@ -188,6 +415,11 @@ class OutboundMessageListener {
     if (delayBeforeClose != null) {
       await Future.delayed(delayBeforeClose!);
     }
+    // Before the close, so a reader woken by it finds the flag already set.
+    // This covers the far end going away - `onSocketDone` and `onSocketError`
+    // both arrive here. A close started anywhere else reaches
+    // [abortPendingRequests] through `AtLookupImpl`.
+    abortPendingRequests();
     await _connection.close();
   }
 }

--- a/packages/at_lookup/lib/src/monitor_client.dart
+++ b/packages/at_lookup/lib/src/monitor_client.dart
@@ -10,6 +10,17 @@ import 'package:at_lookup/at_lookup.dart';
 import 'package:at_utils/at_logger.dart';
 
 /// Utility class to execute monitor verb.
+/// Deprecated with no replacement, because nothing uses it: a tree-wide
+/// search finds its own declaration and nothing else.
+///
+/// It also predates the connect timeouts - `_createNewConnection` builds its
+/// socket directly rather than through `SecureSocketUtil`, so it never got
+/// them. A caller wanting a notification stream should use
+/// [AtLookUp.withSecureSocket] and [AtLookupMuxable.notifications], which
+/// share one connection, one listener and one reconnect policy with the rest
+/// of at_lookup.
+@Deprecated('Use AtLookUp.withSecureSocket and AtLookupMuxable.notifications. '
+    'Removed in the next major release.')
 class MonitorClient {
   final _monitorVerbResponseQueue = Queue();
   late String response;

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.6.1
+version: 3.7.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_lookup
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -11,10 +11,10 @@ resolution: workspace
 
 dependencies:
   at_utils: ^3.0.19
-  at_commons: ^5.13.0
+  at_commons: ^5.16.0
   mutex: ^3.0.0
   meta: ^1.16.0
-  at_chops: ^3.3.0
+  at_chops: ^3.6.0
 
 dev_dependencies:
   mocktail: ^1.0.4

--- a/packages/at_lookup/pubspec.yaml
+++ b/packages/at_lookup/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_lookup
 description: A Dart library that contains the core commands that can be used with a secondary server (scan, update, lookup, llookup, plookup, etc.)
-version: 3.7.0
+version: 3.7.0-rc1
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_lookup
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_lookup/test/at_lookup_test.dart
+++ b/packages/at_lookup/test/at_lookup_test.dart
@@ -1,3 +1,9 @@
+// These tests exercise the atChops credential ladder itself, so they are
+// written in the vocabulary at_chops has deprecated (AtChops, AtSigningInput,
+// AtSigningResult). They go when the ladder does.
+// TODO(4.0): remove with the credential ladder.
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 import 'dart:io';
 
@@ -222,6 +228,100 @@ void main() {
               enrollmentId: enrollmentIdFromServer),
           throwsA(predicate((e) =>
               e is UnAuthenticatedException && e.message.contains('AT0401'))));
+    });
+  });
+
+  group('A connection records the identity it authenticated as', () {
+    const pkamSignature = 'a-signature';
+
+    /// Wires the mocks for one PKAM exchange and hands back the metadata
+    /// object the connection will carry, so a test can read what the
+    /// authentication wrote onto it.
+    OutboundConnectionMetadata primePkam(
+        {String? enrollmentId, bool succeeds = true}) {
+      registerFallbackValue(FakeAtSigningInput());
+      when(() => mockAtChops.sign(any()))
+          .thenReturn(AtSigningResult()..result = pkamSignature);
+      var readCount = 0;
+      when(() => mockOutboundListener.read()).thenAnswer((_) => Future.value(
+          readCount++ == 0
+              ? fromChallenge
+              : (succeeds
+                  ? 'data:success'
+                  : 'error:AT0401-Exception: pkam authentication failed')));
+
+      final metaData = OutboundConnectionMetadata()..isAuthenticated = false;
+      when(() => mockOutBoundConnection.getMetaData()).thenReturn(metaData);
+      when(() => mockOutBoundConnection.isInValid()).thenReturn(false);
+
+      final enrollmentClause =
+          enrollmentId == null ? '' : 'enrollmentId:$enrollmentId:';
+      final command = 'pkam:signingAlgo:rsa2048:hashingAlgo:sha256:'
+          '$enrollmentClause$pkamSignature\n';
+      when(() => mockOutBoundConnection.write(command))
+          .thenAnswer((invocation) {
+        mockSecureSocket.write(command);
+        return Future.value();
+      });
+      return metaData;
+    }
+
+    AtLookupImpl newAtLookup() {
+      final atLookup = AtLookupImpl('@alice', atServerHost, 64,
+          secondaryAddressFinder: mockSecondaryAddressFinder,
+          secureSocketFactory: mockSocketFactory,
+          socketListenerFactory: mockSecureSocketListenerFactory,
+          outboundConnectionFactory: mockOutboundConnectionFactory);
+      atLookup.atChops = mockAtChops;
+      return atLookup;
+    }
+
+    test('pkam auth records the enrollment id it authenticated with', () async {
+      const enrollmentIdFromServer = '5a21feb4-dc04-4603-829c-15f523789170';
+      final metaData = primePkam(enrollmentId: enrollmentIdFromServer);
+      final before = DateTime.now().toUtc();
+
+      expect(
+          await newAtLookup()
+              .pkamAuthenticate(enrollmentId: enrollmentIdFromServer),
+          true);
+
+      expect(metaData.authenticatedAsEnrollmentId, enrollmentIdFromServer,
+          reason: 'the connection must carry the enrollment id it sent');
+      expect(metaData.authenticatedAt, isNotNull,
+          reason: 'an authenticated connection must be stamped with when');
+      expect(metaData.authenticatedAt!.isBefore(before), false,
+          reason: 'the stamp is this authentication, not an earlier one');
+      expect(metaData.authenticatedAt!.isUtc, true);
+    });
+
+    test('pkam auth with no enrollment id records none, not the field',
+        () async {
+      final metaData = primePkam();
+      final atLookup = newAtLookup()
+        // What the NEXT authentication would use. This one is being handed
+        // nothing, and sends nothing, so it must record nothing.
+        ..enrollmentId = 'f0c5e2b0-0000-4000-8000-000000000001';
+
+      expect(await atLookup.pkamAuthenticate(), true);
+
+      expect(metaData.authenticatedAsEnrollmentId, isNull,
+          reason: 'the recorded identity is what went on the wire, '
+              'not what AtLookUp.enrollmentId holds');
+      expect(metaData.authenticatedAt, isNotNull);
+    });
+
+    test('a refused pkam auth records nothing', () async {
+      final metaData = primePkam(succeeds: false);
+
+      await expectLater(newAtLookup().pkamAuthenticate(),
+          throwsA(isA<UnAuthenticatedException>()));
+
+      expect(metaData.isAuthenticated, false,
+          reason: 'nothing may be recorded until the atServer accepts');
+      expect(metaData.authenticatedAsEnrollmentId, isNull,
+          reason: 'a refusal must leave the connection unidentified');
+      expect(metaData.authenticatedAt, isNull);
     });
   });
 

--- a/packages/at_lookup/test/at_lookup_test_utils.dart
+++ b/packages/at_lookup/test/at_lookup_test_utils.dart
@@ -1,3 +1,8 @@
+// Builds the AtChopsImpl the ladder tests hand to AtLookupImpl, in the
+// vocabulary at_chops has deprecated.
+// TODO(4.0): remove with the credential ladder.
+// ignore_for_file: deprecated_member_use
+
 import 'dart:async';
 import 'dart:io';
 

--- a/packages/at_lookup/test/fake_at_server_socket.dart
+++ b/packages/at_lookup/test/fake_at_server_socket.dart
@@ -1,0 +1,184 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:at_lookup/src/connection/outbound_connection_impl.dart';
+import 'package:at_lookup/src/connection/outbound_message_listener.dart';
+
+/// A [Socket] the test drives by hand, over a REAL [StreamController].
+///
+/// at_lookup's other socket double, `createMockAtServerSocket`, stubs `listen`
+/// to return a `MockStreamSubscription`. That subscription delivers nothing and
+/// cannot show that pausing stops delivery, so no test in this package has ever
+/// driven bytes in through a socket — every one calls
+/// `OutboundMessageListener.messageHandler` directly. This class closes that
+/// gap: bytes arrive the way the atServer sends them, and pause, resume, done
+/// and error are real events with counters on them.
+///
+/// The controller is deliberately **single-subscription**. A broadcast
+/// controller ignores `pause()` and buffers nothing, so a back-pressure
+/// assertion written against one passes whether or not the code under test
+/// pauses anything.
+///
+/// Anything this fake does not implement throws [UnimplementedError] naming the
+/// member, so an unsupported call fails loudly instead of returning null into a
+/// non-nullable type.
+/// Implements [SecureSocket], not [Socket], purely so it can be injected
+/// through `AtLookupImpl`'s own `secureSocketFactory` seam - which is typed
+/// `Future<SecureSocket>`. Nothing calls a SecureSocket-specific member on it:
+/// `createOutBoundConnection` passes the socket straight to the connection
+/// factory. Implementing the narrower type forced tests to mock the connection
+/// factory as well and hand it a throwaway SecureSocket that was never read
+/// from - two moving parts to inject one fake.
+class FakeAtServerSocket implements SecureSocket {
+  late final StreamController<Uint8List> _inbound = StreamController<Uint8List>(
+    onListen: () => listenCount++,
+    onPause: () => pauseCount++,
+    onResume: () => resumeCount++,
+    onCancel: () => cancelCount++,
+  );
+
+  /// Everything the client wrote, in order, as strings.
+  final List<String> written = <String>[];
+
+  /// When true, every write throws - a reachable atServer that rejects
+  /// commands, which is a distinct failure from one that cannot be reached.
+  bool failWrites = false;
+
+  /// The subscription the last [listen] handed out.
+  ///
+  /// [OutboundMessageListener.listen] discards its subscription, so a test that
+  /// wants to pause delivery has no other handle on it.
+  StreamSubscription<Uint8List>? subscription;
+
+  int listenCount = 0;
+  int pauseCount = 0;
+  int resumeCount = 0;
+  int cancelCount = 0;
+  int flushCount = 0;
+  bool destroyed = false;
+
+  /// True while the subscription the listener holds is paused.
+  bool get isPaused => subscription?.isPaused ?? false;
+
+  /// Push bytes at the client as the atServer would, then let the event loop
+  /// deliver them. Await this and the listener has seen them - or has provably
+  /// not, when the subscription is paused.
+  Future<void> serverSends(String data) async {
+    _inbound.add(Uint8List.fromList(utf8.encode(data)));
+    await settle();
+  }
+
+  /// The far end went away. Drives the listener's `onDone`.
+  Future<void> serverCloses() async {
+    await _inbound.close();
+    await settle();
+  }
+
+  /// The far end faulted. Drives the listener's `onError`.
+  Future<void> serverErrors(Object error) async {
+    _inbound.addError(error);
+    await settle();
+  }
+
+  /// Yield long enough for stream delivery and the async `messageHandler` it
+  /// calls. `Duration.zero` alone drains microtasks but not the timer queue
+  /// that an awaited handler can land on.
+  Future<void> settle() async {
+    for (var i = 0; i < 3; i++) {
+      await Future.delayed(Duration.zero);
+    }
+  }
+
+  @override
+  StreamSubscription<Uint8List> listen(
+    void Function(Uint8List event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) {
+    return subscription = _inbound.stream.listen(
+      onData,
+      onError: onError,
+      onDone: onDone,
+      cancelOnError: cancelOnError,
+    );
+  }
+
+  @override
+  void write(Object? object) {
+    // The guard belongs on EVERY write entry point. It was on `add` alone at
+    // first, and `BaseConnection.write` calls this one - so the fake accepted
+    // the write, the test saw no exception, and it read as at_lookup
+    // swallowing a failed send. It does not: `BaseConnection.write` rethrows.
+    if (failWrites) throw const SocketException('write rejected');
+    written.add('$object');
+  }
+
+  @override
+  void writeln([Object? object = '']) {
+    if (failWrites) throw const SocketException('write rejected');
+    written.add('$object\n');
+  }
+
+  @override
+  void add(List<int> data) {
+    if (failWrites) throw const SocketException('write rejected');
+    written.add(utf8.decode(data));
+  }
+
+  @override
+  Future<void> flush() async => flushCount++;
+
+  @override
+  void destroy() {
+    destroyed = true;
+    if (!_inbound.isClosed) _inbound.close();
+  }
+
+  @override
+  Future<void> close() async => destroy();
+
+  @override
+  bool setOption(SocketOption option, bool enabled) => true;
+
+  @override
+  InternetAddress get remoteAddress => InternetAddress('127.0.0.66');
+
+  @override
+  int get remotePort => 6464;
+
+  @override
+  InternetAddress get address => InternetAddress('127.0.0.1');
+
+  @override
+  int get port => 0;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => throw UnimplementedError(
+      'FakeAtServerSocket does not implement '
+      '${invocation.memberName}. Add it here rather than working around it.');
+}
+
+/// A listener wired to a real [OutboundConnectionImpl] over a
+/// [FakeAtServerSocket], already listening.
+///
+/// The connection is the production class, not a double, so the harness
+/// exercises the real `close()`/`write()` path down to the socket.
+class FakeAtServerRig {
+  final FakeAtServerSocket socket;
+  final OutboundConnectionImpl connection;
+  final OutboundMessageListener listener;
+
+  FakeAtServerRig._(this.socket, this.connection, this.listener);
+
+  factory FakeAtServerRig({int bufferCapacity = 10240000}) {
+    final socket = FakeAtServerSocket();
+    final connection = OutboundConnectionImpl(socket);
+    final listener =
+        OutboundMessageListener(connection, bufferCapacity: bufferCapacity);
+    listener.listen();
+    return FakeAtServerRig._(socket, connection, listener);
+  }
+}

--- a/packages/at_lookup/test/injected_authenticator_test.dart
+++ b/packages/at_lookup/test/injected_authenticator_test.dart
@@ -1,0 +1,146 @@
+// The injected authenticator is the replacement for the atChops credential
+// ladder, so these tests hold both sides and use the vocabulary at_chops has
+// deprecated (AtChops, AtSigningInput, AtSigningResult) to stand in for the
+// old one.
+// TODO(4.0): remove the ladder side with the credential ladder.
+// ignore_for_file: deprecated_member_use
+
+import 'dart:io';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_commons/at_commons.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_lookup/src/connection/outbound_message_listener.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import 'at_lookup_test_utils.dart';
+
+class FakeAtSigningInput extends Fake implements AtSigningInput {}
+
+/// The injected authenticator, which takes over from the
+/// atChops/privateKey/cramSecret ladder.
+void main() {
+  late OutboundConnection mockOutBoundConnection;
+  late SecondaryAddressFinder mockSecondaryAddressFinder;
+  late OutboundMessageListener mockOutboundListener;
+  late AtLookupSecureSocketFactory mockSocketFactory;
+  late AtLookupSecureSocketListenerFactory mockSecureSocketListenerFactory;
+  late AtLookupOutboundConnectionFactory mockOutboundConnectionFactory;
+  late AtChops mockAtChops;
+  late SecureSocket mockSecureSocket;
+
+  const host = '127.0.0.1';
+  const port = 12345;
+  const fromChallenge = 'data:_03fe0ff2-ac50-4c80-8f43-88480beba888@alice'
+      ':c3d345fc-5691-4f90-bc34-17cba31f060f';
+
+  /// Responses the fake atServer hands back, in order.
+  late List<String> replies;
+
+  setUp(() {
+    mockOutBoundConnection = MockOutboundConnectionImpl();
+    mockSecondaryAddressFinder = MockSecondaryAddressFinder();
+    mockOutboundListener = MockOutboundMessageListener();
+    mockSocketFactory = MockSecureSocketFactory();
+    mockSecureSocketListenerFactory = MockSecureSocketListenerFactory();
+    mockOutboundConnectionFactory = MockOutboundConnectionFactory();
+    mockAtChops = MockAtChops();
+    registerFallbackValue(SecureSocketConfig());
+    registerFallbackValue(FakeAtSigningInput());
+    mockSecureSocket = createMockAtServerSocket(host, port);
+
+    when(() => mockSecondaryAddressFinder.findSecondary('@alice'))
+        .thenAnswer((_) async => SecondaryAddress(host, port));
+    when(() => mockSocketFactory.createSocket(host, '$port', any()))
+        .thenAnswer((_) => Future<SecureSocket>.value(mockSecureSocket));
+    when(() => mockOutboundConnectionFactory
+        .createOutboundConnection(mockSecureSocket))
+        .thenAnswer((_) => mockOutBoundConnection);
+    when(() => mockSecureSocketListenerFactory
+        .createListener(mockOutBoundConnection))
+        .thenAnswer((_) => mockOutboundListener);
+    when(() => mockOutBoundConnection.getMetaData())
+        .thenReturn(OutboundConnectionMetadata()..isAuthenticated = false);
+    when(() => mockOutBoundConnection.isInValid()).thenReturn(false);
+    when(() => mockOutBoundConnection.write(any()))
+        .thenAnswer((_) => Future.value());
+
+    replies = [];
+    when(() => mockOutboundListener.read())
+        .thenAnswer((_) => Future.value(replies.removeAt(0)));
+  });
+
+  AtLookupImpl build() => AtLookupImpl('@alice', host, 64,
+      secondaryAddressFinder: mockSecondaryAddressFinder,
+      secureSocketFactory: mockSocketFactory,
+      socketListenerFactory: mockSecureSocketListenerFactory,
+      outboundConnectionFactory: mockOutboundConnectionFactory);
+
+  test('an injected authenticator runs, and the ladder does not', () async {
+    replies = [fromChallenge, 'data:success', 'data:[]'];
+    final atLookup = build();
+    // atChops is set too, so the ladder COULD run. This is the whole claim:
+    // the injected authenticator is preferred over it, not merely available
+    // when it is absent.
+    atLookup.atChops = mockAtChops;
+    // Stubbed so that if the ladder DID run it would succeed rather than
+    // crash on an unstubbed mock. Otherwise removing the preference fails
+    // this test with a type error instead of with the assertion below, and
+    // a type error proves nothing about which route was taken.
+    when(() => mockAtChops.sign(any()))
+        .thenReturn(AtSigningResult()..result = 'ladder-signature');
+
+    var authenticatorCalls = 0;
+    atLookup.authenticator = (executor) async {
+      authenticatorCalls++;
+      final challenge = await executor.sendSync('from:@alice\n');
+      expect(challenge, fromChallenge,
+          reason: 'sendSync must return what the atServer replied');
+      await executor.sendSync('pkam:signature\n');
+      return true;
+    };
+
+    final result = await atLookup.executeCommand('scan\n', auth: true);
+
+    expect(authenticatorCalls, 1, reason: 'the authenticator must have run');
+    verifyNever(() => mockAtChops.sign(any()));
+    expect(result, 'data:[]');
+    expect(mockOutBoundConnection.getMetaData()!.isAuthenticated, isTrue,
+        reason: 'a successful authenticator must be recorded on the '
+            'connection, exactly as the ladder records it');
+  });
+
+  test('an authenticator reporting failure raises UnAuthenticatedException',
+      () async {
+    replies = [fromChallenge];
+    final atLookup = build();
+    atLookup.authenticator = (executor) async {
+      await executor.sendSync('from:@alice\n');
+      return false;
+    };
+
+    await expectLater(
+        () => atLookup.executeCommand('scan\n', auth: true),
+        throwsA(predicate((dynamic e) =>
+            e is UnAuthenticatedException &&
+            e.message.contains('The authenticator reported failure'))));
+    expect(mockOutBoundConnection.getMetaData()!.isAuthenticated, isFalse,
+        reason: 'a failed authentication must not be recorded');
+  });
+
+  test('with no authenticator the atChops ladder still runs', () async {
+    // The "alongside" half of the seam: nothing about the existing route
+    // changes while an authenticator is absent.
+    replies = [fromChallenge, 'data:success', 'data:[]'];
+    final atLookup = build();
+    atLookup.atChops = mockAtChops;
+    when(() => mockAtChops.sign(any()))
+        .thenReturn(AtSigningResult()..result = 'sig');
+
+    final result = await atLookup.executeCommand('scan\n', auth: true);
+
+    verify(() => mockAtChops.sign(any())).called(1);
+    expect(result, 'data:[]');
+  });
+}

--- a/packages/at_lookup/test/muxable_notifications_test.dart
+++ b/packages/at_lookup/test/muxable_notifications_test.dart
@@ -66,10 +66,12 @@ void main() {
       AtLookUp.withSecureSocket(
         atSign: '@alice',
         rootDomain: const AtRootDomain(host, 64),
-        secureSocketConfig: SecureSocketConfig(),
         authenticator: authenticator,
         secondaryAddressFinder: addressFinder,
-        transport: AtLookupTransport(socketFactory: socketFactory),
+        transport: AtLookupTransport(
+          secureSocketConfig: SecureSocketConfig(),
+          socketFactory: socketFactory,
+        ),
       );
 
   /// An authenticator that succeeds without doing anything. `_authenticateWith`

--- a/packages/at_lookup/test/muxable_notifications_test.dart
+++ b/packages/at_lookup/test/muxable_notifications_test.dart
@@ -172,7 +172,8 @@ void main() {
       // interlock that does not exist, and the atServer would not refuse it.
       final atLookup = authenticated();
 
-      await atLookup.startNotifications(lastNotificationTime: 1755600000000);
+      await atLookup.startNotifications(
+          getLastNotificationTime: () async => 1755600000000);
 
       expect(socket.written, ['monitor:selfNotifications:1755600000000\n']);
       expect(socket.written.single, isNot(contains('multiplexed')),
@@ -223,7 +224,8 @@ void main() {
         ..heartbeatInterval = const Duration(hours: 1);
 
       await atLookup.startNotifications(
-          regex: '.wavi', lastNotificationTime: 1755600000000);
+          regex: '.wavi',
+          getLastNotificationTime: () async => 1755600000000);
       expect(sockets, hasLength(1));
       expect(authCount, 1);
       final first = socket;
@@ -359,6 +361,78 @@ void main() {
           reason: 'and must not be told the connection went down');
 
       sub.resume();
+      await atLookup.stopNotifications();
+    });
+
+    test('a reconnect asks the caller for its CURRENT watermark', () async {
+      // The caller's position moves as it consumes notifications, and it is
+      // the caller that holds it durably. Freezing the value at
+      // startNotifications makes every reconnect re-request the whole retained
+      // backlog — which is exactly what a caller keeping a watermark is
+      // keeping one to avoid.
+      var watermark = 1755600000000;
+      final atLookup = authenticated()
+        ..heartbeatInterval = const Duration(hours: 1);
+      await atLookup.startNotifications(
+          getLastNotificationTime: () async => watermark);
+      final first = socket;
+      expect(first.written, ['monitor:selfNotifications:1755600000000\n']);
+
+      // The caller consumes notifications and advances; then the far end goes.
+      watermark = 1755600009999;
+      await first.serverCloses();
+      await first.settle();
+      await Future.delayed(const Duration(milliseconds: 1400));
+
+      expect(sockets, hasLength(2),
+          reason: 'the test needs an actual reconnect to have happened');
+      expect(sockets.last.written,
+          ['monitor:selfNotifications:1755600009999\n'],
+          reason: 'the reconnect must carry where the caller has got to, not '
+              'where it was when notifications started');
+
+      await atLookup.stopNotifications();
+    });
+
+    test('a restart inside the backoff window is not disturbed by the old loop',
+        () async {
+      // stopNotifications puts `_isNotifying` back to false and a following
+      // startNotifications puts it back to true - so a reconnect loop still
+      // sleeping from before the stop wakes to a flag that says "carry on",
+      // and would act on the connection the RESTART established: a second
+      // `monitor:` on a live socket, its heartbeat reset, and an `up` with no
+      // preceding down.
+      final atLookup = authenticated();
+      await atLookup.startNotifications();
+
+      // Drop the connection so a reconnect loop starts and parks on its
+      // first backoff (1s), then stop and restart well inside that window.
+      await socket.serverCloses();
+      await socket.settle();
+      expect(atLookup.isReconnectingNotifications, isTrue,
+          reason: 'the test needs a loop actually sleeping, or it proves '
+              'nothing about what happens when one wakes');
+
+      await atLookup.stopNotifications();
+      expect(atLookup.isReconnectingNotifications, isFalse,
+          reason: 'a stop must not leave this reading true - it is what '
+              'disarms the disconnect handler on the next connection');
+
+      await atLookup.startNotifications();
+      final restarted = socket;
+      final states = <bool>[];
+      atLookup.notificationConnectionUp.listen(states.add);
+
+      // Past the first backoff, so the orphaned loop has woken.
+      await Future.delayed(const Duration(milliseconds: 1400));
+
+      expect(restarted.written.where((w) => w.startsWith('monitor:')),
+          hasLength(1),
+          reason: 'the restart sent its own monitor:; a loop from the '
+              'previous session must not send a second one on this socket');
+      expect(states, isNot(contains(true)),
+          reason: 'and must not announce an `up` the restart already made');
+
       await atLookup.stopNotifications();
     });
 

--- a/packages/at_lookup/test/muxable_notifications_test.dart
+++ b/packages/at_lookup/test/muxable_notifications_test.dart
@@ -364,6 +364,51 @@ void main() {
       await atLookup.stopNotifications();
     });
 
+    test('a restart replaces the connection-up stream, it does not reuse it',
+        () async {
+      // stopNotifications closes this stream. A caller that held one
+      // subscription across a stop/start would be listening to a closed
+      // stream and would never learn the new connection came up - so the
+      // contract is that both streams are re-read after each start, and this
+      // pins it rather than leaving it to the dartdoc alone.
+      final atLookup = authenticated();
+      // Registered up front: a failing expect below would otherwise skip the
+      // teardown and leave a live reconnect loop, which then builds sockets
+      // into the NEXT test's list through the shared factory.
+      addTearDown(atLookup.stopNotifications);
+
+      await atLookup.startNotifications();
+      final before = <bool>[];
+      var beforeClosed = false;
+      atLookup.notificationConnectionUp
+          .listen(before.add, onDone: () => beforeClosed = true);
+      await socket.settle();
+
+      await atLookup.stopNotifications();
+      await socket.settle();
+      expect(beforeClosed, isTrue,
+          reason: 'the stop must close the stream, which is what makes the '
+              'old subscription useless rather than merely silent');
+      // The stop emits its own `false` before closing, so this subscriber has
+      // seen its own session end. What it must never see is anything about
+      // the session that follows.
+      final seenByStopTime = before.length;
+
+      await atLookup.startNotifications();
+      final after = <bool>[];
+      atLookup.notificationConnectionUp.listen(after.add);
+      await socket.serverCloses();
+      await socket.settle();
+
+      expect(after, contains(false),
+          reason: 'a subscription taken after the restart tracks the new '
+              'connection');
+      expect(before, hasLength(seenByStopTime),
+          reason: 'and the pre-stop subscription learns nothing about the new '
+              'connection - the reason a caller must re-read the getter after '
+              'each start');
+    });
+
     test('a reconnect asks the caller for its CURRENT watermark', () async {
       // The caller's position moves as it consumes notifications, and it is
       // the caller that holds it durably. Freezing the value at

--- a/packages/at_lookup/test/muxable_notifications_test.dart
+++ b/packages/at_lookup/test/muxable_notifications_test.dart
@@ -214,7 +214,7 @@ void main() {
 
   group('reconnect, reauth and heartbeat', () {
     test('losing the connection reconnects, reauthenticates, and re-issues '
-        'the SAME monitor:', () async {
+        'monitor: with the same regex', () async {
       var authCount = 0;
       final atLookup = build(authenticator: (_) async {
         authCount++;
@@ -248,9 +248,11 @@ void main() {
               'must run again - reconnecting without reauthenticating gives a '
               'socket the atServer will not send notifications on');
       expect(socket.written, ['monitor:selfNotifications:1755600000000 .wavi\n'],
-          reason: 'the reconnect must re-issue the SAME monitor: - dropping '
-              'the regex would start delivering everything, and dropping the '
-              'watermark would replay from the beginning');
+          reason: 'the regex is REMEMBERED across a reconnect - dropping it '
+              'would start delivering everything. The watermark beside it is '
+              'not remembered but re-asked, and this callback returns a '
+              'constant, so the command matches; the advancing case is its '
+              'own test');
       expect(atLookup.isReconnectingNotifications, isFalse,
           reason: 'and the loop must finish once it succeeds');
 
@@ -407,6 +409,51 @@ void main() {
           reason: 'and the pre-stop subscription learns nothing about the new '
               'connection - the reason a caller must re-read the getter after '
               'each start');
+    });
+
+    test('a watermark read that throws does not leave the client deaf',
+        () async {
+      // This callback is CALLER code running inside the reconnect loop. If it
+      // throws and the attempt aborts, the connection it already opened and
+      // authenticated stays valid - so every later attempt skips the connect,
+      // re-runs only this call, and backs off forever with `monitor:` never
+      // sent. The symptom is nothing at all: no notifications, no error, just
+      // an `up` that never arrives.
+      var boom = false;
+      final atLookup = authenticated()
+        ..heartbeatInterval = const Duration(hours: 1);
+      addTearDown(atLookup.stopNotifications);
+
+      await atLookup.startNotifications(getLastNotificationTime: () async {
+        if (boom) throw StateError('watermark store unreadable');
+        return 1755600000000;
+      });
+      expect(socket.written, ['monitor:selfNotifications:1755600000000\n']);
+
+      boom = true;
+      await socket.serverCloses();
+      await Future.delayed(const Duration(milliseconds: 1400));
+
+      expect(sockets, hasLength(2),
+          reason: 'the attempt must have reached the point of opening a '
+              'socket, or this proves nothing about what follows the connect');
+      expect(sockets.last.written,
+          ['monitor:selfNotifications\n'],
+          reason: 'a failed watermark read must still send monitor: - without '
+              'one the atServer replays a window, which is recoverable, where '
+              'sending nothing is a connection that can never deliver');
+      expect(atLookup.isReconnectingNotifications, isFalse,
+          reason: 'and the reconnect must be considered finished, not left '
+              'spinning on a connection it will never speak to');
+
+      // The control arm: the same callback recovering must behave normally,
+      // so this cannot pass by the watermark being ignored altogether.
+      boom = false;
+      await sockets.last.serverCloses();
+      await Future.delayed(const Duration(milliseconds: 1400));
+      expect(sockets.last.written,
+          ['monitor:selfNotifications:1755600000000\n'],
+          reason: 'a transient watermark failure is not terminal');
     });
 
     test('a reconnect asks the caller for its CURRENT watermark', () async {

--- a/packages/at_lookup/test/muxable_notifications_test.dart
+++ b/packages/at_lookup/test/muxable_notifications_test.dart
@@ -325,6 +325,102 @@ void main() {
 
       await atLookup.stopNotifications();
     });
+
+    test('a paused subscriber does not lose its connection to the heartbeat',
+        () async {
+      // Pausing is the back-pressure contract this stream advertises, not
+      // misuse - and a paused subscription stops the socket being read, so
+      // nothing can fill the read queue and a probe could never be answered.
+      // Probing anyway times the read out and destroys a healthy connection.
+      final atLookup = authenticated()
+        ..heartbeatInterval = const Duration(milliseconds: 30)
+        ..heartbeatResponseTimeout = const Duration(milliseconds: 60);
+      await atLookup.startNotifications();
+      final s = socket;
+      final states = <bool>[];
+      atLookup.notificationConnectionUp.listen(states.add);
+
+      final sub = atLookup.notifications.listen((_) {});
+      sub.pause();
+      // Several intervals and several response budgets.
+      await Future.delayed(const Duration(milliseconds: 300));
+
+      expect(s.written.where((w) => w.startsWith('noop:')), isEmpty,
+          reason: 'the probe must be SKIPPED while delivery is paused. This '
+              'is the mechanism: asserting only that the socket survived '
+              'would pass even if a probe went out and happened to be '
+              'answered');
+      expect(s.destroyed, isFalse,
+          reason: 'a subscriber applying back-pressure must not have its '
+              'connection torn down underneath it');
+      expect(states, isNot(contains(false)),
+          reason: 'and must not be told the connection went down');
+
+      sub.resume();
+      await atLookup.stopNotifications();
+    });
+
+    test('close() fails a pending read even while delivery is paused',
+        () async {
+      // The case `_closeConnection`'s own dartdoc names: with delivery paused
+      // the socket's done event is buffered, so the onDone route that fails a
+      // pending read never runs, and the abort inside `_closeConnection` is
+      // the only thing left. A test that closes while delivery is live cannot
+      // see that - onDone gets there first and the abort could be deleted
+      // without anything going red.
+      final atLookup = authenticated();
+      await atLookup.pkamAuthenticate();
+      await atLookup.startNotifications();
+      final sub = atLookup.notifications.listen((_) {});
+      sub.pause();
+
+      Object? thrown;
+      final pending = atLookup.executeCommand('noop:0\n').then<void>(
+        (_) {},
+        onError: (Object e) => thrown = e,
+      );
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      await atLookup.close();
+      await pending.timeout(const Duration(seconds: 5),
+          onTimeout: () => fail('the pending read was never failed, so it is '
+              'sitting out its transient budget holding the request mutex - '
+              'the next request on this instance would queue behind a '
+              'response that can never arrive'));
+
+      expect(thrown, isNotNull,
+          reason: 'closing must fail the request in flight, and while paused '
+              'only the abort inside _closeConnection can do it');
+
+      sub.resume();
+    });
+
+    test('a connection built before the stream is read still reconnects',
+        () async {
+      // The ordering the `notifications` getter exists for: authenticating -
+      // or any verb - builds the connection while no controller exists, so
+      // createConnection installs no seams at all. Reading the stream
+      // afterwards has to install BOTH of them. With only the routing seam,
+      // the socket going away reaches nothing and the muxable never learns it
+      // is down.
+      final atLookup = authenticated();
+      await atLookup.pkamAuthenticate();
+      await atLookup.startNotifications();
+      final states = <bool>[];
+      atLookup.notificationConnectionUp.listen(states.add);
+
+      await socket.serverCloses();
+      await socket.settle();
+
+      expect(states, contains(false),
+          reason: 'the disconnect seam must be installed by the stream getter '
+              'as well as by createConnection - without it a connection built '
+              'before the first read goes down in silence');
+      expect(atLookup.isReconnectingNotifications, isTrue,
+          reason: 'and losing it must start the reconnect loop');
+
+      await atLookup.stopNotifications();
+    });
   });
 
   group('a connection that cannot be established', () {

--- a/packages/at_lookup/test/muxable_notifications_test.dart
+++ b/packages/at_lookup/test/muxable_notifications_test.dart
@@ -1,0 +1,437 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:at_commons/at_commons.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import 'at_lookup_test_utils.dart';
+import 'fake_at_server_socket.dart';
+
+/// [AtLookupMuxable] - the notification stream, over a REAL listener.
+///
+/// The factories are mocked only to get a [FakeAtServerSocket] underneath; the
+/// connection, the listener and the framing are all production code, so a
+/// notification here travels the same path it does against a live atServer.
+/// A test that stubbed the listener would pass whether or not the framing
+/// worked.
+void main() {
+  const host = '127.0.0.1';
+  const port = 12345;
+
+  /// Every socket the factory has handed out, in order.
+  ///
+  /// A fresh one per connection, because reconnection is under test: a rig
+  /// that returned the same destroyed socket would make a successful
+  /// reconnect indistinguishable from a failed one.
+  late List<FakeAtServerSocket> sockets;
+
+  /// The socket currently in use - the most recent one the factory handed out.
+  late FakeAtServerSocket socket;
+  late MockSecondaryAddressFinder addressFinder;
+  late MockSecureSocketFactory socketFactory;
+
+  setUp(() {
+    sockets = [];
+    addressFinder = MockSecondaryAddressFinder();
+    socketFactory = MockSecureSocketFactory();
+    registerFallbackValue(SecureSocketConfig());
+
+    when(() => addressFinder.findSecondary('@alice'))
+        .thenAnswer((_) async => SecondaryAddress(host, port));
+    // The ONE injection point: a fresh fake socket per connection, reaching
+    // the muxable through the factory's `transport` parameter. Everything
+    // above it - the connection, the listener, both framings, reconnect - is
+    // production code, so a notification here travels the path it travels
+    // live. A fresh socket per call because reconnection is under test: reuse
+    // a destroyed one and a successful reconnect looks like a failed one.
+    when(() => socketFactory.createSocket(host, '$port', any()))
+        .thenAnswer((_) async {
+      final s = FakeAtServerSocket();
+      sockets.add(s);
+      socket = s;
+      return s;
+    });
+  });
+
+  /// Built through the FACTORY, and held as the INTERFACE.
+  ///
+  /// Not a stylistic choice: this is the shape every caller has at the end of
+  /// this project, so testing through it is what proves the factory produces
+  /// something fully usable without naming the concrete class. Reaching for
+  /// `AtLookupImpl(...)` here would test a constructor the plan is retiring
+  /// and would leave the factory's own seam unexercised.
+  AtLookupMuxable build({AtAuthenticator? authenticator}) =>
+      AtLookUp.withSecureSocket(
+        atSign: '@alice',
+        rootDomain: const AtRootDomain(host, 64),
+        secureSocketConfig: SecureSocketConfig(),
+        authenticator: authenticator,
+        secondaryAddressFinder: addressFinder,
+        transport: AtLookupTransport(socketFactory: socketFactory),
+      );
+
+  /// An authenticator that succeeds without doing anything. `_authenticateWith`
+  /// records the authentication itself, so returning true is enough to get
+  /// past `monitor:`'s auth gate.
+  AtLookupMuxable authenticated() => build(authenticator: (_) async => true);
+
+  group('the notification stream', () {
+    test('a notification from the atServer arrives on it', () async {
+      final atLookup = authenticated();
+      await atLookup.startNotifications();
+      final seen = <String>[];
+      atLookup.notifications.listen(seen.add);
+
+      await socket.serverSends('notification: {"id":"n1"}\n');
+      await socket.settle();
+
+      expect(seen, ['notification: {"id":"n1"}']);
+    });
+
+    test('notifications arriving BEFORE a listener attaches are not lost',
+        () async {
+      // The single-subscription property, and the reason for it. A broadcast
+      // controller drops everything sent before someone subscribes, and a
+      // dropped notification is indistinguishable from one never sent.
+      final atLookup = authenticated();
+      await atLookup.startNotifications();
+
+      await socket.serverSends('notification: {"id":"early"}\n');
+      await socket.settle();
+
+      final seen = <String>[];
+      atLookup.notifications.listen(seen.add);
+      await socket.settle();
+
+      expect(seen, ['notification: {"id":"early"}'],
+          reason: 'a buffered notification must be delivered on subscribe - '
+              'this is exactly what a broadcast controller would have lost');
+    });
+
+    test('it is single-subscription, so a second listener is refused',
+        () async {
+      final atLookup = authenticated();
+      atLookup.notifications.listen((_) {});
+
+      expect(() => atLookup.notifications.listen((_) {}), throwsStateError,
+          reason: 'a broadcast stream would accept this, and with it lose '
+              'buffering and pause');
+    });
+
+    test('a verb response is not delivered as a notification', () async {
+      final atLookup = authenticated();
+      await atLookup.startNotifications();
+      final seen = <String>[];
+      atLookup.notifications.listen(seen.add);
+
+      await socket.serverSends('data:the_key_is\n@bob:phone@alice\n@alice@');
+      await socket.settle();
+
+      expect(seen, isEmpty,
+          reason: 'a multi-line data value still reads as data: on its prefix, '
+              'so it is never routed to the notification stream');
+    });
+  });
+
+  group('back-pressure reaches the socket through the stream', () {
+    test('pausing the notification stream pauses the socket', () async {
+      final atLookup = authenticated();
+      await atLookup.startNotifications();
+      final seen = <String>[];
+      final sub = atLookup.notifications.listen(seen.add);
+      await socket.settle();
+
+      sub.pause();
+      await socket.settle();
+      expect(socket.pauseCount, greaterThanOrEqualTo(1),
+          reason: 'pausing the notification stream must reach the SOCKET, not '
+              'merely buffer in this process - onPause is wired through to '
+              'the listener, which pauses its subscription');
+
+      sub.resume();
+      await socket.settle();
+      await socket.serverSends('notification: {"id":"after"}\n');
+      await socket.settle();
+      expect(seen, ['notification: {"id":"after"}'],
+          reason: 'and resuming must restore delivery');
+
+      await sub.cancel();
+    });
+  });
+
+  group('startNotifications', () {
+    test('sends monitor: with selfNotifications, and NOT multiplexed',
+        () async {
+      // A RAW-LITERAL wire pin. `multiplexed` is accepted by the shared verb
+      // syntax and read by no atServer - measured against at_server
+      // origin/trunk, zero occurrences - so setting it would advertise an
+      // interlock that does not exist, and the atServer would not refuse it.
+      final atLookup = authenticated();
+
+      await atLookup.startNotifications(lastNotificationTime: 1755600000000);
+
+      expect(socket.written, ['monitor:selfNotifications:1755600000000\n']);
+      expect(socket.written.single, isNot(contains('multiplexed')),
+          reason: 'no atServer implements this flag; sending it would claim a '
+              'safety property that is not there');
+      expect(atLookup.isNotifying, isTrue);
+    });
+
+    test('a regex is passed through', () async {
+      final atLookup = authenticated();
+
+      await atLookup.startNotifications(regex: '.wavi');
+
+      expect(socket.written, ['monitor:selfNotifications .wavi\n']);
+    });
+
+    test('called twice, it sends once', () async {
+      final atLookup = authenticated();
+
+      await atLookup.startNotifications();
+      await atLookup.startNotifications();
+
+      expect(socket.written, hasLength(1),
+          reason: 'a second monitor: on the same connection would duplicate '
+              'every notification');
+    });
+
+    test('it refuses when nothing can authenticate', () async {
+      // No authenticator, and the ladder has no credential either.
+      final atLookup = build();
+
+      expect(() => atLookup.startNotifications(),
+          throwsA(isA<UnAuthenticatedException>()),
+          reason: 'monitor requires authentication; failing loudly beats a '
+              'connection that silently never receives anything');
+    });
+  });
+
+  group('reconnect, reauth and heartbeat', () {
+    test('losing the connection reconnects, reauthenticates, and re-issues '
+        'the SAME monitor:', () async {
+      var authCount = 0;
+      final atLookup = build(authenticator: (_) async {
+        authCount++;
+        return true;
+      })
+        // Parked, so this test measures reconnection and not the probe.
+        ..heartbeatInterval = const Duration(hours: 1);
+
+      await atLookup.startNotifications(
+          regex: '.wavi', lastNotificationTime: 1755600000000);
+      expect(sockets, hasLength(1));
+      expect(authCount, 1);
+      final first = socket;
+      expect(first.written, ['monitor:selfNotifications:1755600000000 .wavi\n']);
+
+      // The far end goes away.
+      await first.serverCloses();
+      await Future.delayed(const Duration(milliseconds: 50));
+      expect(atLookup.isReconnectingNotifications, isTrue,
+          reason: 'the listener must tell the muxable the socket died - '
+              'without the onDisconnect seam nothing here ever learns it');
+
+      // First delay in the backoff is 1s.
+      await Future.delayed(const Duration(milliseconds: 1400));
+
+      expect(sockets, hasLength(2),
+          reason: 'a new connection must have been opened');
+      expect(authCount, 2,
+          reason: 'the new connection is unauthenticated, so the authenticator '
+              'must run again - reconnecting without reauthenticating gives a '
+              'socket the atServer will not send notifications on');
+      expect(socket.written, ['monitor:selfNotifications:1755600000000 .wavi\n'],
+          reason: 'the reconnect must re-issue the SAME monitor: - dropping '
+              'the regex would start delivering everything, and dropping the '
+              'watermark would replay from the beginning');
+      expect(atLookup.isReconnectingNotifications, isFalse,
+          reason: 'and the loop must finish once it succeeds');
+
+      await atLookup.stopNotifications();
+    });
+
+    test('notifications flow again on the reconnected socket', () async {
+      final atLookup = authenticated()
+        ..heartbeatInterval = const Duration(hours: 1);
+      await atLookup.startNotifications();
+      final seen = <String>[];
+      atLookup.notifications.listen(seen.add);
+
+      await socket.serverCloses();
+      await Future.delayed(const Duration(milliseconds: 1400));
+      await socket.serverSends('notification: {"id":"after-reconnect"}\n');
+      await socket.settle();
+
+      expect(seen, ['notification: {"id":"after-reconnect"}'],
+          reason: 'the framing seam must be re-installed on the NEW listener - '
+              'createConnection builds a fresh one, so a seam wired only at '
+              'startup would go quiet after the first outage');
+
+      await atLookup.stopNotifications();
+    });
+
+    test('stopNotifications ends the reconnect loop', () async {
+      final atLookup = authenticated()
+        ..heartbeatInterval = const Duration(hours: 1);
+      await atLookup.startNotifications();
+
+      await socket.serverCloses();
+      await Future.delayed(const Duration(milliseconds: 50));
+      expect(atLookup.isReconnectingNotifications, isTrue);
+
+      await atLookup.stopNotifications();
+      await Future.delayed(const Duration(milliseconds: 1400));
+
+      expect(sockets, hasLength(1),
+          reason: 'a reconnect landing after stopNotifications would resurrect '
+              'the connection the caller just asked to be rid of');
+    });
+
+    test('the heartbeat probes a quiet connection with noop:0', () async {
+      final atLookup = authenticated()
+        ..heartbeatInterval = const Duration(milliseconds: 40);
+      await atLookup.startNotifications();
+      final s = socket;
+      expect(s.written, hasLength(1), reason: 'just the monitor: so far');
+
+      await Future.delayed(const Duration(milliseconds: 90));
+
+      expect(s.written.last, 'noop:0\n',
+          reason: 'a connection that only ever reads cannot tell a quiet '
+              'atServer from a dead socket');
+      await s.serverSends('data:ok\n@alice@');
+      await atLookup.stopNotifications();
+    });
+
+    test('an unanswered heartbeat starts recovery', () async {
+      final atLookup = authenticated()
+        ..heartbeatInterval = const Duration(milliseconds: 30)
+        ..heartbeatResponseTimeout = const Duration(milliseconds: 60);
+      await atLookup.startNotifications();
+      final s = socket;
+
+      // Probe goes out at ~30ms, times out at ~90ms, closes the connection,
+      // whose onDone drives the disconnect seam.
+      await Future.delayed(const Duration(milliseconds: 300));
+
+      expect(s.destroyed, isTrue,
+          reason: 'an unanswered probe must close the connection');
+      expect(atLookup.isReconnectingNotifications, isTrue,
+          reason: 'and closing it must start the reconnect loop - closing '
+              'without reconnecting leaves a listener that is silent forever');
+
+      await atLookup.stopNotifications();
+    });
+  });
+
+  group('a connection that cannot be established', () {
+    // Ported from at_client's monitor_test.dart, which asserted the same
+    // behaviour on machinery that now lives here: a monitor that cannot
+    // connect must not report itself as listening. The failure has to surface
+    // rather than be swallowed, or a permanently deaf client looks healthy.
+    test('a failure to connect surfaces, and reports nothing as up', () async {
+      final atLookup = authenticated();
+      final seen = <bool>[];
+      atLookup.notificationConnectionUp.listen(seen.add);
+      when(() => socketFactory.createSocket(host, '$port', any()))
+          .thenAnswer((_) async => throw const SocketException('refused'));
+
+      await expectLater(
+          atLookup.startNotifications(), throwsA(isA<Exception>()));
+
+      expect(atLookup.isNotifying, isFalse,
+          reason: 'a connection that never opened is not notifying');
+      expect(seen, isEmpty,
+          reason: 'nothing may report the connection up - a subscriber that '
+              'saw `true` here would wait forever for notifications on a '
+              'socket that does not exist');
+    });
+
+    test('a failure to send monitor: surfaces the same way', () async {
+      final atLookup = authenticated();
+      final seen = <bool>[];
+      atLookup.notificationConnectionUp.listen(seen.add);
+      // Connect succeeds; the write does not. at_client's monitor_test had
+      // this as "secondary reachable but rejecting commands".
+      when(() => socketFactory.createSocket(host, '$port', any()))
+          .thenAnswer((_) async {
+        final s = FakeAtServerSocket()..failWrites = true;
+        sockets.add(s);
+        socket = s;
+        return s;
+      });
+
+      await expectLater(
+          atLookup.startNotifications(), throwsA(isA<Exception>()));
+
+      expect(atLookup.isNotifying, isFalse);
+      expect(seen, isEmpty);
+    });
+  });
+
+  group('notificationConnectionUp', () {
+    test('reports up on start, down on loss, up again on reconnect', () async {
+      final atLookup = authenticated()
+        ..heartbeatInterval = const Duration(hours: 1);
+      // Subscribed BEFORE the trigger: it is a broadcast stream, so it does
+      // not replay, and a listener attached afterwards sees nothing.
+      final seen = <bool>[];
+      atLookup.notificationConnectionUp.listen(seen.add);
+
+      await atLookup.startNotifications();
+      await socket.settle();
+      expect(seen, [true], reason: 'monitor: accepted on a live connection');
+
+      await socket.serverCloses();
+      await Future.delayed(const Duration(milliseconds: 50));
+      expect(seen, [true, false],
+          reason: 'the muxable owns reconnection, so it is the only thing that '
+              'knows the connection dropped - a subscriber cannot tell an '
+              'outage from a quiet atServer any other way');
+
+      await Future.delayed(const Duration(milliseconds: 1400));
+      expect(seen, [true, false, true],
+          reason: 'and it must say so again when the reconnect succeeds');
+
+      await atLookup.stopNotifications();
+    });
+
+    test('reports down when notifications are stopped', () async {
+      final atLookup = authenticated()
+        ..heartbeatInterval = const Duration(hours: 1);
+      final seen = <bool>[];
+      atLookup.notificationConnectionUp.listen(seen.add);
+
+      await atLookup.startNotifications();
+      await socket.settle();
+      await atLookup.stopNotifications();
+      await socket.settle();
+
+      expect(seen, [true, false],
+          reason: 'a deliberate stop is still a transition a subscriber must '
+              'see - otherwise it reads as a connection that is still up');
+    });
+  });
+
+  group('stopNotifications', () {
+    test('closes the stream and the connection', () async {
+      final atLookup = authenticated();
+      await atLookup.startNotifications();
+      var done = false;
+      atLookup.notifications.listen((_) {}, onDone: () => done = true);
+      await socket.settle();
+
+      await atLookup.stopNotifications();
+      await socket.settle();
+
+      expect(atLookup.isNotifying, isFalse);
+      expect(done, isTrue,
+          reason: 'a stream that can never produce another event must close, '
+              'not hang');
+      expect(socket.destroyed, isTrue);
+    });
+  });
+}

--- a/packages/at_lookup/test/outbound_message_listener_test.dart
+++ b/packages/at_lookup/test/outbound_message_listener_test.dart
@@ -181,9 +181,14 @@ void main() {
   });
 
   group('A group of tests to verify AtTimeOutException', () {
-    OutboundMessageListener outboundMessageListener =
-        OutboundMessageListener(mockOutBoundConnection);
+    // Built per test, not once for the group. Every test here drives a timeout,
+    // and a timeout closes the connection - which now also aborts anything
+    // waiting on it, permanently, because a listener is never reused across
+    // connections in production. Shared, the first test's timeout would make
+    // every later one fail on a dead connection instead of on its own deadline.
+    late OutboundMessageListener outboundMessageListener;
     setUp(() {
+      outboundMessageListener = OutboundMessageListener(mockOutBoundConnection);
       when(() => mockOutBoundConnection.isInValid()).thenAnswer((_) => false);
       when(() => mockOutBoundConnection.close())
           .thenAnswer((Invocation invocation) async {});

--- a/packages/at_lookup/test/socket_delivery_test.dart
+++ b/packages/at_lookup/test/socket_delivery_test.dart
@@ -1,0 +1,405 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:at_lookup/at_lookup.dart';
+// Not in the barrel by design - decision 4 keeps the listener private
+// to the package, so tests reach it by path as the fake socket does.
+import 'package:at_lookup/src/connection/outbound_message_listener.dart';
+
+import 'package:test/test.dart';
+
+import 'fake_at_server_socket.dart';
+
+/// Delivery THROUGH a socket, which nothing in this package covered before.
+///
+/// The existing `outbound_message_listener_test.dart` feeds bytes by calling
+/// `messageHandler` directly, so it proves the parser and the waiting path but
+/// says nothing about the socket wiring: that `listen()` reaches the stream,
+/// that a paused subscription stops delivery, or that done and error close the
+/// connection. Each test here builds its own rig; none shares state.
+void main() {
+  group('bytes reach the listener through the socket', () {
+    test('a complete response in one packet', () async {
+      final rig = FakeAtServerRig();
+
+      await rig.socket.serverSends('data:phone@alice\n@alice@');
+
+      expect(await rig.listener.read(), 'data:phone@alice');
+      expect(rig.socket.listenCount, 1,
+          reason: 'the listener must have subscribed exactly once');
+    });
+
+    test('a response split across packets, as the atServer sends it', () async {
+      final rig = FakeAtServerRig();
+
+      await rig.socket.serverSends('data:public:phone@');
+      await rig.socket.serverSends('alice\n@ali');
+      await rig.socket.serverSends('ce@');
+
+      expect(await rig.listener.read(), 'data:public:phone@alice');
+    });
+
+    test('two responses in order on one connection', () async {
+      final rig = FakeAtServerRig();
+
+      await rig.socket.serverSends('data:one@alice\n@alice@');
+      await rig.socket.serverSends('data:two@alice\n@alice@');
+
+      expect(await rig.listener.read(), 'data:one@alice');
+      expect(await rig.listener.read(), 'data:two@alice');
+    });
+
+    test('what the client writes arrives at the socket', () async {
+      final rig = FakeAtServerRig();
+
+      await rig.connection.write('from:@alice\n');
+
+      expect(rig.socket.written, ['from:@alice\n']);
+      expect(rig.socket.flushCount, 1,
+          reason: 'BaseConnection.write must flush, or bytes can sit in the '
+              'buffer while the test waits for a reply that was never sent');
+    });
+  });
+
+  group('back-pressure reaches the socket', () {
+    // The discriminating pair. A broadcast controller would ignore pause() and
+    // deliver anyway, so the first expectation is what proves the harness can
+    // detect a missing pause at all; the second proves it is not simply
+    // dropping everything.
+    test('a paused subscription delivers nothing, and resuming delivers it',
+        () async {
+      final rig = FakeAtServerRig();
+      String? got;
+      unawaited(rig.listener
+          .read(transientWaitTimeMillis: 5000, maxWaitMilliSeconds: 5000)
+          .then((v) => got = v));
+      await rig.socket.settle();
+
+      rig.socket.subscription!.pause();
+      expect(rig.socket.pauseCount, 1,
+          reason: 'pausing the subscription must reach the controller');
+
+      await rig.socket.serverSends('data:paused@alice\n@alice@');
+      await Future.delayed(const Duration(milliseconds: 50));
+      expect(got, isNull,
+          reason: 'a paused subscription must not deliver, and the read must '
+              'still be waiting');
+
+      rig.socket.subscription!.resume();
+      await Future.delayed(const Duration(milliseconds: 50));
+      // Asserted after the wait, not at the call: a controller schedules
+      // onResume rather than running it synchronously, so checking it on the
+      // next line reads 0 and looks like a broken resume.
+      expect(rig.socket.resumeCount, 1,
+          reason: 'resuming must reach the controller');
+      expect(got, 'data:paused@alice',
+          reason: 'resuming must deliver the bytes buffered while paused');
+    });
+
+    // The pair above pauses through the FAKE's handle on the subscription,
+    // which proves the controller honours pause but says nothing about the
+    // listener. These pause through the LISTENER, which is the handle
+    // production code has - `listen()` used to discard its subscription, so
+    // nothing in at_lookup could stop delivery at all.
+    test('the listener can stop delivery through its own subscription',
+        () async {
+      final rig = FakeAtServerRig();
+      String? got;
+      unawaited(rig.listener
+          .read(transientWaitTimeMillis: 5000, maxWaitMilliSeconds: 5000)
+          .then((v) => got = v));
+      await rig.socket.settle();
+
+      expect(rig.listener.isDeliveryPaused, isFalse,
+          reason: 'a fresh listener is delivering');
+      rig.listener.pauseDelivery();
+      expect(rig.socket.pauseCount, 1,
+          reason: 'pauseDelivery must reach the socket, not just set a flag - '
+              'if listen() discarded its subscription this is 0');
+      expect(rig.listener.isDeliveryPaused, isTrue);
+
+      await rig.socket.serverSends('data:held@alice\n@alice@');
+      await Future.delayed(const Duration(milliseconds: 50));
+      expect(got, isNull,
+          reason: 'bytes must not be delivered while the listener has paused '
+              'its own subscription');
+
+      rig.listener.resumeDelivery();
+      await Future.delayed(const Duration(milliseconds: 50));
+      expect(rig.listener.isDeliveryPaused, isFalse);
+      expect(got, 'data:held@alice',
+          reason: 'and must arrive once the listener resumes');
+    });
+
+    test('pauses are counted, so two need two resumes', () async {
+      // Measured, not assumed: StreamSubscription counts pauses. A design that
+      // pairs one resume against two pauses leaves the socket stopped for
+      // good, and the symptom is a hang with no error anywhere.
+      final rig = FakeAtServerRig();
+
+      rig.listener.pauseDelivery();
+      rig.listener.pauseDelivery();
+      rig.listener.resumeDelivery();
+      expect(rig.listener.isDeliveryPaused, isTrue,
+          reason: 'one resume must NOT undo two pauses');
+
+      rig.listener.resumeDelivery();
+      expect(rig.listener.isDeliveryPaused, isFalse,
+          reason: 'the second resume balances the second pause');
+    });
+
+    test('resuming a listener that never paused is harmless', () async {
+      final rig = FakeAtServerRig();
+
+      rig.listener.resumeDelivery();
+
+      expect(rig.listener.isDeliveryPaused, isFalse);
+      await rig.socket.serverSends('data:fine@alice\n@alice@');
+      expect(
+          await rig.listener
+              .read(maxWaitMilliSeconds: 500, transientWaitTimeMillis: 500),
+          'data:fine@alice',
+          reason: 'an unmatched resume must not disturb delivery');
+    });
+
+    test('pausing before listen() is a no-op, not a crash', () async {
+      // The muxable wires pause/resume to a stream controller, and a listener
+      // can be handed one before its socket exists. Null-safe by design.
+      final socket = FakeAtServerSocket();
+      final connection = OutboundConnectionImpl(socket);
+      final listener = OutboundMessageListener(connection);
+
+      expect(listener.isDeliveryPaused, isFalse);
+      expect(() => listener.pauseDelivery(), returnsNormally);
+      expect(() => listener.resumeDelivery(), returnsNormally);
+      expect(socket.pauseCount, 0,
+          reason: 'there is no subscription yet, so nothing to pause');
+    });
+  });
+
+  group('a response with no colon', () {
+    // The bare `@<atSign>@` that completes the handshake carries no colon, and
+    // `_isValidResponse` accepts it, so it reaches `_stripPrompt`. Before the
+    // guard, `substring(0, -1)` threw a RangeError inside the socket's data
+    // handler; `runZonedGuarded` reported that as a socket error and destroyed
+    // a healthy connection, and the caller saw only a timeout.
+    test('comes back, and leaves the connection alive', () async {
+      final rig = FakeAtServerRig();
+
+      await rig.socket.serverSends('@alice@\n@alice@');
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      expect(rig.socket.destroyed, isFalse,
+          reason: 'a colonless response must not destroy the connection - a '
+              'RangeError raised in the data handler surfaces as a socket '
+              'error and closes it');
+      expect(rig.connection.getMetaData()!.isClosed, isFalse,
+          reason: 'and must not mark the connection closed');
+      expect(
+          await rig.listener
+              .read(maxWaitMilliSeconds: 500, transientWaitTimeMillis: 500),
+          '@alice@',
+          reason: 'the handshake prompt is a valid response and must be '
+              'returned unchanged');
+    });
+  });
+
+  group('the notification framing', () {
+    // A verb response ends `\n@<atSign>@`; a notification is not a reply to
+    // anything, so no prompt follows it and it ends at a bare `\n`. One
+    // listener has to know both.
+    test('a notification goes to onNotification, not to the verb queue',
+        () async {
+      final rig = FakeAtServerRig();
+      final seen = <String>[];
+      rig.listener.onNotification = seen.add;
+
+      await rig.socket.serverSends('notification: {"id":"abc"}\n');
+      expect(seen, ['notification: {"id":"abc"}']);
+
+      // and the verb channel is undisturbed by it
+      await rig.socket.serverSends('data:phone@alice\n@alice@');
+      expect(
+          await rig.listener
+              .read(maxWaitMilliSeconds: 500, transientWaitTimeMillis: 500),
+          'data:phone@alice');
+      expect(seen, hasLength(1),
+          reason: 'a verb response must not be delivered as a notification');
+    });
+
+    test('a data value containing newlines is not mistaken for one', () async {
+      final rig = FakeAtServerRig();
+      final seen = <String>[];
+      rig.listener.onNotification = seen.add;
+
+      await rig.socket.serverSends('data:the_key_is\n@bob:phone@alice\n@alice@');
+
+      // Asserted before the read, so a listener that routes this away fails
+      // here with the reason - not thirty seconds later on a starved read.
+      expect(seen, isEmpty,
+          reason: 'the test is on the buffer prefix, so a multi-line value '
+              'still reads as data: and is never routed');
+      expect(
+          await rig.listener
+              .read(maxWaitMilliSeconds: 500, transientWaitTimeMillis: 500),
+          'data:the_key_is\n@bob:phone@alice');
+    });
+
+    test('two notifications in one packet are two, not one', () async {
+      // The atServer has no reason to put one notification per TCP segment.
+      // messageHandler's fast path appends everything up to the LAST newline
+      // in bulk, so an intermediate newline never reaches the framing check
+      // and both lines arrive fused into one string.
+      final rig = FakeAtServerRig();
+      final seen = <String>[];
+      rig.listener.onNotification = seen.add;
+
+      await rig.socket
+          .serverSends('notification: {"id":"a"}\nnotification: {"id":"b"}\n');
+
+      expect(seen, [
+        'notification: {"id":"a"}',
+        'notification: {"id":"b"}',
+      ]);
+    });
+
+    test('a notification split across packets still arrives once', () async {
+      final rig = FakeAtServerRig();
+      final seen = <String>[];
+      rig.listener.onNotification = seen.add;
+
+      await rig.socket.serverSends('notification: {"id":');
+      expect(seen, isEmpty, reason: 'incomplete - no newline yet');
+      await rig.socket.serverSends('"split"}\n');
+
+      expect(seen, ['notification: {"id":"split"}']);
+    });
+
+    test('with nothing installed, a notification poisons the next response',
+        () async {
+      // The behaviour the seam exists to fix, pinned so its absence is
+      // visible: with no callback the notification bytes stay in the buffer
+      // and prefix whatever the atServer says next, which then fails
+      // _isValidResponse. This is why Monitor was given a listener of its own.
+      final rig = FakeAtServerRig();
+
+      await rig.socket.serverSends('notification: {"id":"abc"}\n');
+      await rig.socket.serverSends('data:after@alice\n@alice@');
+
+      expect(
+          () => rig.listener
+              .read(maxWaitMilliSeconds: 500, transientWaitTimeMillis: 500),
+          throwsA(predicate((dynamic e) =>
+              e is AtLookUpException && e.errorMessage == 'Unexpected response found')),
+          reason: 'the unrouted notification is still in the buffer and is '
+              'returned joined to the response that followed it');
+    });
+  });
+
+  group('the far end going away closes the connection', () {
+    test('onDone destroys the socket and marks the connection closed',
+        () async {
+      final rig = FakeAtServerRig();
+
+      await rig.socket.serverCloses();
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      expect(rig.socket.destroyed, isTrue);
+      expect(rig.connection.getMetaData()!.isClosed, isTrue);
+    });
+
+    test('onError destroys the socket and marks the connection closed',
+        () async {
+      final rig = FakeAtServerRig();
+
+      await rig.socket.serverErrors(const SocketException('reset by peer'));
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      expect(rig.socket.destroyed, isTrue);
+      expect(rig.connection.getMetaData()!.isClosed, isTrue);
+    });
+  });
+
+  group('a request in flight when the connection goes away', () {
+    /// A response can only arrive on the socket the listener is reading, so a
+    /// connection that is gone can never produce one. Until `read` gives up it
+    /// holds `AtLookupImpl.requestResponseMutex`, so every later request on the
+    /// same instance queues behind a dead one for the whole transient budget.
+    ///
+    /// Each arm measures the WAIT, not the throw: the throw happens either way,
+    /// and only its timing distinguishes "noticed the connection died" from
+    /// "sat out the budget".
+    Future<int> millisUntilReadFails(
+      FakeAtServerRig rig,
+      Future<void> Function() killIt,
+    ) async {
+      final sw = Stopwatch()..start();
+      Object? thrown;
+      final done = rig.listener.read(transientWaitTimeMillis: 3000).then<void>(
+        (_) {},
+        onError: (Object e) {
+          thrown = e;
+        },
+      );
+      await rig.socket.settle();
+
+      await killIt();
+      await done;
+      sw.stop();
+
+      expect(thrown, isNotNull,
+          reason: 'a read with no response and a dead connection must fail, '
+              'not return');
+      return sw.elapsedMilliseconds;
+    }
+
+    test('a locally closed connection fails the pending read at once',
+        () async {
+      final rig = FakeAtServerRig();
+
+      final waited = await millisUntilReadFails(rig, rig.connection.close);
+
+      expect(waited, lessThan(1000),
+          reason: 'closing the connection from this side - what '
+              'AtClientImpl.stop() does on every atSign switch - must fail the '
+              'request in flight immediately. Waiting out the transient budget '
+              'holds the request mutex, and the next request on this '
+              'AtLookupImpl queues behind a response that can never come');
+    });
+
+    test('a far end that hangs up fails the pending read at once', () async {
+      final rig = FakeAtServerRig();
+
+      final waited = await millisUntilReadFails(rig, rig.socket.serverCloses);
+
+      expect(waited, lessThan(1000),
+          reason: 'onDone already closes the connection; the read waiting on '
+              'that same socket must not then wait out its budget');
+    });
+
+    test('a far end that faults fails the pending read at once', () async {
+      final rig = FakeAtServerRig();
+
+      final waited = await millisUntilReadFails(
+          rig, () => rig.socket.serverErrors(const SocketException('reset')));
+
+      expect(waited, lessThan(1000),
+          reason: 'onError already closes the connection; the read waiting on '
+              'that same socket must not then wait out its budget');
+    });
+
+    test('a response already queued when the connection dies is still returned',
+        () async {
+      final rig = FakeAtServerRig();
+
+      await rig.socket.serverSends('data:phone@alice\n@alice@');
+      await rig.connection.close();
+
+      expect(await rig.listener.read(transientWaitTimeMillis: 3000),
+          'data:phone@alice',
+          reason: 'the bytes arrived before the connection went away, so the '
+              'caller is owed the response - aborting on a closed connection '
+              'must not discard one already parsed');
+    });
+  });
+}

--- a/packages/at_lookup/test/socket_delivery_test.dart
+++ b/packages/at_lookup/test/socket_delivery_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:at_commons/at_commons.dart' show ConnectionInvalidException;
 import 'package:at_lookup/at_lookup.dart';
 // Not in the barrel by design - decision 4 keeps the listener private
 // to the package, so tests reach it by path as the fake socket does.
@@ -347,9 +348,13 @@ void main() {
       await done;
       sw.stop();
 
-      expect(thrown, isNotNull,
-          reason: 'a read with no response and a dead connection must fail, '
-              'not return');
+      expect(thrown, isA<ConnectionInvalidException>(),
+          reason: 'the TYPE is the user-visible half of this fix: a caller '
+              'told the connection went away can reconnect, where an '
+              'AtTimeoutException sends it looking at the atServer. Asserting '
+              'only that something was thrown leaves that swap unpinned - the '
+              'timing bound below catches the mechanism being absent, not the '
+              'wrong exception coming out of it');
       return sw.elapsedMilliseconds;
     }
 


### PR DESCRIPTION
### Why
- Remove code duplication
- Building the future shape now so we can drive removal of problem with callers creating AtLookupImpl instances in its current shape which has evolved with multiple optional conflicting parameters. (Note: my pq feature branch, from which this PR has been carved, uses only the new shape now.)
- Enable an AtClient to _choose_ to reuse the same connection for different purposes - default, monitor, sync

### What I did

- `AtLookUp.withSecureSocket(...)` — the entry point, returning an `AtLookupMuxable`. Static, so it adds nothing to the `implements` contract and breaks none of the classes that mock `AtLookUp`. `AtLookupImpl`'s constructor is deprecated in its favour; the class itself stays exported for now and does not move; but it will be no longer exported at version 4.
- The muxable owns reconnect, reauth and heartbeat, because it owns the socket: backoff, the **same** `monitor:` re-issued with its regex and its watermark (dropping either would replay everything, or from the beginning), and `noop:0` to probe a quiet connection. `notificationConnectionUp` reports that state.
- `AtLookupMuxable` gains the members callers were reaching for through a cast to the concrete class — `authenticator`, `isConnectionAvailable`, `readResponse`, plus `scan(auth:)` and `lookup(metadata:)`. Those last two were a defect this surfaced: `AtLookupImpl` accepted **more** than `AtLookUp` declared, so a caller moving to the interface silently lost parameters.
- `AtLookupTransport` bundles the three connection factories, so a caller holding only the interface can still say how connections are made.
- Fixes: a request in flight when its connection closes now fails immediately instead of stalling the **next** request for the whole response budget; and a response carrying no colon no longer destroys the connection (`substring(0, -1)` on the bare `@<atSign>@` that completes the handshake).
- `read()` waits on an event rather than polling, and its two budgets come from `AtNetworkTimeouts` — the between-chunks default moves from **10s to 30s**. A connection also now records the identity it authenticated as.
- Deprecated, removal in 4.0: `MonitorClient` (no other caller in the tree, and it predates the connect timeouts) and `executeVerb`'s inert `sync` parameter.
- Deps: `at_commons: ^5.16.0` (reads `AtNetworkTimeouts.defaultResponseBudget`), `at_chops: ^3.6.0`.

### How I did it

See commit & diffs. Carved from `gkc-pq-d1-spike` — this branch is byte-identical to the spike over `packages/at_lookup`.

### How to verify it

Tests pass — 130/130, and `dart analyze` is clean (bare, as CI runs it). at_client, at_auth, at_onboarding_cli and at_server_status each analyze with zero errors against this branch.

### Description for the changelog

`AtLookUp.withSecureSocket` returns an `AtLookupMuxable` that owns its own connection — reconnect, reauth and heartbeat included — and reports it through `notificationConnectionUp`. `AtLookupImpl`'s constructor and `MonitorClient` are deprecated. A closed connection now fails its in-flight request immediately instead of stalling the next one, and a response with no colon no longer destroys a healthy connection.
