### PR TITLE
chore(at_chops): dart format

### DIFF
--- a/packages/at_chops/CHANGELOG.md
+++ b/packages/at_chops/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 3.6.1
 
+- chore: dart format, and a stale symbol name in one test comment
+
 - fix: an ML-DSA-65 PKAM key of the wrong length now says what is likely wrong
   with it. `PkamMlDsa65SigningAlgo.sign` reported only
   `ML-DSA-65 secret key must be 4032 bytes: N`, which names neither the

--- a/packages/at_chops/example/pq/at_pqc.dart
+++ b/packages/at_chops/example/pq/at_pqc.dart
@@ -34,8 +34,8 @@ Future<void> _mlDsa65RoundTrip() async {
   final Uint8List message = Uint8List.fromList(utf8.encode('hello pqc'));
   final Uint8List signature =
       await AtPqc.mlDsa65.signBytes(message, secretKey: kp.privateKeyBytes);
-  final bool ok =
-      await AtPqc.mlDsa65.verifyBytes(message, signature: signature, publicKey: kp.publicKeyBytes);
+  final bool ok = await AtPqc.mlDsa65
+      .verifyBytes(message, signature: signature, publicKey: kp.publicKeyBytes);
 
   print('ML-DSA-65 signature verified: $ok');
 }

--- a/packages/at_chops/example/pq/ml_dsa_65_pure_dart.dart
+++ b/packages/at_chops/example/pq/ml_dsa_65_pure_dart.dart
@@ -9,17 +9,21 @@ Future<void> main() async {
   final ({Uint8List publicKey, Uint8List secretKey}) kp =
       await algo.generateKeyPair();
 
-  print('Public key (${kp.publicKey.length} bytes): ${base64Encode(kp.publicKey)}');
-  print('Secret key (${kp.secretKey.length} bytes): ${base64Encode(kp.secretKey)}');
+  print(
+      'Public key (${kp.publicKey.length} bytes): ${base64Encode(kp.publicKey)}');
+  print(
+      'Secret key (${kp.secretKey.length} bytes): ${base64Encode(kp.secretKey)}');
 
   // Alice signs a message with her secret key.
   final Uint8List message = Uint8List.fromList(utf8.encode('hello pqc'));
-  final Uint8List signature = await algo.signBytes(message, secretKey: kp.secretKey);
+  final Uint8List signature =
+      await algo.signBytes(message, secretKey: kp.secretKey);
 
   print('Signature (${signature.length} bytes): ${base64Encode(signature)}');
 
   // Bob verifies the signature against Alice's public key.
-  final bool ok = await algo.verifyBytes(message, signature: signature, publicKey: kp.publicKey);
+  final bool ok = await algo.verifyBytes(message,
+      signature: signature, publicKey: kp.publicKey);
 
   print('Verified: $ok');
 }

--- a/packages/at_chops/example/pq/ml_kem_768_openssl_dart_ffi.dart
+++ b/packages/at_chops/example/pq/ml_kem_768_openssl_dart_ffi.dart
@@ -17,7 +17,8 @@ Future<void> main() async {
   final ({Uint8List publicKey, Uint8List secretKey}) kp =
       await algo.generateKeyPair();
 
-  print('Public key (${kp.publicKey.length} bytes): ${base64Encode(kp.publicKey)}');
+  print(
+      'Public key (${kp.publicKey.length} bytes): ${base64Encode(kp.publicKey)}');
 
   // Bob encapsulates using Alice's public key — produces a ciphertext and
   // his copy of the shared secret.

--- a/packages/at_chops/example/pq/ml_kem_768_pure_dart.dart
+++ b/packages/at_chops/example/pq/ml_kem_768_pure_dart.dart
@@ -11,8 +11,10 @@ Future<void> main() async {
   final ({Uint8List publicKey, Uint8List secretKey}) kp =
       await algo.generateKeyPair();
 
-  print('Public key (${kp.publicKey.length} bytes): ${base64Encode(kp.publicKey)}');
-  print('Secret key (${kp.secretKey.length} bytes): ${base64Encode(kp.secretKey)}');
+  print(
+      'Public key (${kp.publicKey.length} bytes): ${base64Encode(kp.publicKey)}');
+  print(
+      'Secret key (${kp.secretKey.length} bytes): ${base64Encode(kp.secretKey)}');
 
   // Bob encapsulates using Alice's public key.
   final ({Uint8List ciphertext, Uint8List sharedSecret}) bobResult =

--- a/packages/at_chops/example/pq/x25519_openssl_dart_ffi.dart
+++ b/packages/at_chops/example/pq/x25519_openssl_dart_ffi.dart
@@ -17,13 +17,17 @@ Future<void> main() async {
   final ({Uint8List publicKey, Uint8List privateKey}) kp2 =
       await algo.generateKeyPair();
 
-  final Uint8List aliceSharedSecret = await algo.dh(kp1.privateKey, kp2.publicKey);
-  final Uint8List bobSharedSecret = await algo.dh(kp2.privateKey, kp1.publicKey);
+  final Uint8List aliceSharedSecret =
+      await algo.dh(kp1.privateKey, kp2.publicKey);
+  final Uint8List bobSharedSecret =
+      await algo.dh(kp2.privateKey, kp1.publicKey);
 
   final String aliceSsString = base64Encode(aliceSharedSecret);
   final String bobSsString = base64Encode(bobSharedSecret);
 
-  print('Alice ss (${aliceSsString.length}): $aliceSsString | bytes (${aliceSharedSecret.length})');
-  print('Bob ss   (${bobSsString.length}): $bobSsString | bytes (${bobSharedSecret.length})');
+  print(
+      'Alice ss (${aliceSsString.length}): $aliceSsString | bytes (${aliceSharedSecret.length})');
+  print(
+      'Bob ss   (${bobSsString.length}): $bobSsString | bytes (${bobSharedSecret.length})');
   print('Match: ${aliceSsString == bobSsString}');
 }

--- a/packages/at_chops/example/pq/x25519_pure_dart.dart
+++ b/packages/at_chops/example/pq/x25519_pure_dart.dart
@@ -11,13 +11,17 @@ Future<void> main() async {
   final ({Uint8List publicKey, Uint8List privateKey}) kp2 =
       await algo.generateKeyPair();
 
-  final Uint8List aliceSharedSecret = await algo.dh(kp1.privateKey, kp2.publicKey);
-  final Uint8List bobSharedSecret = await algo.dh(kp2.privateKey, kp1.publicKey);
+  final Uint8List aliceSharedSecret =
+      await algo.dh(kp1.privateKey, kp2.publicKey);
+  final Uint8List bobSharedSecret =
+      await algo.dh(kp2.privateKey, kp1.publicKey);
 
   final String aliceSsString = base64Encode(aliceSharedSecret);
   final String bobSsString = base64Encode(bobSharedSecret);
 
-  print('Alice ss (${aliceSsString.length}): $aliceSsString | bytes (${aliceSharedSecret.length})');
-  print('Bob ss   (${bobSsString.length}): $bobSsString | bytes (${bobSharedSecret.length})');
+  print(
+      'Alice ss (${aliceSsString.length}): $aliceSsString | bytes (${aliceSharedSecret.length})');
+  print(
+      'Bob ss   (${bobSsString.length}): $bobSsString | bytes (${bobSharedSecret.length})');
   print('Match: ${aliceSsString == bobSsString}');
 }

--- a/packages/at_chops/lib/src/algorithm/encryption/ml_kem_768_ffi.dart
+++ b/packages/at_chops/lib/src/algorithm/encryption/ml_kem_768_ffi.dart
@@ -157,9 +157,9 @@ final class MlKem768FfiAlgo with KemSeedMixin implements AtKemAlgorithm {
   /// persistable. A caller holding this key across restarts stores the seed
   /// and calls [keyPairFromSeed] again on the next start.
   @override
-  Future<({Uint8List publicKey, Uint8List secretKey})>
-      keyPairFromValidatedSeed(Uint8List seed) =>
-          _generateKeyPairFromSeed(seed);
+  Future<({Uint8List publicKey, Uint8List secretKey})> keyPairFromValidatedSeed(
+          Uint8List seed) =>
+      _generateKeyPairFromSeed(seed);
 
   Future<({Uint8List publicKey, Uint8List secretKey})> _generateKeyPairFromSeed(
       Uint8List seed) async {

--- a/packages/at_chops/lib/src/algorithm/encryption/ml_kem_pure_dart.dart
+++ b/packages/at_chops/lib/src/algorithm/encryption/ml_kem_pure_dart.dart
@@ -16,9 +16,7 @@ import 'package:pqcrypto/pqcrypto.dart';
 /// parameter set a caller gets. The two levels are the same algorithm at
 /// different sizes, and as separate copies they had already begun to drift;
 /// this base holds the one implementation.
-abstract base class MlKemPureDart
-    with KemSeedMixin
-    implements AtKemAlgorithm {
+abstract base class MlKemPureDart with KemSeedMixin implements AtKemAlgorithm {
   final KyberLevel _level;
 
   const MlKemPureDart(this._level);
@@ -71,8 +69,9 @@ abstract base class MlKemPureDart
   }
 
   @override
-  Future<({Uint8List publicKey, Uint8List secretKey})>
-      keyPairFromValidatedSeed(Uint8List seed) => generateKeyPair(seed);
+  Future<({Uint8List publicKey, Uint8List secretKey})> keyPairFromValidatedSeed(
+          Uint8List seed) =>
+      generateKeyPair(seed);
 
   /// Generate a fresh key pair, raw public and secret key bytes.
   ///

--- a/packages/at_chops/lib/src/algorithm/encryption/pq_hpke.dart
+++ b/packages/at_chops/lib/src/algorithm/encryption/pq_hpke.dart
@@ -189,8 +189,7 @@ Future<Uint8List> pqSeal(
   // can open. Refused here for the same reason an unsupported version is
   // refused above.
   if (enc.ciphertext.length != row.suite.nEnc) {
-    throw PqSealException(
-        'version 0x${version.toRadixString(16)} is KEM '
+    throw PqSealException('version 0x${version.toRadixString(16)} is KEM '
         '0x${row.suite.kemId.toRadixString(16)}, whose encapsulation is '
         '${row.suite.nEnc} bytes; this KEM produced ${enc.ciphertext.length}');
   }

--- a/packages/at_chops/lib/src/algorithm/encryption/rfc9180_hpke.dart
+++ b/packages/at_chops/lib/src/algorithm/encryption/rfc9180_hpke.dart
@@ -63,7 +63,7 @@ class HpkeSuite {
     required this.nn,
     required this.nh,
     required this.nEnc,
-  })  :
+  }) :
         // The envelope declares the encapsulation length in two bytes, so a
         // suite whose KEM exceeds that cannot be carried in it at all. Checked
         // here rather than at seal time because every row is a const, so a new

--- a/packages/at_chops/lib/src/algorithm/encryption/x_wing_ffi.dart
+++ b/packages/at_chops/lib/src/algorithm/encryption/x_wing_ffi.dart
@@ -61,8 +61,8 @@ final class XWingFfiAlgo with KemSeedMixin implements AtKemAlgorithm {
     seed ??= newSeed();
     final _Expanded e = await _expand(seed);
     try {
-      final Uint8List publicKey = XWingCore.concatPublicKey(
-          e.mlKemKeyPair.publicKey, e.x25519Public);
+      final Uint8List publicKey =
+          XWingCore.concatPublicKey(e.mlKemKeyPair.publicKey, e.x25519Public);
       return (publicKey: publicKey, secretKey: Uint8List.fromList(seed));
     } finally {
       _mlKem.releaseKeyPair(e.mlKemKeyPair);
@@ -73,8 +73,9 @@ final class XWingFfiAlgo with KemSeedMixin implements AtKemAlgorithm {
   /// rather than an OpenSSL handle, so a key recovered through
   /// [keyPairFromSeed] does survive a restart.
   @override
-  Future<({Uint8List publicKey, Uint8List secretKey})>
-      keyPairFromValidatedSeed(Uint8List seed) => generateKeyPair(seed);
+  Future<({Uint8List publicKey, Uint8List secretKey})> keyPairFromValidatedSeed(
+          Uint8List seed) =>
+      generateKeyPair(seed);
 
   @override
   Future<({Uint8List ciphertext, Uint8List sharedSecret})> encapsulate(

--- a/packages/at_chops/lib/src/algorithm/encryption/x_wing_pure_dart.dart
+++ b/packages/at_chops/lib/src/algorithm/encryption/x_wing_pure_dart.dart
@@ -92,8 +92,9 @@ final class XWingPureDartAlgo with KemSeedMixin implements AtKemAlgorithm {
   /// through [keyPairFromSeed], because that identity does not hold for
   /// ML-KEM.
   @override
-  Future<({Uint8List publicKey, Uint8List secretKey})>
-      keyPairFromValidatedSeed(Uint8List seed) => generateKeyPair(seed);
+  Future<({Uint8List publicKey, Uint8List secretKey})> keyPairFromValidatedSeed(
+          Uint8List seed) =>
+      generateKeyPair(seed);
 
   @override
   Future<({Uint8List ciphertext, Uint8List sharedSecret})> encapsulate(
@@ -166,8 +167,8 @@ final class XWingPureDartAlgo with KemSeedMixin implements AtKemAlgorithm {
   /// components.
   Future<_Expanded> _expand(Uint8List seed) async {
     final halves = XWingCore.expandSeed(seed);
-    final (publicKey: pkM, secretKey: skM) = await MlKem768PureDartAlgo.instance
-        .generateKeyPair(halves.mlKemSeed);
+    final (publicKey: pkM, secretKey: skM) =
+        await MlKem768PureDartAlgo.instance.generateKeyPair(halves.mlKemSeed);
     final Uint8List skX = halves.x25519Secret;
     final crypto.SimpleKeyPair x25519Pair =
         await _x25519.newKeyPairFromSeed(skX);

--- a/packages/at_chops/lib/src/algorithm/signing/ml_dsa_65_ffi.dart
+++ b/packages/at_chops/lib/src/algorithm/signing/ml_dsa_65_ffi.dart
@@ -61,32 +61,37 @@ final class MlDsa65FfiAlgo implements AtSigningAlgorithm, AtSignatureAlgorithm {
         EvpPkeyCtxNewFromNameDart>('EVP_PKEY_CTX_new_from_name');
     _ctxFree = _lib.lookupFunction<EvpPkeyCtxFreeNative, EvpPkeyCtxFreeDart>(
         'EVP_PKEY_CTX_free');
-    _pkeyFree = _lib.lookupFunction<EvpPkeyFreeNative, EvpPkeyFreeDart>(
-        'EVP_PKEY_free');
-    _keygenInit = _lib.lookupFunction<EvpPkeyKeygenInitNative,
-        EvpPkeyKeygenInitDart>('EVP_PKEY_keygen_init');
+    _pkeyFree = _lib
+        .lookupFunction<EvpPkeyFreeNative, EvpPkeyFreeDart>('EVP_PKEY_free');
+    _keygenInit =
+        _lib.lookupFunction<EvpPkeyKeygenInitNative, EvpPkeyKeygenInitDart>(
+            'EVP_PKEY_keygen_init');
     _keygen = _lib.lookupFunction<EvpPkeyKeygenNative, EvpPkeyKeygenDart>(
         'EVP_PKEY_keygen');
-    _getRawPublicKey = _lib.lookupFunction<EvpPkeyGetRawKeyNative,
-        EvpPkeyGetRawKeyDart>('EVP_PKEY_get_raw_public_key');
-    _getRawPrivateKey = _lib.lookupFunction<EvpPkeyGetRawKeyNative,
-        EvpPkeyGetRawKeyDart>('EVP_PKEY_get_raw_private_key');
+    _getRawPublicKey =
+        _lib.lookupFunction<EvpPkeyGetRawKeyNative, EvpPkeyGetRawKeyDart>(
+            'EVP_PKEY_get_raw_public_key');
+    _getRawPrivateKey =
+        _lib.lookupFunction<EvpPkeyGetRawKeyNative, EvpPkeyGetRawKeyDart>(
+            'EVP_PKEY_get_raw_private_key');
     _newRawPrivateKeyEx = _lib.lookupFunction<EvpPkeyNewRawPrivateKeyExNative,
         EvpPkeyNewRawPrivateKeyExDart>('EVP_PKEY_new_raw_private_key_ex');
     _newRawPublicKeyEx = _lib.lookupFunction<EvpPkeyNewRawPublicKeyExNative,
         EvpPkeyNewRawPublicKeyExDart>('EVP_PKEY_new_raw_public_key_ex');
-    _mdCtxNew = _lib.lookupFunction<EvpMdCtxNewNative, EvpMdCtxNewDart>(
-        'EVP_MD_CTX_new');
+    _mdCtxNew = _lib
+        .lookupFunction<EvpMdCtxNewNative, EvpMdCtxNewDart>('EVP_MD_CTX_new');
     _mdCtxFree = _lib.lookupFunction<EvpMdCtxFreeNative, EvpMdCtxFreeDart>(
         'EVP_MD_CTX_free');
-    _digestSignInit = _lib.lookupFunction<EvpDigestSignInitNative,
-        EvpDigestSignInitDart>('EVP_DigestSignInit');
+    _digestSignInit =
+        _lib.lookupFunction<EvpDigestSignInitNative, EvpDigestSignInitDart>(
+            'EVP_DigestSignInit');
     _digestSign = _lib.lookupFunction<EvpDigestSignNative, EvpDigestSignDart>(
         'EVP_DigestSign');
-    _digestVerifyInit = _lib.lookupFunction<EvpDigestVerifyInitNative,
-        EvpDigestVerifyInitDart>('EVP_DigestVerifyInit');
-    _digestVerify = _lib
-        .lookupFunction<EvpDigestVerifyNative, EvpDigestVerifyDart>(
+    _digestVerifyInit =
+        _lib.lookupFunction<EvpDigestVerifyInitNative, EvpDigestVerifyInitDart>(
+            'EVP_DigestVerifyInit');
+    _digestVerify =
+        _lib.lookupFunction<EvpDigestVerifyNative, EvpDigestVerifyDart>(
             'EVP_DigestVerify');
   }
 

--- a/packages/at_chops/lib/src/key/key_type.dart
+++ b/packages/at_chops/lib/src/key/key_type.dart
@@ -1,4 +1,4 @@
-enum EncryptionKeyType { 
+enum EncryptionKeyType {
   rsa2048,
   rsa4096,
   ecc,

--- a/packages/at_chops/test/aes_gcm_encryption_algo_test.dart
+++ b/packages/at_chops/test/aes_gcm_encryption_algo_test.dart
@@ -86,7 +86,8 @@ void main() {
 
       final encrypted =
           await algo.encrypt(plain, iv: iv, aad: utf8.encode('header-A'));
-      expect(() => algo.decrypt(encrypted, iv: iv, aad: utf8.encode('header-B')),
+      expect(
+          () => algo.decrypt(encrypted, iv: iv, aad: utf8.encode('header-B')),
           throwsA(isA<AtDecryptionException>()));
     });
 

--- a/packages/at_chops/test/diagnostic_message_test.dart
+++ b/packages/at_chops/test/diagnostic_message_test.dart
@@ -17,10 +17,8 @@ void main() {
   final sharedSecret = Uint8List(32);
 
   Matcher throwsArgumentErrorNaming(String value) =>
-      throwsA(isA<ArgumentError>().having(
-          (e) => e.message.toString(),
-          'message',
-          allOf(contains(value), isNot(contains(r'${')))));
+      throwsA(isA<ArgumentError>().having((e) => e.message.toString(),
+          'message', allOf(contains(value), isNot(contains(r'${')))));
 
   test('an unknown pqSeal version is named in hex in the diagnostic', () {
     expect(() => pqSealDeriveKeyAndNonce(sharedSecret, version: 0x7f),
@@ -37,8 +35,8 @@ void main() {
         nh: 32,
         nEnc: 1120);
     expect(
-        () => labeledExtract(
-            bogusKdf, Uint8List(0), 'psk_id_hash', Uint8List(0)),
+        () =>
+            labeledExtract(bogusKdf, Uint8List(0), 'psk_id_hash', Uint8List(0)),
         throwsArgumentErrorNaming('0x9999'));
   });
 
@@ -52,8 +50,7 @@ void main() {
         nh: 32,
         nEnc: 1120);
     expect(
-        () => labeledExpand(
-            bogusKdf, Uint8List(32), 'key', Uint8List(0), 32),
+        () => labeledExpand(bogusKdf, Uint8List(32), 'key', Uint8List(0), 32),
         throwsArgumentErrorNaming('0x9999'));
   });
 }

--- a/packages/at_chops/test/kem_seed_contract_test.dart
+++ b/packages/at_chops/test/kem_seed_contract_test.dart
@@ -66,12 +66,12 @@ void main() {
     final mlKemSeed = mlKem.newSeed();
     final mlKemPair = await mlKem.keyPairFromSeed(mlKemSeed);
     expect(mlKemPair.secretKey, isNot(mlKemSeed));
-    expect(mlKemPair.secretKey,
-        hasLength(MlKem1024PureDartAlgo.secretKeyLength),
+    expect(
+        mlKemPair.secretKey, hasLength(MlKem1024PureDartAlgo.secretKeyLength),
         reason: 'it is the expanded decapsulation key, 3168 bytes to the '
             'seed\'s 64');
-    expect(() => mlKem.keyPairFromSeed(mlKemPair.secretKey),
-        throwsArgumentError,
+    expect(
+        () => mlKem.keyPairFromSeed(mlKemPair.secretKey), throwsArgumentError,
         reason: 'so code that persisted `secretKey` — correct for X-Wing — '
             'cannot recover an ML-KEM key at all');
   });

--- a/packages/at_chops/test/ml_dsa_65_algo_test.dart
+++ b/packages/at_chops/test/ml_dsa_65_algo_test.dart
@@ -18,8 +18,12 @@ void main() {
       expect(kp.secretKey.length, equals(4032));
 
       final Uint8List message = Uint8List.fromList('instance keygen'.codeUnits);
-      final Uint8List sig = await algo.signBytes(message, secretKey: kp.secretKey);
-      expect(await algo.verifyBytes(message, signature: sig, publicKey: kp.publicKey), isTrue);
+      final Uint8List sig =
+          await algo.signBytes(message, secretKey: kp.secretKey);
+      expect(
+          await algo.verifyBytes(message,
+              signature: sig, publicKey: kp.publicKey),
+          isTrue);
     });
 
     test('sign/verify round-trip yields true', () async {
@@ -30,7 +34,8 @@ void main() {
       final algo = MlDsa65PureDartAlgo();
       final Uint8List message = Uint8List.fromList('Hello ML-DSA-65'.codeUnits);
       final Uint8List sig = await algo.signBytes(message, secretKey: sk);
-      final bool ok = await algo.verifyBytes(message, signature: sig, publicKey: pub);
+      final bool ok =
+          await algo.verifyBytes(message, signature: sig, publicKey: pub);
 
       expect(ok, isTrue);
     });
@@ -45,9 +50,8 @@ void main() {
       final MlDsa65KeyPair kp = await MlDsa65KeyPair.generate();
       final Uint8List sk = base64Decode(kp.atPrivateKey.privateKey);
 
-      final Uint8List sig = await MlDsa65PureDartAlgo().signBytes(
-          Uint8List.fromList('test'.codeUnits),
-          secretKey: sk);
+      final Uint8List sig = await MlDsa65PureDartAlgo()
+          .signBytes(Uint8List.fromList('test'.codeUnits), secretKey: sk);
 
       expect(sig.length, equals(3309));
     });
@@ -61,7 +65,8 @@ void main() {
       final algo = MlDsa65PureDartAlgo();
       final Uint8List message = Uint8List.fromList('data'.codeUnits);
       final Uint8List sig = await algo.signBytes(message, secretKey: sk);
-      final bool ok = await algo.verifyBytes(message, signature: sig, publicKey: wrongPub);
+      final bool ok =
+          await algo.verifyBytes(message, signature: sig, publicKey: wrongPub);
 
       expect(ok, isFalse);
     });
@@ -76,7 +81,8 @@ void main() {
       final Uint8List sig = await algo.signBytes(message, secretKey: sk);
 
       final Uint8List tampered = Uint8List.fromList('tampered'.codeUnits);
-      final bool ok = await algo.verifyBytes(tampered, signature: sig, publicKey: pub);
+      final bool ok =
+          await algo.verifyBytes(tampered, signature: sig, publicKey: pub);
 
       expect(ok, isFalse);
     });
@@ -134,7 +140,8 @@ void main() {
           throwsA(isA<ArgumentError>()));
     });
 
-    test('verifyBytes returns false (never throws) for a wrong-length public key',
+    test(
+        'verifyBytes returns false (never throws) for a wrong-length public key',
         () async {
       final MlDsa65KeyPair kp = await MlDsa65KeyPair.generate();
       final Uint8List sk = base64Decode(kp.atPrivateKey.privateKey);
@@ -149,7 +156,8 @@ void main() {
       expect(ok, isFalse);
     });
 
-    test('verifyBytes returns false (never throws) for a wrong-length signature',
+    test(
+        'verifyBytes returns false (never throws) for a wrong-length signature',
         () async {
       final MlDsa65KeyPair kp = await MlDsa65KeyPair.generate();
       final Uint8List pub = base64Decode(kp.atPublicKey.publicKey);
@@ -162,35 +170,43 @@ void main() {
       expect(ok, isFalse);
     });
 
-    test('MlDsa65KeyPair.create throws AtSigningException for a wrong-length public key',
+    test(
+        'MlDsa65KeyPair.create throws AtSigningException for a wrong-length public key',
         () {
-      final String badPub = base64Encode(Uint8List(MlDsa65Sizes.publicKeyBytes - 1));
+      final String badPub =
+          base64Encode(Uint8List(MlDsa65Sizes.publicKeyBytes - 1));
       final String sk = base64Encode(Uint8List(MlDsa65Sizes.secretKeyBytes));
 
       expect(() => MlDsa65KeyPair.create(badPub, sk),
           throwsA(isA<AtSigningException>()));
     });
 
-    test('MlDsa65KeyPair.create throws AtSigningException for a wrong-length secret key',
+    test(
+        'MlDsa65KeyPair.create throws AtSigningException for a wrong-length secret key',
         () {
       final String pub = base64Encode(Uint8List(MlDsa65Sizes.publicKeyBytes));
-      final String badSk = base64Encode(Uint8List(MlDsa65Sizes.secretKeyBytes + 1));
+      final String badSk =
+          base64Encode(Uint8List(MlDsa65Sizes.secretKeyBytes + 1));
 
       expect(() => MlDsa65KeyPair.create(pub, badSk),
           throwsA(isA<AtSigningException>()));
     });
 
-    test('MlDsa65KeyPair.create throws AtSigningException for invalid base64 public key',
+    test(
+        'MlDsa65KeyPair.create throws AtSigningException for invalid base64 public key',
         () {
-      final String validSk = base64Encode(Uint8List(MlDsa65Sizes.secretKeyBytes));
+      final String validSk =
+          base64Encode(Uint8List(MlDsa65Sizes.secretKeyBytes));
 
       expect(() => MlDsa65KeyPair.create('!!!invalid-base64!!!', validSk),
           throwsA(isA<AtSigningException>()));
     });
 
-    test('MlDsa65KeyPair.create throws AtSigningException for invalid base64 secret key',
+    test(
+        'MlDsa65KeyPair.create throws AtSigningException for invalid base64 secret key',
         () {
-      final String validPub = base64Encode(Uint8List(MlDsa65Sizes.publicKeyBytes));
+      final String validPub =
+          base64Encode(Uint8List(MlDsa65Sizes.publicKeyBytes));
 
       expect(() => MlDsa65KeyPair.create(validPub, '!!!invalid-base64!!!'),
           throwsA(isA<AtSigningException>()));

--- a/packages/at_chops/test/ml_kem_768_ffi_test.dart
+++ b/packages/at_chops/test/ml_kem_768_ffi_test.dart
@@ -71,7 +71,8 @@ void main() {
           () async {
         final ffiAlgo = MlKem768FfiAlgo.fromLib(lib!);
         final ffiKp = await ffiAlgo.generateKeyPair(seed);
-        final pureKp = await MlKem768PureDartAlgo.instance.generateKeyPair(seed);
+        final pureKp =
+            await MlKem768PureDartAlgo.instance.generateKeyPair(seed);
         try {
           expect(ffiKp.publicKey, equals(pureKp.publicKey));
         } finally {
@@ -122,7 +123,8 @@ void main() {
       }
     });
 
-    test('decapsulate throws ArgumentError for a wrong-length secret-key '
+    test(
+        'decapsulate throws ArgumentError for a wrong-length secret-key '
         'handle', () async {
       final algo = MlKem768FfiAlgo.fromLib(lib!);
       final kp = await algo.generateKeyPair();

--- a/packages/at_chops/test/pkam_mldsa65_signing_algo_test.dart
+++ b/packages/at_chops/test/pkam_mldsa65_signing_algo_test.dart
@@ -55,14 +55,13 @@ void main() async {
       final bad = AtPkamKeyPair.create('pub', '-----BEGIN RSA PRIVATE KEY');
       expect(
           () => PkamMlDsa65SigningAlgo(bad).sign(dataInBytes),
-          throwsA(predicate((e) =>
-              e is AtException && e.toString().contains('base64'))));
+          throwsA(predicate(
+              (e) => e is AtException && e.toString().contains('base64'))));
     });
   });
 
   group('The AtChopsImpl pkam dispatch', () {
-    final atChops =
-        AtChopsImpl(AtChopsKeys.create(null, pkamKeyPair));
+    final atChops = AtChopsImpl(AtChopsKeys.create(null, pkamKeyPair));
 
     test('signingAlgoType mldsa65 produces a genuine ML-DSA signature',
         () async {
@@ -77,8 +76,7 @@ void main() async {
       // proves the dispatch signed ML-DSA rather than RSA-with-a-claim.
       expect(
           await MlDsa65PureDartAlgo().verifyBytes(dataInBytes,
-              signature: signature,
-              publicKey: mlDsaKeyPair.publicKeyBytes),
+              signature: signature, publicKey: mlDsaKeyPair.publicKeyBytes),
           true);
     });
 

--- a/packages/at_chops/test/pq_hpke_test.dart
+++ b/packages/at_chops/test/pq_hpke_test.dart
@@ -21,8 +21,9 @@ final class _FixedKem implements AtKemAlgorithm {
   final Uint8List _ct;
   _FixedKem(this._ss, this._ct);
   @override
-  Future<({Uint8List publicKey, Uint8List secretKey})> generateKeyPair() async =>
-      throw UnsupportedError('not used in this test');
+  Future<({Uint8List publicKey, Uint8List secretKey})>
+      generateKeyPair() async =>
+          throw UnsupportedError('not used in this test');
   @override
   Uint8List newSeed() => throw UnsupportedError('not used in this test');
   @override
@@ -41,8 +42,8 @@ final class _FixedKem implements AtKemAlgorithm {
 
 Uint8List _utf8(String s) => Uint8List.fromList(utf8.encode(s));
 
-Matcher _opensWith(PqOpenFailure reason) => throwsA(isA<PqOpenException>()
-    .having((e) => e.reason, 'reason', reason));
+Matcher _opensWith(PqOpenFailure reason) =>
+    throwsA(isA<PqOpenException>().having((e) => e.reason, 'reason', reason));
 
 void main() {
   final xwing = XWingPureDartAlgo.instance;
@@ -130,7 +131,9 @@ void main() {
       final kp = await xwing.generateKeyPair();
       final envelope = await pqSeal(xwing, kp.publicKey, _utf8('payload'),
           info: _utf8('context-seal'));
-      expect(() => pqOpen(xwing, kp.secretKey, envelope, info: _utf8('context-open')),
+      expect(
+          () => pqOpen(xwing, kp.secretKey, envelope,
+              info: _utf8('context-open')),
           _opensWith(PqOpenFailure.authFailure));
     });
 
@@ -138,7 +141,8 @@ void main() {
       final kp = await xwing.generateKeyPair();
       final envelope = await pqSeal(xwing, kp.publicKey, _utf8('payload'),
           info: _noInfo, aad: _utf8('aad-seal'));
-      expect(() => pqOpen(xwing, kp.secretKey, envelope,
+      expect(
+          () => pqOpen(xwing, kp.secretKey, envelope,
               info: _noInfo, aad: _utf8('aad-open')),
           _opensWith(PqOpenFailure.authFailure));
     });
@@ -147,8 +151,8 @@ void main() {
   group('pqOpen rejects malformed envelopes', () {
     test('unsupported version → versionMismatch', () async {
       final kp = await xwing.generateKeyPair();
-      final envelope = await pqSeal(
-          xwing, kp.publicKey, _utf8('payload'), info: _noInfo);
+      final envelope =
+          await pqSeal(xwing, kp.publicKey, _utf8('payload'), info: _noInfo);
       // 0xff rather than 0x02: 0x02 is RFC 9180 and is now supported, so using
       // it here would test the AEAD rather than the version check.
       final bad = Uint8List.fromList(envelope)..[0] = 0xff;
@@ -185,8 +189,8 @@ void main() {
 
     test('a secret key of the wrong length → malformedEnvelope', () async {
       final kp = await xwing.generateKeyPair();
-      final envelope = await pqSeal(
-          xwing, kp.publicKey, _utf8('payload'), info: _noInfo);
+      final envelope =
+          await pqSeal(xwing, kp.publicKey, _utf8('payload'), info: _noInfo);
       expect(() => pqOpen(xwing, Uint8List(7), envelope, info: _noInfo),
           _opensWith(PqOpenFailure.malformedEnvelope));
     });
@@ -226,8 +230,7 @@ void main() {
       final envelope = await pqSeal(kem, kp.publicKey, _utf8('payload'),
           info: _noInfo, version: 0x03);
       expect(envelope[0], equals(0x03));
-      expect(
-          await pqOpen(kem, kp.secretKey, envelope, info: _noInfo),
+      expect(await pqOpen(kem, kp.secretKey, envelope, info: _noInfo),
           equals(_utf8('payload')));
     });
 
@@ -254,7 +257,8 @@ void main() {
     // _FixedKem double (see below) and print the envelope hex.
 
     test('fixed-KEM construction KAT: seal is deterministic + opens', () async {
-      final ss = Uint8List.fromList(List<int>.generate(32, (i) => i)); // [0x00..0x1f]
+      final ss =
+          Uint8List.fromList(List<int>.generate(32, (i) => i)); // [0x00..0x1f]
       // 1120 bytes, the 0x02 suite's Nenc: pqSeal refuses a ciphertext that is
       // not the version's own encapsulation length, so the double has to
       // produce a realistic one. Deterministic, so the envelope still is.

--- a/packages/at_chops/test/wire_literal_pins_test.dart
+++ b/packages/at_chops/test/wire_literal_pins_test.dart
@@ -26,7 +26,7 @@ void main() {
     test('SigningAlgoType member names, values and order', () {
       // The member NAME is the wire literal: `pkam:signingAlgo:<name>:...`,
       // the enroll-request JSON's "signingAlgo", the signed envelope's
-      // claim, and the keyfile's keyAlgorithmType all emit `.name`. No other
+      // claim, and the keyfile's algorithm all emit `.name`. No other
       // at_chops test asserts the string form, so an enum rename would pass
       // the entire suite while changing the PKAM verb.
       expect(SigningAlgoType.values.map((a) => a.name).toList(),
@@ -91,8 +91,7 @@ void main() {
   });
 
   group('KEM sizes that frame the envelope', () {
-    test('X-Wing: 1120-byte ciphertext (the 0x0460 in every v1/v2 header)',
-        () {
+    test('X-Wing: 1120-byte ciphertext (the 0x0460 in every v1/v2 header)', () {
       expect(XWingPureDartAlgo.ciphertextLength, 1120);
       expect(XWingPureDartAlgo.publicKeyLength, 1216);
       expect(XWingPureDartAlgo.seedLength, 32);


### PR DESCRIPTION
**- What I did**

`dart format` across at_chops, carved from `gkc-pq-d1-spike`. One entry folded under the existing **3.6.1** heading — that version is unpublished (pub.dev tops out at 3.6.0), so nothing is bumped.

One exception to "formatting only", and it is a single comment word: in `test/wire_literal_pins_test.dart`, *"the keyfile's `keyAlgorithmType`"* becomes *"the keyfile's `algorithm`"*. `keyAlgorithmType` names nothing in trunk's code either — it survives only in at_auth's CHANGELOG and in that comment — so the comment was already stale here and this corrects it.

**- How I did it**

See commit & diffs.

The format-only claim is **verified rather than asserted**: each changed file's trunk and branch versions were normalised through the same formatter and compared, and 21 of the 22 came out byte-identical. The rig was controlled — the formatter was confirmed to have actually altered the trunk side rather than silently no-opping, which would have made every file compare equal and reported a false clean.

**- How to verify it**

Tests pass — 428. `dart analyze --fatal-warnings` clean, and the package now passes its own `dart format . -o none --set-exit-if-changed` gate.

**- Description for the changelog**

chore: dart format, and a stale symbol name in one test comment