### PR TITLE
fix(at_auth): the _apsk shape, a self-enrollment that can approve itself, and two keyfile gaps

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,5 +1,38 @@
 ## 4.0.0-rc1
 
+- fix: **the `_apsk` an enrolment advertises is spelled by its
+  algorithm alone.** ⚠️ This changes behaviour introduced earlier in this same
+  **unpublished** `4.0.0-rc1`; it is not a break against `3.3.0`, the last
+  published version. Exactly one active `rsa2048` key rides `apskLegacy` as the
+  bare string; anything else rides `apsk` as the array. A key package used to
+  force the array as well, on the grounds that a bare value cannot state the
+  algorithm of whatever signed the package — but where that signer is rsa2048
+  the bare value states exactly it, and where it is not, the algorithm already
+  chose the array. So the condition only ever fired on the case it was wrong
+  about, and that case is reachable: a legacy posture names an empty data
+  signing set, so nothing is advertised, while a pq key-exchange mode still
+  carries a package.
+  **Why it mattered.** at_client composes this same record at every start and
+  republishes on any difference, and it spells that key bare. The two composers
+  of one record therefore disagreed about its shape — at_auth installed the
+  array, the enrolment's first start rewrote it bare — and that republish
+  discards the chain link the approver conveyed against the old value, leaving
+  the enrollment silently unsigned. Pinned in `enrollment_test.dart` with the
+  mldsa65 arm as its control.
+
+- feat: **a self-enrollment submitted by an atSign that holds no enrollment is
+  approved over the connection that requested it.** The atServer's
+  self-enrolment auto-approve needs an APKAM-authenticated connection, and an
+  atSign authenticating with its flat PKAM key has none — so its request lands
+  `pending`. It is approvable on that same connection, because a connection
+  carrying no enrollment id is granted full access, so such a request now mints
+  a symmetric key, wraps it to the atSign's own encryption public key, and
+  approves itself through the ordinary approver. The wrap is what keeps the
+  record's copy recoverable afterwards.
+  The discriminator is the **session's** enrollment id rather than the
+  connection's: `pending` also means an atServer too old to auto-approve an
+  APKAM retrofit, and that case keeps its existing deny-and-throw.
+
 A release candidate: adopt it deliberately. The headline is post-quantum
 credentials — an enrollment can authenticate with ML-DSA-65 while the fleet
 still reads what it advertises.
@@ -74,6 +107,21 @@ still reads what it advertises.
   retry budget as consecutive failures, and opens key records written without
   an `iv`.
 - An aborted self-retrofit denies the pending enrollment it created.
+- **`FileAtKeysIo.update` no longer recreates a keyfile deleted while the
+  update was in flight**, and throws `AtKeysSourceAbsentException` instead.
+  `update` is a read-modify-write of material that must already be there —
+  its own read throws when the file is absent at the start — so writing a
+  file that is absent at the end contradicted the call it began. Deleting a
+  `.atKeys` file is how a device is decommissioned, and a background task
+  mid-update would silently put it back. `flush` is unchanged and still
+  creates the file, which is its job.
+- **An OTP enrolment that advertises a signing key now files its private half.**
+  `AtEnrollmentRequest.advertisedSigningKey` reached the `_apsk` advertisement
+  but never the keyfile, so the enrolment published a key it did not hold: the
+  next start found the in-use algorithm missing, minted a second keypair and
+  republished, orphaning the advertised key and unverifying anything signed
+  against it. The self-enrolment and first-enrolment paths already filed it;
+  this was the third.
 
 ## 3.3.0
 - feat: add `AtAuthSession` (exported) — the explicit auth→client hand-off artifact: the confirmed subset of an auth request that client creation actually needs (`atSign`, `rootDomain`, `namespace`, `atKeysIo`, `enrollmentId`), promoted to its own type so "request" no longer doubles as "session". Keys cross the boundary as an `AtKeysIo` *source*, not as live crypto state: the client derives its own `AtKeys` via `atKeysIo.read(atSign)` rather than adopting auth's `AtChops`/`AtLookUp`. The session also carries auth's already-authenticated `atLookUp` so a caller can *opt in* to reusing that connection (`AtClientManager.fromAuthSession(session, reuse: true)`) and skip a second PKAM handshake; the default hand-off rebuilds a fresh connection.

--- a/packages/at_auth/README.md
+++ b/packages/at_auth/README.md
@@ -196,7 +196,10 @@ Persistence has three verbs:
   throws if the file already exists.
 - `update(atsign, mutate)` — **the one to reach for when adding key
   material.** It reads, applies your mutation and persists as a single
-  operation, holding the keyfile lock across all three steps. The callback
+  operation, holding the keyfile lock across all three steps. It never
+  creates the file: it throws `AtKeysSourceAbsentException` if the keyfile is
+  absent when it starts, and also if it is deleted while the update is in
+  flight. The callback
   returns whether anything changed, so finding the material already there
   costs no write:
 

--- a/packages/at_auth/lib/src/at_auth_impl.dart
+++ b/packages/at_auth/lib/src/at_auth_impl.dart
@@ -578,7 +578,8 @@ class AtAuthImpl implements AtAuth {
     if (advertisedSigningKey != null) {
       atAuthKeys.fileSigningMaterial(
           enrollmentId: enrollmentIdFromServer,
-          algorithm: CryptographicMaterialAlgorithm.of(advertisedSigningKey.algorithm.name),
+          algorithm: CryptographicMaterialAlgorithm.of(
+              advertisedSigningKey.algorithm.name),
           publicKey: advertisedSigningKey.publicKey,
           privateKey: advertisedSigningKey.privateKey);
     }

--- a/packages/at_auth/lib/src/auth/probe_default.dart
+++ b/packages/at_auth/lib/src/auth/probe_default.dart
@@ -14,5 +14,4 @@
 ///
 /// A caller wanting the other one, or something else entirely, sets
 /// `probeSocket`.
-export 'probe_default_web.dart'
-    if (dart.library.io) 'probe_default_io.dart';
+export 'probe_default_web.dart' if (dart.library.io) 'probe_default_io.dart';

--- a/packages/at_auth/lib/src/enroll/apsk_advertisement.dart
+++ b/packages/at_auth/lib/src/enroll/apsk_advertisement.dart
@@ -27,7 +27,8 @@ import 'package:at_chops/at_chops.dart' show SHA256HashingAlgo, SigningAlgoType;
 /// two keys of one **algorithm**, so a reader selecting by algorithm must
 /// consider every entry naming it, not the first. The APKAM authentication
 /// key is the exception: it is advertised only while the enrollment holds no
-/// signing key of its own, and the first mint withdraws it.
+/// signing key of its own, and the first mint withdraws it from the
+/// advertisement.
 ///
 /// ```json
 /// {"v": 1, "keys": [

--- a/packages/at_auth/lib/src/enroll/enrollment_submitter.dart
+++ b/packages/at_auth/lib/src/enroll/enrollment_submitter.dart
@@ -128,22 +128,31 @@ class EnrollmentSubmitter {
   ///
   /// Everything else sends the array: an enrollment whose advertised key's
   /// algorithm is not the rsa2048 a bare value implies, since nothing could
-  /// read it otherwise; and an APKAM-key-advertising enrollment carrying a key
-  /// package, whose signer's algorithm the bare form cannot state.
+  /// read it otherwise.
   ///
   /// **[advertisedSigningKey] is preferred over [apkamPublicKey] whenever it
   /// is there.** An enrollment that owns a signing key advertises *that*,
   /// because that is what signs; the APKAM key authenticates connections and
   /// signs nothing once a signing key exists.
   ///
-  /// ⚠️ **With a signing key present, a key package no longer forces the
-  /// array.** It forced it while the package was signed by the APKAM key,
-  /// whose algorithm is whatever the enrollment authenticates with — which a
-  /// bare value, meaning `rsa2048` by convention, cannot state. A package
-  /// signed by an rsa2048 *signing* key is exactly what the bare form does
-  /// state, and rollout 1 depends on that: an un-upgraded peer has to
-  /// base64-decode this value as an RSA key, and it is also the value that
-  /// peer verifies the package against.
+  /// ⚠️ **The algorithm decides the form, and nothing else may — because the
+  /// client composes this same record and decides it that way.** `apskValueOf`
+  /// spells exactly one active rsa2048 entry bare and everything else as the
+  /// array. Any second condition here makes the two composers of one record
+  /// disagree about its shape for the same key: this side installs the array,
+  /// the enrollment's first start composes the bare string, `publishPublicSigningKey`
+  /// sees a difference and republishes — and that republish discards the chain
+  /// link the approver conveyed against the old value, leaving the enrollment
+  /// silently unsigned.
+  ///
+  /// A key package used to force the array here, on the grounds that a bare
+  /// value cannot state the algorithm of whatever signed the package. Where
+  /// that signer is rsa2048 the bare value states exactly it; where it is
+  /// anything else the algorithm test has already sent the array. So the
+  /// condition only ever fired on the case it was wrong about: an
+  /// APKAM-advertising rsa2048 enrollment in pq key-exchange mode, which is
+  /// reachable — a legacy posture names an empty signing set, so nothing is
+  /// advertised, while `--key-exchange pq` still carries a package.
   ({Map<String, dynamic>? apsk, String? apskLegacy}) _apskFor({
     required String apkamPublicKey,
     required SigningAlgoType signingAlgo,
@@ -157,8 +166,7 @@ class EnrollmentSubmitter {
     final alg = advertisedSigningKey?.algorithm ?? signingAlgo;
     final pub = advertisedSigningKey?.publicKey ?? apkamPublicKey;
 
-    if (alg == SigningAlgoType.rsa2048 &&
-        (advertisedSigningKey != null || metadata?['keyPackage'] == null)) {
+    if (alg == SigningAlgoType.rsa2048) {
       return (apsk: null, apskLegacy: pub);
     }
     // One key: at request time the enrollment holds this one and nothing else.
@@ -175,12 +183,13 @@ class EnrollmentSubmitter {
   /// The keyfile's spelling of [algorithm]. The material tokens equal the
   /// [SigningAlgoType] member names — both are the wire spelling — so a second
   /// spelling here would file material the reader skips.
-  static CryptographicMaterialAlgorithm _materialAlgorithmOf(SigningAlgoType algorithm) =>
+  static CryptographicMaterialAlgorithm _materialAlgorithmOf(
+          SigningAlgoType algorithm) =>
       switch (algorithm) {
         SigningAlgoType.mldsa65 => CryptographicMaterialAlgorithm.mlDsa65,
         SigningAlgoType.rsa2048 => CryptographicMaterialAlgorithm.rsa2048,
         _ => throw AtEnrollmentException(
-            'a self-enrollment mints rsa2048 or mldsa65; '
+            'an enrollment mints rsa2048 or mldsa65; '
             '${algorithm.name} has no keyfile material spelling here'),
       };
 
@@ -376,6 +385,25 @@ class EnrollmentSubmitter {
           privateKey: apkam.privateKey);
     }
 
+    // Filed, not merely advertised. An enrollment whose `_apsk` names a key
+    // its keyfile does not hold signs with something else, and the next
+    // start's SigningKeyMinting finds the in-use algorithm missing, mints a
+    // SECOND key and republishes — orphaning the key this record already
+    // published and unverifying whatever was signed against it.
+    //
+    // Into `atAuthKeys` rather than `constructionKeys`: this is the
+    // enrollment's own signing material, not something the metadataBuilder
+    // minted, and it is filed here because only now is there an id to file it
+    // under.
+    final signing = atEnrollmentRequest.advertisedSigningKey;
+    if (signing != null) {
+      atAuthKeys.fileSigningMaterial(
+          enrollmentId: enrollmentIdFromServer,
+          algorithm: _materialAlgorithmOf(signing.algorithm),
+          publicKey: signing.publicKey,
+          privateKey: signing.privateKey);
+    }
+
     return AtEnrollmentResponse(enrollmentIdFromServer, enrollStatus,
         atSign: atEnrollmentRequest.atSign,
         rootDomain: atEnrollmentRequest.rootDomain,
@@ -451,8 +479,7 @@ class EnrollmentSubmitter {
       //    rsa2048 would have it believe it holds a mode it does not.
       final alreadyRetrofitted = existing.keys
           .where((m) =>
-              m.role ==
-                  CryptographicMaterialRole.privateAuthentication &&
+              m.role == CryptographicMaterialRole.privateAuthentication &&
               m.status == CryptographicMaterialStatus.active &&
               m.enrollmentId != null)
           .firstOrNull;
@@ -502,9 +529,55 @@ class EnrollmentSubmitter {
       final metadata = await _buildMetadata(
           request.metadataBuilder, request.atSign, constructionKeys);
 
-      // No otp and no encryptedAPKAMSymmetricKey: the connection's APKAM
-      // authentication is the whole authority, and the keyfile already holds
-      // every secret an approver would otherwise convey.
+      // Whether this connection will have to approve its own request.
+      //
+      // A PRE-ENROLLMENT atSign authenticates with the flat
+      // `at_pkam_publickey`, so the atServer marks the connection
+      // `pkamLegacy` and leaves its enrollment id null. The self-enrolment
+      // auto-approve is gated on an APKAM-authenticated connection, so such a
+      // request lands `pending` — and it is approvable on this same
+      // connection, because the atServer grants a connection carrying no
+      // enrollment id full access. The client is therefore its own approver.
+      //
+      // ⚠️ **Read off the SESSION, not off `atLookUp.enrollmentId`, and the
+      // difference is not cosmetic.** `pending` has two causes, and only one
+      // of them may be approved here: this one, and an APKAM self-enrolment
+      // against an atServer too old to auto-approve it. The second keeps the
+      // deny-and-throw below, which is a deliberate ruling about old servers
+      // — so the discriminator has to be which identity is being retrofitted,
+      // which is what the session states, rather than a connection field a
+      // caller may not have set.
+      final selfApproves = request.session.enrollmentId == null;
+
+      // No otp: the connection's own authentication is the whole authority.
+      //
+      // An APKAM-authenticated retrofit also sends no
+      // `encryptedAPKAMSymmetricKey` — the keyfile already holds every secret
+      // an approver would otherwise convey. A self-approving one must send
+      // one, because `enroll:approve` requires the encryption private key and
+      // the self-encryption key wrapped under a symmetric key, and there has
+      // to be a symmetric key for that. It is wrapped to the atSign's own
+      // encryption public key, exactly as an ordinary legacy-mode request
+      // wraps it, so the record keeps a copy the atSign's own encryption
+      // private key can recover — nothing here is stranded by being minted in
+      // a process that then forgets it.
+      String? encryptedAPKAMSymmetricKey;
+      if (selfApproves) {
+        final encryptionPublicKey = existing.defaultEncryptionPublicKey;
+        if (encryptionPublicKey == null) {
+          throw AtEnrollmentException(
+              'a self-approving enrollment wraps its symmetric key to the '
+              'atSign\'s encryption public key, and this keyfile carries '
+              'none');
+        }
+        final symmetric =
+            AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256);
+        encryptedAPKAMSymmetricKey = base64Encode((RsaEncryptionAlgo()
+              ..atPublicKey =
+                  AtPublicKey.fromString(encryptionPublicKey.toString()))
+            .encrypt(utf8.encode(symmetric.key)));
+      }
+
       final enrollVerbBuilder = EnrollVerbBuilder()
         ..appName = request.appName
         ..deviceName = request.deviceName
@@ -512,6 +585,7 @@ class EnrollmentSubmitter {
         ..signingAlgo = request.signingAlgo.name
         ..namespaces = request.namespaces
         ..apkamKeysExpiryDuration = request.apkamKeysExpiryDuration
+        ..encryptedAPKAMSymmetricKey = encryptedAPKAMSymmetricKey
         ..metadata = metadata;
       // The retrofitted enrollment publishes the key it just minted, not the
       // one the keyfile arrived with: `_apsk` is per enrollment, and this is a
@@ -532,7 +606,28 @@ class EnrollmentSubmitter {
           await _executeEnrollCommand(enrollVerbBuilder, atLookUp, auth: true);
       final enrollJson = jsonDecode(serverResponse);
       final String newEnrollmentId = enrollJson[AtConstants.enrollmentId];
-      final enrollStatus = getEnrollStatusFromString(enrollJson['status']);
+      var enrollStatus = getEnrollStatusFromString(enrollJson['status']);
+
+      if (enrollStatus == EnrollmentStatus.pending && selfApproves) {
+        // The ordinary approver, on its ordinary path: it unwraps the
+        // symmetric key sent above with this connection's encryption private
+        // key, then wraps the encryption private key and the self-encryption
+        // key under it. Nothing about this approval is special-cased — what
+        // is unusual is only that the approver and the enrollee are one
+        // process.
+        _logger.info('Enrollment $newEnrollmentId is pending on a connection '
+            'holding no enrollment id, so this client approves its own '
+            'request');
+        enrollStatus = (await _approver.approve(
+                EnrollmentRequestDecision.approved(
+                    enrollmentId: newEnrollmentId,
+                    apkamSymmetricKey:
+                        AtBytes.fromString(encryptedAPKAMSymmetricKey!),
+                    atSign: request.atSign),
+                atLookUp))
+            .enrollStatus;
+      }
+
       if (enrollStatus != EnrollmentStatus.approved) {
         // Deny the record this call just created, before giving up on it.
         //

--- a/packages/at_auth/lib/src/enroll/models/enrollment_update_request.dart
+++ b/packages/at_auth/lib/src/enroll/models/enrollment_update_request.dart
@@ -76,8 +76,8 @@ class EnrollmentUpdateRequest {
   /// A key that has stopped signing is listed with
   /// `KeyEntryStatus.retired` rather than dropped: envelopes are stored durably
   /// and verified later, so the keys an enrollment has retired are exactly the
-  /// ones that signed its older ones, and withdrawing one retroactively
-  /// unverifies everything it signed.
+  /// ones that signed its older ones, and withdrawing one from the
+  /// advertisement retroactively unverifies everything it signed.
   final List<ApskSigningKey>? signingKeys;
 
   /// The **bare** RSA `_apsk` string to publish verbatim, for an enrollment

--- a/packages/at_auth/lib/src/keys/at_keys.dart
+++ b/packages/at_auth/lib/src/keys/at_keys.dart
@@ -175,7 +175,8 @@ class AtKeys {
       _enrollments[enrollmentId]?.materialsByKeyId[keyId]?[type];
 
   /// Looks up one of the atSign's own materials by `(keyId, role)`.
-  CryptographicMaterial? getAtSignKey(String keyId, CryptographicMaterialRole type) =>
+  CryptographicMaterial? getAtSignKey(
+          String keyId, CryptographicMaterialRole type) =>
       _atSignMaterialsByKeyId[keyId]?[type];
 
   /// Every material of [enrollmentId] sharing [keyId] — e.g. the
@@ -287,7 +288,8 @@ class AtKeys {
   /// cannot drift from what the file actually holds. An id whose suffix is
   /// not a number is ignored rather than rejected: a keyfile written by a
   /// build that spells generations differently must still be readable.
-  int nextAuthenticationGeneration(String enrollmentId, CryptographicMaterialAlgorithm algorithm) =>
+  int nextAuthenticationGeneration(
+          String enrollmentId, CryptographicMaterialAlgorithm algorithm) =>
       _nextGeneration(
           _enrollments[enrollmentId]?.materialsByKeyId.keys ?? const [],
           keyIdPrefix('auth', algorithm));
@@ -326,7 +328,8 @@ class AtKeys {
 
   /// The generation [fileSigningMaterial] will use next for [enrollmentId]'s
   /// [algorithm] — one past the highest already filed, or 1.
-  int nextSigningGeneration(String enrollmentId, CryptographicMaterialAlgorithm algorithm) =>
+  int nextSigningGeneration(
+          String enrollmentId, CryptographicMaterialAlgorithm algorithm) =>
       _nextGeneration(
           _enrollments[enrollmentId]?.materialsByKeyId.keys ?? const [],
           keyIdPrefix('sign', algorithm));
@@ -338,9 +341,10 @@ class AtKeys {
   /// place and keeps its generation forever, so the next mint lands beside it
   /// rather than over it; `addKey` refuses a duplicate keyId, which is what
   /// makes that safe rather than merely tidy.
-  int nextAtSignGeneration(String role, CryptographicMaterialAlgorithm algorithm) =>
+  int nextAtSignGeneration(
+          String role, CryptographicMaterialAlgorithm algorithm) =>
       _nextGeneration(
-      _atSignMaterialsByKeyId.keys, keyIdPrefix(role, algorithm));
+          _atSignMaterialsByKeyId.keys, keyIdPrefix(role, algorithm));
 
   /// The keyId prefix a [role]/[algorithm] pair is filed under —
   /// `<role>:<algorithm>:`, completed by a generation number.
@@ -482,17 +486,24 @@ class AtKeys {
   /// `retired`; now that its `status` is an open token the entry can carry the
   /// keyfile's own word for it, so nothing is guessed — and skipping is not the
   /// cautious option it looks like. The advertisement is rewritten whole on
-  /// every publish, so an omitted entry is a **withdrawal**: it erases both the
-  /// key that verifies what it signed and whatever its owner last said about
-  /// it.
+  /// every publish, so an omitted entry is a **withdrawal from the
+  /// advertisement**: it erases both the key that verifies what it signed
+  /// and whatever its owner last said about it.
   ///
   /// Same keyId shape and same unknown-algorithm skip as [signingKeysFor]; an
   /// enrollment's other `privateSigning` material is not a signing key of its
   /// own and is not advertised as one.
-  List<({SigningAlgoType algorithm, String publicKey, CryptographicMaterialStatus status})>
-      withdrawnSigningKeysFor(String enrollmentId) {
-    final withdrawn =
-        <({SigningAlgoType algorithm, String publicKey, CryptographicMaterialStatus status})>[];
+  List<
+      ({
+        SigningAlgoType algorithm,
+        String publicKey,
+        CryptographicMaterialStatus status
+      })> withdrawnSigningKeysFor(String enrollmentId) {
+    final withdrawn = <({
+      SigningAlgoType algorithm,
+      String publicKey,
+      CryptographicMaterialStatus status
+    })>[];
     for (final keyId in _enrollments[enrollmentId]?.materialsByKeyId.keys ??
         const <String>[]) {
       if (!isRoleKeyId(keyId, 'sign')) continue;
@@ -537,15 +548,16 @@ class AtKeys {
   /// Retires the keypair rather than removing it, and **both halves**. The
   /// public half is what [withdrawnSigningKeysFor] reads back so the
   /// enrollment can go on advertising it as `retired`, which is what keeps
-  /// envelopes signed before the withdrawal verifiable; the private half stays
-  /// because nothing in this file is ever deleted.
+  /// envelopes signed before the withdrawal from service verifiable; the
+  /// private half stays because nothing in this file is ever deleted.
   ///
   /// Selects exactly what [signingKeysFor] would have returned for
   /// [algorithm]: the `sign:<algo>:<n>` shape, not the `privateSigning` role,
   /// which an enrollment can hold material for under more than one keyId.
-  /// Withdrawing a signing key must not withdraw anything else that happens to
-  /// sign.
-  List<String> retireSigningKeys(String enrollmentId, CryptographicMaterialAlgorithm algorithm,
+  /// Withdrawing a signing key from service must not withdraw anything else
+  /// that happens to sign.
+  List<String> retireSigningKeys(
+      String enrollmentId, CryptographicMaterialAlgorithm algorithm,
       {CryptographicMaterialStatus to = CryptographicMaterialStatus.retired}) {
     final Map<String, Map<String, CryptographicMaterial>> byKeyId =
         _enrollments[enrollmentId]?.materialsByKeyId ?? const {};
@@ -597,13 +609,16 @@ class AtKeys {
   /// retired → dead): a same-status call is a no-op and a backward transition
   /// throws, as does an unknown [keyId] or `to: CryptographicMaterialStatus.active`.
   void retireKey(String enrollmentId, String keyId,
-          {CryptographicMaterialStatus to = CryptographicMaterialStatus.retired}) =>
+          {CryptographicMaterialStatus to =
+              CryptographicMaterialStatus.retired}) =>
       _retire(_enrollments[enrollmentId]?.materialsByKeyId, keyId, to,
           'enrollment "$enrollmentId"');
 
   /// [retireKey] for the atSign's own material — the signing root, an nskey
   /// private.
-  void retireAtSignKey(String keyId, {CryptographicMaterialStatus to = CryptographicMaterialStatus.retired}) =>
+  void retireAtSignKey(String keyId,
+          {CryptographicMaterialStatus to =
+              CryptographicMaterialStatus.retired}) =>
       _retire(_atSignMaterialsByKeyId, keyId, to, 'the atSign');
 
   void _retire(Map<String, Map<String, CryptographicMaterial>>? container,
@@ -966,8 +981,7 @@ class AtKeys {
     return materials.every((material) {
       final counterpart = material.enrollmentId == null
           ? other.getAtSignKey(material.keyId, material.role)
-          : other.getKey(
-              material.enrollmentId!, material.keyId, material.role);
+          : other.getKey(material.enrollmentId!, material.keyId, material.role);
       return counterpart == material;
     });
   }
@@ -1151,8 +1165,7 @@ class AtKeys {
   CryptographicMaterial? _activeAuthenticationMaterial(String enrollmentId) =>
       keysForEnrollment(enrollmentId)
           .where((m) =>
-              m.role ==
-                  CryptographicMaterialRole.privateAuthentication &&
+              m.role == CryptographicMaterialRole.privateAuthentication &&
               m.status == CryptographicMaterialStatus.active)
           .firstOrNull;
 

--- a/packages/at_auth/lib/src/keys/io/at_keys_io.dart
+++ b/packages/at_auth/lib/src/keys/io/at_keys_io.dart
@@ -72,6 +72,13 @@ abstract class WrittenAtKeysIo extends AtKeysIo with KeyIOMixin {
   /// how a caller that finds the material already there — re-delivery is the
   /// substrate's normal mode — avoids rewriting the store to say nothing.
   /// Throwing from it abandons the write too.
+  ///
+  /// **This never creates.** It is a read-modify-write of material that must
+  /// already be there, and [read] throws when it is not — so an implementation
+  /// that can observe its backing going away between the read and the write
+  /// must refuse rather than write it back. For a keyfile that matters beyond
+  /// tidiness: the file is the credential, deleting it is how a device is
+  /// decommissioned, and putting it back defeats the delete.
   Future<void> update(
       Atsign atsign, FutureOr<bool> Function(AtKeys keys) mutate) async {
     final keys = await read(atsign.toString());

--- a/packages/at_auth/lib/src/keys/io/file_io.dart
+++ b/packages/at_auth/lib/src/keys/io/file_io.dart
@@ -80,17 +80,33 @@ class FileAtKeysIo extends WrittenAtKeysIo {
     await AtKeysFileLock(file.path).synchronized(() async {
       final keys = await read(atsign.toString());
       if (await mutate(keys) == false) return;
-      await _writeValidated(file, atsign, keys);
+      await _writeValidated(file, atsign, keys, requireExisting: true);
     });
   }
 
   /// The flush body, without the lock — so [update] can hold the lock across
   /// its own read as well. `AtKeysFileLock` is not reentrant: calling [flush]
   /// from inside [update] would wait on a lock this call already holds.
-  Future<void> _writeValidated(File file, Atsign atsign, AtKeys atKeys) async {
+  /// [requireExisting] refuses instead of creating when the keyfile is gone.
+  /// [update] passes it and [flush] does not: `flush` means "persist these
+  /// keys", and creating the file is its first job, while `update` is a
+  /// read-modify-write of material that must already be there — its own
+  /// [read] throws when the file is absent at the start, so completing by
+  /// writing a file that is absent at the end contradicts the call it began.
+  ///
+  /// What that silently undid: the keyfile is the credential, and deleting it
+  /// is how a device is decommissioned. An update in flight when the owner
+  /// deletes it would put it back, and nothing said so.
+  Future<void> _writeValidated(File file, Atsign atsign, AtKeys atKeys,
+      {bool requireExisting = false}) async {
     final document = await _encodeAtRest(atKeys, atsign);
 
     if (!file.existsSync()) {
+      if (requireExisting) {
+        throw AtKeysSourceAbsentException(
+            'Tried updating ${file.path}, but it was deleted while the update '
+            'was in flight; nothing was written');
+      }
       await _writeAtRestDocument(file, document);
       return;
     }

--- a/packages/at_auth/lib/src/keys/serialization/assurance.dart
+++ b/packages/at_auth/lib/src/keys/serialization/assurance.dart
@@ -244,14 +244,12 @@ class AtKeysAssurance {
     required CryptographicMaterial candidate,
   }) {
     if (candidate.status != CryptographicMaterialStatus.active ||
-        candidate.role !=
-            CryptographicMaterialRole.privateAuthentication) {
+        candidate.role != CryptographicMaterialRole.privateAuthentication) {
       return;
     }
     for (final material in existing) {
       if (material.status != CryptographicMaterialStatus.active ||
-          material.role !=
-              CryptographicMaterialRole.privateAuthentication) {
+          material.role != CryptographicMaterialRole.privateAuthentication) {
         continue;
       }
       // Whatever the owner, and whatever the algorithm. The same enrollment

--- a/packages/at_auth/lib/src/keys/serialization/atkey_material.dart
+++ b/packages/at_auth/lib/src/keys/serialization/atkey_material.dart
@@ -32,25 +32,34 @@ extension type const CryptographicMaterialAlgorithm._(String value)
   /// String vocabularies beside it; it is not a membership check, and
   /// making it one would break the round-trip promise above.
   const CryptographicMaterialAlgorithm.of(String value) : this._(value);
-  static const CryptographicMaterialAlgorithm aes256 = CryptographicMaterialAlgorithm._('aes256');
-  static const CryptographicMaterialAlgorithm rsa2048 = CryptographicMaterialAlgorithm._('rsa2048');
-  static const CryptographicMaterialAlgorithm eccSecp256r1 = CryptographicMaterialAlgorithm._('ecc_secp256r1');
-  static const CryptographicMaterialAlgorithm ed25519 = CryptographicMaterialAlgorithm._('ed25519');
-  static const CryptographicMaterialAlgorithm x25519 = CryptographicMaterialAlgorithm._('x25519');
-  static const CryptographicMaterialAlgorithm mlKem768 = CryptographicMaterialAlgorithm._('mlkem768');
-  static const CryptographicMaterialAlgorithm mlDsa65 = CryptographicMaterialAlgorithm._('mldsa65');
+  static const CryptographicMaterialAlgorithm aes256 =
+      CryptographicMaterialAlgorithm._('aes256');
+  static const CryptographicMaterialAlgorithm rsa2048 =
+      CryptographicMaterialAlgorithm._('rsa2048');
+  static const CryptographicMaterialAlgorithm eccSecp256r1 =
+      CryptographicMaterialAlgorithm._('ecc_secp256r1');
+  static const CryptographicMaterialAlgorithm ed25519 =
+      CryptographicMaterialAlgorithm._('ed25519');
+  static const CryptographicMaterialAlgorithm x25519 =
+      CryptographicMaterialAlgorithm._('x25519');
+  static const CryptographicMaterialAlgorithm mlKem768 =
+      CryptographicMaterialAlgorithm._('mlkem768');
+  static const CryptographicMaterialAlgorithm mlDsa65 =
+      CryptographicMaterialAlgorithm._('mldsa65');
 
   /// X-Wing hybrid KEM (ML-KEM-768 + X25519) — one of the two KEMs an APKAM
   /// key package or nskey keypair may use. The atSign-level `pq_signing_root`
   /// is not on this list: it is ML-DSA-65, a signing key with nothing to
   /// encapsulate to.
-  static const CryptographicMaterialAlgorithm xWing = CryptographicMaterialAlgorithm._('xwing');
+  static const CryptographicMaterialAlgorithm xWing =
+      CryptographicMaterialAlgorithm._('xwing');
 
   /// Pure ML-KEM-1024 (FIPS 203) — the other, for deployments that need key
   /// establishment with no non-FIPS component and no hybrid combiner. Which of
   /// the two an atSign uses is its own configuration; a holder's key package
   /// and nskey advertisement say which they hold.
-  static const CryptographicMaterialAlgorithm mlKem1024 = CryptographicMaterialAlgorithm._('mlkem1024');
+  static const CryptographicMaterialAlgorithm mlKem1024 =
+      CryptographicMaterialAlgorithm._('mlkem1024');
 
   /// The tokens this version knows about. For warn-level tooling only —
   /// never reject a value for not being in this set.
@@ -88,16 +97,26 @@ extension type const CryptographicMaterialRole._(String value)
   /// Takes any token, for the same reason as
   /// [CryptographicMaterialAlgorithm.of].
   const CryptographicMaterialRole.of(String value) : this._(value);
-  static const CryptographicMaterialRole symmetricEncryption = CryptographicMaterialRole._('symmetricEncryption');
-  static const CryptographicMaterialRole symmetricAuthentication = CryptographicMaterialRole._('symmetricAuthentication');
-  static const CryptographicMaterialRole publicEncryption = CryptographicMaterialRole._('publicEncryption');
-  static const CryptographicMaterialRole privateDecryption = CryptographicMaterialRole._('privateDecryption');
-  static const CryptographicMaterialRole publicVerification = CryptographicMaterialRole._('publicVerification');
-  static const CryptographicMaterialRole privateSigning = CryptographicMaterialRole._('privateSigning');
-  static const CryptographicMaterialRole publicEncapsulation = CryptographicMaterialRole._('publicEncapsulation');
-  static const CryptographicMaterialRole privateDecapsulation = CryptographicMaterialRole._('privateDecapsulation');
-  static const CryptographicMaterialRole publicKeyAgreement = CryptographicMaterialRole._('publicKeyAgreement');
-  static const CryptographicMaterialRole privateKeyAgreement = CryptographicMaterialRole._('privateKeyAgreement');
+  static const CryptographicMaterialRole symmetricEncryption =
+      CryptographicMaterialRole._('symmetricEncryption');
+  static const CryptographicMaterialRole symmetricAuthentication =
+      CryptographicMaterialRole._('symmetricAuthentication');
+  static const CryptographicMaterialRole publicEncryption =
+      CryptographicMaterialRole._('publicEncryption');
+  static const CryptographicMaterialRole privateDecryption =
+      CryptographicMaterialRole._('privateDecryption');
+  static const CryptographicMaterialRole publicVerification =
+      CryptographicMaterialRole._('publicVerification');
+  static const CryptographicMaterialRole privateSigning =
+      CryptographicMaterialRole._('privateSigning');
+  static const CryptographicMaterialRole publicEncapsulation =
+      CryptographicMaterialRole._('publicEncapsulation');
+  static const CryptographicMaterialRole privateDecapsulation =
+      CryptographicMaterialRole._('privateDecapsulation');
+  static const CryptographicMaterialRole publicKeyAgreement =
+      CryptographicMaterialRole._('publicKeyAgreement');
+  static const CryptographicMaterialRole privateKeyAgreement =
+      CryptographicMaterialRole._('privateKeyAgreement');
 
   /// The APKAM keypair an enrollment **authenticates** with, and nothing
   /// else — the key PKAM proves possession of.
@@ -111,8 +130,10 @@ extension type const CryptographicMaterialRole._(String value)
   /// An enrollment holds at most one ACTIVE pair of these; several active
   /// signing keys are normal, because signature agility means holding one per
   /// algorithm.
-  static const CryptographicMaterialRole privateAuthentication = CryptographicMaterialRole._('privateAuthentication');
-  static const CryptographicMaterialRole publicAuthentication = CryptographicMaterialRole._('publicAuthentication');
+  static const CryptographicMaterialRole privateAuthentication =
+      CryptographicMaterialRole._('privateAuthentication');
+  static const CryptographicMaterialRole publicAuthentication =
+      CryptographicMaterialRole._('publicAuthentication');
 
   /// The tokens this version knows about. For warn-level tooling only —
   /// never reject a value for not being in this set.
@@ -174,11 +195,7 @@ extension type const CryptographicMaterialStatus._(String value)
 
   /// The tokens this version knows about. For warn-level tooling only —
   /// never reject a value for not being in this set.
-  static const Set<CryptographicMaterialStatus> known = {
-    active,
-    retired,
-    dead
-  };
+  static const Set<CryptographicMaterialStatus> known = {active, retired, dead};
 
   /// Where [status] sits in the forward order, or null when this build has
   /// never heard of it.
@@ -194,8 +211,7 @@ extension type const CryptographicMaterialStatus._(String value)
   /// after `retired`, so callers refuse a transition involving one rather
   /// than guessing a direction. Guessing "newest is furthest forward" would
   /// let a future value silently reactivate a key its owner withdrew.
-  static int? rankOf(CryptographicMaterialStatus status) =>
-      switch (status) {
+  static int? rankOf(CryptographicMaterialStatus status) => switch (status) {
         active => 0,
         retired => 1,
         dead => 2,
@@ -406,8 +422,7 @@ List<Map<String, dynamic>> encodeAtKeysDocument(
         throw AtKeysValidationException(
             'Material for keyId "${material.keyId}" does not match the enrollmentId of its group');
       }
-      if (group
-          .any((existing) => existing.role == material.role)) {
+      if (group.any((existing) => existing.role == material.role)) {
         throw AtKeysValidationException(
             'Duplicate role "${material.role}" for keyId "${material.keyId}"');
       }

--- a/packages/at_auth/test/assurance_test.dart
+++ b/packages/at_auth/test/assurance_test.dart
@@ -216,7 +216,9 @@ void main() {
     test('accepts map update when a key status moves forward', () {
       final existing = _documentMap(keys: [_symmetricMaterial()]);
       final candidate = _documentMap(
-        keys: [_symmetricMaterial().withStatus(CryptographicMaterialStatus.retired)],
+        keys: [
+          _symmetricMaterial().withStatus(CryptographicMaterialStatus.retired)
+        ],
       );
 
       assurance.validateMapUpdate(existing: existing, candidate: candidate);
@@ -224,10 +226,14 @@ void main() {
 
     test('rejects map update when a key status moves backward', () {
       final existing = _documentMap(
-        keys: [_symmetricMaterial().withStatus(CryptographicMaterialStatus.dead)],
+        keys: [
+          _symmetricMaterial().withStatus(CryptographicMaterialStatus.dead)
+        ],
       );
       final candidate = _documentMap(
-        keys: [_symmetricMaterial().withStatus(CryptographicMaterialStatus.retired)],
+        keys: [
+          _symmetricMaterial().withStatus(CryptographicMaterialStatus.retired)
+        ],
       );
 
       expect(

--- a/packages/at_auth/test/at_auth_test.dart
+++ b/packages/at_auth/test/at_auth_test.dart
@@ -4,7 +4,9 @@ import 'dart:io';
 import 'package:at_auth/src/at_auth_impl.dart';
 import 'package:at_auth/src/auth/models/at_auth_requests.dart';
 import 'package:at_auth/src/auth/pkam_authenticator.dart';
+import 'package:at_auth/src/auth/models/at_auth_session.dart';
 import 'package:at_auth/src/enroll/at_enrollment.dart';
+import 'package:at_auth/src/enroll/at_enrollment_impl.dart';
 import 'package:at_auth/src/enroll/models/at_enrollment_request.dart';
 import 'package:at_auth/src/enroll/models/at_enrollment_response.dart';
 import 'package:at_auth/src/exception/at_auth_exceptions.dart';
@@ -136,6 +138,119 @@ void main() {
       expect(atKeys.enrollmentId, testEnrollmentId,
           reason: 'and the stored field is what a no-id request falls back '
               'to, per AtAuthImpl.authenticate');
+    });
+
+    // UC-G1.1's second clause names a **retrofitted** file specifically, and
+    // that word is the whole assertion. The sibling above uses a legacy-only
+    // fixture, where the resolver answers null — so "authentication used the
+    // flat field" and "the resolver had nothing to offer" are
+    // indistinguishable there. Neither of its two assertions calls
+    // `authenticate` at all; both are about the document.
+    //
+    // A retrofitted document is the one shape where both answers are real and
+    // they DIFFER: the flat field still names the legacy enrollment, because
+    // that enrollment goes on authenticating until the atServer's cap retires
+    // it, while the only active typed privateAuthentication belongs to the new
+    // one.
+    //
+    // The default and the explicit argument are SEPARATE tests on purpose. As
+    // two assertions in one body the second never runs once the first fails,
+    // so a mutation could not show the control staying green — which is the
+    // only thing that says the control is not entangled with the property
+    // under test.
+    Future<InMemoryAtKeysIo> retrofittedKeyfile() async {
+      final keysIo = InMemoryAtKeysIo();
+      await keysIo.write(
+          '@alice',
+          AtKeys()
+            ..apkamPublicKey = AtBytes.fromString(base64Encode(
+                utf8.encode('legacy-rsa-public')))
+            ..apkamPrivateKey = AtBytes.fromString(base64Encode(
+                utf8.encode('legacy-rsa-private')))
+            ..defaultEncryptionPublicKey = AtBytes.fromString(
+                base64Encode(utf8.encode('enc-public')))
+            ..defaultEncryptionPrivateKey = AtBytes.fromString(
+                base64Encode(utf8.encode('enc-private')))
+            ..defaultSelfEncryptionKey =
+                AtBytes.fromString(base64Encode(utf8.encode('self-key')))
+            ..enrollmentId = 'legacy-1');
+
+      // Retrofit it for real rather than hand-building the end state: a
+      // hand-assembled document is a claim about what a retrofit produces,
+      // and this test is about what `authenticate` does with the real thing.
+      final approving = MockAtLookUp();
+      when(() => approving.executeCommand(any(that: startsWith('enroll:')),
+              auth: any(named: 'auth')))
+          .thenAnswer((_) async =>
+              'data:{"enrollmentId":"new-123","status":"approved"}');
+      await AtEnrollmentImpl().submit(
+          AtSelfEnrollmentRequest(
+              session: AtAuthSession(
+                  atSign: '@alice',
+                  rootDomain: AtRootDomain.atsignDomain,
+                  atKeysIo: keysIo,
+                  enrollmentId: 'legacy-1'),
+              appName: 'selfapp',
+              deviceName: 'selfdevice',
+              namespaces: {'app_1': 'rw'}),
+          approving);
+
+      // THE PREMISE, not an assertion of either test. If these ever agree,
+      // both tests below pass for a reason that has nothing to do with which
+      // source `authenticate` read.
+      final retrofitted = await keysIo.read('@alice'.toAtsign());
+      // ignore: deprecated_member_use_from_same_package
+      expect(retrofitted.enrollmentId, 'legacy-1');
+      expect(retrofitted.resolveAuthenticatingEnrollment(), 'new-123',
+          reason: 'the two sources must give different, non-null answers or '
+              'this fixture discriminates nothing');
+      return keysIo;
+    }
+
+    /// The enrollment id that reached `PkamAuthenticator.authenticate` — what
+    /// actually signs the PKAM challenge, rather than what the document says.
+    Future<String?> idReachingPkam(InMemoryAtKeysIo keysIo,
+        {String? supplied}) async {
+      final authenticator = MockPkamAuthenticator();
+      when(() => authenticator.authenticate(any(), any(),
+              enrollmentId: any(named: 'enrollmentId')))
+          .thenAnswer((_) async => true);
+      final auth = AtAuthImpl(
+          atLookUp: MockAtLookUp(),
+          pkamAuthenticator: authenticator,
+          atEnrollment: mockAtEnrollment,
+          atServerStatus: mockAtServerStatus)
+        ..secondaryAddressFinder = fakeSecondaryAddressFinder
+        ..probeSocket = ((host, port) async {});
+      final request = AtAuthRequest('@alice', atKeysIo: keysIo);
+      if (supplied != null) request.enrollmentId = supplied;
+      await auth.authenticate(request);
+      return verify(() => authenticator.authenticate(any(), any(),
+              enrollmentId: captureAny(named: 'enrollmentId')))
+          .captured
+          .single as String?;
+    }
+
+    test(
+        'on a RETROFITTED keyfile a no-id request authenticates as the LEGACY '
+        'enrollment, not the resolver\'s answer', () async {
+      expect(await idReachingPkam(await retrofittedKeyfile()), 'legacy-1',
+          reason: 'a request carrying no enrollment id must authenticate as '
+              'the FLAT stored enrollment. The resolver names new-123 here '
+              'and is deliberately not consulted — signing the PKAM challenge '
+              'as the enrollment that merely holds the active typed material '
+              'would authenticate as somebody else');
+    });
+
+    test('and an explicitly supplied enrollment id is used as given', () async {
+      // The control for the test above, and separate from it so a mutation can
+      // show this one staying green. It can: an explicit id never reaches the
+      // `??=` that the default is about, so this says the assertion above is
+      // about the DEFAULT specifically rather than about `authenticate`
+      // ignoring its argument.
+      expect(
+          await idReachingPkam(await retrofittedKeyfile(), supplied: 'new-123'),
+          'new-123');
     });
 
     test(
@@ -431,8 +546,8 @@ void main() {
       when(() => mockAtLookUp.close()).thenAnswer((_) async => {});
       when(() => mockPkamAuthenticator.authenticate(any(), any(),
           enrollmentId: 'abc123')).thenAnswer((_) => Future.value(true));
-      when(() => mockAtEnrollment.submit(any(), mockAtLookUp)).thenAnswer(
-          (_) => Future.value(
+      when(() => mockAtEnrollment.submit(any(), mockAtLookUp)).thenAnswer((_) =>
+          Future.value(
               AtEnrollmentResponse('abc123', EnrollmentStatus.approved)));
 
       final atOnboardingRequest = AtOnboardingRequest('@alice🛠')

--- a/packages/at_auth/test/at_keys_file_lock_test.dart
+++ b/packages/at_auth/test/at_keys_file_lock_test.dart
@@ -155,12 +155,13 @@ void main() {
     final started = DateTime.now();
     await expectLater(
         lock.synchronized(() async => 1).timeout(const Duration(seconds: 4)),
-        throwsA(isA<FileSystemException>().having((e) => e.message, 'message',
-            contains('The last failure was'))),
+        throwsA(isA<FileSystemException>().having(
+            (e) => e.message, 'message', contains('The last failure was'))),
         reason: 'the wait must be bounded even when the failure is not '
             'contention, and the timeout must name the real cause rather '
             'than blaming a process that holds nothing');
-    expect(DateTime.now().difference(started), lessThan(const Duration(seconds: 3)),
+    expect(DateTime.now().difference(started),
+        lessThan(const Duration(seconds: 3)),
         reason: 'it must give up at its own deadline, not spin');
   });
 

--- a/packages/at_auth/test/at_keys_test.dart
+++ b/packages/at_auth/test/at_keys_test.dart
@@ -516,8 +516,7 @@ void main() {
       expect(atKeys.keysForEnrollment('unknown'), isEmpty);
     });
 
-    test('unknown role/algorithm tokens round-trip unmodified',
-        () {
+    test('unknown role/algorithm tokens round-trip unmodified', () {
       // role and algorithm are open Strings: a reader must
       // hold and re-emit tokens it does not recognise, so a keyfile written
       // by a newer client survives a read-modify-flush by an older one.
@@ -535,8 +534,8 @@ void main() {
 
       final reparsed = AtKeys.fromJson(atKeys.toJson());
       expect(
-        reparsed.getAtSignKey(
-            'from-the-future', CryptographicMaterialRole.of('somethingNotInventedYet')),
+        reparsed.getAtSignKey('from-the-future',
+            CryptographicMaterialRole.of('somethingNotInventedYet')),
         futuristic,
       );
       expect(reparsed, atKeys);
@@ -588,7 +587,8 @@ void main() {
 
       final retired = atKeys.atSignKeysForKeyId('pair').toList();
       expect(retired, hasLength(2));
-      expect(retired.map((m) => m.status), everyElement(CryptographicMaterialStatus.retired));
+      expect(retired.map((m) => m.status),
+          everyElement(CryptographicMaterialStatus.retired));
       expect(
         atKeys
             .getAtSignKey('pair', CryptographicMaterialRole.publicEncryption)!
@@ -616,8 +616,8 @@ void main() {
       atKeys.retireAtSignKey('solo');
       atKeys.retireAtSignKey('solo', to: CryptographicMaterialStatus.dead);
 
-      expect(
-          atKeys.atSignKeysForKeyId('solo').single.status, CryptographicMaterialStatus.dead);
+      expect(atKeys.atSignKeysForKeyId('solo').single.status,
+          CryptographicMaterialStatus.dead);
     });
 
     test('throws on a backward transition', () {
@@ -628,8 +628,8 @@ void main() {
         () => atKeys.retireAtSignKey('solo'),
         throwsA(isA<ArgumentError>()),
       );
-      expect(
-          atKeys.atSignKeysForKeyId('solo').single.status, CryptographicMaterialStatus.dead);
+      expect(atKeys.atSignKeysForKeyId('solo').single.status,
+          CryptographicMaterialStatus.dead);
     });
 
     test('throws for an unknown keyId', () {
@@ -645,7 +645,8 @@ void main() {
       final atKeys = AtKeys(keysList: [symmetricKey('solo')]);
 
       expect(
-        () => atKeys.retireAtSignKey('solo', to: CryptographicMaterialStatus.active),
+        () => atKeys.retireAtSignKey('solo',
+            to: CryptographicMaterialStatus.active),
         throwsA(isA<ArgumentError>()),
       );
     });
@@ -728,8 +729,7 @@ void main() {
           target.keysForKeyId('the-new-enrollment', 'kem:xwing').single;
       expect(adopted.enrollmentId, 'the-new-enrollment');
       expect(adopted.keyId, 'kem:xwing');
-      expect(
-          adopted.role, CryptographicMaterialRole.symmetricEncryption);
+      expect(adopted.role, CryptographicMaterialRole.symmetricEncryption);
       expect(adopted.algorithm, CryptographicMaterialAlgorithm.aes256);
       expect(adopted.bytes.toString(), 'c2VjcmV0');
       // The builder's own timestamp, not the adoption's.
@@ -811,7 +811,8 @@ void main() {
     CryptographicMaterial authKey(String keyId,
             {required String enrollmentId,
             String value = 'YXV0aA==',
-            CryptographicMaterialStatus status = CryptographicMaterialStatus.active}) =>
+            CryptographicMaterialStatus status =
+                CryptographicMaterialStatus.active}) =>
         CryptographicMaterial(
             keyId: keyId,
             enrollmentId: enrollmentId,
@@ -844,6 +845,36 @@ void main() {
               .status,
           CryptographicMaterialStatus.retired);
       expect(atKeys.resolveAuthenticatingEnrollment(), 'E1');
+    });
+
+    test('a retired key does not free its keyId for reuse', () {
+      // The invariants are status-AWARE about the slot — that is what the
+      // test above establishes — and status-BLIND about the id. Retiring is
+      // what lets a replacement exist; it is not what lets it take the old
+      // name. Without this, "retirement frees the slot" reads as though it
+      // freed the identifier too.
+      final atKeys = AtKeys(
+          atsign: '@alice'.toAtsign(),
+          keysList: [authKey('auth:rsa2048:1', enrollmentId: 'E1')]);
+
+      atKeys.retireKey('E1', 'auth:rsa2048:1');
+
+      expect(() => atKeys.addKey(authKey('auth:rsa2048:1', enrollmentId: 'E1')),
+          throwsArgumentError,
+          reason: 'a replacement re-using the retired keyId must still be '
+              'refused: identity is (enrollment, keyId), so a document '
+              'holding two materials under one has no way to say which a '
+              'reader means');
+
+      // The control, without which the refusal above could be about the
+      // retire rather than the id: the same add under a NEW id is accepted.
+      atKeys.addKey(authKey('auth:rsa2048:2', enrollmentId: 'E1'));
+      expect(
+          atKeys
+              .getKey('E1', 'auth:rsa2048:2',
+                  CryptographicMaterialRole.privateAuthentication)!
+              .status,
+          CryptographicMaterialStatus.active);
     });
 
     test('only one enrollment may hold an active authentication key', () {
@@ -920,9 +951,11 @@ void main() {
     // shape, which are only comparable if they are given the same material.
     String b64(String label) => base64Encode(utf8.encode(label));
 
-    CryptographicMaterial part(
-            String keyId, CryptographicMaterialRole type, CryptographicMaterialAlgorithm algo, String value,
-            {String? enrollmentId, CryptographicMaterialStatus status = CryptographicMaterialStatus.active}) =>
+    CryptographicMaterial part(String keyId, CryptographicMaterialRole type,
+            CryptographicMaterialAlgorithm algo, String value,
+            {String? enrollmentId,
+            CryptographicMaterialStatus status =
+                CryptographicMaterialStatus.active}) =>
         CryptographicMaterial(
             keyId: keyId,
             enrollmentId: enrollmentId,
@@ -933,10 +966,12 @@ void main() {
             status: status);
 
     /// A complete signing keypair for [enrollmentId], both halves.
-    List<CryptographicMaterial> signingPair(String enrollmentId, CryptographicMaterialAlgorithm algo,
+    List<CryptographicMaterial> signingPair(
+            String enrollmentId, CryptographicMaterialAlgorithm algo,
             {int generation = 1,
             String value = 'a',
-            CryptographicMaterialStatus status = CryptographicMaterialStatus.active}) =>
+            CryptographicMaterialStatus status =
+                CryptographicMaterialStatus.active}) =>
         [
           part('sign:$algo:$generation',
               CryptographicMaterialRole.privateSigning, algo, '$value-priv',
@@ -1012,7 +1047,8 @@ void main() {
           ...signingPair('E1', CryptographicMaterialAlgorithm.ed25519,
               value: 'old', status: CryptographicMaterialStatus.retired),
           // What a newer client's keyfile looks like from here.
-          ...signingPair('E1', CryptographicMaterialAlgorithm.of('pq-something-later'),
+          ...signingPair(
+              'E1', CryptographicMaterialAlgorithm.of('pq-something-later'),
               value: 'future'),
           ...signingPair('E1', CryptographicMaterialAlgorithm.mlDsa65,
               value: 'live'),
@@ -1189,8 +1225,7 @@ void main() {
         // keyfile's word travels out unchanged.
         final atKeys = AtKeys(atsign: '@alice'.toAtsign(), keysList: [
           ...signingPair('E1', CryptographicMaterialAlgorithm.rsa2048,
-              value: 'rsa',
-              status: CryptographicMaterialStatus.of('revoked')),
+              value: 'rsa', status: CryptographicMaterialStatus.of('revoked')),
           ...signingPair('E1', CryptographicMaterialAlgorithm.mlDsa65,
               value: 'mldsa'),
         ]);

--- a/packages/at_auth/test/at_keys_update_test.dart
+++ b/packages/at_auth/test/at_keys_update_test.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:at_auth/src/exception/at_auth_exceptions.dart';
 import 'package:at_auth/src/keys/at_keys.dart';
 import 'package:at_auth/src/keys/io/file_io.dart';
 import 'package:at_auth/src/keys/io/memory_io.dart';
@@ -199,6 +200,52 @@ void main() {
         throwsA(isA<FileSystemException>()),
       );
     }, timeout: Timeout(Duration(seconds: 40)));
+
+    test('refuses a keyfile deleted while the update was in flight', () async {
+      final io = FileAtKeysIo(filePath: pathFor);
+      final file = File(pathFor(atSign));
+      expect(file.existsSync(), isTrue,
+          reason: 'control: setUp wrote the keyfile this update reads');
+
+      // The owner deletes the keyfile between the read and the write. That is
+      // not contrived: a client files key material from an unawaited startup
+      // tail, and deleting `.atKeys` is how a device is decommissioned, so the
+      // two land on the same isolate with awaits between them.
+      await expectLater(
+        io.update(atSign.toAtsign(), (keys) {
+          file.deleteSync();
+          expect(file.existsSync(), isFalse,
+              reason: 'control: the delete took effect inside the mutate, so '
+                  'the assertion below is about what update did next');
+          keys.addKey(keyNamed('filed-during-the-delete'));
+          return true;
+        }),
+        throwsA(isA<AtKeysSourceAbsentException>()),
+      );
+
+      expect(file.existsSync(), isFalse,
+          reason: 'update must not resurrect a keyfile its owner deleted: the '
+              'file IS the credential, so putting it back defeats the delete. '
+              'It used to be recreated here, silently');
+    });
+
+    test('flush still creates the keyfile, which is what update must not do',
+        () async {
+      // The distinguishing arm. Both go through the same writer, and only
+      // update refuses — so a change that made the writer refuse outright
+      // would break this and not the test above.
+      final io = FileAtKeysIo(filePath: pathFor);
+      final file = File(pathFor(atSign));
+      final keys = await io.read(atSign);
+      file.deleteSync();
+      expect(file.existsSync(), isFalse, reason: 'control: gone before flush');
+
+      await io.flush(atSign.toAtsign(), keys);
+
+      expect(file.existsSync(), isTrue,
+          reason: 'flush means "persist these keys" and creating the file is '
+              'its first job — a fresh keyfile has to come from somewhere');
+    });
   });
 
   group('the default update', () {

--- a/packages/at_auth/test/at_self_enrollment_test.dart
+++ b/packages/at_auth/test/at_self_enrollment_test.dart
@@ -121,6 +121,18 @@ void main() {
     expect(after.apkamPublicKey.toString(), legacyApkamPub);
     expect(after.apkamPrivateKey.toString(), legacyApkamPriv);
     expect(after.defaultSelfEncryptionKey.toString(), selfKey);
+
+    // The two answers the document now gives, and they differ on purpose.
+    // The flat field says legacy-1 because that enrollment goes on
+    // authenticating; the resolver says new-123 because the typed material is
+    // the only ACTIVE privateAuthentication. Asserting only the first would
+    // leave the document's own account of which enrollment is live untested.
+    expect(after.resolveAuthenticatingEnrollment(), 'new-123',
+        reason: 'the retrofit leaves exactly one active privateAuthentication '
+            'and it belongs to the new enrollment, so the resolver has one '
+            'candidate and names it. A retrofit that left the legacy material '
+            'active as well would make this ambiguous and the resolver would '
+            'refuse rather than answer');
   });
 
   group('the retrofit signing-algo selector', () {
@@ -460,6 +472,166 @@ void main() {
           reason: 'advertise-without-file leaves the next start finding the '
               'in-use algorithm missing, minting a SECOND key and '
               'republishing — orphaning the key this record already named');
+    });
+  });
+  /// A PRE-ENROLLMENT atSign — one that holds no enrollment at all and
+  /// authenticates with the flat `at_pkam_publickey`.
+  ///
+  /// The atServer marks such a connection `pkamLegacy` and leaves its
+  /// enrollment id null, and its self-enrolment auto-approve is gated on an
+  /// APKAM-authenticated connection — so the request lands `pending` instead.
+  /// Measured against a live atServer, which then accepted an `enroll:approve`
+  /// for that id **on the same connection**, because it grants a connection
+  /// carrying no enrollment id full access.
+  ///
+  /// ⚠️ **`pending` has a second cause, and it must keep its old answer.** An
+  /// APKAM self-enrolment against an atServer too old to auto-approve it also
+  /// comes back `pending`, and that one is denied and thrown. The two arms
+  /// below differ in the session's enrollment id and in NOTHING else — same
+  /// keyfile shape, same request, same server responses.
+  group('a client holding no enrollment approves its own request', () {
+    late final AtEncryptionKeyPair encryptionKeyPair;
+    late final String selfEncryptionKey;
+
+    setUpAll(() {
+      // A real keypair: the submitter wraps the symmetric key to the public
+      // half and the approver unwraps it with the private half, so a stub
+      // would leave the round trip untested.
+      encryptionKeyPair = AtChopsUtil.generateAtEncryptionKeyPair();
+      selfEncryptionKey =
+          AtChopsUtil.generateSymmetricKey(EncryptionKeyType.aes256).key;
+    });
+
+    AtKeys keysFor({String? enrollmentId}) => AtKeys()
+      ..apkamPublicKey = AtBytes.fromString(legacyApkamPub)
+      ..apkamPrivateKey = AtBytes.fromString(legacyApkamPriv)
+      ..defaultEncryptionPublicKey =
+          AtBytes.fromString(encryptionKeyPair.atPublicKey.publicKey)
+      ..defaultEncryptionPrivateKey =
+          AtBytes.fromString(encryptionKeyPair.atPrivateKey.privateKey)
+      ..defaultSelfEncryptionKey = AtBytes.fromString(selfEncryptionKey)
+      ..enrollmentId = enrollmentId;
+
+    /// A lookup that parks every `enroll:request` as `pending` — which is what
+    /// BOTH arms meet — and approves or denies whatever is asked of it after.
+    MockAtLookUp parkingLookUp() {
+      final mock = MockAtLookUp();
+      when(() => mock.atChops).thenReturn(AtChopsImpl(
+          AtChopsKeys.create(encryptionKeyPair, null)
+            ..selfEncryptionKey = AESKey(selfEncryptionKey)));
+      when(() => mock.executeCommand(any(that: startsWith('enroll:request:')),
+              auth: any(named: 'auth')))
+          .thenAnswer((_) async =>
+              'data:{"enrollmentId":"new-123","status":"pending"}');
+      when(() => mock.executeCommand(any(that: startsWith('enroll:approve:')),
+              auth: any(named: 'auth')))
+          .thenAnswer((_) async =>
+              'data:{"enrollmentId":"new-123","status":"approved"}');
+      // executeVerb is deliberately NOT stubbed: `deny` goes through it, and
+      // the submitter's cleanup is best-effort and reports what happened, so
+      // an unstubbed deny still leaves the control arm asserting the message
+      // it cares about.
+      return mock;
+    }
+
+    Future<(MockAtLookUp, AtAuthSession)> fixture({String? enrollmentId}) async {
+      final keysIo = InMemoryAtKeysIo();
+      await keysIo.write(atSign, keysFor(enrollmentId: enrollmentId));
+      return (
+        parkingLookUp(),
+        AtAuthSession(
+            atSign: atSign,
+            rootDomain: AtRootDomain.atsignDomain,
+            atKeysIo: keysIo,
+            enrollmentId: enrollmentId)
+      );
+    }
+
+    List<String> commandsSent(MockAtLookUp mock) => verify(() =>
+            mock.executeCommand(captureAny(), auth: any(named: 'auth')))
+        .captured
+        .cast<String>();
+
+    test('it approves the enrollment it just created, over the same connection',
+        () async {
+      final (mock, session) = await fixture();
+
+      final response = await AtEnrollmentImpl().submit(
+          AtSelfEnrollmentRequest(
+              session: session,
+              appName: 'firstApp',
+              deviceName: 'firstDevice-abc',
+              namespaces: {'*': 'rw', '__manage': 'rw'}),
+          mock);
+
+      expect(response.enrollStatus, EnrollmentStatus.approved,
+          reason: 'the atServer parked it pending because the auto-approve '
+              'branch needs an APKAM connection; approving it over the same '
+              'connection is what makes the retrofit land');
+      final sent = commandsSent(mock);
+      expect(sent, hasLength(2));
+      expect(sent[0], startsWith('enroll:request:'));
+      expect(sent[1], startsWith('enroll:approve:'));
+      expect(jsonDecode(sent[1].substring('enroll:approve:'.length)),
+          containsPair('enrollmentId', 'new-123'));
+    });
+
+    test('the request carries a wrapped symmetric key, because approving needs '
+        'one', () async {
+      final (mock, session) = await fixture();
+
+      await AtEnrollmentImpl().submit(
+          AtSelfEnrollmentRequest(
+              session: session,
+              appName: 'firstApp',
+              deviceName: 'firstDevice-abc',
+              namespaces: {'*': 'rw'}),
+          mock);
+
+      final params = jsonDecode(
+              commandsSent(mock)[0].substring('enroll:request:'.length))
+          as Map<String, dynamic>;
+      final wrapped = params['encryptedAPKAMSymmetricKey'] as String?;
+      expect(wrapped, isNotNull,
+          reason: 'enroll:approve requires the encryption private key and the '
+              'self-encryption key wrapped under a symmetric key, so there '
+              'has to be one — and an APKAM retrofit, which conveys nothing, '
+              'sends none');
+      // Wrapped to the atSign's OWN encryption public key, so the record keeps
+      // a copy this atSign can still recover. The approve leg unwrapping it
+      // successfully is what proves the wrap: a wrong key throws there.
+      expect(
+          utf8.decode((RsaEncryptionAlgo()
+                ..atPrivateKey = AtPrivateKey.fromString(
+                    encryptionKeyPair.atPrivateKey.privateKey))
+              .decrypt(base64Decode(wrapped!))),
+          isNotEmpty);
+    });
+
+    /// The control, and it can go red while every assertion above stays green:
+    /// same `pending` response, same keyfile shape, only the session's
+    /// enrollment id differs.
+    test('an APKAM retrofit meeting the same pending response is still denied',
+        () async {
+      final (mock, session) = await fixture(enrollmentId: 'legacy-1');
+
+      await expectLater(
+          AtEnrollmentImpl().submit(
+              AtSelfEnrollmentRequest(
+                  session: session,
+                  appName: 'selfapp',
+                  deviceName: 'selfdevice',
+                  namespaces: {'app_1': 'rw'}),
+              mock),
+          throwsA(isA<AtEnrollmentException>().having((e) => e.message,
+              'message', contains('expected the self-enrollment to be '
+                  'auto-approved'))),
+          reason: 'a pending APKAM self-enrolment means an atServer without '
+              'the auto-approve, which is a different situation and keeps its '
+              'own answer');
+      expect(commandsSent(mock).where((c) => c.startsWith('enroll:approve:')),
+          isEmpty,
+          reason: 'approving here would silently paper over an old atServer');
     });
   });
 }

--- a/packages/at_auth/test/enrollment_test.dart
+++ b/packages/at_auth/test/enrollment_test.dart
@@ -43,7 +43,8 @@ void main() {
       return mock;
     }
 
-    test('a key package the builder mints is the ENROLLMENT\'s, not the atSign\'s',
+    test(
+        'a key package the builder mints is the ENROLLMENT\'s, not the atSign\'s',
         () async {
       // The builder runs before the request, so it files what it mints with no
       // enrollment id — the atServer has not named one yet. The two sibling
@@ -86,6 +87,88 @@ void main() {
           isNull,
           reason: 'a key package belongs to the enrollment that advertised it, '
               'not to the atSign');
+    });
+  });
+
+  group('an OTP enrolment that owns a signing key from birth', () {
+    const atSign = '@alice🛠';
+    const enrollmentId = 'otp-enrollment-1';
+
+    // Distinct from any real key, and compared RAW: the property under test is
+    // which bytes reached the keyfile, not that something plausible did.
+    const signingPub = 'bWludGVkLXNpZ25pbmctcHVibGlj';
+    const signingPriv = 'bWludGVkLXNpZ25pbmctcHJpdmF0ZQ==';
+
+    MockAtLookUp approvingLookUp() {
+      final mock = MockAtLookUp();
+      when(() => mock.executeCommand(any(that: startsWith('enroll:')),
+              auth: any(named: 'auth')))
+          .thenAnswer((_) async =>
+              'data:{"enrollmentId":"$enrollmentId","status":"pending"}');
+      when(() => mock.executeVerb(any(), sync: any(named: 'sync')))
+          .thenAnswer((_) async => 'data:${encryptionPublicKeyMap[atSign]}');
+      return mock;
+    }
+
+    Future<AtKeys> submit(
+        ({
+          SigningAlgoType algorithm,
+          String publicKey,
+          String privateKey
+        })? advertised) async {
+      final response = await AtEnrollmentImpl().submit(
+          AtEnrollmentRequest(
+              atSign: atSign,
+              appName: 'wavi',
+              deviceName: 'iphone',
+              otp: 'ABC123',
+              namespaces: {'wavi': 'rw'},
+              signingAlgo: SigningAlgoType.rsa2048,
+              advertisedSigningKey: advertised),
+          approvingLookUp());
+      return response.atAuthKeys!;
+    }
+
+    test('the signing key is FILED, not merely advertised', () async {
+      final keys = await submit((
+        algorithm: SigningAlgoType.rsa2048,
+        publicKey: signingPub,
+        privateKey: signingPriv
+      ));
+
+      final held = keys.signingKeysFor(enrollmentId);
+      expect(held, hasLength(1));
+      expect(held.single.algorithm, SigningAlgoType.rsa2048);
+      expect(held.single.publicKey, signingPub);
+      expect(held.single.privateKey, signingPriv,
+          reason: 'advertise-without-file leaves the next start finding the '
+              'in-use algorithm missing, minting a SECOND key and '
+              'republishing — orphaning the key this record already named');
+    });
+
+    test('and it is the ENROLLMENT\'s, not the atSign\'s', () async {
+      final keys = await submit((
+        algorithm: SigningAlgoType.rsa2048,
+        publicKey: signingPub,
+        privateKey: signingPriv
+      ));
+
+      // The other half of the same claim: material in the atSign's container
+      // is not returned by keysForEnrollment and is not reaped when the
+      // enrollment is retired.
+      expect(keys.keysForEnrollment(enrollmentId).map((m) => m.keyId),
+          contains('sign:rsa2048:1'));
+    });
+
+    test('without one, nothing is filed', () async {
+      // The negative control, and it is every caller in the tree today: no
+      // AtEnrollmentRequest sets advertisedSigningKey, so this path must be
+      // byte-for-byte what it was.
+      final keys = await submit(null);
+
+      expect(keys.signingKeysFor(enrollmentId), isEmpty,
+          reason: 'an enrollment that advertised no signing key holds none; '
+              'filing one anyway would publish a key nothing asked for');
     });
   });
 
@@ -558,6 +641,77 @@ void main() {
           reason: 'there would be no public half for the approver to '
               'encapsulate the symmetric key to, so the enrollment could '
               'never obtain one');
+    });
+
+    /// The wire FORM of `_apsk`, which two composers decide and must decide
+    /// the same way.
+    ///
+    /// at_auth writes this record at enrolment; `apskValueOf` in at_client
+    /// composes the same record at every start and republishes on any
+    /// difference. A form the client would not have chosen is therefore
+    /// rewritten on the enrolment's first start — and that republish discards
+    /// the chain link the approver conveyed against the old value, leaving the
+    /// enrollment silently unsigned. So the rule here is the client's rule:
+    /// exactly one active rsa2048 key is spelled bare, everything else as the
+    /// array.
+    group('the form follows the algorithm alone', () {
+      Future<Map<String, dynamic>> paramsFor(
+          {required SigningAlgoType signingAlgo,
+          ({
+            SigningAlgoType algorithm,
+            String publicKey,
+            String privateKey
+          })? advertised}) async {
+        final (mockAtLookUp, sent) = mockLookUpRecordingEnrollCommands();
+        await AtEnrollmentImpl().submit(
+            AtEnrollmentRequest.pq(
+              session: freshSession(),
+              appName: 'wavi',
+              deviceName: 'pixel',
+              namespaces: {'wavi': 'rw'},
+              otp: 'A123FE',
+              signingAlgo: signingAlgo,
+              advertisedSigningKey: advertised,
+              metadataBuilder: (_) async => {
+                    'keyPackage': {'v': 1, 'keys': []}
+                  },
+              apkamSymmetricKeyResolver: _unusedResolver,
+            ),
+            mockAtLookUp);
+        return jsonDecode(sent.single.substring(sent.single.indexOf('{')))
+            as Map<String, dynamic>;
+      }
+
+      test('an rsa2048 APKAM key with a key package is spelled BARE',
+          () async {
+        // The case a key package used to force into the array. It is
+        // reachable: a legacy posture names an empty signing set, so nothing
+        // is advertised, while `--key-exchange pq` still carries a package.
+        final params = await paramsFor(signingAlgo: SigningAlgoType.rsa2048);
+
+        expect(params['apskLegacy'], params['apkamPublicKey'],
+            reason: 'the bare value IS the key, and the key here is the APKAM '
+                'one because the enrollment advertises no signing key of its '
+                'own');
+        expect(params['apsk'], isNull,
+            reason: 'never both - they would disagree about one record');
+        expect(params['apskLegacy'], isNot(startsWith('{')),
+            reason: 'stated the other way round, so this cannot pass on a '
+                'serialization that merely contains the key');
+      });
+
+      test('an mldsa65 APKAM key with a key package is spelled as the ARRAY',
+          () async {
+        // The control, and the discriminator: without it the assertion above
+        // is satisfied by a writer that can only ever emit the bare form. Only
+        // the algorithm moves between the two.
+        final params = await paramsFor(signingAlgo: SigningAlgoType.mldsa65);
+
+        expect(params['apskLegacy'], isNull);
+        expect((params['apsk']['keys'] as List).single['alg'], 'mldsa65',
+            reason: 'a bare value says rsa2048 by convention and cannot state '
+                'any other algorithm, so nothing could read this key from it');
+      });
     });
   });
 

--- a/packages/at_auth/test/enrollment_update_test.dart
+++ b/packages/at_auth/test/enrollment_update_test.dart
@@ -215,6 +215,55 @@ void main() {
           isTrue);
     });
 
+    test('nothing this API can compose names namespaces or an approval state',
+        () async {
+      final l = lookUp();
+
+      // Every field EnrollmentUpdateRequest has, set at once — not the
+      // one-field request each arm above sends. A namespaces entry can only
+      // reach the wire if some field puts it there, so the request that names
+      // everything is the one that would show it.
+      //
+      // Asserted over the emitted command rather than by reading the class,
+      // and over the PRODUCTION composer rather than a hand-built
+      // EnrollVerbBuilder: that builder does carry a `namespaces` field — it
+      // is what enroll:request uses — so building one here and observing it
+      // empty says only that this test did not set it.
+      await AtEnrollmentImpl().update(
+          EnrollmentUpdateRequest(
+            enrollmentId: enrollmentId,
+            apkamPublicKey: pkamPublicKeyMap[atSign]!,
+            apkamPrivateKey: pkamPrivateKeyMap[atSign]!,
+            signingAlgo: SigningAlgoType.rsa2048,
+            signingKeys: [
+              ApskSigningKey.forPublicKey(
+                  alg: SigningAlgoType.mldsa65, pub: 'AAEC'),
+            ],
+            metadata: {'keyPackage': 'kp'},
+          ),
+          l.lookUp);
+
+      // The set, not two named absences. `namespaces` has a spelling to look
+      // for; an approval state does not — `EnrollParams` carries none, so a
+      // check for 'status' or 'approval' is a tautology that no change to
+      // this package could ever redden. Equality goes red for any key that
+      // appears, whatever it ends up called, and its being a closed set is
+      // simultaneously the positive control: a request that emitted nothing
+      // fails it too.
+      expect(paramsOf(l.commands.single).keys.toSet(), {
+        'enrollmentId',
+        'apkamPublicKey',
+        'signingAlgo',
+        'apkamPublicKeySignature',
+        'apsk',
+        'metadata',
+      },
+          reason: 'an enrollment cannot widen its own grant or approve '
+              'itself, and the atServer refusing it is the second line rather '
+              'than the first: there is no field here to carry either. The '
+              'six above are everything this API can put on the wire');
+    });
+
     test('the private half never reaches the wire', () async {
       final l = lookUp();
       final privateKey = pkamPrivateKeyMap[atSign]!;

--- a/packages/at_auth/test/file_retrofit_serializer_test.dart
+++ b/packages/at_auth/test/file_retrofit_serializer_test.dart
@@ -44,7 +44,8 @@ void main() {
     // The control. Without it, the test above would pass just as well against
     // a serialiser that always locks, or one that locks nothing and happens to
     // schedule sequentially - this proves the file case is doing the work.
-    final trace = await interleavingOf(fileRetrofitSerializer, InMemoryAtKeysIo());
+    final trace =
+        await interleavingOf(fileRetrofitSerializer, InMemoryAtKeysIo());
 
     expect(trace.length, 4);
     expect(trace.sublist(0, 2), ['in0', 'in1'],

--- a/packages/at_auth/test/first_enrollment_test.dart
+++ b/packages/at_auth/test/first_enrollment_test.dart
@@ -179,9 +179,9 @@ void main() {
               mock),
           throwsA(isA<StateError>()));
 
-      verifyNever(
-          () => mock.executeCommand(any(that: startsWith('enroll:request')),
-              auth: any(named: 'auth')));
+      verifyNever(() => mock.executeCommand(
+          any(that: startsWith('enroll:request')),
+          auth: any(named: 'auth')));
     });
 
     test('a builder that throws on a LATER enrollment still degrades',
@@ -193,8 +193,8 @@ void main() {
       final mock = approvingLookUp();
       // The later-enrollment path also reads the atSign's encryption public
       // key, which the first-enrollment path does not.
-      when(() => mock.executeVerb(any(), sync: any(named: 'sync')))
-          .thenAnswer((_) async => 'data:${demo.encryptionPublicKeyMap['@alice🛠']}');
+      when(() => mock.executeVerb(any(), sync: any(named: 'sync'))).thenAnswer(
+          (_) async => 'data:${demo.encryptionPublicKeyMap['@alice🛠']}');
 
       final response = await AtEnrollmentImpl().submit(
           AtEnrollmentRequest(

--- a/packages/at_auth/test/passphrase_envelope_test.dart
+++ b/packages/at_auth/test/passphrase_envelope_test.dart
@@ -172,8 +172,9 @@ void main() {
           reason: 'owaspMinimum raises the costs, not the key length - if it '
               'ever varies hashLength this control stops being one');
 
-      final envelope = jsonDecode(
-          await codec.encode(doc, 'right', hashParams: standard)) as Map;
+      final envelope =
+          jsonDecode(await codec.encode(doc, 'right', hashParams: standard))
+              as Map;
 
       expect(
         await codec.decode(envelope.cast<String, dynamic>(),

--- a/packages/at_auth/test/plural_enrollments_test.dart
+++ b/packages/at_auth/test/plural_enrollments_test.dart
@@ -49,7 +49,8 @@ void main() {
         ],
       };
 
-  CryptographicMaterial authMaterial(String enrollmentId, CryptographicMaterialAlgorithm algorithm) =>
+  CryptographicMaterial authMaterial(
+          String enrollmentId, CryptographicMaterialAlgorithm algorithm) =>
       CryptographicMaterial(
         keyId: 'auth:$algorithm:1',
         enrollmentId: enrollmentId,

--- a/packages/at_auth/test/pq_native_onboard_test.dart
+++ b/packages/at_auth/test/pq_native_onboard_test.dart
@@ -95,12 +95,19 @@ void main() {
   tearDown(() => tempDir.deleteSync(recursive: true));
 
   AtOnboardingRequest requestFor(
-          {SigningAlgoType? signingAlgo, bool? mintLegacyMaterial}) =>
+          {SigningAlgoType? signingAlgo,
+          bool? mintLegacyMaterial,
+          ({
+            SigningAlgoType algorithm,
+            String publicKey,
+            String privateKey
+          })? advertisedSigningKey}) =>
       AtOnboardingRequest(atSign)
         ..atKeysIo = keysIo
         ..appName = 'wavi'
         ..deviceName = 'iphone'
         ..mintLegacyMaterial = mintLegacyMaterial
+        ..advertisedSigningKey = advertisedSigningKey
         ..signingAlgoType = signingAlgo ?? SigningAlgoType.rsa2048;
 
   /// The request the onboard actually submitted.
@@ -181,6 +188,67 @@ void main() {
               'out of the box — decisions 37');
       expect(published.single.value.toString(),
           keys.defaultEncryptionPublicKey!.toString());
+    });
+  });
+
+  /// UC-G3.1's third door.
+  ///
+  /// Three paths create an enrollment holding a data signing keypair, and
+  /// at_auth files the private half at three separate points. Two were pinned
+  /// — `enrollment_test.dart` and `at_self_enrollment_test.dart` each carry
+  /// "the signing key is FILED, not merely advertised". This one, the
+  /// activation, was driven by no test in any pack until 2026-08-31.
+  ///
+  /// ⚠️ **`packages/at_client/test/pq_native_onboard_test.dart` looks like
+  /// coverage and is not**: it asserts the activation REQUEST carries the key,
+  /// which is a claim about the request object. What reaches the keyfile is
+  /// whatever at_auth copies out of it after the atServer answers, and that is
+  /// a different statement — an enrollment whose `_apsk` names a key its
+  /// keyfile does not hold signs with something else entirely, and the next
+  /// start finds the in-use algorithm missing, mints a SECOND keypair and
+  /// republishes, orphaning the key the record already named.
+  group('the activation files the signing key it advertises', () {
+    ({SigningAlgoType algorithm, String publicKey, String privateKey})
+        advertised(SigningAlgoType algorithm) => (
+              algorithm: algorithm,
+              publicKey: base64Encode(utf8.encode('advertised-public')),
+              privateKey: base64Encode(utf8.encode('advertised-private')),
+            );
+
+    test('the PRIVATE half reaches the keyfile, under the enrollment id',
+        () async {
+      final key = advertised(SigningAlgoType.rsa2048);
+      await atAuth.onboard(
+          requestFor(
+              signingAlgo: SigningAlgoType.mldsa65, advertisedSigningKey: key),
+          cramSecret);
+
+      final held = (await keysIo.read(atSign)).signingKeysFor(enrollmentId);
+      expect(held, hasLength(1),
+          reason: 'filed, and filed where the reader looks. `enrollmentId` is '
+              'the id the mocked atServer RETURNED and appears nowhere in the '
+              'request, so a non-empty answer here is also what proves the '
+              'filing used the assigned id rather than anything the caller '
+              'supplied — and that it went into the enrollment\'s container '
+              'rather than the atSign\'s, which `signingKeysFor` never reads');
+      expect(held.single.privateKey, key.privateKey,
+          reason: 'the PRIVATE half is the whole point — a public half alone '
+              'is an advertisement of a key this atSign cannot sign with');
+      expect(held.single.publicKey, key.publicKey);
+      expect(held.single.algorithm, SigningAlgoType.rsa2048,
+          reason: 'the algorithm travels with the key rather than following '
+              'the APKAM\'s, which is mldsa65 here — an activation at pqReady '
+              'authenticates post-quantum and signs data with rsa2048, and '
+              'the two are read back separately');
+    });
+
+    test('without one, nothing is filed', () async {
+      await atAuth.onboard(requestFor(), cramSecret);
+
+      expect((await keysIo.read(atSign)).signingKeysFor(enrollmentId), isEmpty,
+          reason: 'the control. Without it the two rows above are satisfied '
+              'by a path that files something unconditionally, and nothing '
+              'would attribute the filing to the advertised key');
     });
   });
 

--- a/packages/at_auth/test/test_utils/at_keys.dart
+++ b/packages/at_auth/test/test_utils/at_keys.dart
@@ -26,7 +26,8 @@ final _defaultCreatedAt = DateTime.utc(2024, 1, 1);
 CryptographicMaterial symmetricKey(
   String keyId, {
   String value = 'c2VjcmV0',
-  CryptographicMaterialAlgorithm algorithm = CryptographicMaterialAlgorithm.aes256,
+  CryptographicMaterialAlgorithm algorithm =
+      CryptographicMaterialAlgorithm.aes256,
   List<String> operations = const [],
   String? enrollmentId,
   DateTime? createdAt,

--- a/packages/at_auth/test/unknown_status_tolerance_test.dart
+++ b/packages/at_auth/test/unknown_status_tolerance_test.dart
@@ -29,8 +29,7 @@ void main() {
                 'keyId': 'k1',
                 'material': [
                   {
-                    'role':
-                        CryptographicMaterialRole.privateAuthentication,
+                    'role': CryptographicMaterialRole.privateAuthentication,
                     'algorithm': CryptographicMaterialAlgorithm.rsa2048,
                     'createdAt': '2026-08-14T00:00:00.000Z',
                     'status': status,
@@ -112,13 +111,15 @@ void main() {
 
       // The contrast arm: a known status moves, so the refusal above is about
       // the unknown token rather than retireKey being broken outright.
-      final known = AtKeys.fromJson(documentWith(CryptographicMaterialStatus.active));
+      final known =
+          AtKeys.fromJson(documentWith(CryptographicMaterialStatus.active));
       known.retireKey('e1', 'k1');
       expect(known.keys.single.status, CryptographicMaterialStatus.retired);
     });
 
     test('may not be retired TO, either', () {
-      final keys = AtKeys.fromJson(documentWith(CryptographicMaterialStatus.active));
+      final keys =
+          AtKeys.fromJson(documentWith(CryptographicMaterialStatus.active));
       expect(
           () => keys.retireKey('e1', 'k1',
               to: CryptographicMaterialStatus.of(unknown)),
@@ -133,25 +134,45 @@ void main() {
       // Declaration index used to supply this for free, which also meant
       // reordering the enum silently redefined every transition check in the
       // package. It is a contract now, so it is pinned as one.
-      expect(CryptographicMaterialStatus.rankOf(CryptographicMaterialStatus.active), 0);
-      expect(CryptographicMaterialStatus.rankOf(CryptographicMaterialStatus.retired), 1);
-      expect(CryptographicMaterialStatus.rankOf(CryptographicMaterialStatus.dead), 2);
-      expect(CryptographicMaterialStatus.rankOf(CryptographicMaterialStatus.of(unknown)), isNull);
-      expect(CryptographicMaterialStatus.rankOf(CryptographicMaterialStatus.of('')), isNull);
+      expect(
+          CryptographicMaterialStatus.rankOf(
+              CryptographicMaterialStatus.active),
+          0);
+      expect(
+          CryptographicMaterialStatus.rankOf(
+              CryptographicMaterialStatus.retired),
+          1);
+      expect(
+          CryptographicMaterialStatus.rankOf(CryptographicMaterialStatus.dead),
+          2);
+      expect(
+          CryptographicMaterialStatus.rankOf(
+              CryptographicMaterialStatus.of(unknown)),
+          isNull);
+      expect(
+          CryptographicMaterialStatus.rankOf(
+              CryptographicMaterialStatus.of('')),
+          isNull);
     });
 
     test('still refuses a backward move between known tokens', () {
       // The invariant the enum's index used to carry. If this passes while
       // the rank function is broken, the tolerance above was bought by
       // dropping the rule it was meant to preserve.
-      final keys = AtKeys.fromJson(documentWith(CryptographicMaterialStatus.dead));
-      expect(() => keys.retireKey('e1', 'k1', to: CryptographicMaterialStatus.retired),
+      final keys =
+          AtKeys.fromJson(documentWith(CryptographicMaterialStatus.dead));
+      expect(
+          () => keys.retireKey('e1', 'k1',
+              to: CryptographicMaterialStatus.retired),
           throwsA(isA<ArgumentError>()));
     });
 
     test('refuses to reactivate, as before', () {
-      final keys = AtKeys.fromJson(documentWith(CryptographicMaterialStatus.retired));
-      expect(() => keys.retireKey('e1', 'k1', to: CryptographicMaterialStatus.active),
+      final keys =
+          AtKeys.fromJson(documentWith(CryptographicMaterialStatus.retired));
+      expect(
+          () => keys.retireKey('e1', 'k1',
+              to: CryptographicMaterialStatus.active),
           throwsA(isA<ArgumentError>()));
     });
   });

--- a/packages/at_auth/test/wire_literal_pins_test.dart
+++ b/packages/at_auth/test/wire_literal_pins_test.dart
@@ -515,7 +515,9 @@ void main() {
           SigningAlgoType.ecc_secp256r1.name);
     });
 
-    test('CryptographicMaterialRole tokens and CryptographicMaterialStatus names', () {
+    test(
+        'CryptographicMaterialRole tokens and CryptographicMaterialStatus names',
+        () {
       expect(CryptographicMaterialRole.known, {
         'symmetricEncryption',
         'symmetricAuthentication',
@@ -541,10 +543,22 @@ void main() {
       // And the forward order, which stopped being declaration index when
       // status became an open String. It is a stated ranking now, so it is
       // pinned like any other contract.
-      expect(CryptographicMaterialStatus.rankOf(CryptographicMaterialStatus.of('active')), 0);
-      expect(CryptographicMaterialStatus.rankOf(CryptographicMaterialStatus.of('retired')), 1);
-      expect(CryptographicMaterialStatus.rankOf(CryptographicMaterialStatus.of('dead')), 2);
-      expect(CryptographicMaterialStatus.rankOf(CryptographicMaterialStatus.of('pending')), isNull,
+      expect(
+          CryptographicMaterialStatus.rankOf(
+              CryptographicMaterialStatus.of('active')),
+          0);
+      expect(
+          CryptographicMaterialStatus.rankOf(
+              CryptographicMaterialStatus.of('retired')),
+          1);
+      expect(
+          CryptographicMaterialStatus.rankOf(
+              CryptographicMaterialStatus.of('dead')),
+          2);
+      expect(
+          CryptographicMaterialStatus.rankOf(
+              CryptographicMaterialStatus.of('pending')),
+          isNull,
           reason: 'a token this build has never seen has no position in the '
               'forward order, and must not acquire one by accident');
     });


### PR DESCRIPTION
Note to reviewers: This PR is vs what is currently in trunk but not yet published; it's the follow-up "cleanup" PR before we publish at_auth 4.0.0-rc1

## Why

**Two composers of one record must agree on its shape.** at_auth installs an enrolment's `_apsk` advertisement; at_client composes the same record at every start and republishes on any difference. They disagreed — at_auth wrote the array form whenever a key package was present, at_client writes it bare for a single rsa2048 key — so the enrolment's first start rewrote what its approver had installed. That republish discards the chain link the approver conveyed against the old value, and the enrollment is left silently unsigned. Nothing goes red.

**An atSign that holds no enrollment must be able to enroll itself.** The atServer's self-enrolment auto-approve needs an APKAM-authenticated connection. An atSign authenticating with its flat PKAM key has none, so its request lands `pending` — and there is no second device to approve it from. This is the first-credential case, and it was a dead end.

**Deleting a keyfile must stay deleted.** The `.atKeys` file *is* the credential, and removing it is how a device is decommissioned. `FileAtKeysIo.update` recreated one deleted while the update was in flight, so a background task could silently put a decommissioned device's credential back.

**An enrolment must hold every key it advertises.** An OTP enrolment published its advertised signing key without filing the private half. The next start found the in-use algorithm missing, minted a second keypair and republished — orphaning the advertised key and unverifying everything signed against it.

---

## What

**The `_apsk` shape — spelled by algorithm alone**
- `enroll/enrollment_submitter.dart`: exactly one active `rsa2048` key rides `apskLegacy` as the bare string; anything else rides `apsk` as the array. The key package no longer forces the array.
- Why the old condition was wrong in principle: where the package's signer is `rsa2048` the bare value states exactly that algorithm, and where it is not, the algorithm had already chosen the array. It only ever fired on the case it was wrong about — and that case is reachable, because a legacy posture advertises nothing while a pq key-exchange mode still carries a package.

**Self-enrollment that can approve itself**
- `enroll/enrollment_submitter.dart`: a request from an atSign holding no enrollment mints a symmetric key, wraps it to the atSign's own encryption public key, and approves itself through the ordinary approver over the same connection — legitimate because a connection carrying no enrollment id is granted full access. The wrap is what keeps the record's copy recoverable afterwards.
- The discriminator is the **session's** enrollment id, not the connection's: `pending` also means an atServer too old to auto-approve an APKAM retrofit, and that case keeps its existing deny-and-throw.

**The keyfile contract**
- `keys/io/at_keys_io.dart`: `update` is documented as never creating — it is a read-modify-write of material that must already be there, and its own `read` throws when absent, so writing a file that is absent at the end contradicts the call that began.
- `keys/io/file_io.dart`: throws `AtKeysSourceAbsentException` instead of recreating. `flush` is unchanged and still creates, which is its job.

**Filing what is advertised**
- `enroll/enrollment_submitter.dart`: the OTP path files the private half of `AtEnrollmentRequest.advertisedSigningKey`. The self-enrolment and first-enrolment paths already did; this was the third.
- `keys/at_keys.dart`, `enroll/apsk_advertisement.dart`, `enroll/models/enrollment_update_request.dart`: dartdoc only — "withdrawal" now reads "withdrawal **from the advertisement**", which is what it always meant and is the distinction the sentence turns on.

⚠️ **Nothing here is BREAKING against a published version.** The last published at_auth is `3.3.0`; `4.0.0-rc1` is unpublished, so these entries fold under its existing heading. The `_apsk` change does alter behaviour introduced earlier in that same rc — which is why the CHANGELOG says so in as many words — but a consumer upgrading from `3.3.0` meets `4.0.0` whole, and this is not a separate break for them.

---

## How to verify it

Tests pass: **363** in at_auth, `dart analyze --fatal-warnings` clean.

Also run against **trunk's** dependents, because `dart analyze` never loads a mock and these changes touch types at_client's test doubles implement: at_client, at_client_flutter and at_onboarding_cli all analyze clean, and trunk's **full at_client unit suite passes** against this branch.

**Added — the `_apsk` shape** (`enrollment_test.dart`). These two are the review surface for the format change; the mldsa65 arm is the control that stops the rsa2048 arm passing for the wrong reason.
- `an rsa2048 APKAM key with a key package is spelled BARE`
- `an mldsa65 APKAM key with a key package is spelled as the ARRAY`

**Added — self-enrollment** (`at_self_enrollment_test.dart`)
- `it approves the enrollment it just created, over the same connection`
- `the request carries a wrapped symmetric key, because approving needs one`
- `an APKAM retrofit meeting the same pending response is still denied` — the discriminator, and the arm that would go green if the session/connection distinction were dropped

**Added — the keyfile contract** (`at_keys_update_test.dart`)
- `refuses a keyfile deleted while the update was in flight`
- `flush still creates the keyfile, which is what update must not do` — the control: without it, a change that broke both would look like a pass

**Added — filing what is advertised** (`enrollment_test.dart`, `pq_native_onboard_test.dart`)
- `the signing key is FILED, not merely advertised`
- `and it is the ENROLLMENT's, not the atSign's`
- `the PRIVATE half reaches the keyfile, under the enrollment id`
- `without one, nothing is filed` (both files)

**Added — surrounding** (`at_auth_test.dart`, `at_keys_test.dart`, `enrollment_update_test.dart`)
- `on a RETROFITTED keyfile a no-id request authenticates as the LEGACY enrollment`
- `and an explicitly supplied enrollment id is used as given`
- `a retired key does not free its keyId for reuse`
- `nothing this API can compose names namespaces or an approval state`

16 net new tests; none removed.

**Skip list — 13 of the 26 changed Dart files are FORMAT-ONLY.** Verified rather than asserted: each file's trunk and branch versions were normalised through the same formatter and compared, and these came out byte-identical.
`at_auth_impl.dart`, `auth/probe_default.dart`, `keys/serialization/assurance.dart`, `keys/serialization/atkey_material.dart`, `assurance_test.dart`, `at_keys_file_lock_test.dart`, `file_retrofit_serializer_test.dart`, `first_enrollment_test.dart`, `passphrase_envelope_test.dart`, `plural_enrollments_test.dart`, `test_utils/at_keys.dart`, `unknown_status_tolerance_test.dart`, `wire_literal_pins_test.dart`.

That includes `wire_literal_pins_test.dart`: **the at-rest pins did not move.** Nothing in this PR changes a persisted format — the `_apsk` change is about which of two already-pinned spellings is chosen, not about either spelling.

## Description for the changelog

The `_apsk` an enrolment advertises is spelled by its algorithm alone — one active rsa2048 key bare, anything else as the array — so at_auth and at_client no longer disagree about the record's shape and an enrolment's first start stops discarding the chain link its approver conveyed. A self-enrollment submitted by an atSign holding no enrollment is approved over the connection that requested it. `FileAtKeysIo.update` throws `AtKeysSourceAbsentException` rather than recreating a keyfile deleted mid-update. An OTP enrolment that advertises a signing key now files its private half.
