### PR TITLE
feat(at_client): AtClientStorage owns the keystore and the sync queue

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 3.14.1
+- feat: `AtClientStorage` — a client's local keystore and its sync queue as one
+  object, with `HiveAtClientStorage` as the default. A client claims its storage
+  when it is created and a second client is refused it; after the claim is
+  dropped the same principal may take it again, a different one only after
+  `forgetPrincipal()` or `clear()`. `AtSyncQueue` gains `clear()`. Groundwork
+  for injecting storage and for in-memory and SQLite backends.
 - fix: `AtCollection` — resolve received (shared-in) items in the id-scoped
   read path. `Query.watch()` (delta path), `getOrNull` / `get(id, owner)` and
   `exists(id, owner)` missed items stored locally as

--- a/packages/at_client/lib/at_client.dart
+++ b/packages/at_client/lib/at_client.dart
@@ -6,6 +6,8 @@ export 'package:at_client/src/client/data_event.dart';
 export 'package:at_client/src/client/local_secondary.dart';
 export 'package:at_client/src/client/remote_secondary.dart';
 export 'package:at_client/src/client/request_options.dart';
+export 'package:at_client/src/storage/at_client_storage.dart';
+export 'package:at_client/src/storage/hive_at_client_storage.dart';
 export 'package:at_client/src/crypto/crypto.dart';
 export 'package:at_client/src/key_stream/key_stream.dart';
 export 'package:at_client/src/listener/connectivity_listener.dart';

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -8,7 +8,7 @@ import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/client/secondary.dart';
 import 'package:at_client/src/client/verb_builder_manager.dart';
-import 'package:at_client/src/manager/storage_manager.dart';
+import 'package:at_client/src/sync/at_sync_queue.dart';
 import 'package:at_client/src/response/response.dart';
 import 'package:at_client/src/service/encryption_service.dart';
 import 'package:at_client/src/service/file_transfer_service.dart';
@@ -43,9 +43,12 @@ class AtClientImpl implements AtClient {
   Atsign get atSign => _atSign;
   AtKeyValueStore<String, AtData, AtMetaData?>? _localSecondaryKeyStore;
 
-  /// Owns the local persistence bundle's lifecycle (commit-log-free); null
-  /// when an external keystore was injected or storage is not required.
-  StorageManager? _storageManager;
+  /// The keystore and sync queue this client holds; null when an external
+  /// keystore was injected or storage is not required.
+  AtClientStorage? _storage;
+
+  @visibleForTesting
+  AtClientStorage? get storage => _storage;
   @visibleForTesting
   LocalSecondary? localSecondary;
   RemoteSecondary? _remoteSecondary;
@@ -388,14 +391,23 @@ class AtClientImpl implements AtClient {
 
   Future<void> _init({AtLookUp? atLookUp}) async {
     if (_preference!.isLocalStoreRequired) {
+      AtSyncQueue? syncQueue;
       if (_localSecondaryKeyStore == null) {
-        _storageManager = StorageManager(preference);
-        await _storageManager!.init(_atSign, preference!.keyStoreSecret);
+        final storagePath = preference!.hiveStoragePath;
+        if (storagePath == null) {
+          throw Exception('Please set local storage path');
+        }
+        final storage =
+            HiveAtClientStorage(atSign: _atSign, storagePath: storagePath);
+        await storage.attach(this);
+        _storage = storage;
+        syncQueue = storage.syncQueue;
       }
 
       localSecondary = LocalSecondary(
         this,
-        keyStore: _localSecondaryKeyStore ?? _storageManager?.keyValueStore,
+        keyStore: _localSecondaryKeyStore ?? _storage?.keyStore,
+        syncQueue: syncQueue,
         onEvent: emitDataEvent,
       );
       _atChops ??= await _createAtChops(_atSign);
@@ -648,7 +660,10 @@ class AtClientImpl implements AtClient {
   }
 
   @override
-  AtPersistenceBundle? get persistenceBundle => _storageManager?.bundleOrNull;
+  AtPersistenceBundle? get persistenceBundle {
+    final storage = _storage;
+    return storage is HiveAtClientStorage ? storage.bundle : null;
+  }
 
   @override
   RemoteSecondary? getRemoteSecondary() {

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -99,8 +99,10 @@ class LocalSecondary implements Secondary {
   LocalSecondary(
     this._atClient, {
     this.keyStore,
+    AtSyncQueue? syncQueue,
     void Function(DataEvent)? onEvent,
-  }) : _onEvent = onEvent {
+  })  : _syncQueue = syncQueue,
+        _onEvent = onEvent {
     _logger = AtSignLogger('LocalSecondary (${_atClient.getCurrentAtSign()})');
     keyStore ??= _atClient.persistenceBundle?.keyValueStore;
   }

--- a/packages/at_client/lib/src/storage/at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/at_client_storage.dart
@@ -1,0 +1,100 @@
+import 'package:at_client/src/client/at_client_spec.dart';
+import 'package:at_client/src/sync/at_sync_queue.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:meta/meta.dart';
+
+/// The local storage one [AtClient] holds: its keystore and its sync queue.
+abstract class AtClientStorage {
+  /// Claims this storage for [owner].
+  ///
+  /// Throws [StateError] if a different client holds it, or if a different
+  /// principal held it last and neither [forgetPrincipal] nor [clear] has run
+  /// since. The same client attaching again is a no-op.
+  Future<void> attach(AtClient owner);
+
+  /// Drops [owner]'s claim, keeping the backend open.
+  Future<void> detach(AtClient owner);
+
+  AtKeyValueStore<String, AtData, AtMetaData?> get keyStore;
+
+  AtSyncQueue get syncQueue;
+
+  /// Forgets which principal last held this storage, keeping the data.
+  ///
+  /// Throws [StateError] while a client is attached.
+  Future<void> forgetPrincipal();
+
+  /// Empties keystore and queue and forgets the last principal. Idempotent.
+  ///
+  /// A holder that clears and then writes is stamped again by [detach].
+  Future<void> clear();
+
+  /// Closes the backend. Idempotent.
+  Future<void> close();
+}
+
+/// The claim rules every [AtClientStorage] shares; a backend supplies
+/// [openBackend] and [clearData].
+abstract class AtClientStorageBase implements AtClientStorage {
+  AtClient? _owner;
+  String? _lastPrincipal;
+
+  /// The `(atSign, enrollmentId)` a client acts as.
+  static String principalOf(AtClient client) =>
+      '${client.getCurrentAtSign()}|${client.enrollmentId ?? 'legacy'}';
+
+  bool get isAttached => _owner != null;
+
+  @override
+  Future<void> attach(AtClient owner) async {
+    if (identical(_owner, owner)) return;
+    final holder = _owner;
+    if (holder != null) {
+      throw StateError('this storage is held by ${principalOf(holder)}; a '
+          'client cannot attach to storage another client holds');
+    }
+    final principal = principalOf(owner);
+    final last = _lastPrincipal;
+    if (last != null && last != principal) {
+      throw StateError('this storage was last held by $last and $principal '
+          'now asks for it; call forgetPrincipal() to hand it over '
+          'deliberately, or clear() to empty it first');
+    }
+    await openBackend();
+    _owner = owner;
+    _lastPrincipal = principal;
+  }
+
+  @override
+  Future<void> detach(AtClient owner) async {
+    if (!identical(_owner, owner)) return;
+    _lastPrincipal = principalOf(owner);
+    _owner = null;
+  }
+
+  @override
+  Future<void> forgetPrincipal() async {
+    if (_owner != null) {
+      throw StateError('this storage is attached; detach the client before '
+          'forgetting its principal');
+    }
+    _lastPrincipal = null;
+  }
+
+  @override
+  Future<void> clear() async {
+    await clearData();
+    _lastPrincipal = null;
+  }
+
+  /// Opens the backend. Idempotent.
+  @protected
+  Future<void> openBackend();
+
+  /// Empties keystore and queue.
+  @protected
+  Future<void> clearData();
+
+  @protected
+  void dropClaim() => _owner = null;
+}

--- a/packages/at_client/lib/src/storage/hive_at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/hive_at_client_storage.dart
@@ -1,0 +1,69 @@
+import 'package:at_client/src/manager/storage_manager.dart';
+import 'package:at_client/src/preference/at_client_preference.dart';
+import 'package:at_client/src/storage/at_client_storage.dart';
+import 'package:at_client/src/sync/at_sync_queue.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+
+/// The default storage: a Hive keystore and sync queue under [storagePath].
+class HiveAtClientStorage extends AtClientStorageBase {
+  HiveAtClientStorage({required this.atSign, required this.storagePath});
+
+  final String atSign;
+  final String storagePath;
+
+  StorageManager? _manager;
+  AtSyncQueue? _queue;
+  bool _closed = false;
+
+  // NOTE: the persistence layer opens every box on the global Hive instance,
+  // named by atSign, so two of these for one atSign share boxes whatever their
+  // paths.
+
+  /// The persistence bundle, or `null` before the first [attach].
+  AtPersistenceBundle? get bundle => _manager?.bundleOrNull;
+
+  @override
+  AtKeyValueStore<String, AtData, AtMetaData?> get keyStore =>
+      _openManager.keyValueStore;
+
+  @override
+  AtSyncQueue get syncQueue {
+    final q = _queue;
+    if (q == null) throw StateError('storage for $atSign is not open');
+    return q;
+  }
+
+  StorageManager get _openManager {
+    final m = _manager;
+    if (m == null) throw StateError('storage for $atSign is not open');
+    return m;
+  }
+
+  @override
+  Future<void> openBackend() async {
+    if (_closed) throw StateError('storage for $atSign has been closed');
+    if (_manager != null) return;
+    final manager =
+        StorageManager(AtClientPreference()..hiveStoragePath = storagePath);
+    await manager.init(atSign, null);
+    final queue = AtSyncQueue(atSign: atSign);
+    await queue.open();
+    _manager = manager;
+    _queue = queue;
+  }
+
+  @override
+  Future<void> clearData() async {
+    await _openManager.bundle.clear();
+    await syncQueue.clear();
+  }
+
+  @override
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    dropClaim();
+    await _queue?.close();
+    await _manager?.bundleOrNull?.close();
+  }
+}

--- a/packages/at_client/lib/src/sync/at_sync_queue.dart
+++ b/packages/at_client/lib/src/sync/at_sync_queue.dart
@@ -205,6 +205,13 @@ class AtSyncQueue {
     await _box!.delete(atKey);
   }
 
+  /// Drops every entry, keeping the box open.
+  Future<void> clear() async {
+    _ensureOpen();
+    _inMemoryQueue.clear();
+    await _box!.clear();
+  }
+
   /// Returns up to [limit] atKey strings from the front of the
   /// in-memory queue, in FIFO order. Does NOT remove them — the
   /// caller is expected to call [remove] per atKey after a successful

--- a/packages/at_client/test/storage/at_client_storage_wiring_test.dart
+++ b/packages/at_client/test/storage/at_client_storage_wiring_test.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:at_client/at_client.dart';
+import 'package:at_client/src/sync/at_sync_queue.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+      'a created client holds a HiveAtClientStorage, and its LocalSecondary '
+      'shares that storage\'s queue rather than opening one of its own',
+      () async {
+    final dir = Directory.systemTemp.createTempSync('at_client_wiring_');
+    final pref = AtClientPreference()
+      ..hiveStoragePath = dir.path
+      ..commitLogPath = '${dir.path}/commit';
+    final client =
+        await AtClientImpl.create('@storagewire', 'wavi', pref) as AtClientImpl;
+
+    final storage = client.storage;
+    expect(storage, isA<HiveAtClientStorage>());
+    expect(client.persistenceBundle, isNotNull);
+
+    await storage!.syncQueue
+        .enqueue('k.wavi@storagewire', SyncQueueOp.updateAll);
+    expect(client.localSecondary!.syncQueueSyncSnapshot, 1,
+        reason: 'the queue LocalSecondary reads must be the one the storage '
+            'owns, or a write and its push live in different queues');
+
+    await storage.close();
+    AtClientImpl.atClientInstanceMap.remove('@storagewire');
+    dir.deleteSync(recursive: true);
+  });
+}

--- a/packages/at_client/test/storage/hive_at_client_storage_test.dart
+++ b/packages/at_client/test/storage/hive_at_client_storage_test.dart
@@ -1,0 +1,146 @@
+import 'dart:io';
+
+import 'package:at_client/at_client.dart';
+import 'package:at_client/src/sync/at_sync_queue.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class _FakeClient extends Mock implements AtClient {
+  _FakeClient(this._atSign, this._enrollmentId);
+  final String _atSign;
+  final String? _enrollmentId;
+  @override
+  String? getCurrentAtSign() => _atSign;
+  @override
+  String? get enrollmentId => _enrollmentId;
+}
+
+void main() {
+  late Directory dir;
+  final opened = <HiveAtClientStorage>[];
+
+  HiveAtClientStorage storageFor(String atSign) {
+    final s = HiveAtClientStorage(atSign: atSign, storagePath: dir.path);
+    opened.add(s);
+    return s;
+  }
+
+  setUp(() {
+    dir = Directory.systemTemp.createTempSync('at_client_storage_');
+  });
+
+  tearDown(() async {
+    for (final s in opened) {
+      await s.close();
+    }
+    opened.clear();
+    dir.deleteSync(recursive: true);
+  });
+
+  group('attach', () {
+    test('the same client attaching twice is a no-op', () async {
+      final s = storageFor('@hivestore1');
+      final owner = _FakeClient('@hivestore1', 'e1');
+      await s.attach(owner);
+      await s.attach(owner);
+      expect(s.isAttached, isTrue);
+    });
+
+    test('a different client is refused, and the message names the holder',
+        () async {
+      final s = storageFor('@hivestore2');
+      await s.attach(_FakeClient('@hivestore2', 'e1'));
+      expect(
+          () => s.attach(_FakeClient('@hivestore2', 'e2')),
+          throwsA(isA<StateError>().having(
+              (e) => e.message, 'message', contains('is held by @hivestore2|e1'))),
+          reason: 'two clients on one store is the silent sharing this '
+              'exists to refuse');
+    });
+
+    test('after detach the same principal attaches again as a new instance',
+        () async {
+      final s = storageFor('@hivestore3');
+      final first = _FakeClient('@hivestore3', 'e1');
+      await s.attach(first);
+      await s.detach(first);
+      await s.attach(_FakeClient('@hivestore3', 'e1'));
+      expect(s.isAttached, isTrue,
+          reason: 'a restart within the process is the legitimate reuse');
+    });
+
+    test('after detach a different principal is refused until forgetPrincipal',
+        () async {
+      final s = storageFor('@hivestore4');
+      final first = _FakeClient('@hivestore4', 'e1');
+      await s.attach(first);
+      await s.detach(first);
+      final second = _FakeClient('@hivestore4', 'e2');
+      expect(
+          () => s.attach(second),
+          throwsA(isA<StateError>().having((e) => e.message, 'message',
+              contains('last held by @hivestore4|e1'))),
+          reason: 'records and queued pushes are that principal\'s; a '
+              'different enrollment must not inherit them by accident');
+      await s.forgetPrincipal();
+      await s.attach(second);
+      expect(s.isAttached, isTrue,
+          reason: 'forgetPrincipal is the deliberate hand-over');
+    });
+
+    test('forgetPrincipal refuses while attached', () async {
+      final s = storageFor('@hivestore5');
+      await s.attach(_FakeClient('@hivestore5', 'e1'));
+      expect(() => s.forgetPrincipal(), throwsA(isA<StateError>()));
+    });
+  });
+
+  group('clear', () {
+    test('empties the queue and the keystore, and forgets the principal',
+        () async {
+      final s = storageFor('@hivestore6');
+      final first = _FakeClient('@hivestore6', 'e1');
+      await s.attach(first);
+      await s.syncQueue.enqueue('k@hivestore6', SyncQueueOp.updateAll);
+      await s.keyStore.put('k@hivestore6', AtData()..data = 'v');
+      expect(s.syncQueue.size, 1);
+      expect(await s.keyStore.exists('k@hivestore6'), isTrue);
+
+      await s.detach(first);
+      await s.clear();
+
+      expect(s.syncQueue.size, 0,
+          reason: 'a queue carrying another test\'s '
+              'entries is what poisoned the functional pack');
+      expect(await s.keyStore.exists('k@hivestore6'), isFalse);
+      await s.attach(_FakeClient('@hivestore6', 'e2'));
+      expect(s.isAttached, isTrue,
+          reason: 'clear also forgets the principal, so the next holder need '
+              'not be the last');
+    });
+
+    test('a holder that clears and keeps writing is stamped again on detach',
+        () async {
+      final s = storageFor('@hivestore9');
+      final first = _FakeClient('@hivestore9', 'e1');
+      await s.attach(first);
+      await s.clear();
+      await s.syncQueue.enqueue('k@hivestore9', SyncQueueOp.updateAll);
+      await s.detach(first);
+      expect(() => s.attach(_FakeClient('@hivestore9', 'e2')),
+          throwsA(isA<StateError>()),
+          reason: 'clear cannot license inheriting what was written after it');
+    });
+  });
+
+  group('close', () {
+    test('close is idempotent and drops the claim', () async {
+      final s = storageFor('@hivestore8');
+      await s.attach(_FakeClient('@hivestore8', 'e1'));
+      await s.close();
+      await s.close();
+      expect(s.isAttached, isFalse);
+    });
+  });
+}

--- a/packages/at_client/test/storage/hive_at_client_storage_test.dart
+++ b/packages/at_client/test/storage/hive_at_client_storage_test.dart
@@ -53,8 +53,8 @@ void main() {
       await s.attach(_FakeClient('@hivestore2', 'e1'));
       expect(
           () => s.attach(_FakeClient('@hivestore2', 'e2')),
-          throwsA(isA<StateError>().having(
-              (e) => e.message, 'message', contains('is held by @hivestore2|e1'))),
+          throwsA(isA<StateError>().having((e) => e.message, 'message',
+              contains('is held by @hivestore2|e1'))),
           reason: 'two clients on one store is the silent sharing this '
               'exists to refuse');
     });


### PR DESCRIPTION
## Why now
This whole thing came up during testing on the pqc feature branch and cost me a whole day. So I'm fixing the structural problems now, and doing so with an eye on the wasm split which will be following soon after the pqc release.

## What I did

Why this PR: an `AtClient`'s local keystore and its sync queue (the local writes still to be pushed to the atServer) were opened independently — the keystore at the configured path, the queue on Hive's global instance under a box named only by atSign. Messy messy messy.

This PR is a stepping stone - the first of a short series of PRs. It introduces the client-library object that owns the atclient storage (currently just the keystore and the sync queue, maybe more in futuure), wires it in as the default with today's Hive behaviour, and adds the claim rules — without yet changing how storage is configured or released. Later PRs add in-memory and SQLite backends, let an app inject storage through a factory in place of `hiveStoragePath`, make `stop()` release storage, and move the test packs onto in-memory storage. Small steps keep each one reviewable and let trunk pick up the fix early.

## Details:
- `AtClientStorage`: keystore and sync queue as one object with a claim. A client attaches on creation; a second client is refused; after a detach a different principal (atSign + enrollment) is refused until `forgetPrincipal()` (hand over, keep the data) or `clear()` (empty both halves). `detach()` records the departing holder.
- `HiveAtClientStorage` wraps the existing `StorageManager` and `AtSyncQueue` and is the default; `LocalSecondary` takes its queue from the storage instead of opening its own. `AtSyncQueue` gains `clear()`.
- Not in this PR: refusing a second `HiveAtClientStorage` for the same atSign. Nothing releases storage until `stop()` learns to, so that guard would refuse every test that rebuilds a client for one atSign; it arrives with the release change.

## How I did it
See commit & diffs

## How to verify it
Tests pass. new test file `test/storage/hive_at_client_storage_test.dart` pins the rules - if any of the guards are removed by accident in future in the lib code then a test will fail; `at_client_storage_wiring_test.dart` pins that a created client's `LocalSecondary` shares the storage's queue by identity.

**- Description for the changelog**
feat: `AtClientStorage` — a client's keystore and sync queue as one bundle, with `HiveAtClientStorage` as the default.
