### PR TITLE
feat(at_commons): enroll:infons, a read verb for facts about a namespace

### DIFF
--- a/packages/at_commons/CHANGELOG.md
+++ b/packages/at_commons/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 5.17.0
+
+- feat: `enroll:infons:<namespace>` — "info about a namespace". A read verb
+  alongside `enroll:listns`, taking the same authorisation, returning a JSON
+  **map** of facts about the namespace rather than a list of its members. Its
+  first member is `lastRevokedAt`: the latest moment a revocation touched an
+  enrollment granted that namespace, or null.
+  A map because the fact is about the NAMESPACE and not about any member: on a
+  roster of approved enrollments the same value would have had to be repeated on
+  every row under a name apologising for where it lived. `enroll:listns` is
+  unchanged, which matters — a client resolves conveyance recipients through it,
+  and its returning approved enrollments only is what keeps a revoked enrollment
+  off every roster.
+
 ## 5.16.0
 
 - feat: add `AtNetworkTimeouts.defaultResponseBudget` (90s) — the overall budget

--- a/packages/at_commons/lib/src/verb/syntax.dart
+++ b/packages/at_commons/lib/src/verb/syntax.dart
@@ -148,7 +148,7 @@ class VerbSyntax {
   static const notifyRemove = r'notify:remove:(?<id>[\w\d\-\_]+)';
   static const enroll =
       // The non-capturing group (?::)? matches ":" if the operation is request|approve|deny|revoke
-      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|listns|list|fetch|unrevoke|delete|update)))(:(?<force>force))?(:(?<listNamespace>[^:{\n]+))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
+      r'^enroll:(?<operation>(?:(request|approve|deny|revoke|listns|infons|list|fetch|unrevoke|delete|update)))(:(?<force>force))?(:(?<listNamespace>[^:{\n]+))?(?::)?((?<enrollParams>.+)|(<=list:)<enrollParams>.?)?$';
   static const otp =
       r'^otp:(?<operation>get|put)(:(?<otp>(?<=put:)\w{6,}))?(:(?:ttl:(?<ttl>\d+)))?$';
   static const keys = r'^keys:((?<operation>put|get|delete):?)'

--- a/packages/at_commons/pubspec.yaml
+++ b/packages/at_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_commons
 description: A library of Dart and Flutter utility classes that are used across other components of the atPlatform.
-version: 5.16.0
+version: 5.17.0
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_commons
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_commons/test/syntax_test.dart
+++ b/packages/at_commons/test/syntax_test.dart
@@ -401,6 +401,51 @@ void main() {
       expect(verbParams['operation'], 'listns');
     });
 
+    test('A test to verify enroll:infons parses the listNamespace', () {
+      String command = 'enroll:infons:wavi\n';
+      var verbParams =
+          VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim())!;
+      expect(verbParams['operation'], 'infons');
+      expect(verbParams['listNamespace'], 'wavi');
+    });
+
+    test('A test to verify enroll:infons leaves enroll:listns alone', () {
+      // The two are siblings and neither is a prefix of the other, so adding
+      // `infons` must not change how `listns` parses. Asserted rather than
+      // assumed, because an alternation is exactly where a new token changes
+      // what an old one matches.
+      String command = 'enroll:listns:wavi\n';
+      var verbParams =
+          VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim())!;
+      expect(verbParams['operation'], 'listns');
+      expect(verbParams['listNamespace'], 'wavi');
+    });
+
+    test('a trailing suffix is absorbed into enrollParams, for every operation',
+        () {
+      // Known and PRE-EXISTING: `enroll:listnsX:wavi` parses as
+      // operation=listns with enrollParams=X:wavi, and always has. `infons` is
+      // neither more nor less permissive than its siblings, which is the
+      // property worth pinning — if this is ever tightened it must be tightened
+      // for all of them together, or two verbs start disagreeing about what a
+      // malformed command means.
+      for (final op in ['infons', 'listns', 'list']) {
+        final params =
+            VerbUtil.getVerbParam(VerbSyntax.enroll, 'enroll:${op}X:wavi')!;
+        expect(params['operation'], op,
+            reason: 'the operation is matched and the suffix falls through');
+        expect(params['enrollParams'], 'X:wavi');
+      }
+    });
+
+    test('A test to verify an unknown enroll operation is still refused', () {
+      // The negative control on the alternation: it must have widened by
+      // exactly one token. Without this, a pattern that had been loosened to
+      // accept anything would satisfy every assertion above.
+      String command = 'enroll:bogusop:wavi\n';
+      expect(VerbUtil.getVerbParam(VerbSyntax.enroll, command.trim()), isNull);
+    });
+
     test('EnrollParams round-trips metadata and signingAlgo', () {
       final params = EnrollParams()
         ..signingAlgo = 'mldsa65'


### PR DESCRIPTION
**- What I did**

- Added `enroll:infons:<namespace>` to the enroll verb syntax — a read verb alongside `enroll:listns`, taking the same authorisation, returning a JSON **map** of facts about the namespace rather than a list of its members. Its first member is `lastRevokedAt`.
- Four syntax tests, including a negative control and a pin on pre-existing suffix absorption.
- Opened `5.17.0`. `5.16.0` is published, so this is a new heading rather than a fold.

`enroll:listns` is byte-identical, and that matters rather than being incidental: a client resolves conveyance recipients through it, and its returning approved enrollments only is what keeps a revoked enrollment off every roster. Widening it would move that safety property out of the server's filter and into every caller.

A map rather than a scalar on the roster because the fact is about the **namespace**, not about any member — on a roster the same value would be repeated on every row under a field name apologising for where it lived.

**- How I did it**

See commit & diffs.

**- How to verify it**

Tests pass.

The negative control is the one worth a look: `enroll:bogusop:wavi` must still return null. Without it, a pattern loosened to accept anything would satisfy every other assertion in the file.

**- Description for the changelog**

feat: `enroll:infons:<namespace>` — "info about a namespace". A read verb alongside `enroll:listns`, taking the same authorisation, returning a JSON map of facts about the namespace. Its first member is `lastRevokedAt`: the latest moment a revocation touched an enrollment granted that namespace, or null.