### PR TITLE
docs(wasm): the client storage design and today's rulings, from the spike

### DIFF
--- a/docs/projects/wasm/decisions.md
+++ b/docs/projects/wasm/decisions.md
@@ -242,6 +242,63 @@ surface is read-compatible with typed Dart peers but not write-compatible.** See
 outright: it would force every JS app into a Dart build step, destroying the
 `npm install` story this entire project exists to deliver.
 
+### D-12 — Client storage is one injected bundle, and it owns the sync queue (2026-09-05)
+
+`at_client` gains a storage abstraction of its own: a single object owning **both** the
+local keystore and the sync queue. This supersedes [§2.3](design.md#23-the-sync-queue)'s
+design of a separate spec interface for the queue, and S3 with it. Three implementations
+are in scope — the Hive-backed default, a SQLite-backed one, and an in-memory one that
+touches no disk at all.
+
+The abstraction is `at_client`'s, not an extension of `at_persistence_secondary_server`'s
+`AtPersistenceBundle`. That package is owned by `at_server` and reaches this tree through
+a `dependency_overrides` git ref, so extending it would mean a coordinated cross-repo
+change and a publish before `at_client` could depend on the result.
+
+**Why one bundle rather than two interfaces.** The keystore and the queue choose their
+storage independently today, under two different keys, and neither key is the principal.
+The keystore goes through `StorageManager` to `_factory.initialize(atSign, path)`; the
+queue reads `preference.hiveStoragePath` and, when it is null, opens on the **global**
+Hive instance under a box named from the atSign alone. The null case is exactly the
+injected-keystore case, so a caller that injects a store today gets an isolated keystore
+and a silently *shared* queue — and an "in-memory" store that still writes a Hive box to
+disk. One owner makes both unrepresentable rather than guarded against.
+
+**Ownership and lifetime.** The bundle refuses a second opener: ownership is enforced
+inside the bundle rather than by a registry `at_client` keeps, so a backend cannot forget
+the check and bundles `at_client` never sees are covered too. The claim is released when
+the client closes, and `stop()` is what releases it.
+
+**What this resolves.** [OQ-3](#5-open-questions), for storage: the capability hangs off a
+factory rather than `AtClientPreference`. `AtClientPreference.hiveStoragePath` is
+deprecated in this major, its successor being a bundle injected through a new static
+factory on `AtClient` — which builds *and* wires, closing by construction the hole where a
+client came back with its service getters throwing. Deprecating `AtClientManager` is the
+direction of travel; where its `AtSignChangeListener` capability goes is deferred, because
+that capability exists only to announce that a global current atSign changed.
+
+**Surface (ruled 2026-09-05).** The owner of a claim is the client object, compared by
+identity — not the instance key, which for a legacy client is the bare atSign and so cannot
+tell two legacy clients of one atSign apart. Owned storage is closed on release; injected
+storage is only detached, the client knowing which it has. After detach, only the same
+principal may re-attach until `clear()` runs — the bundle remembers who held it last, so a
+different enrollment cannot inherit records it cannot decrypt and pushes it cannot make.
+A deliberate hand-over is `forgetPrincipal()`, which lifts the last-holder guard while keeping
+every record;
+`clear()` empties keystore and queue together and forgets the principal too, so a
+half-cleared store is unrepresentable and getting past the guard never costs the records. The surface is in
+[`design.md`](design.md#22-storage-bootstrap) §2.2.
+
+**Cost, stated honestly.** `stop()` is the atSign-switch-away path, so releasing storage
+there means switching back reopens a cold store and pulls again. That is accepted. It is
+not free: a cold store is precisely the condition under which a local-first write followed
+by a read routed to the atServer loses the race, which is how this was found. `start()`
+does not rebuild what `stop()` nulls, so a stopped client must never be handed back. The
+manager's same-atSign short-circuit already refuses one, and nothing else in production
+reaches a cached client; X1 pins that guard before X4 changes `stop()`, since the guard is
+what a released client's safety then rests on. (Amended 2026-09-05: first written as "two
+paths hand back a stopped client" — one was already guarded, the other has no caller.)
+
 ---
 
 ## 2. Measured findings
@@ -464,7 +521,9 @@ is one release instead of two. Decide per package at execution time.
 `AtServiceFactory`?** `AtServiceFactory` (`at_client_manager.dart:265`) is the closer
 analogue and already has real overrides; `AtClientPreference` is what callers already
 touch and already carries `CryptoConfig` as precedent. See
-[`design.md`](design.md) §4.
+[`design.md`](design.md) §4. **Resolved for storage by D-12** — a bundle injected through
+a static factory on `AtClient`, not a preference field. Open for the remaining
+capabilities.
 
 **OQ-4 — File transfer: change the API, or extract the component?** Either
 `uploadFile`/`downloadFile`/`reuploadFiles` move to `(bytes, name)` or a stream
@@ -528,6 +587,7 @@ covered by T3.1 and X1. Note D-7 makes this the *less* critical of the two paths
 | 2026-08-13 | Measured the JS/TS language boundary (§2.5) and the dart2js library matrix (§2.4); confirmed no Dart web compiler gates `dart:io`.                                                                  |
 | 2026-08-13 | **D-7..D-9 ruled.** dart2js is the JS/TS compile target; the facade lives in `at_client_web` with D-4 unamended; keys cross as strings and events as callbacks. `js-api.md` added as the sixth doc. |
 | 2026-08-18 | Added JS-6 (throw vs. return-tuple, supabase-js precedent) to `js-api.md` §11. |
+| 2026-09-05 | **D-12 ruled.** Client storage becomes one injected bundle owning the keystore and the sync queue; S3 and §2.3's separate queue interface are superseded. `hiveStoragePath` deprecated; `stop()` releases storage. OQ-3 resolved for storage. |
 | 2026-08-18 | `plans/wasm/api-designing.md` written: the three-layer Dart facade split (Layer A/B/C) and the Axis A/B/C reference-SDK survey. `plans/wasm/key-storage.md` written, depending on the split. |
 | 2026-08-18 | Measured the collections API's write/read asymmetry (§2.6, F1–F12) against `packages/at_client/lib/src/collections/collections.dart`. |
 | 2026-08-18 | **D-9 amended, D-10 and D-11 ruled.** Collections (`AtCollection<T>`) become the sole JS/TS data plane; the flat key/value plane from the original §5.2 is removed, not deprecated in place. The Dart gear is typed via a declared `typeTag`; app types are never compiled into `at_client_web`. Write-compatibility with typed Dart peers is left open pending an upstream `writeTypeTag` or a bounded carrier-class shim (JS-7). `js-api.md` §5–§11 rewritten to match; `plans/wasm/api-designing.md` §2.3/§2.4/§2.6 rewritten for the collections-shaped Layer B. JS-2 resolved; JS-8 (the `AtClientManager` singleton blocking multi-instance clients) recorded. |

--- a/docs/projects/wasm/design.md
+++ b/docs/projects/wasm/design.md
@@ -216,25 +216,116 @@ When non-null, `StorageManager` is skipped entirely and `LocalSecondary` takes t
 injected store. Good, but it means a web caller must construct the whole store itself
 rather than choosing a backend.
 
-**Design.** Make the factory selectable from `AtClientPreference` —
-`AtPersistenceBackendId` already carries `hive` and `sqlite`. Replace `hiveStoragePath`
-with an opaque storage location that means a filesystem path on native and a database
-name on web (§4). Add a `SqlitePersistenceConfig.clientDefaults(...)` mirroring
-`HivePersistenceConfig.clientDefaults` for the commit-log-free client bundle shape.
+**Design** (ruled by [D-12](decisions.md#d-12--client-storage-is-one-injected-bundle-and-it-owns-the-sync-queue-2026-09-05)).
+`at_client` owns a storage abstraction covering the keystore **and** the sync queue
+(§2.3), and a bundle is injected rather than located: `hiveStoragePath` is deprecated in
+this major, and its successor is a constructed bundle passed to a new static factory on
+`AtClient`. A location *string* was considered and rejected — it leaves `at_client`
+constructing the backend, which is what forces a backend import or a conditional barrel
+into the package. `AtKeysIo` (§2.4) is the shape: a neutral interface here, real
+implementations supplied by whoever knows the platform.
+
+Three implementations are in scope — the Hive-backed default, a SQLite-backed one (needing
+`SqlitePersistenceConfig.clientDefaults(...)` mirroring `HivePersistenceConfig.clientDefaults`
+for the commit-log-free client bundle shape), and an in-memory one that touches no disk.
+The in-memory implementation has a named consumer: `tests/at_functional_test` shares one
+Hive directory across every file through `test_utils.dart`'s
+`preference.hiveStoragePath = 'test/hive/client/$atsign'`, so one file inherits the next's
+pending sync queue. That is not hypothetical — it is how a scoped enrollment's client came
+to push another test's namespace keys and be refused `AT0009` by the atServer.
+
+The surface, as ruled on 2026-09-05 (four points, each in
+[D-12](decisions.md#d-12--client-storage-is-one-injected-bundle-and-it-owns-the-sync-queue-2026-09-05)):
+
+```dart
+/// The local storage one AtClient owns: its keystore and its sync queue.
+abstract class AtClientStorage {
+  /// Claims this storage for [owner]. Throws if a different client holds it,
+  /// or if a different principal held it last and [clear] has not run since;
+  /// the same client claiming again is a no-op.
+  Future<void> attach(AtClient owner);
+
+  /// Drops [owner]'s claim. Whether the backend is then closed is the
+  /// client's decision, not this object's — see below.
+  Future<void> detach(AtClient owner);
+
+  AtKeyValueStore<String, AtData, AtMetaData?> get keyStore;
+  AtSyncQueue get syncQueue;
+
+  /// Forgets which principal last held this storage, keeping the data. The
+  /// next [attach] may be a different principal. Throws while attached.
+  Future<void> forgetPrincipal();
+
+  /// Empties both halves, keeping the backend open. Idempotent.
+  Future<void> clear();
+
+  /// Closes the backend. Idempotent.
+  Future<void> close();
+}
+```
+
+- **The owner is the client object, compared by identity.** Not the instance key: for a
+  legacy client that key is the bare atSign, so two legacy clients of one atSign would
+  present the same owner and an idempotent re-attach rule would wave the second through —
+  the silent sharing this exists to refuse. Identity tells two instances apart; the refusal
+  message still describes the holder by atSign and enrollment for a human.
+- **Owned storage is closed on release; injected storage is only detached.** The client
+  knows which it has — it either built the bundle or was handed it — so the flag lives on
+  the client and this interface stays neutral. An in-memory fixture therefore survives
+  `stop()` and can be inspected afterwards; an app can hand one bundle to a later client.
+- **After detach, only the same principal may re-attach.** The bundle remembers the
+  `(atSign, enrollmentId)` that last held it and refuses a different one until `clear()`
+  has run. A new instance of the same principal — a restart within the process, a client
+  stopped and rebuilt — attaches freely. The contents are principal-specific twice over:
+  records encrypted under that principal's keys, and queued pushes that need that
+  principal's authorisation. A different principal inheriting them is the `AT0009` shape
+  from the functional pack, and this makes it unrepresentable rather than a fixture's job
+  to avoid.
+- **`forgetPrincipal()` is the deliberate hand-over.** It drops the guard and keeps the
+  data, so a caller that *means* to give one principal's storage to another — the same
+  atSign moving from a legacy client to an enrolled one — says so in one call, rather than
+  reaching for `clear()` and losing the records to get past the refusal. It throws while
+  a client is attached: hand-over happens between holders, never under one.
+- **`clear()` empties keystore and queue together**, and forgets the last principal.
+  `detach()` stamps the departing holder as the last principal, so a holder that clears
+  and then keeps writing is still guarded; the fixture sequence is detach, clear, next.
+- **The Hive backend cannot yet refuse a second *instance* for one atSign.** Every box is
+  on the global Hive instance and named by atSign, so two `HiveAtClientStorage` objects for
+  one atSign share boxes whatever their paths — and nothing releases storage until X4, so a
+  per-atSign guard would refuse every test that rebuilds a client for the same atSign
+  (`local_secondary_test.dart` does it fifteen times). X2 ships the per-object claim; the
+  per-atSign guard lands with X4, once `stop()` releases. The upstream bundle already offers it
+  for the keystore; the queue is the half that matters, because a queue carrying another
+  test's entries is exactly what poisoned the functional pack. A half-cleared store —
+  data without its pending writes, or writes without their data — is not representable.
 
 ### 2.3 The sync queue
 
 **The canonical runtime landmine, and the one to lead with when explaining this
 project.**
 
-```text
-// at_client/lib/src/sync/at_sync_queue.dart:121
-_box = await Hive.openBox<String>(boxNameForAtSign(_atSign));
+On trunk (after X3, `at_sync_queue.dart` — `AtSyncQueue.open()`):
+
+```dart
+if (store != null) {
+  _store = store;
+} else if (injectedBox != null) {
+  _store = HiveBoxSyncQueueStore(injectedBox);
+} else {
+  _store = HiveBoxSyncQueueStore(
+      await Hive.openBox<String>(boxNameForAtSign(_atSign)));
+}
 ```
 
-Opened lazily from `LocalSecondary._ensureSyncQueueOpen()`
-(`local_secondary.dart:110-134`), against the **global Hive singleton**, assuming
-someone already called `Hive.init`. `local_secondary.dart:118-121` documents that
+The default still opens on the **global** Hive instance, under a box named from the atSign
+alone — so two enrollments of one atSign share a queue whatever their paths, and an
+injected keystore, which supplies no store, shares it too. The `SyncQueueStore` indirection
+is what lets a storage bundle hand the queue its own store instead. (`gkc-pq-d1-spike`
+carries a variant that opens on `HiveInstances.forPath(path)` when the preference names a
+path, falling back to the global instance; the X3 merge-back has to keep both.)
+
+Opened lazily from `LocalSecondary._ensureSyncQueueOpen()` when no storage bundle
+supplied a queue, assuming someone already called `Hive.init`. `local_secondary.dart:118-121` documents that
 ordering dependency in a comment — it is an implicit global contract, not an enforced
 one.
 
@@ -243,11 +334,15 @@ compiles everywhere; and injecting a keystore to bypass `StorageManager` makes i
 rather than fixing it. `at_client`'s pubspec carries a direct `hive: ^2.2.3` dependency
 solely for this file.
 
-**Design.** A small spec interface with Hive and SQLite implementations, matching how
-the keystore is factored. A test seam already exists — `open({Box<String>? injectedBox})`
-at `at_sync_queue.dart:116`, documented as a test seam at `:85-89` — but it is not
-reachable from `AtClientImpl.create`, so plumbing it is a cheap intermediate step (§3).
-Drop the direct `hive` dependency once this and §2.2 land.
+**Design** (ruled by [D-12](decisions.md#d-12--client-storage-is-one-injected-bundle-and-it-owns-the-sync-queue-2026-09-05)).
+The queue does **not** get a spec interface of its own. It belongs to the storage bundle
+of §2.2, which owns the keystore beside it, so the queue can no longer be located
+separately from the store whose writes it tracks. This supersedes the earlier design here
+— a small parallel interface matching how the keystore is factored — and S3 with it, which
+plumbed `open({Box<String>? injectedBox})` (`at_sync_queue.dart`, documented as a test
+seam) through to `AtClientImpl.create` as an intermediate step. The seam stays useful for
+tests; it stops being the route to backend selection. Drop the direct `hive` dependency
+once this and §2.2 land.
 
 ### 2.4 Key material — the exemplar
 

--- a/docs/projects/wasm/implementation-plan.md
+++ b/docs/projects/wasm/implementation-plan.md
@@ -19,6 +19,7 @@ for the trajectory see [`roadmap.md`](roadmap.md); for the non-Dart consumer sto
 - [3. Phase 1 — cheap seams (S)](#3-phase-1--cheap-seams-s)
 - [4. Phase 2 — transport (T)](#4-phase-2--transport-t)
 - [5. Phase 3 — persistence (P)](#5-phase-3--persistence-p)
+- [5a. Client storage bundle (X)](#5a-client-storage-bundle-x)
 - [6. Phase 4 — the sweep (I) and crypto (C)](#6-phase-4--the-sweep-i-and-crypto-c)
 - [7. Phase 5 — `at_client_web` (W)](#7-phase-5--at_client_web-w)
 - [8. Phase 6 — the JS/TS facade (J)](#8-phase-6--the-jsts-facade-j)
@@ -159,9 +160,13 @@ Preparation. Changes no public interface, breaks nothing, and shrinks every late
 - **S2 — Plumb `MonitorOutboundConnectionFactory`.** ✅ Written, #2163 (draft).
   `Monitor` accepts it at `monitor.dart:93`; `NotificationServiceImpl._` (`notification_service_impl.dart:76-84`)
   never passes it, and `create` does not expose it. Expose and pass.
-- **S3 — Plumb the `AtSyncQueue` box seam.** ✅ Written, #2164 (draft, conflicting).
-  `open({Box<String>? injectedBox})` at `at_sync_queue.dart:116` is not reachable from `AtClientImpl.create`. Make it so —
-  this is the intermediate step toward S-token-free storage in P5.
+- **S3 — Plumb the `AtSyncQueue` box seam.** ⛔ **Superseded by
+  [D-12](decisions.md#d-12--client-storage-is-one-injected-bundle-and-it-owns-the-sync-queue-2026-09-05)**;
+  written as #2164 (draft, conflicting) before the ruling. It plumbed
+  `open({Box<String>? injectedBox})` through to `AtClientImpl.create` as the intermediate
+  step toward backend-selectable storage. The queue no longer gets a route of its own: it
+  belongs to the storage bundle (X-series below), which owns the keystore beside it. The
+  injected-box seam stays as a test seam. **#2164 needs rework, not rebasing.**
 - **S4 — Delete `sync_isolate_manager.dart`.** ✅ Written, #2162.
   `@Deprecated`, `// coverage:ignore-file`, zero references anywhere in `packages/`
   outside itself, and the only `dart:isolate`
@@ -231,12 +236,110 @@ parallel. Design in [`design.md`](design.md) §0.2 and §5.
   not instantiate — confirm that, then gate rather than port.
 - **P4 — Extend `SqlitePersistenceConfig`** with the web open parameters (database
   name, VFS choice) alongside the native `storagePath`.
-- **P5 — Add `SqlitePersistenceConfig.clientDefaults(...)`** for the commit-log-free
-  client bundle shape, mirroring `HivePersistenceConfig.clientDefaults`. → X1
+- **P5 — ~~Add~~ `SqlitePersistenceConfig.clientDefaults(...)`** — **already published**:
+  `at_persistence_secondary_server` 5.2.1 carries it (`sqlite_persistence_config.dart`),
+  mirroring `HivePersistenceConfig.clientDefaults`. Nothing to add; X3's SQLite bundle
+  consumes it. → X3
 
 **Note:** this phase is native-side `at_server` work that stands on its own merits. The
 SQLite backend improvements benefit native and server deployments regardless of the
 browser outcome.
+
+---
+
+## 5a. Client storage bundle (X)
+
+`at_client`-side, and the successor to S3. Design in
+[`design.md`](design.md#22-storage-bootstrap) §2.2 and §2.3; ruled in
+[`decisions.md`](decisions.md#d-12--client-storage-is-one-injected-bundle-and-it-owns-the-sync-queue-2026-09-05)
+D-12. Independent of the P series, which is `at_server`-side.
+
+- **X1 — Pin the stopped-client guard.** ✅ Merged, #2203. Prerequisite for X4, and worth landing alone.
+  `stop()` nulls `_syncService`, `_notificationService` and `_enrollmentService`; `start()`
+  only clears `_isStopped`, and the getters throw `StateError` rather than rebuilding — so
+  a stopped client must never be handed back. It already is not: the same-atSign
+  short-circuit in `AtClientManager.setCurrentAtSign` carries `isStopped == false`, and
+  nothing outside the manager calls `AtClientImpl.create` in production. What was missing
+  is the test. `crypto_provider_reconcile_test.dart` pins the short-circuit's crypto
+  adoption and never stops the client, so the clause could be deleted with nothing going
+  red. `at_client_manager_stopped_client_test.dart` pins it; deleting the clause reddens
+  it, quoting its reason. (First written as two open holes; one was already guarded and the
+  other has no caller.)
+- **X2 — Define `AtClientStorage`.** ✅ Merged, #2204. The neutral interface owning the keystore and the
+  sync queue, with the claim/release semantics D-12 requires: the bundle refuses a second
+  opener itself rather than `at_client` keeping a registry. Ships with the Hive-backed
+  implementation wired in as the default, so it is exercised rather than declared. The
+  per-object claim only: the Hive backend's per-atSign guard waits for X4, because nothing
+  releases storage before then and the guard would refuse every same-atSign rebuild.
+- **X3 — Three implementations.** ✅ Merged, #2205, and merged back into the spike at
+  `51bdb6230`. Hive-backed (today's behaviour), SQLite-backed, and
+  in-memory covering keystore *and* queue so nothing touches disk. The in-memory one **is**
+  `SqliteAtClientStorage` on `:memory:`, and both SQLite-backed classes are exported only from
+  `package:at_client/sqlite.dart`, so X5's pack imports that barrel. → X5, and the SQLite one
+  pairs with P5.
+- **X4 — Inject it, and release it.** A new static factory on `AtClient` that builds *and*
+  wires the services, taking a bundle; `stop()` releases the claim and closes what the
+  bundle opened. Deprecate `AtClientPreference.hiveStoragePath` with a migration note.
+  Depends on X1. **Measured 2026-09-05 on trunk `d13516d95` (the X3 merge), storage-release
+  semantics built and run against the packs before landing anything:** 69 tests red across three causes —
+  (a) 38 fixtures that rebuild a client for one atSign without stopping the previous one,
+  which the per-atSign Hive guard now refuses; (b) a sync round outliving `stop()` and
+  touching closed storage (`processSyncRequests → syncQueueSyncSnapshot → size`), fixed
+  first and separately as *a stopped sync service abandons its round* (#2206); (c) **the e2e pack
+  depends on cached-client resurrection for key material** — `getAtClient()` calls
+  `setCurrentAtSign` with no `atKeysIo`/`atChops`, and its own comment says so; a fresh
+  client on switch-back rebuilt `AtChops` from its keystore and 14 tests died with
+  `PKAM Keypair required for signing`. Why the reopened keystore lacked the keys is NOT
+  established. And trunk's `AtClient.stop()` dartdoc *promises* resurrection: "Local
+  storage is NOT closed. The instance remains in the internal cache and reuses its
+  still-open local keystore when resumed". X4's storage release therefore changes a
+  documented contract, and the packs (X5) and that dartdoc move with it. The storage-release
+  work is parked as a git stash named `x4-release-wip` on the repository's stash stack
+  (its label names a branch since deleted; resume by branching from trunk and popping it)
+  until then.
+- **X5 — Move the functional pack onto an in-memory bundle per file.** The named consumer:
+  `test_utils.dart` shares `test/hive/client/$atsign` across every file, so one file
+  inherits the next's pending sync queue and the next client's scoped enrollment is refused
+  `AT0009` pushing keys it did not write. Depends on X3.
+- **X6 — Consumers.** `at_client_flutter` and `at_onboarding_cli` move onto the factory, so
+  both are WASM-ready ahead of the next major. Whether they move in this major or the next
+  is open.
+
+**Sequencing.** Each X item lands as its own PR on **trunk** and is merged back into
+`gkc-pq-d1-spike` before the next starts, so the drift never accumulates into one large
+reconciliation. The one reconciliation worth writing down rather than discovering at
+merge time is X4's: `create()` differs between trunk and the spike in three hunks — the
+`(atSign, enrollmentId)` cache key (`_resolveCacheKey`), the two `refuse*` guards before `start()`, and
+filing under the identity `_init` settled. Keep the key and the filing; **delete
+`refuseChangedStoragePath`**, which a bundle holding its own claim makes redundant; keep
+`refuseChangedRolloutAxes`. `stop()` is identical on both branches, and
+`_stopBackgroundProcesses()` differs only by the spike's `_pqBootstrap?.stop()`. That diff was
+measured 2026-09-05 against trunk `ba281fda3`, before X2 and X3 landed; the X4 row's
+measurement is against `d13516d95`, after them.
+
+**Found 2026-09-05 by the wrap-up's cold read and done the same day:** the X3 merge-back
+had been skipped. It landed as `51bdb6230`; `at_sync_queue.dart` kept trunk's `SyncQueueStore`
+abstraction and the spike's `HiveInstances.forPath(path)` default together, and the queue's
+`storagePath` became optional so trunk's SQLite storage compiles on the spike. Also owed: nine dangling links to a `plans/wasm/`
+directory that does not exist (`implementation-plan.md`, `js-api.md`, `decisions.md`).
+
+**Deferred to the major:** deprecating `AtClientManager`. Its `AtSignChangeListener`
+capability exists only because there is a global current atSign, and where that goes is
+undecided, and the migration is large:
+
+```bash
+grep -rl 'AtClientManager' --include='*.dart' packages tests | wc -l
+```
+
+**Also deferred to the major (ruled 2026-09-05):** `NotificationParams.forUpdate` with no
+value is an anti-pattern — the peer is told about a record it must then look up, and a
+local-first `put` may not have reached the atServer when it does — and should be refused;
+refusing is breaking, so it waits for the major. Until then the hazard is documented on
+`useRemoteAtServer` in `request_options.dart`.
+
+**Considered and rejected (2026-09-05):** renaming or re-homing `waitUntilCaughtUp`. It
+does wait for pending pushes (`pendingPushCount == 0`), the null-as-zero treatment of that
+count is sound for at_client's own sync service, and the extension seam is fine as it is.
 
 ---
 

--- a/docs/projects/wasm/roadmap.md
+++ b/docs/projects/wasm/roadmap.md
@@ -221,7 +221,11 @@ changes and are accepted as such — [`decisions.md`](decisions.md) D-3.
 `at_auth`'s WASM split is **owned by the PQ program**, not by this project:
 projects **S-5** (at_auth 4.0.0 — the `at_auth_io.dart` barrel, dropping the
 `FileAtKeysIo` default, registrar onto `package:http`) and **S-6** (consumer bumps),
-at [`../pq/implementation-plan.md`](../pq/implementation-plan.md) lines 312–339. That
+at [`../pq/implementation-plan.md`](../pq/implementation-plan.md) — ⚠️ this cited
+**lines 312–339**, and a line number is not an address: that plan was restructured
+on 2026-08-26 and the range now lands on unrelated prose. Find S-5 and S-6 by name
+in [`../pq/detail/implementation-plan.md`](../pq/detail/implementation-plan.md).
+That
 plan explicitly names *this* effort as the separate "wasm-port" that owns
 `at_lookup` and `at_chops`.
 


### PR DESCRIPTION
**- What I did**

Brings trunk's `docs/projects/wasm/` up to the spike's, so the design that the merged storage PRs (#2203, #2204, #2205) implement is on the branch they landed on rather than only on the PQ branch. Four files change; the other two are already identical.

- `decisions.md` — D-12: a client's local keystore and its sync queue become one storage object that a client claims; the surface as ruled — attach/detach by client identity, only the same principal may re-attach until `forgetPrincipal()` (hand over, keep the data) or `clear()` (empty both halves); the in-memory implementation is SQLite on `:memory:`, behind `package:at_client/sqlite.dart` so the main import stays SQLite-free. OQ-3 resolved for storage.
- `implementation-plan.md` — the X series with its status: X1–X3 merged with their PR numbers; X4 (a factory taking a storage object, `stop()` releasing storage, `hiveStoragePath` deprecated) with what building its release semantics against the packs measured and why it is parked; X5–X6 owed; S3 superseded by the bundle. Two rulings made in passing are recorded here: `NotificationParams.forUpdate` with no value is an anti-pattern deferred to the major, and `waitUntilCaughtUp` stays as it is.
- `design.md` §2.2/§2.3 — rewritten to describe trunk's code: the bundle and its surface; the queue storing through `SyncQueueStore` with the global Hive instance as the default.
- `roadmap.md` — corrects a citation into the PQ plan that pointed at line numbers which no longer hold, and points at the PQ plan's detail file instead. That file arrives with the PQ branch, so until then this is the one forward reference in the set; the two other cross-links into the PQ plan resolve on trunk today.

Every file is byte-identical to the spike's copy (`cmp`), and every intra-set link resolves (101 checked, 0 broken).

**- How I did it**
See commit & diffs

**- How to verify it**
Docs only; the acceptance rails that read Markdown cover `docs/projects/pq/`, not this set.

**- Description for the changelog**
Not applicable — project documentation.
