### PR TITLE
fix(at_auth): require the PKAM algorithms where nothing can derive them

### DIFF
--- a/packages/at_auth/CHANGELOG.md
+++ b/packages/at_auth/CHANGELOG.md
@@ -1,5 +1,28 @@
 ## 4.0.0-rc1
 
+- fix: **`authenticatorForChops` requires `signingAlgo` and `hashingAlgo`.**
+  ⚠️ This tightens a signature added earlier in this same **unpublished**
+  `4.0.0-rc1`; `3.3.0`, the last published version, carries no
+  `at_authenticator.dart` at all. Both parameters defaulted, to `rsa2048` and
+  `sha256`. This is the one authenticator with no keystore behind its signer,
+  so the caller is the only party that knows what the AtChops holds — and a
+  default made a caller that forgot indistinguishable from one that meant RSA.
+  An ML-DSA key put through the RSA routine fails inside at_chops on a key
+  length, naming neither the caller nor the mismatch. The compiler now names
+  the call site instead.
+- fix: **`AtKeys.authenticationAlgorithmFor` refuses an algorithm this build
+  cannot sign with, rather than returning null.** ⚠️ Also unpublished — the
+  method does not exist in `3.3.0`. Null had two meanings — "this enrollment
+  files no typed material, so its keypair is the flat RSA pair" and "its typed
+  material names an algorithm I cannot read" — and a caller could not tell them
+  apart afterwards. The obvious reading of null, *legacy, so rsa2048*, signs a
+  different enrollment's credentials with the wrong routine on the second.
+  `authenticationFor` already refused exactly that case; the refusal moves up
+  so the algorithm-only call is held to the same terms, and a caller holding
+  its own signer stops being the one path that guesses.
+  `signingAlgorithmForEnrollment` still reports both as null and is unchanged —
+  it is the call to make where that is wanted.
+
 - fix: **the `_apsk` an enrolment advertises is spelled by its
   algorithm alone.** ⚠️ This changes behaviour introduced earlier in this same
   **unpublished** `4.0.0-rc1`; it is not a break against `3.3.0`, the last

--- a/packages/at_auth/lib/src/auth/at_authenticator.dart
+++ b/packages/at_auth/lib/src/auth/at_authenticator.dart
@@ -86,14 +86,19 @@ AtAuthenticator authenticatorFor(
 /// keystore to read, nor [authenticatorForPrivateKey] because it holds no
 /// private key of its own - the key material is inside the AtChops.
 ///
-/// [signingAlgo] defaults to rsa2048, which is what at_lookup signed with when
-/// nothing named an algorithm.
+/// [signingAlgo] and [hashingAlgo] are required, because this is the one
+/// authenticator that cannot work them out for itself: there is no keystore
+/// behind the signer, so the caller is the only party that knows what the
+/// AtChops holds. Defaulting either made a caller that forgot indistinguishable
+/// from one that meant `rsa2048`/`sha256`, and an ML-DSA key put through the
+/// RSA routine fails inside at_chops on a key length, naming neither the
+/// caller nor the mismatch.
 AtAuthenticator authenticatorForChops(
   String atSign,
   AtChops chops, {
+  required SigningAlgoType signingAlgo,
+  required HashingAlgoType hashingAlgo,
   String? enrollmentId,
-  SigningAlgoType signingAlgo = SigningAlgoType.rsa2048,
-  HashingAlgoType hashingAlgo = HashingAlgoType.sha256,
   Map<String, dynamic> clientConfig = const {},
 }) =>
     (executor) async {
@@ -226,6 +231,14 @@ Future<bool> _pkam(
     // only the ALGORITHM from the keyfile: `authenticationFor` would build an
     // AtChops this call is about to discard, and it throws on a keyfile
     // missing material a caller with its own signer never needed.
+    //
+    // Null below means the enrollment files no typed material, so the flat
+    // fields' RSA pair is what it authenticates with. It cannot also mean
+    // "typed material this build cannot read": authenticationAlgorithmFor
+    // refuses that rather than reporting null, so the fallback is a statement
+    // about the keyfile and not a guess about the injected signer. Those two
+    // were one null once, and rsa2048 was then a guess about somebody else's
+    // credentials.
     signer = injectedChops;
     signingAlgo = keys.authenticationAlgorithmFor(enrollmentId) ??
         SigningAlgoType.rsa2048;

--- a/packages/at_auth/lib/src/keys/at_keys.dart
+++ b/packages/at_auth/lib/src/keys/at_keys.dart
@@ -1199,21 +1199,13 @@ class AtKeys {
   /// Falling back to the flat fields there would authenticate as whoever owns
   /// them, and at_lookup's default is `rsa2048`, so the wrong key would be
   /// signed by the wrong routine. A keyfile written by a newer client is the
-  /// way this happens.
+  /// way this happens. [authenticationAlgorithmFor] raises it, so a caller
+  /// wanting only the algorithm is refused on the same terms as one wanting
+  /// the signer.
   ({AtChops chops, SigningAlgoType? algorithm}) authenticationFor(
       String? enrollmentId) {
     final algorithm = authenticationAlgorithmFor(enrollmentId);
     if (algorithm == null) {
-      final material = enrollmentId == null
-          ? null
-          : _activeAuthenticationMaterial(enrollmentId);
-      if (material != null) {
-        throw AtKeyNotFoundException(
-            'Enrollment $enrollmentId authenticates with '
-            '"${material.algorithm}", which this build cannot sign '
-            'with. Its keypair is in this keyfile; the flat fields are a '
-            'different enrollment\'s and are not a substitute for it.');
-      }
       return (chops: toAtChops(), algorithm: null);
     }
     return (chops: toAtChopsForEnrollment(enrollmentId!), algorithm: algorithm);
@@ -1225,8 +1217,32 @@ class AtKeys {
   /// building one it will discard is not free — [toAtChops] throws on a
   /// keyfile that is missing any of the material it needs, so resolving
   /// eagerly would fail a caller that never needed the keypair at all.
-  SigningAlgoType? authenticationAlgorithmFor(String? enrollmentId) =>
-      enrollmentId == null ? null : signingAlgorithmForEnrollment(enrollmentId);
+  ///
+  /// Null means the flat fields and nothing else: this enrollment files no
+  /// typed authentication material, so its keypair is the flat RSA pair and
+  /// `rsa2048` is what signs it. An enrollment whose typed material names an
+  /// algorithm this build cannot sign with is **refused** rather than reported
+  /// as null, because the two are indistinguishable afterwards and the obvious
+  /// reading of null — legacy, so `rsa2048` — would sign a different
+  /// enrollment's credentials with the wrong routine. Where both really are
+  /// wanted as null, [signingAlgorithmForEnrollment] is the call that says so.
+  ///
+  /// Throws [AtKeyNotFoundException] for that case. A keyfile written by a
+  /// newer client is the way it happens.
+  SigningAlgoType? authenticationAlgorithmFor(String? enrollmentId) {
+    if (enrollmentId == null) return null;
+    final algorithm = signingAlgorithmForEnrollment(enrollmentId);
+    if (algorithm != null) return algorithm;
+    final material = _activeAuthenticationMaterial(enrollmentId);
+    if (material != null) {
+      throw AtKeyNotFoundException(
+          'Enrollment $enrollmentId authenticates with '
+          '"${material.algorithm}", which this build cannot sign '
+          'with. Its keypair is in this keyfile; the flat fields are a '
+          'different enrollment\'s and are not a substitute for it.');
+    }
+    return null;
+  }
 
   @Deprecated('legacy, please use addKey to add additional keys.')
   AtKeys copyWith(AtKeys other) {

--- a/packages/at_auth/test/at_authenticator_test.dart
+++ b/packages/at_auth/test/at_authenticator_test.dart
@@ -1,6 +1,7 @@
 import 'package:at_auth/at_auth.dart';
 import 'package:at_chops/at_chops.dart';
 import 'package:at_commons/at_commons.dart';
+import 'package:at_auth/src/keys/serialization/atkey_material.dart';
 import 'package:at_demo_data/at_demo_data.dart' as demo;
 import 'package:at_lookup/at_lookup.dart';
 import 'package:test/test.dart';
@@ -155,6 +156,52 @@ void main() {
       await expectLater(
           () => authenticatorFor(io, atSign)(executor), throwsA(anything));
     });
+
+    test(
+        'is refused when the keyfile names an algorithm this build cannot '
+        'sign with', () async {
+      // The keyfile holds THIS enrollment's key, under an algorithm from a
+      // newer client. The algorithm used to resolve to null and rsa2048 was
+      // the fallback, so the injected signer signed the challenge under a
+      // guess about a key nothing here can read - while a caller WITHOUT an
+      // injected signer was refused for the same keyfile.
+      final io = InMemoryAtKeysIo();
+      await io.write(
+          atSign,
+          AtKeys()
+            ..defaultEncryptionPublicKey =
+                AtBytes.fromString(demo.encryptionPublicKeyMap[atSign]!)
+            ..fileApkamMaterial(
+                enrollmentId: 'future-algorithm',
+                algorithm:
+                    CryptographicMaterialAlgorithm.of('sphincs-plus-256s'),
+                publicKey: 'dHlwZWQtcHVibGlj',
+                privateKey: 'dHlwZWQtcHJpdmF0ZQ=='));
+      final injected = AtChopsImpl(AtChopsKeys.create(
+          null,
+          AtPkamKeyPair.create(demo.pkamPublicKeyMap[atSign]!,
+              demo.pkamPrivateKeyMap[atSign]!)));
+
+      final refused = RecordingExecutor(['data:$challenge', 'data:success']);
+      await expectLater(
+          () => authenticatorFor(io, atSign,
+              enrollmentId: 'future-algorithm', chops: injected)(refused),
+          throwsA(isA<AtKeyNotFoundException>()));
+      expect(refused.sent, isEmpty,
+          reason: 'the refusal lands before anything is sent, not after a '
+              'challenge has been signed under a guessed algorithm');
+
+      // The control, and the discriminator: the same keyfile and the same
+      // injected signer, for an enrollment it holds no material for. Absent
+      // material is still rsa2048, so the refusal is keyed on unreadable
+      // material rather than on the keyfile being unusual.
+      final accepted = RecordingExecutor(['data:$challenge', 'data:success']);
+      expect(
+          await authenticatorFor(io, atSign,
+              enrollmentId: 'never-held-here', chops: injected)(accepted),
+          isTrue);
+      expect(accepted.sent.last, contains('signingAlgo:rsa2048'));
+    });
   });
 
   group('the legacy credential', () {
@@ -202,7 +249,9 @@ void main() {
           AtPkamKeyPair.create(demo.pkamPublicKeyMap[atSign]!,
               demo.pkamPrivateKeyMap[atSign]!)));
 
-      final ok = await authenticatorForChops(atSign, chops)(executor);
+      final ok = await authenticatorForChops(atSign, chops,
+          signingAlgo: SigningAlgoType.rsa2048,
+          hashingAlgo: HashingAlgoType.sha256)(executor);
 
       expect(ok, isTrue);
       expect(executor.sent.last, startsWith('pkam:'));
@@ -219,7 +268,10 @@ void main() {
           AtPkamKeyPair.create(demo.pkamPublicKeyMap[atSign]!,
               demo.pkamPrivateKeyMap[atSign]!)));
 
-      await expectLater(() => authenticatorForChops(atSign, chops)(executor),
+      await expectLater(
+          () => authenticatorForChops(atSign, chops,
+              signingAlgo: SigningAlgoType.rsa2048,
+              hashingAlgo: HashingAlgoType.sha256)(executor),
           throwsA(isA<UnAuthenticatedException>()));
       expect(executor.sent, hasLength(1));
     });

--- a/packages/at_auth/test/at_keys_test.dart
+++ b/packages/at_auth/test/at_keys_test.dart
@@ -344,6 +344,32 @@ void main() {
       expect(
           retrofitted().authenticationAlgorithmFor(flatEnrollmentId), isNull);
     });
+
+    test(
+        'authenticationAlgorithmFor refuses what it cannot sign with, rather '
+        'than reporting null', () {
+      // The two answers this used to collapse into one null. A caller holding
+      // its own signer reads null as "legacy, so rsa2048" — right for an
+      // enrollment the keyfile holds nothing for, and a guess about somebody
+      // else's key for one whose typed material this build cannot read.
+      final futureAlgo = createKeys()
+        ..fileApkamMaterial(
+            enrollmentId: 'future-algorithm',
+            algorithm: CryptographicMaterialAlgorithm.of('sphincs-plus-256s'),
+            publicKey: typedApkamPublicKey,
+            privateKey: 'dHlwZWQtcHJpdmF0ZQ==');
+
+      expect(() => futureAlgo.authenticationAlgorithmFor('future-algorithm'),
+          throwsA(isA<AtKeyNotFoundException>()));
+      expect(futureAlgo.authenticationAlgorithmFor('never-held-here'), isNull,
+          reason: 'absent material still answers null - the refusal is keyed '
+              'on material this build cannot read, not on the keyfile');
+      expect(
+          futureAlgo.signingAlgorithmForEnrollment('future-algorithm'), isNull,
+          reason: 'signingAlgorithmForEnrollment is the call that still '
+              'reports both cases as null, and its many callers depend on '
+              'that; the refusal belongs to the authentication resolution');
+    });
   });
 
   group('AtKeys typed key lookup', () {


### PR DESCRIPTION
**- What I did**

Two breaking tightenings in at_auth, done **now** so they ride the forthcoming
`4.0.0` rather than forcing another major shortly after it:

- `authenticatorForChops` takes `signingAlgo` and `hashingAlgo` as **required**
  arguments. It is the one authenticator with no keystore behind its signer, so
  only the caller knows what the AtChops holds — and a default made a caller
  that forgot indistinguishable from one that meant RSA.
- `AtKeys.authenticationAlgorithmFor` **refuses** an algorithm this build cannot
  sign with instead of returning null. Null meant both *no typed material, so
  the flat RSA pair* and *typed material I cannot read*; on the second, the
  obvious reading signs another enrollment's credentials with the wrong routine.
  `authenticationFor` already refused exactly that case.

Neither is a break against `3.3.0`, the last published version — it carries no
`at_authenticator.dart` and no `authenticationAlgorithmFor` at all. So the cost
of doing this now is two lines in this package's own tests; the cost of doing it
later is a major release.

**- How I did it**

See commit & diffs.

**- How to verify it**

Tests pass — at_auth 365, up from 363.

**- Description for the changelog**

`authenticatorForChops` now requires `signingAlgo` and `hashingAlgo`, and
`AtKeys.authenticationAlgorithmFor` refuses an algorithm this build cannot sign
with rather than returning null. Both tighten shapes added earlier in the
unpublished `4.0.0-rc1`; neither is a break against `3.3.0`.
