### PR TITLE
chore: update version name in CHANGELOG to 1.16.1-rc1

### DIFF
--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.16.1
+## 1.16.1-rc1
 - fix: pass passPhrase to FileAtKeysIo during onboarding so password-protected atKeys files are written correctly
 
 ## 1.16.0


### PR DESCRIPTION
## What

<!-- What does this PR do? Describe the change and the problem it solves. -->

Updated version to 1.16.1-rc1 until the full release of atauth 4.0.0

## How

<!-- How was this implemented? Include any key decisions or trade-offs. -->

## How to verify

<!-- Steps to verify the change works as expected. -->

1. 
2. 

## Skills impact

If this PR changes a public API in `at_client`, `at_client_flutter`, or `at_auth`,
consider whether `packages/at_client_skills/` needs a follow-up release.

- [x] No public API change — skill unaffected
- [ ] Public API changed — I have opened or will open an `at_client_skills` PR to reflect this
