### PR TITLE
test(at_client): pin the guard against handing back a stopped client

### DIFF
--- a/packages/at_client/test/at_client_manager_stopped_client_test.dart
+++ b/packages/at_client/test/at_client_manager_stopped_client_test.dart
@@ -1,0 +1,32 @@
+import 'package:at_client/at_client.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('setCurrentAtSign after stop()', () {
+    AtClientPreference pref() => AtClientPreference()
+      ..hiveStoragePath = 'test/hive'
+      ..commitLogPath = 'test/hive/path';
+
+    test(
+        'the same-atSign short-circuit never hands back a stopped client, and '
+        'the client it does hand back has its services wired', () async {
+      final atSign = '@stoppedshortcircuit';
+      final manager = AtClientManager(atSign);
+      await manager.setCurrentAtSign(atSign, 'wavi', pref());
+      final first = manager.atClient;
+      await first.stop();
+      expect(first.isStopped, isTrue);
+
+      await manager.setCurrentAtSign(atSign, 'wavi', pref());
+      final again = manager.atClient;
+      expect(again.isStopped, isFalse,
+          reason: 'setCurrentAtSign must not return a client that is still '
+              'stopped; the short-circuit has to fall through for one');
+      expect(() => again.syncService, returnsNormally,
+          reason: 'stop() nulls the services, so whatever hands the client '
+              'back must have wired them again');
+      expect(() => again.notificationService, returnsNormally,
+          reason: 'as for syncService');
+    });
+  });
+}


### PR DESCRIPTION
**- What I did**
Added single unit test to cover an edge case

- Pinned that `AtClientManager.setCurrentAtSign`'s same-atSign short-circuit refuses a stopped client. `stop()` nulls the services and `start()` does not rebuild them, so a stopped client handed back throws on first use; the `isStopped == false` clause is what prevents that, and nothing tested it
- `setCurrentAtSign` currently does that rebuild itself: on the full path it stops the outgoing client, gets one back from the service factory, then assigns `notificationService` and `syncService` onto it. The short-circuit skips all of that, which is why it must not be taken for a stopped client.
- Deleting the clause turns the new test red, quoting its reason.

**- How I did it**
See commit & diffs

**- How to verify it**
Tests pass

**- Description for the changelog**
test: `setCurrentAtSign` is pinned never to hand back a stopped client.
