### PR TITLE
chore(at_server_status): 1.1.2-rc1

### DIFF
--- a/packages/at_server_status/CHANGELOG.md
+++ b/packages/at_server_status/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.2
+## 1.1.2-rc1
 
 - refactor: builds its lookup with `AtLookUp.withSecureSocket`, passing
   `authenticator: null` - every call it makes is `auth: false` and it holds no

--- a/packages/at_server_status/pubspec.yaml
+++ b/packages/at_server_status/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_server_status
 description: A Dart library that provides a means to check on the status of the @‎root server as well as the secondary server for any particular @‎sign.
-version: 1.1.2
+version: 1.1.2-rc1
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_server_status
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/


### PR DESCRIPTION
**- What I did**

- `at_server_status` becomes **`1.1.2-rc1`** — version and CHANGELOG heading together, matching the convention at_auth used for its own candidate (`9f36de7d7`).

**Why a candidate.** 1.1.2 declares `at_lookup: ^3.7.0-rc1`, and no *stable* version satisfies that range until at_lookup 3.7.0 ships. Publishing this as a stable release would therefore resolve its consumers onto the at_lookup release candidate — reached through a patch bump they would take without thinking, which is precisely what the candidate exists to prevent. Making this a candidate too keeps the whole chain opt-in.

**- How I did it**

See commit & diffs. Two lines. Carved from `gkc-pq-d1-spike` and byte-identical to it over `packages/at_server_status`; touches nothing outside that package.

**- How to verify it**

No consumer constraint needed changing — `at_auth` is on `^1.1.0` and `at_onboarding_cli` on `^1.0.5`, and a prerelease strictly *above* a range's lower bound is admitted; only a prerelease **of** the bound is excluded. That is why `^3.7.0` had to become `^3.7.0-rc1` for at_lookup while these needed nothing. Verified by resolving the whole workspace and analyzing both consumers: zero errors.

⚠️ **Owed at the real release:** this returns to `1.1.2` when at_lookup 3.7.0 ships stable and its constraint reverts to `^3.7.0`.

**- Description for the changelog**

`at_server_status` publishes as `1.1.2-rc1` while its `at_lookup` floor is a release candidate, so consumers are not pulled onto a candidate by a routine upgrade.
