### PR TITLE
feat(at_server_status): 1.1.2 - build the lookup with AtLookUp.withSecureSocket

### DIFF
--- a/packages/at_server_status/CHANGELOG.md
+++ b/packages/at_server_status/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 1.1.2
+
+- refactor: builds its lookup with `AtLookUp.withSecureSocket`, passing
+  `authenticator: null` - every call it makes is `auth: false` and it holds no
+  key material at all.
+- refactor: drops `AtLookupImpl.findSecondary` for
+  `CacheableSecondaryAddressFinder`, which that deprecated static was a thin
+  wrapper over. The finder is constructed **inside** the future deliberately:
+  the wrapper did its own `rootDomain!`, so a null root domain surfaced as a
+  rejected future and became `RootStatus.unavailable`. Asserting at the call
+  site instead would throw before `catchError` is attached and turn an
+  unavailable root into an uncaught exception.
+- build: `at_lookup` `^3.0.49` -> `^3.7.0-rc1`, and `at_commons` becomes a direct
+  dependency. Both were needed by the change above and both were being
+  satisfied by workspace resolution, which hides the problem locally: a
+  consumer resolving the published package would have got an at_lookup with no
+  `withSecureSocket` in it.
+
 ## 1.1.1
 
 - fix: Make this work properly with atServer proxy services

--- a/packages/at_server_status/lib/at_status_impl.dart
+++ b/packages/at_server_status/lib/at_status_impl.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
-import 'package:at_lookup/at_lookup.dart';
+import 'package:at_commons/at_commons.dart';
+import 'package:at_lookup/at_lookup_io.dart';
 
 import 'at_server_status.dart';
 
@@ -68,11 +69,20 @@ class AtStatusImpl implements AtServerStatus {
     // ignore: omit_local_variable_types
     AtStatus atStatus = AtStatus();
     atStatus.atSign = atSign;
-    // ignore: deprecated_member_use
-    await AtLookupImpl.findSecondary(atSign, _rootUrl, _rootPort!)
+    // at_lookup's own `findSecondary` static was a thin wrapper over this finder, and
+    // both it and the class it lived on are now deprecated.
+    //
+    // The finder is built INSIDE the future deliberately: the wrapper did its
+    // own `rootDomain!`, so a null `_rootUrl` surfaced as a rejected future
+    // and landed in `catchError` below as RootStatus.unavailable. Asserting at
+    // the call site instead would throw before `catchError` is attached, and
+    // turn an unavailable root into an uncaught exception.
+    await Future(() => CacheableSecondaryAddressFinder(_rootUrl!, _rootPort!)
+            .findSecondary(atSign))
+        .then((address) => address.toString())
         .then((serverLocation) async {
       // enum RootStatus { running, stopped, unavailable, found, notFound }
-      if (serverLocation != null && serverLocation.isNotEmpty) {
+      if (serverLocation.isNotEmpty) {
         atStatus.rootStatus = RootStatus.found;
         atStatus.serverLocation = serverLocation;
       } else {
@@ -96,8 +106,15 @@ class AtStatusImpl implements AtServerStatus {
       atStatus.rootStatus = RootStatus.notFound;
     } else {
       // ignore: omit_local_variable_types
-      AtLookupImpl atLookupImpl =
-          AtLookupImpl(atSign!, _rootUrl!, _rootPort!);
+      // authenticator: null - every call below passes `auth: false`, and this
+      // class holds no key material at all. Stating it beats a connection that
+      // would fail at the first authenticated verb.
+      final atLookupImpl = AtLookUp.withSecureSocket(
+        atSign: atSign!,
+        rootDomain: AtRootDomain(_rootUrl!, _rootPort!),
+        transport: secureSocketTransport(SecureSocketConfig()),
+        authenticator: null,
+      );
       await atLookupImpl.executeCommand('from:$atSign\n');
       await atLookupImpl.scan(auth: false).then((keysList) async {
         if (keysList.isNotEmpty) {

--- a/packages/at_server_status/pubspec.yaml
+++ b/packages/at_server_status/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_status
 description: A Dart library that provides a means to check on the status of the @‎root server as well as the secondary server for any particular @‎sign.
-version: 1.1.1
+version: 1.1.2
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_server_status
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/
@@ -10,7 +10,14 @@ environment:
 resolution: workspace
 
 dependencies:
-  at_lookup: ^3.0.49
+  # 3.7.0 for AtLookUp.withSecureSocket. Raised in the same commit as the
+  # first use: workspace resolution would otherwise mask the break, and
+  # publish validation only checks satisfiability - so a consumer could
+  # resolve 3.0.49 and get a package that does not compile.
+  at_lookup: ^3.7.0-rc1
+  # Direct now, for AtRootDomain and SecureSocketConfig, which the factory
+  # signature names. It was arriving transitively through at_lookup.
+  at_commons: ^5.13.0
 
 dev_dependencies:
   uuid: ^4.0.0


### PR DESCRIPTION
**- What I did**

- `at_status_impl` builds its lookup with `AtLookUp.withSecureSocket`, passing `authenticator: null`. Every call this package makes is `auth: false` and it holds no key material at all — null is the accurate statement of that, which is why the factory requires the parameter rather than defaulting it.
- Dropped the deprecated `AtLookupImpl.findSecondary` static for `CacheableSecondaryAddressFinder`, which it was a thin wrapper over. The finder is constructed **inside** the future deliberately: the wrapper did its own `rootDomain!`, so a null root domain surfaced as a rejected future and became `RootStatus.unavailable`. Asserting at the call site instead would throw before `catchError` is attached, turning an unavailable root into an uncaught exception.
- Deps: `at_lookup` `^3.0.49` → `^3.7.0-rc1`, and `at_commons` becomes a **direct** dependency (the factory signature names `AtRootDomain` and `SecureSocketConfig`; it was arriving transitively). Both are raised in the same commit as the first use — workspace resolution masks the break locally, and publish validation only checks satisfiability, so a consumer could otherwise resolve `3.0.49` and get a package with no `withSecureSocket` in it.

**- How I did it**

See commit & diffs. Carved from `gkc-pq-d1-spike` — this branch is byte-identical to the spike over `packages/at_server_status`, and touches nothing outside that package.

**- How to verify it**

`dart analyze` clean, and at_auth and at_onboarding_cli — this package's in-repo consumers — both analyze with zero errors against it.

⚠️ **Six tests in `at_server_status_test.dart` fail here and fail identically on trunk**: `+10 -6`, the same six names, both arms run in the same session. They expect `RootStatus.notFound` and get `RootStatus.unavailable`, because the atDirectory has no entry for the atSigns they use, so `_checkRootLocation` throws. Pre-existing and not touched by this PR.

⚠️ **Blocked on a publish, not on review:** `at_lookup` `3.7.0-rc1` has to reach pub.dev before this can be published, since that is the floor declared above.

**- Description for the changelog**

`at_server_status` builds its lookup through `AtLookUp.withSecureSocket` and resolves the atServer address with `CacheableSecondaryAddressFinder`, dropping the deprecated `AtLookupImpl.findSecondary`. `at_lookup` is raised to `^3.7.0-rc1` and `at_commons` becomes a direct dependency.
