### PR TITLE
fix(at_chops): an ML-DSA PKAM key of the wrong length names its likely cause

### DIFF
--- a/packages/at_chops/CHANGELOG.md
+++ b/packages/at_chops/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 3.6.1
+
+- fix: an ML-DSA-65 PKAM key of the wrong length now says what is likely wrong
+  with it. `PkamMlDsa65SigningAlgo.sign` reported only
+  `ML-DSA-65 secret key must be 4032 bytes: N`, which names neither the
+  credential nor the likeliest cause — and the likeliest cause is not a corrupt
+  key. A PKAM key of about 1.2 kB is an RSA-2048 private key, and a caller ends
+  up holding one by naming one enrollment's algorithm while carrying another
+  enrollment's credentials: a retrofitted keyfile holds ML-DSA material for the
+  new enrollment and the original RSA keypair in the flat fields, and the two
+  are selected separately. The message now states the size, the expected size,
+  and — only for a key in the RSA-2048 range — that the algorithm and the
+  credentials most likely come from different enrollments.
+  - Message only. A correctly sized key signs exactly as before, which the
+    third case of `pkam_mldsa65_wrong_key_message_test.dart` pins, and the
+    RSA hint is conditional so a 7-byte key is not told it might be RSA.
+
 ## 3.6.0
 
 Shipped as a minor despite the breaks below. Both are source-breaking only for

--- a/packages/at_chops/lib/src/algorithm/pkam_mldsa65_signing_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/pkam_mldsa65_signing_algo.dart
@@ -5,6 +5,7 @@ import 'package:at_chops/src/algorithm/at_algorithm.dart';
 import 'package:at_chops/src/key/impl/at_pkam_key_pair.dart';
 import 'package:at_commons/at_commons.dart';
 import 'package:at_chops/src/algorithm/signing/ml_dsa_65_pure_dart.dart';
+import 'package:at_chops/src/algorithm/spec/ml_dsa_65_spec.dart';
 
 /// PKAM signing and verification with an ML-DSA-65 (FIPS 204) APKAM keypair.
 ///
@@ -45,6 +46,29 @@ class PkamMlDsa65SigningAlgo implements AtSigningAlgorithm {
       throw AtSigningException(
           'an mldsa65 PKAM private key must be base64 of the raw '
           'ML-DSA-65 secret key');
+    }
+    // The length check is here rather than left to `signBytesSync` because
+    // this is the last frame that knows the key was offered as a PKAM
+    // credential. Below, the same mistake reports only "must be 4032 bytes:
+    // N", which names neither the credential nor the likeliest cause — and
+    // the likeliest cause is not a corrupt key.
+    //
+    // A PKAM key of about 1.2 kB is an RSA-2048 private key, and the way a
+    // caller ends up here holding one is by naming one enrollment's algorithm
+    // while carrying another enrollment's credentials: a keyfile that has been
+    // retrofitted holds ML-DSA material for the new enrollment and the
+    // original RSA keypair in the flat fields, and the two are selected
+    // separately. Saying so costs one branch and saves reading a byte count as
+    // corruption.
+    if (secretKey.length != MlDsa65Sizes.secretKeyBytes) {
+      throw AtSigningException(
+          'this PKAM key is ${secretKey.length} bytes, and an ML-DSA-65 '
+          'secret key is ${MlDsa65Sizes.secretKeyBytes}. '
+          '${secretKey.length > 1000 && secretKey.length < 1400 ? 'A key this size is an RSA-2048 private key, so the declared '
+              'algorithm and the credentials most likely come from different '
+              'enrollments — check that the enrollment id being authenticated '
+              'as is the one whose key material was loaded. ' : ''}'
+          'Signing was not attempted');
     }
     return MlDsa65PureDartAlgo.signBytesSync(data, secretKey: secretKey);
   }

--- a/packages/at_chops/pubspec.yaml
+++ b/packages/at_chops/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_chops
 description: Package for at_protocol cryptographic and hashing operations
-version: 3.6.0
+version: 3.6.1
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_chops
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_chops/test/pkam_mldsa65_wrong_key_message_test.dart
+++ b/packages/at_chops/test/pkam_mldsa65_wrong_key_message_test.dart
@@ -1,0 +1,73 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:at_chops/at_chops.dart';
+import 'package:at_chops/src/algorithm/spec/ml_dsa_65_spec.dart';
+import 'package:at_commons/at_commons.dart' show AtSigningException;
+import 'package:test/test.dart';
+
+/// A PKAM key of the wrong length is almost never a corrupt key.
+///
+/// The way a caller reaches this frame holding an RSA private key while
+/// declaring ML-DSA-65 is by naming one enrollment's algorithm and carrying
+/// another enrollment's credentials — a retrofitted keyfile holds ML-DSA
+/// material for the new enrollment and the original RSA keypair in the flat
+/// fields, and the two are selected separately. Reported as a bare byte count
+/// it reads as corruption, and the search starts in the wrong place.
+void main() {
+  PkamMlDsa65SigningAlgo algoWithKeyOfLength(int bytes) =>
+      PkamMlDsa65SigningAlgo(AtPkamKeyPair.create(
+        base64Encode(Uint8List(MlDsa65Sizes.publicKeyBytes)),
+        base64Encode(Uint8List(bytes)),
+      ));
+
+  test('an RSA-sized PKAM key names the likely cause, not just the length', () {
+    // 1216 bytes: the length an RSA-2048 private key decodes to, and the
+    // value this message was written for.
+    expect(
+      () => algoWithKeyOfLength(1216).sign(Uint8List.fromList([1, 2, 3])),
+      throwsA(isA<AtSigningException>().having(
+          (e) => e.toString(),
+          'says the size, the expected size, and the likely cause',
+          allOf(
+            contains('1216'),
+            contains('${MlDsa65Sizes.secretKeyBytes}'),
+            contains('RSA-2048'),
+            contains('different'),
+          ))),
+      reason: 'a caller meeting this is looking at a credential/algorithm '
+          'mismatch, and the message has to say so - the byte count alone '
+          'sends them looking for a corrupt key',
+    );
+  });
+
+  test('a key that is merely the wrong length says so without guessing', () {
+    // The negative control: the RSA hint must be CONDITIONAL, or it is an
+    // assertion the message makes about every wrong key regardless of size.
+    expect(
+      () => algoWithKeyOfLength(7).sign(Uint8List.fromList([1, 2, 3])),
+      throwsA(isA<AtSigningException>().having(
+          (e) => e.toString(),
+          'states the mismatch and claims nothing about its cause',
+          allOf(
+            contains('7 bytes'),
+            contains('${MlDsa65Sizes.secretKeyBytes}'),
+            isNot(contains('RSA-2048')),
+          ))),
+      reason: 'a 7-byte key is not an RSA key, and saying it might be would '
+          'be a worse message than the byte count this replaced',
+    );
+  });
+
+  test('a correctly sized key is not refused here', () async {
+    // Proves the guard discriminates on length rather than refusing the path:
+    // a real ML-DSA-65 keypair must sign.
+    final pair = await MlDsa65KeyPair.generate();
+    final algo = PkamMlDsa65SigningAlgo(AtPkamKeyPair.create(
+        pair.atPublicKey.publicKey, pair.atPrivateKey.privateKey));
+    expect(algo.sign(Uint8List.fromList([1, 2, 3])), isNotEmpty,
+        reason: 'a valid ML-DSA-65 secret key must sign; a guard that '
+            'refused this would have replaced a bad message with a broken '
+            'signing path');
+  });
+}


### PR DESCRIPTION
**- What I did**

- `PkamMlDsa65SigningAlgo.sign` reported only `ML-DSA-65 secret key must be 4032 bytes: N`. That names neither the credential nor the likeliest cause — and the likeliest cause is not a corrupt key.
- A PKAM key of about 1.2 kB is an RSA-2048 private key. A caller ends up holding one by naming one enrollment's algorithm while carrying another enrollment's credentials — a retrofitted keyfile holds ML-DSA material for the new enrollment and the original RSA keypair in the flat fields, and the two are selected separately.
- The message now states the size, the expected size, and — only for a key in the RSA-2048 range — that the algorithm and the credentials most likely come from different enrollments.
- Message only. A correctly sized key signs exactly as before.
- Bumped to 3.6.1: 3.6.0 is published, so there was no in-progress heading to fold into.

**- How I did it**

See commit & diffs.

**- How to verify it**

Tests pass. `packages/at_chops` 428/428, and `test/pkam_mldsa65_wrong_key_message_test.dart` carries three cases with the mutation run: removing the guard reddens both message cases showing the old bare `ArgumentError` as the actual, and leaves the valid-key case green. The RSA hint is conditional, so a 7-byte key is not told it might be RSA.

**- Description for the changelog**

An ML-DSA-65 PKAM key of the wrong length now names its likely cause rather than reporting only a byte count.