### PR TITLE
fix(at_client): a stopped sync service abandons its round

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## 3.14.1
+- fix: `stop()` no longer races an in-flight sync round. The round ends at its
+  next step once the service is stopped, its request is reported as stopped
+  rather than as an unexpected exception, and what it had not pushed stays
+  queued for the next sync. `stop()` does not drain: an app that wants its
+  pending writes on the atServer first awaits `waitUntilCaughtUp`.
+  `LocalSecondary.syncQueueSyncSnapshot` is null for a closed queue, as for one
+  never opened.
 - feat: `AtClientStorage` — a client's local keystore and its sync queue as one
   object, with `HiveAtClientStorage` as the default. A client claims its storage
   when it is created and a second client is refused it; after the claim is

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -97,6 +97,10 @@ abstract class AtClient {
   /// keystore-event timers, closes the data-event stream, and stops the sync
   /// and notification services and the remote secondary connection.
   ///
+  /// Does not drain: a sync round in flight is abandoned at its next step and
+  /// its work retries on the next sync. An app that wants its pending writes
+  /// on the atServer first awaits `SyncService.waitUntilCaughtUp`.
+  ///
   /// Local storage is NOT closed. The instance remains in the internal cache
   /// and reuses its still-open local keystore when resumed by calling
   /// [AtClientManager.setCurrentAtSign] for the same atSign, which wires up

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -144,14 +144,18 @@ class LocalSecondary implements Secondary {
   }
 
   /// Synchronous, side-effect-free snapshot of the current queue
-  /// size. Returns `null` when the queue hasn't been opened yet
+  /// size. Returns `null` when the queue hasn't been opened yet, or has
+  /// been closed
   /// (the caller hasn't done any sync-eligible writes). Used by
   /// `SyncServiceImpl._informSyncProgress` to attach
   /// `pendingPushCount` to events without awaiting (which would
   /// change the relative ordering of progress emission and the
   /// sync round it describes). Production callers that don't mind
   /// the lazy-open should use [syncQueueSize] instead.
-  int? get syncQueueSyncSnapshot => _syncQueue?.size;
+  int? get syncQueueSyncSnapshot {
+    final q = _syncQueue;
+    return q != null && q.isOpen ? q.size : null;
+  }
 
   /// Returns up to [limit] atKey strings from the front of the
   /// pending-write queue in FIFO order. Does NOT remove them; the

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -238,6 +238,12 @@ class SyncServiceImpl implements SyncService {
     _syncProgressListeners.remove(listener);
   }
 
+  /// Ends an in-flight round at its next resumption point once [stop] has
+  /// been called, so a stopped service touches storage no further.
+  void _bailIfStopped() {
+    if (isStopped) throw const _SyncAbandoned();
+  }
+
   @visibleForTesting
   Future<void> processSyncRequests() async {
     _logger.finest('in _processSyncRequests');
@@ -317,6 +323,12 @@ class SyncServiceImpl implements SyncService {
         ..startedAt = DateTime.now().toUtc()
         ..message = 'Exception: $e'
         ..atClientException = wrapped);
+    } on _SyncAbandoned {
+      _logger.info('sync ${syncRequest.id} abandoned: the service was stopped');
+      syncRequest.result!.atClientException = AtClientException(
+          error_codes['AtClientException'], 'SyncService has been stopped');
+      _syncError(syncRequest);
+      _syncInProgress = false;
     } catch (e) {
       // Catch-all: with on-demand triggering, an unhandled exception
       // from the sync path would become an unhandled async error and
@@ -546,7 +558,9 @@ class SyncServiceImpl implements SyncService {
     // pending local write for it).
     final pendingPushAtKeys =
         Set<String>.from(await localSecondary.peekSyncQueue());
+    _bailIfStopped();
     var lastReceivedServerCommitId = await getLastReceivedServerCommitId();
+    _bailIfStopped();
     if (serverCommitId > lastReceivedServerCommitId) {
       _logger.finer('Pulling changes into local secondary'
           ' | lastReceivedServerCommitId $lastReceivedServerCommitId'
@@ -555,14 +569,17 @@ class SyncServiceImpl implements SyncService {
       final keyInfoList = await _syncFromServer(
           serverCommitId, lastReceivedServerCommitId, pendingPushAtKeys,
           localCommitIdBeforeSync: localCommitIdBeforeSync);
+      _bailIfStopped();
       syncResult.keyInfoList.addAll(keyInfoList);
     }
     final pushQueueSize = await localSecondary.syncQueueSize;
+    _bailIfStopped();
     if (pushQueueSize > 0) {
       _logger.finer(
           'Found $pushQueueSize pending atKeys in the sync queue; pushing.');
       // Hint to casual reader: This is where we sync new changes from this client to the server
       final keyInfoList = await _pushFromSyncQueue();
+      _bailIfStopped();
       syncResult.keyInfoList.addAll(keyInfoList);
     }
     syncResult.lastSyncedOn = DateTime.now().toUtc();
@@ -601,12 +618,14 @@ class SyncServiceImpl implements SyncService {
     var batchesDone = 0;
     while (true) {
       final atKeys = await localSecondary.peekSyncQueue(limit: batchSize);
+      _bailIfStopped();
       if (atKeys.isEmpty) break;
       // Snapshot the queue size BEFORE this batch so the
       // no-progress guard at the bottom can detect "the entries
       // we just tried didn't get removed" without conflating it
       // with "the queue is large because more writes arrived".
       final queueSizeBefore = await localSecondary.syncQueueSize;
+      _bailIfStopped();
       // Build the batch. Order in `batchRequests` mirrors the order
       // we got from `peekSyncQueue` — and the response comes back
       // 1-indexed by batch id, so index N-1 in our list is the entry
@@ -616,6 +635,7 @@ class SyncServiceImpl implements SyncService {
       final batchSources = <_BatchSource>[];
       for (final atKey in atKeys) {
         final entry = await localSecondary.readSyncQueueEntry(atKey);
+        _bailIfStopped();
         if (entry == null) {
           // The queue says we should push this atKey but the
           // persisted record is gone (rare race — concurrent remove,
@@ -623,11 +643,13 @@ class SyncServiceImpl implements SyncService {
           _logger.warning(
               'sync queue race: $atKey missing persisted record; removing');
           await localSecondary.removeFromSyncQueue(atKey);
+          _bailIfStopped();
           continue;
         }
         final String command;
         try {
           command = await _buildCommandFromQueueEntry(atKey, entry.op);
+          _bailIfStopped();
         } on KeyNotFoundException {
           // The keystore doesn't have a value for this atKey
           // (UPDATE / UPDATE_ALL / UPDATE_META). The race-tolerated
@@ -638,6 +660,7 @@ class SyncServiceImpl implements SyncService {
           _logger
               .info('keystore miss for $atKey on push; dropping queue entry');
           await localSecondary.removeFromSyncQueue(atKey);
+          _bailIfStopped();
           continue;
         }
         _logger.info('Will push ${entry.op} for $atKey');
@@ -657,6 +680,7 @@ class SyncServiceImpl implements SyncService {
       List<dynamic> batchResponse;
       try {
         batchResponse = await sendBatch(batchRequests);
+        _bailIfStopped();
       } on Exception catch (e) {
         // Network or auth failure for the whole batch. Leave queue
         // entries in place — next round retries.
@@ -695,6 +719,7 @@ class SyncServiceImpl implements SyncService {
             _highestPushedCommitId = commitId;
           }
           await localSecondary.removeFromSyncQueue(source.atKey);
+          _bailIfStopped();
           keyInfoList.add(KeyInfo(
             source.atKey,
             SyncDirection.localToRemote,
@@ -725,6 +750,7 @@ class SyncServiceImpl implements SyncService {
         localCommitId: _latestKnownServerCommitId,
         serverCommitId: _latestKnownServerCommitId,
       );
+      _bailIfStopped();
       // Defensive: if every entry in this batch failed (e.g. a
       // server-side per-key authorization issue), the entries we
       // tried weren't removed from the queue. Compare against the
@@ -737,7 +763,9 @@ class SyncServiceImpl implements SyncService {
       // here is whether the in-batch entries themselves got
       // removed.
       final pendingNow = await localSecondary.syncQueueSize;
+      _bailIfStopped();
       final pendingFront = await localSecondary.peekSyncQueue(limit: 1);
+      _bailIfStopped();
       final atKeysSet = atKeys.toSet();
       final allBatchKeysStillPresent =
           pendingFront.isNotEmpty && atKeysSet.contains(pendingFront.first);
@@ -819,6 +847,7 @@ class SyncServiceImpl implements SyncService {
     try {
       int? skipDeletesUntil = await setAndGetSkipDeletesUntil(
           localCommitIdBeforeSync, serverCommitId);
+      _bailIfStopped();
 
       while (serverCommitId > lastReceivedServerCommitId) {
         _sendTelemetry('_syncFromServer.whileLoop', {
@@ -830,6 +859,7 @@ class SyncServiceImpl implements SyncService {
                 lastReceivedServerCommitId, serverCommitId,
                 localCommitIdBeforeSync: localCommitIdBeforeSync,
                 skipDeletesUntil: skipDeletesUntil);
+        _bailIfStopped();
         // Refresh the pending-push snapshot AFTER the network
         // round-trip but BEFORE applying any server entries. The
         // original snapshot was taken at sync-round start; a user
@@ -842,6 +872,7 @@ class SyncServiceImpl implements SyncService {
         // pre-sync entries.
         pendingPushAtKeys = pendingPushAtKeys
             .union(Set<String>.from(await localSecondary.peekSyncQueue()));
+        _bailIfStopped();
         if (listOfCommitEntriesFromServer.isEmpty) {
           // Server walked the full (lastReceivedServerCommitId,
           // serverCommitId] range and returned no entries for this
@@ -890,6 +921,7 @@ class SyncServiceImpl implements SyncService {
                 'updating the lastReceivedServerCommitId to $lastReceivedServerCommitId');
             ConflictInfo? conflictInfo =
                 await _setConflictInfo(serverCommitEntry);
+            _bailIfStopped();
             final keyInfo = KeyInfo(
                 serverCommitEntry['atKey'],
                 SyncDirection.remoteToLocal,
@@ -909,6 +941,7 @@ class SyncServiceImpl implements SyncService {
               _parseToInteger(serverCommitEntry['commitId']);
           _promoteServerCommitId(lastReceivedServerCommitId);
           await _processServerCommitEntry(serverCommitEntry, keyInfoList);
+          _bailIfStopped();
           _logger.finest(
               'Updating lastReceivedServerCommitId to $lastReceivedServerCommitId');
         }
@@ -933,6 +966,7 @@ class SyncServiceImpl implements SyncService {
       // is persisted even if there occurs any exception during sync to local.
       await _atClient.put(_lastReceivedServerCommitIdAtKey,
           lastReceivedServerCommitId.toString());
+      _bailIfStopped();
     }
     return keyInfoList;
   }
@@ -1432,6 +1466,9 @@ class SyncServiceImpl implements SyncService {
   /// causes future [sync] calls to become no-ops until [restart] is
   /// invoked. Idempotent — calling [stop] when already stopped is a
   /// no-op.
+  /// Stops without draining. A round in flight ends at its next step; what it
+  /// had not pushed stays queued for the next sync. Callers wanting the queue
+  /// empty first await `waitUntilCaughtUp`.
   Future<void> stop() async {
     if (isStopped) {
       _logger.info('stop() called, but service is already stopped. Ignoring.');
@@ -1560,4 +1597,9 @@ class _BatchSource {
     required this.atKey,
     required this.op,
   });
+}
+
+/// Thrown inside a sync round once [SyncServiceImpl.stop] has been called.
+class _SyncAbandoned implements Exception {
+  const _SyncAbandoned();
 }

--- a/packages/at_client/lib/src/sync/at_sync_queue.dart
+++ b/packages/at_client/lib/src/sync/at_sync_queue.dart
@@ -94,6 +94,8 @@ class AtSyncQueue {
 
   bool _opened = false;
 
+  bool get isOpen => _opened;
+
   AtSyncQueue({required String atSign})
       : _atSign = atSign,
         _logger = AtSignLogger('AtSyncQueue ($atSign)');

--- a/packages/at_client/test/sync_stop_abandons_test.dart
+++ b/packages/at_client/test/sync_stop_abandons_test.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:at_client/at_client.dart';
+import 'package:at_client/src/service/sync_service_impl.dart';
+import 'package:at_client/src/sync/at_sync_queue.dart';
+import 'package:hive/hive.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class _MockNotificationService extends Mock implements NotificationService {}
+
+class _MockAtClient extends Mock implements AtClient {}
+
+class _MockLocalSecondary extends Mock implements LocalSecondary {}
+
+class _MockRemoteSecondary extends Mock implements RemoteSecondary {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(AtKey());
+  });
+
+  group('stop() during a round', () {
+    late _MockAtClient atClient;
+    late _MockLocalSecondary localSecondary;
+    late SyncServiceImpl sync;
+
+    setUp(() async {
+      atClient = _MockAtClient();
+      localSecondary = _MockLocalSecondary();
+      when(() => atClient.getCurrentAtSign()).thenReturn('@abandon');
+      when(() => atClient.getLocalSecondary()).thenReturn(localSecondary);
+      final notifications = _MockNotificationService();
+      when(() => notifications.subscribe(
+              regex: any(named: 'regex'),
+              shouldDecrypt: any(named: 'shouldDecrypt')))
+          .thenAnswer((_) => const Stream<AtNotification>.empty());
+      when(() => atClient.notificationService).thenReturn(notifications);
+      when(() => atClient.getPreferences()).thenReturn(AtClientPreference());
+      sync = await SyncServiceImpl.create(atClient,
+          remoteSecondary: _MockRemoteSecondary(),
+          warmStartSync: false) as SyncServiceImpl;
+    });
+
+    test('the round ends at its next step and touches nothing further',
+        () async {
+      final gate = Completer<List<String>>();
+      when(() => localSecondary.peekSyncQueue()).thenAnswer((_) => gate.future);
+      when(() => atClient.get(any())).thenAnswer((_) async => AtValue());
+
+      final round = sync.syncInternal(5, SyncRequest()..result = SyncResult(),
+          localCommitIdBeforeSync: 1);
+      await Future<void>.delayed(Duration.zero);
+      await sync.stop();
+      gate.complete(<String>[]);
+
+      await expectLater(round, throwsA(isA<Exception>()),
+          reason: 'a stopped service abandons the round rather than '
+              'finishing it against storage that may be closing');
+      verifyNever(() => atClient.get(any()));
+    });
+
+    test('the same round completes when not stopped (control)', () async {
+      when(() => localSecondary.peekSyncQueue())
+          .thenAnswer((_) async => <String>[]);
+      when(() => atClient.get(any())).thenAnswer((_) async => AtValue());
+
+      try {
+        await sync.syncInternal(5, SyncRequest()..result = SyncResult(),
+            localCommitIdBeforeSync: 1);
+      } catch (_) {}
+      verify(() => atClient.get(any())).called(greaterThan(0));
+    });
+  });
+
+  test(
+      'syncQueueSyncSnapshot is null for a closed queue, as for an unopened one',
+      () async {
+    final atClient = _MockAtClient();
+    when(() => atClient.getCurrentAtSign()).thenReturn('@snapshot');
+    final box =
+        await Hive.openBox<String>('snapshot_probe', bytes: Uint8List(0));
+    final queue = AtSyncQueue(atSign: '@snapshot');
+    await queue.open(injectedBox: box);
+    final ls = LocalSecondary(atClient, keyStore: null, syncQueue: queue);
+    expect(ls.syncQueueSyncSnapshot, 0);
+    await queue.close();
+    expect(ls.syncQueueSyncSnapshot, isNull,
+        reason: 'a closed queue has no size to report; null is what a caller '
+            'already handles for a queue that never opened');
+  });
+}


### PR DESCRIPTION
**- What I did**

`SyncServiceImpl.stop()` does not wait for a sync round that is in flight, and until now the round never checked for stop between its steps — so after `stop()` returned, the round carried on pulling and pushing against a service that had already let go of it, and logged whatever went wrong as an unexpected exception. The end-to-end pack does this seventeen times in a normal run, every time the manager switches atSigns.

Now the round checks after each of its awaits and ends at the next one once the service is stopped. Its request is reported as stopped rather than as an unexpected exception, and nothing is lost: an entry leaves the sync queue only on the server's ack, so what the abandoned round had not pushed is pushed next time, and a pull resumes from the last commit it applied.

`stop()` still does not drain — that is the contract, now written on `AtClient.stop()` and `SyncServiceImpl.stop()`: an app that wants its pending writes on the atServer awaits `waitUntilCaughtUp` first, then stops.

Also: `LocalSecondary.syncQueueSyncSnapshot` returns `null` for a closed queue, as it already did for one never opened, so a round that completes just as the queue closes does not fail on its own progress report.

**- How I did it**
See commit & diffs

**- How to verify it**
Tests pass. `test/sync_stop_abandons_test.dart`: a round stopped mid-flight ends at its next step and touches storage no further (stripping the checks makes exactly that test red, its control stays green). e2e pack 32/32 with 17 rounds logged as abandoned and no unexpected-exception lines; functional 82/82; unit 685.

**- Description for the changelog**
fix: a stopped sync service abandons its in-flight round cleanly; `stop()` does not drain — await `waitUntilCaughtUp` first if you need it to.
