### PR TITLE
feat(at_client): isolate a client's storage, and release it on stop()

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -6,6 +6,15 @@
   pending writes on the atServer first awaits `waitUntilCaughtUp`.
   `LocalSecondary.syncQueueSyncSnapshot` is null for a closed queue, as for one
   never opened.
+- **BREAKING (behaviour):** `AtClient.stop()` releases the client's storage
+  and removes the client from the instance cache. A stopped client keeps nothing
+  open and cannot be restarted; `start()` on one throws, and the next `create()`
+  or `setCurrentAtSign` builds a fresh client on freshly opened storage. Before,
+  a stopped client stayed cached with its store open and was handed back on the
+  next request. Switching atSigns therefore reopens storage cold on the way
+  back. With release in place, `HiveAtClientStorage` refuses a second instance
+  for an atSign whose boxes another instance holds. A client whose
+  construction fails releases the storage it had claimed before rethrowing.
 - feat: `AtClientStorage` — a client's local keystore and its sync queue as one
   object, with `HiveAtClientStorage` as the default. A client claims its storage
   when it is created and a second client is refused it; after the claim is

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,11 @@
 ## 3.14.1
+- fix: `stop()` no longer races an in-flight sync round. The round ends at its
+  next step once the service is stopped, its request is reported as stopped
+  rather than as an unexpected exception, and what it had not pushed stays
+  queued for the next sync. `stop()` does not drain: an app that wants its
+  pending writes on the atServer first awaits `waitUntilCaughtUp`.
+  `LocalSecondary.syncQueueSyncSnapshot` is null for a closed queue, as for one
+  never opened.
 - feat: `AtClientStorage` — a client's local keystore and its sync queue as one
   object, with `HiveAtClientStorage` as the default. A client claims its storage
   when it is created and a second client is refused it; after the claim is

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 3.14.1
+- build: require `at_persistence_secondary_server` ^5.3.0. This package's
+  keystore and sync queue open on `HiveInstances`, which 5.3.0 is the first
+  release to carry; the floor still said ^5.1.0, so a consumer could resolve
+  a version without it and fail to compile.
 - fix: `stop()` no longer races an in-flight sync round. The round ends at its
   next step once the service is stopped, its request is reported as stopped
   rather than as an unexpected exception, and what it had not pushed stays

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -12,9 +12,22 @@
   or `setCurrentAtSign` builds a fresh client on freshly opened storage. Before,
   a stopped client stayed cached with its store open and was handed back on the
   next request. Switching atSigns therefore reopens storage cold on the way
-  back. With release in place, `HiveAtClientStorage` refuses a second instance
-  for an atSign whose boxes another instance holds. A client whose
-  construction fails releases the storage it had claimed before rethrowing.
+  back. With release in place, a storage refuses to open a store another
+  storage already has open. A client whose construction fails releases the
+  storage it had claimed before rethrowing.
+- fix: a client's local storage is isolated by where it was told to put it.
+  Its sync queue now opens on the Hive instance owning its `hiveStoragePath`,
+  the same one its keystore uses; before, the queue opened on the package-global
+  instance under a box named from the atSign alone, so two clients of one atSign
+  shared a queue however different the paths they were given, and a client's
+  keystore and queue could land on different instances. Two clients of one
+  atSign given separate directories are therefore separate stores, which is what
+  lets two enrollments of one atSign — whose namespace scopes differ — run side
+  by side without seeing each other's records or pending writes. The guard that
+  refuses a second opener is keyed by the store rather than by the atSign: the
+  directory plus the atSign, since two atSigns under one directory are two boxes
+  and share nothing. `AtSyncQueue` takes the storage path it should open under,
+  and `AtClientStorage` implementations report the store they point at.
 - feat: `AtClientStorage` — a client's local keystore and its sync queue as one
   object, with `HiveAtClientStorage` as the default. A client claims its storage
   when it is created and a second client is refused it; after the claim is

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -28,6 +28,13 @@
   directory plus the atSign, since two atSigns under one directory are two boxes
   and share nothing. `AtSyncQueue` takes the storage path it should open under,
   and `AtClientStorage` implementations report the store they point at.
+- fix: a delete that supersedes a queued update is no longer lost on push. Queue
+  entries carry a monotonic `seq`, and the drain removes only the version it
+  actually pushed, so a write that replaced the entry mid-flight stays queued for
+  the next round. Before, an unconditional removal discarded it: the server kept
+  the superseded update, the queue read empty, and the client reported itself in
+  sync. `ts` cannot serve as that identity — an update and a delete of one key
+  land well inside the same millisecond.
 - feat: `AtClientStorage` — a client's local keystore and its sync queue as one
   object, with `HiveAtClientStorage` as the default. A client claims its storage
   when it is created and a second client is refused it; after the claim is

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -28,6 +28,14 @@
   directory plus the atSign, since two atSigns under one directory are two boxes
   and share nothing. `AtSyncQueue` takes the storage path it should open under,
   and `AtClientStorage` implementations report the store they point at.
+- feat: `AtClient.create` and `AtClientManager.setCurrentAtSign` accept a
+  `storage:` argument, and `AtServiceFactory.atClient` passes one through. A
+  caller that supplies storage picks both the backend and where it lives, so
+  `AtClientPreference.hiveStoragePath` no longer has to name a location; omit it
+  and the client builds the Hive store under that path exactly as before. The
+  client only borrows storage it was given: `stop()` detaches without closing,
+  so one store can be handed to a later client, while storage the client built
+  itself is still closed on release.
 - fix: a delete that supersedes a queued update is no longer lost on push. Queue
   entries carry a monotonic `seq`, and the drain removes only the version it
   actually pushed, so a write that replaced the entry mid-flight stays queued for

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -44,8 +44,13 @@ class AtClientImpl implements AtClient {
   AtKeyValueStore<String, AtData, AtMetaData?>? _localSecondaryKeyStore;
 
   /// The keystore and sync queue this client holds; null when an external
-  /// keystore was injected or storage is not required.
+  /// keystore was injected, storage is not required, or [stop] has released it.
   AtClientStorage? _storage;
+
+  /// Whether this client built [_storage] itself and so closes it on [stop];
+  /// injected storage is only detached.
+  bool _ownsStorage = false;
+  bool _storageReleased = false;
 
   @visibleForTesting
   AtClientStorage? get storage => _storage;
@@ -344,7 +349,17 @@ class AtClientImpl implements AtClient {
         enrollmentId: enrollmentId,
       );
 
-      await atClientImpl._init(atLookUp: atLookUp);
+      try {
+        await atClientImpl._init(atLookUp: atLookUp);
+      } catch (_) {
+        // A client that failed to build holds nothing: its claim on the storage
+
+        // would otherwise outlive it and refuse every later client.
+
+        await atClientImpl._releaseStorage();
+
+        rethrow;
+      }
     }
 
     atClientInstanceMap[currentAtSign] = atClientImpl;
@@ -401,6 +416,7 @@ class AtClientImpl implements AtClient {
             HiveAtClientStorage(atSign: _atSign, storagePath: storagePath);
         await storage.attach(this);
         _storage = storage;
+        _ownsStorage = true;
         syncQueue = storage.syncQueue;
       }
 
@@ -570,6 +586,10 @@ class AtClientImpl implements AtClient {
       _logger.finer('start() called, but atClient is not stopped. Ignoring');
       return;
     }
+    if (_storageReleased) {
+      throw StateError('this client released its storage when it stopped; '
+          'build a new client rather than restarting this one');
+    }
     _isStopped = false;
   }
 
@@ -584,6 +604,25 @@ class AtClientImpl implements AtClient {
     _logger.info('stop() called: stopping at_client for $_atSign');
 
     await _stopBackgroundProcesses();
+    await _releaseStorage();
+    if (identical(atClientInstanceMap[_atSign], this)) {
+      atClientInstanceMap.remove(_atSign);
+    }
+  }
+
+  /// Drops this client's claim on its storage, closing it if this client built
+  /// it. A stopped client keeps nothing open and cannot be restarted.
+  Future<void> _releaseStorage() async {
+    final storage = _storage;
+    if (storage == null) return;
+    _storageReleased = true;
+    try {
+      await storage.detach(this);
+      if (_ownsStorage) await storage.close();
+    } catch (e) {
+      _logger.warning('Error while releasing storage: $e');
+    }
+    _storage = null;
   }
 
   Future<void> _stopBackgroundProcesses() async {

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -47,6 +47,11 @@ class AtClientImpl implements AtClient {
   /// keystore was injected, storage is not required, or [stop] has released it.
   AtClientStorage? _storage;
 
+  /// Storage handed to this client by its caller, if any. A client that was
+  /// given one never closes it: the caller owns its lifetime and may hand the
+  /// same store to a later client.
+  AtClientStorage? _injectedStorage;
+
   /// Whether this client built [_storage] itself and so closes it on [stop];
   /// injected storage is only detached.
   bool _ownsStorage = false;
@@ -319,6 +324,7 @@ class AtClientImpl implements AtClient {
     AtKeysIo? atKeysIo,
     AtLookUp? atLookUp,
     String? enrollmentId,
+    AtClientStorage? storage,
   }) async {
     currentAtSign = AtUtils.fixAtSign(currentAtSign);
 
@@ -347,6 +353,7 @@ class AtClientImpl implements AtClient {
         atKeysIo: atKeysIo,
         atLookUp: atLookUp,
         enrollmentId: enrollmentId,
+        storage: storage,
       );
 
       try {
@@ -377,7 +384,9 @@ class AtClientImpl implements AtClient {
     AtKeysIo? atKeysIo,
     AtLookUp? atLookUp,
     this.enrollmentId,
+    AtClientStorage? storage,
   }) {
+    _injectedStorage = storage;
     _atSign = theAtSign.toAtsign();
     _logger = AtSignLogger('AtClientImpl ($_atSign)');
     _preference = preference;
@@ -408,15 +417,26 @@ class AtClientImpl implements AtClient {
     if (_preference!.isLocalStoreRequired) {
       AtSyncQueue? syncQueue;
       if (_localSecondaryKeyStore == null) {
-        final storagePath = preference!.hiveStoragePath;
-        if (storagePath == null) {
-          throw Exception('Please set local storage path');
+        // A caller that supplied storage picked the backend and the location;
+        // this client only borrows it, so `stop()` detaches without closing.
+        // Otherwise build the default Hive store under the preference's path
+        // and own it.
+        final injected = _injectedStorage;
+        final AtClientStorage storage;
+        if (injected != null) {
+          storage = injected;
+          _ownsStorage = false;
+        } else {
+          final storagePath = preference!.hiveStoragePath;
+          if (storagePath == null) {
+            throw Exception('Please set local storage path');
+          }
+          storage =
+              HiveAtClientStorage(atSign: _atSign, storagePath: storagePath);
+          _ownsStorage = true;
         }
-        final storage =
-            HiveAtClientStorage(atSign: _atSign, storagePath: storagePath);
         await storage.attach(this);
         _storage = storage;
-        _ownsStorage = true;
         syncQueue = storage.syncQueue;
       }
 

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -97,6 +97,10 @@ abstract class AtClient {
   /// keystore-event timers, closes the data-event stream, and stops the sync
   /// and notification services and the remote secondary connection.
   ///
+  /// Does not drain: a sync round in flight is abandoned at its next step and
+  /// its work retries on the next sync. An app that wants its pending writes
+  /// on the atServer first awaits `SyncService.waitUntilCaughtUp`.
+  ///
   /// Local storage is NOT closed. The instance remains in the internal cache
   /// and reuses its still-open local keystore when resumed by calling
   /// [AtClientManager.setCurrentAtSign] for the same atSign, which wires up

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -144,14 +144,18 @@ class LocalSecondary implements Secondary {
   }
 
   /// Synchronous, side-effect-free snapshot of the current queue
-  /// size. Returns `null` when the queue hasn't been opened yet
+  /// size. Returns `null` when the queue hasn't been opened yet, or has
+  /// been closed
   /// (the caller hasn't done any sync-eligible writes). Used by
   /// `SyncServiceImpl._informSyncProgress` to attach
   /// `pendingPushCount` to events without awaiting (which would
   /// change the relative ordering of progress emission and the
   /// sync round it describes). Production callers that don't mind
   /// the lazy-open should use [syncQueueSize] instead.
-  int? get syncQueueSyncSnapshot => _syncQueue?.size;
+  int? get syncQueueSyncSnapshot {
+    final q = _syncQueue;
+    return q != null && q.isOpen ? q.size : null;
+  }
 
   /// Returns up to [limit] atKey strings from the front of the
   /// pending-write queue in FIFO order. Does NOT remove them; the

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -177,11 +177,19 @@ class LocalSecondary implements Secondary {
     return q.readEntry(atKey);
   }
 
+  /// Removes [atKey]'s queue entry only while it is still the version
+  /// stamped [seq]; returns whether it removed. The drain's success-path
+  /// removal — see [AtSyncQueue.removeIfUnchanged] for why unconditional
+  /// removal there loses whichever write replaced the entry mid-flight.
+  Future<bool> removeFromSyncQueueIfUnchanged(String atKey, int seq) async {
+    final q = await _ensureSyncQueueOpen();
+    return q.removeIfUnchanged(atKey, seq);
+  }
+
   /// Removes [atKey] from both the in-memory queue and the persisted
-  /// box. Called after a successful server-side push, OR when a
-  /// drain attempt finds the underlying keystore value missing
-  /// (race-tolerated removal: a queue write may have committed
-  /// without the keystore write landing, e.g. across a crash).
+  /// box. Called when a drain attempt finds the underlying keystore
+  /// value missing (race-tolerated removal: a queue write may have
+  /// committed without the keystore write landing, e.g. across a crash).
   Future<void> removeFromSyncQueue(String atKey) async {
     final q = await _ensureSyncQueueOpen();
     await q.remove(atKey);

--- a/packages/at_client/lib/src/client/local_secondary.dart
+++ b/packages/at_client/lib/src/client/local_secondary.dart
@@ -111,12 +111,12 @@ class LocalSecondary implements Secondary {
   /// the open; concurrent callers await the same in-flight future so
   /// we never call `Hive.openBox` twice for the same atSign.
   ///
-  /// Must run AFTER the at_persistence_secondary_server's
-  /// `HiveAtPersistenceFactory.initialize(...)` has called
-  /// `Hive.init(...)`, which is guaranteed by the
-  /// [StorageManager] init ordering during AtClient init. We
-  /// intentionally do not call `Hive.init` here — rerunning it with a
-  /// different path would silently misroute the box.
+  /// The queue opens on the instance owning the client's
+  /// `hiveStoragePath` — the same one the keystore uses — so a client's two
+  /// halves cannot land in different places. A client configuring no path
+  /// falls back to the package-global instance, which is why this must still
+  /// run after the keystore's initialisation has called `Hive.init(...)`; we
+  /// never call it here ourselves.
   Future<AtSyncQueue> _ensureSyncQueueOpen() {
     final existing = _syncQueue;
     if (existing != null) return Future.value(existing);
@@ -128,7 +128,9 @@ class LocalSecondary implements Secondary {
           'set; AtClientManager.setCurrentAtSign must run first',
         );
       }
-      final q = AtSyncQueue(atSign: atSign);
+      final q = AtSyncQueue(
+          atSign: atSign,
+          storagePath: _atClient.getPreferences()?.hiveStoragePath);
       await q.open();
       _syncQueue = q;
       return q;

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -80,7 +80,8 @@ class AtClientManager {
       AtChops? atChops,
       AtKeysIo? atKeysIo,
       AtLookUp? atLookUp,
-      String? enrollmentId}) async {
+      String? enrollmentId,
+      AtClientStorage? storage}) async {
     serviceFactory ??= DefaultAtServiceFactory();
 
     _logger.info("setCurrentAtSign called with atSign $atSign");
@@ -111,6 +112,7 @@ class AtClientManager {
         atKeysIo == null &&
         atLookUp == null &&
         enrollmentId == null &&
+        storage == null &&
         _currentAtClient!.isStopped == false) {
       // The full stop/recreate path below recreates via AtClientImpl.create(),
       // which adopts the supplied preference's crypto config onto a re-used
@@ -141,7 +143,8 @@ class AtClientManager {
         atChops: atChops,
         atKeysIo: atKeysIo,
         atLookUp: atLookUp,
-        enrollmentId: enrollmentId);
+        enrollmentId: enrollmentId,
+        storage: storage);
 
     var notificationService = await serviceFactory.notificationService(
         _currentAtClient!, this,
@@ -272,6 +275,7 @@ abstract class AtServiceFactory {
     AtKeysIo? atKeysIo,
     AtLookUp? atLookUp,
     String? enrollmentId,
+    AtClientStorage? storage,
   });
 
   Future<NotificationService> notificationService(
@@ -299,6 +303,7 @@ class DefaultAtServiceFactory implements AtServiceFactory {
     AtKeysIo? atKeysIo,
     AtLookUp? atLookUp,
     String? enrollmentId,
+    AtClientStorage? storage,
   }) async {
     return await AtClientImpl.create(
       atSign,
@@ -309,6 +314,7 @@ class DefaultAtServiceFactory implements AtServiceFactory {
       atKeysIo: atKeysIo,
       atLookUp: atLookUp,
       enrollmentId: enrollmentId,
+      storage: storage,
     );
   }
 

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -238,6 +238,12 @@ class SyncServiceImpl implements SyncService {
     _syncProgressListeners.remove(listener);
   }
 
+  /// Ends an in-flight round at its next resumption point once [stop] has
+  /// been called, so a stopped service touches storage no further.
+  void _bailIfStopped() {
+    if (isStopped) throw const _SyncAbandoned();
+  }
+
   @visibleForTesting
   Future<void> processSyncRequests() async {
     _logger.finest('in _processSyncRequests');
@@ -317,6 +323,12 @@ class SyncServiceImpl implements SyncService {
         ..startedAt = DateTime.now().toUtc()
         ..message = 'Exception: $e'
         ..atClientException = wrapped);
+    } on _SyncAbandoned {
+      _logger.info('sync ${syncRequest.id} abandoned: the service was stopped');
+      syncRequest.result!.atClientException = AtClientException(
+          error_codes['AtClientException'], 'SyncService has been stopped');
+      _syncError(syncRequest);
+      _syncInProgress = false;
     } catch (e) {
       // Catch-all: with on-demand triggering, an unhandled exception
       // from the sync path would become an unhandled async error and
@@ -546,7 +558,9 @@ class SyncServiceImpl implements SyncService {
     // pending local write for it).
     final pendingPushAtKeys =
         Set<String>.from(await localSecondary.peekSyncQueue());
+    _bailIfStopped();
     var lastReceivedServerCommitId = await getLastReceivedServerCommitId();
+    _bailIfStopped();
     if (serverCommitId > lastReceivedServerCommitId) {
       _logger.finer('Pulling changes into local secondary'
           ' | lastReceivedServerCommitId $lastReceivedServerCommitId'
@@ -555,14 +569,17 @@ class SyncServiceImpl implements SyncService {
       final keyInfoList = await _syncFromServer(
           serverCommitId, lastReceivedServerCommitId, pendingPushAtKeys,
           localCommitIdBeforeSync: localCommitIdBeforeSync);
+      _bailIfStopped();
       syncResult.keyInfoList.addAll(keyInfoList);
     }
     final pushQueueSize = await localSecondary.syncQueueSize;
+    _bailIfStopped();
     if (pushQueueSize > 0) {
       _logger.finer(
           'Found $pushQueueSize pending atKeys in the sync queue; pushing.');
       // Hint to casual reader: This is where we sync new changes from this client to the server
       final keyInfoList = await _pushFromSyncQueue();
+      _bailIfStopped();
       syncResult.keyInfoList.addAll(keyInfoList);
     }
     syncResult.lastSyncedOn = DateTime.now().toUtc();
@@ -601,12 +618,14 @@ class SyncServiceImpl implements SyncService {
     var batchesDone = 0;
     while (true) {
       final atKeys = await localSecondary.peekSyncQueue(limit: batchSize);
+      _bailIfStopped();
       if (atKeys.isEmpty) break;
       // Snapshot the queue size BEFORE this batch so the
       // no-progress guard at the bottom can detect "the entries
       // we just tried didn't get removed" without conflating it
       // with "the queue is large because more writes arrived".
       final queueSizeBefore = await localSecondary.syncQueueSize;
+      _bailIfStopped();
       // Build the batch. Order in `batchRequests` mirrors the order
       // we got from `peekSyncQueue` — and the response comes back
       // 1-indexed by batch id, so index N-1 in our list is the entry
@@ -616,6 +635,7 @@ class SyncServiceImpl implements SyncService {
       final batchSources = <_BatchSource>[];
       for (final atKey in atKeys) {
         final entry = await localSecondary.readSyncQueueEntry(atKey);
+        _bailIfStopped();
         if (entry == null) {
           // The queue says we should push this atKey but the
           // persisted record is gone (rare race — concurrent remove,
@@ -623,11 +643,13 @@ class SyncServiceImpl implements SyncService {
           _logger.warning(
               'sync queue race: $atKey missing persisted record; removing');
           await localSecondary.removeFromSyncQueue(atKey);
+          _bailIfStopped();
           continue;
         }
         final String command;
         try {
           command = await _buildCommandFromQueueEntry(atKey, entry.op);
+          _bailIfStopped();
         } on KeyNotFoundException {
           // The keystore doesn't have a value for this atKey
           // (UPDATE / UPDATE_ALL / UPDATE_META). The race-tolerated
@@ -638,6 +660,7 @@ class SyncServiceImpl implements SyncService {
           _logger
               .info('keystore miss for $atKey on push; dropping queue entry');
           await localSecondary.removeFromSyncQueue(atKey);
+          _bailIfStopped();
           continue;
         }
         _logger.info('Will push ${entry.op} for $atKey');
@@ -657,6 +680,7 @@ class SyncServiceImpl implements SyncService {
       List<dynamic> batchResponse;
       try {
         batchResponse = await sendBatch(batchRequests);
+        _bailIfStopped();
       } on Exception catch (e) {
         // Network or auth failure for the whole batch. Leave queue
         // entries in place — next round retries.
@@ -695,6 +719,7 @@ class SyncServiceImpl implements SyncService {
             _highestPushedCommitId = commitId;
           }
           await localSecondary.removeFromSyncQueue(source.atKey);
+          _bailIfStopped();
           keyInfoList.add(KeyInfo(
             source.atKey,
             SyncDirection.localToRemote,
@@ -725,6 +750,7 @@ class SyncServiceImpl implements SyncService {
         localCommitId: _latestKnownServerCommitId,
         serverCommitId: _latestKnownServerCommitId,
       );
+      _bailIfStopped();
       // Defensive: if every entry in this batch failed (e.g. a
       // server-side per-key authorization issue), the entries we
       // tried weren't removed from the queue. Compare against the
@@ -737,7 +763,9 @@ class SyncServiceImpl implements SyncService {
       // here is whether the in-batch entries themselves got
       // removed.
       final pendingNow = await localSecondary.syncQueueSize;
+      _bailIfStopped();
       final pendingFront = await localSecondary.peekSyncQueue(limit: 1);
+      _bailIfStopped();
       final atKeysSet = atKeys.toSet();
       final allBatchKeysStillPresent =
           pendingFront.isNotEmpty && atKeysSet.contains(pendingFront.first);
@@ -819,6 +847,7 @@ class SyncServiceImpl implements SyncService {
     try {
       int? skipDeletesUntil = await setAndGetSkipDeletesUntil(
           localCommitIdBeforeSync, serverCommitId);
+      _bailIfStopped();
 
       while (serverCommitId > lastReceivedServerCommitId) {
         _sendTelemetry('_syncFromServer.whileLoop', {
@@ -830,6 +859,7 @@ class SyncServiceImpl implements SyncService {
                 lastReceivedServerCommitId, serverCommitId,
                 localCommitIdBeforeSync: localCommitIdBeforeSync,
                 skipDeletesUntil: skipDeletesUntil);
+        _bailIfStopped();
         // Refresh the pending-push snapshot AFTER the network
         // round-trip but BEFORE applying any server entries. The
         // original snapshot was taken at sync-round start; a user
@@ -842,6 +872,7 @@ class SyncServiceImpl implements SyncService {
         // pre-sync entries.
         pendingPushAtKeys = pendingPushAtKeys
             .union(Set<String>.from(await localSecondary.peekSyncQueue()));
+        _bailIfStopped();
         if (listOfCommitEntriesFromServer.isEmpty) {
           // Server walked the full (lastReceivedServerCommitId,
           // serverCommitId] range and returned no entries for this
@@ -890,6 +921,7 @@ class SyncServiceImpl implements SyncService {
                 'updating the lastReceivedServerCommitId to $lastReceivedServerCommitId');
             ConflictInfo? conflictInfo =
                 await _setConflictInfo(serverCommitEntry);
+            _bailIfStopped();
             final keyInfo = KeyInfo(
                 serverCommitEntry['atKey'],
                 SyncDirection.remoteToLocal,
@@ -909,6 +941,7 @@ class SyncServiceImpl implements SyncService {
               _parseToInteger(serverCommitEntry['commitId']);
           _promoteServerCommitId(lastReceivedServerCommitId);
           await _processServerCommitEntry(serverCommitEntry, keyInfoList);
+          _bailIfStopped();
           _logger.finest(
               'Updating lastReceivedServerCommitId to $lastReceivedServerCommitId');
         }
@@ -933,6 +966,7 @@ class SyncServiceImpl implements SyncService {
       // is persisted even if there occurs any exception during sync to local.
       await _atClient.put(_lastReceivedServerCommitIdAtKey,
           lastReceivedServerCommitId.toString());
+      _bailIfStopped();
     }
     return keyInfoList;
   }
@@ -1432,6 +1466,9 @@ class SyncServiceImpl implements SyncService {
   /// causes future [sync] calls to become no-ops until [restart] is
   /// invoked. Idempotent — calling [stop] when already stopped is a
   /// no-op.
+  /// Stops without draining. A round in flight ends at its next step; what it
+  /// had not pushed stays queued for the next sync. Callers wanting the queue
+  /// empty first await `waitUntilCaughtUp`.
   Future<void> stop() async {
     if (isStopped) {
       _logger.info('stop() called, but service is already stopped. Ignoring.');
@@ -1560,4 +1597,9 @@ class _BatchSource {
     required this.atKey,
     required this.op,
   });
+}
+
+/// Thrown inside a sync round once [SyncServiceImpl.stop] has been called.
+class _SyncAbandoned implements Exception {
+  const _SyncAbandoned();
 }

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -659,7 +659,7 @@ class SyncServiceImpl implements SyncService {
           // user-level write is already lost.
           _logger
               .info('keystore miss for $atKey on push; dropping queue entry');
-          await localSecondary.removeFromSyncQueue(atKey);
+          await localSecondary.removeFromSyncQueueIfUnchanged(atKey, entry.seq);
           _bailIfStopped();
           continue;
         }
@@ -670,6 +670,7 @@ class SyncServiceImpl implements SyncService {
         batchSources.add(_BatchSource(
           atKey: atKey,
           op: entry.op,
+          seq: entry.seq,
         ));
       }
       if (batchRequests.isEmpty) {
@@ -718,7 +719,8 @@ class SyncServiceImpl implements SyncService {
               commitId > _highestPushedCommitId!) {
             _highestPushedCommitId = commitId;
           }
-          await localSecondary.removeFromSyncQueue(source.atKey);
+          await localSecondary.removeFromSyncQueueIfUnchanged(
+              source.atKey, source.seq);
           _bailIfStopped();
           keyInfoList.add(KeyInfo(
             source.atKey,
@@ -1593,9 +1595,17 @@ class _BatchSource {
   final String atKey;
   final SyncQueueOp op;
 
+  /// The queue entry's [SyncQueueEntry.seq] at batch-build time — the
+  /// version this batch actually pushed. Success-path removal passes it to
+  /// [LocalSecondary.removeFromSyncQueueIfUnchanged], so an entry replaced
+  /// mid-flight (an update superseded by a delete, or by a newer value)
+  /// stays queued for the next round instead of being discarded.
+  final int seq;
+
   const _BatchSource({
     required this.atKey,
     required this.op,
+    required this.seq,
   });
 }
 

--- a/packages/at_client/lib/src/storage/at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/at_client_storage.dart
@@ -34,10 +34,20 @@ abstract class AtClientStorage {
 }
 
 /// The claim rules every [AtClientStorage] shares; a backend supplies
-/// [openBackend] and [clearData].
+/// [location], [openBackend], [closeBackend] and [clearData].
 abstract class AtClientStorageBase implements AtClientStorage {
   AtClient? _owner;
   String? _lastPrincipal;
+  bool _closed = false;
+
+  /// The storages whose backend is open, keyed by [location].
+  ///
+  /// Two storages over one location are one store on disk, so the second is
+  /// refused rather than left to share silently. Keyed by location and not by
+  /// atSign: several clients of one atSign are legitimate so long as each was
+  /// given its own location, which is how two enrollments stay isolated.
+  static final Map<String, AtClientStorageBase> _openByLocation =
+      <String, AtClientStorageBase>{};
 
   /// The `(atSign, enrollmentId)` a client acts as.
   static String principalOf(AtClient client) =>
@@ -45,9 +55,19 @@ abstract class AtClientStorageBase implements AtClientStorage {
 
   bool get isAttached => _owner != null;
 
+  /// The store this points at, in a form two storages over the same records
+  /// report identically — everything that decides which records they resolve
+  /// to, not only where the files sit: a backend keyed by atSign within a
+  /// directory includes the atSign, since two atSigns there share nothing. An
+  /// instance whose data is private to itself reports a token unique to it.
+  String get location;
+
   @override
   Future<void> attach(AtClient owner) async {
     if (identical(_owner, owner)) return;
+    if (_closed) {
+      throw StateError('this storage has been closed and cannot be reopened');
+    }
     final holder = _owner;
     if (holder != null) {
       throw StateError('this storage is held by ${principalOf(holder)}; a '
@@ -60,7 +80,16 @@ abstract class AtClientStorageBase implements AtClientStorage {
           'now asks for it; call forgetPrincipal() to hand it over '
           'deliberately, or clear() to empty it first');
     }
+    final here = location;
+    final occupant = _openByLocation[here];
+    if (occupant != null && !identical(occupant, this)) {
+      final held = occupant._lastPrincipal;
+      throw StateError('another storage is already open at $here'
+          '${held == null ? '' : ', last held by $held'}; close it before '
+          'opening a second there, or give this one its own location');
+    }
     await openBackend();
+    _openByLocation[here] = this;
     _owner = owner;
     _lastPrincipal = principal;
   }
@@ -87,14 +116,25 @@ abstract class AtClientStorageBase implements AtClientStorage {
     _lastPrincipal = null;
   }
 
+  @override
+  Future<void> close() async {
+    if (_closed) return;
+    _closed = true;
+    _owner = null;
+    final here = location;
+    if (identical(_openByLocation[here], this)) _openByLocation.remove(here);
+    await closeBackend();
+  }
+
   /// Opens the backend. Idempotent.
   @protected
   Future<void> openBackend();
 
+  /// Closes the backend. Called at most once, by [close].
+  @protected
+  Future<void> closeBackend();
+
   /// Empties keystore and queue.
   @protected
   Future<void> clearData();
-
-  @protected
-  void dropClaim() => _owner = null;
 }

--- a/packages/at_client/lib/src/storage/at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/at_client_storage.dart
@@ -88,8 +88,16 @@ abstract class AtClientStorageBase implements AtClientStorage {
           '${held == null ? '' : ', last held by $held'}; close it before '
           'opening a second there, or give this one its own location');
     }
-    await openBackend();
+    // Claimed before the await, not after: two attach() calls for the same
+    // location can otherwise both read no occupant and both pass the check
+    // above while the first is still suspended inside openBackend().
     _openByLocation[here] = this;
+    try {
+      await openBackend();
+    } catch (_) {
+      if (identical(_openByLocation[here], this)) _openByLocation.remove(here);
+      rethrow;
+    }
     _owner = owner;
     _lastPrincipal = principal;
   }

--- a/packages/at_client/lib/src/storage/hive_at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/hive_at_client_storage.dart
@@ -16,8 +16,9 @@ class HiveAtClientStorage extends AtClientStorageBase {
   bool _closed = false;
 
   // NOTE: the persistence layer opens every box on the global Hive instance,
-  // named by atSign, so two of these for one atSign share boxes whatever their
-  // paths.
+  // named by atSign, so two of these for one atSign would share boxes whatever
+  // their paths. One open per atSign per isolate.
+  static final Map<String, HiveAtClientStorage> _openByAtSign = {};
 
   /// The persistence bundle, or `null` before the first [attach].
   AtPersistenceBundle? get bundle => _manager?.bundleOrNull;
@@ -43,6 +44,12 @@ class HiveAtClientStorage extends AtClientStorageBase {
   Future<void> openBackend() async {
     if (_closed) throw StateError('storage for $atSign has been closed');
     if (_manager != null) return;
+    final other = _openByAtSign[atSign];
+    if (other != null && !identical(other, this)) {
+      throw StateError('another HiveAtClientStorage already holds $atSign\'s '
+          'boxes in this isolate (at ${other.storagePath}); stop the client '
+          'holding it before opening one at $storagePath');
+    }
     final manager =
         StorageManager(AtClientPreference()..hiveStoragePath = storagePath);
     await manager.init(atSign, null);
@@ -50,6 +57,7 @@ class HiveAtClientStorage extends AtClientStorageBase {
     await queue.open();
     _manager = manager;
     _queue = queue;
+    _openByAtSign[atSign] = this;
   }
 
   @override
@@ -65,5 +73,6 @@ class HiveAtClientStorage extends AtClientStorageBase {
     dropClaim();
     await _queue?.close();
     await _manager?.bundleOrNull?.close();
+    if (identical(_openByAtSign[atSign], this)) _openByAtSign.remove(atSign);
   }
 }

--- a/packages/at_client/lib/src/storage/hive_at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/hive_at_client_storage.dart
@@ -3,6 +3,7 @@ import 'package:at_client/src/preference/at_client_preference.dart';
 import 'package:at_client/src/storage/at_client_storage.dart';
 import 'package:at_client/src/sync/at_sync_queue.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
 
 /// The default storage: a Hive keystore and sync queue under [storagePath].
 class HiveAtClientStorage extends AtClientStorageBase {
@@ -13,12 +14,15 @@ class HiveAtClientStorage extends AtClientStorageBase {
 
   StorageManager? _manager;
   AtSyncQueue? _queue;
-  bool _closed = false;
 
-  // NOTE: the persistence layer opens every box on the global Hive instance,
-  // named by atSign, so two of these for one atSign would share boxes whatever
-  // their paths. One open per atSign per isolate.
-  static final Map<String, HiveAtClientStorage> _openByAtSign = {};
+  /// The store this points at: the canonical directory `HiveInstances.forPath`
+  /// resolves the instance by, plus the atSign the box is named from. Both
+  /// halves are needed — two atSigns under one directory are two boxes and
+  /// share nothing, while one atSign under one directory is a single box
+  /// however many of these point at it.
+  @override
+  String get location =>
+      '${HiveInstances.canonicalPathFor(storagePath)}::$atSign';
 
   /// The persistence bundle, or `null` before the first [attach].
   AtPersistenceBundle? get bundle => _manager?.bundleOrNull;
@@ -42,14 +46,7 @@ class HiveAtClientStorage extends AtClientStorageBase {
 
   @override
   Future<void> openBackend() async {
-    if (_closed) throw StateError('storage for $atSign has been closed');
     if (_manager != null) return;
-    final other = _openByAtSign[atSign];
-    if (other != null && !identical(other, this)) {
-      throw StateError('another HiveAtClientStorage already holds $atSign\'s '
-          'boxes in this isolate (at ${other.storagePath}); stop the client '
-          'holding it before opening one at $storagePath');
-    }
     final manager =
         StorageManager(AtClientPreference()..hiveStoragePath = storagePath);
     await manager.init(atSign, null);
@@ -57,7 +54,6 @@ class HiveAtClientStorage extends AtClientStorageBase {
     await queue.open();
     _manager = manager;
     _queue = queue;
-    _openByAtSign[atSign] = this;
   }
 
   @override
@@ -67,12 +63,8 @@ class HiveAtClientStorage extends AtClientStorageBase {
   }
 
   @override
-  Future<void> close() async {
-    if (_closed) return;
-    _closed = true;
-    dropClaim();
+  Future<void> closeBackend() async {
     await _queue?.close();
     await _manager?.bundleOrNull?.close();
-    if (identical(_openByAtSign[atSign], this)) _openByAtSign.remove(atSign);
   }
 }

--- a/packages/at_client/lib/src/storage/hive_at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/hive_at_client_storage.dart
@@ -53,7 +53,7 @@ class HiveAtClientStorage extends AtClientStorageBase {
     final manager =
         StorageManager(AtClientPreference()..hiveStoragePath = storagePath);
     await manager.init(atSign, null);
-    final queue = AtSyncQueue(atSign: atSign);
+    final queue = AtSyncQueue(atSign: atSign, storagePath: storagePath);
     await queue.open();
     _manager = manager;
     _queue = queue;

--- a/packages/at_client/lib/src/storage/sqlite/sqlite_at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/sqlite/sqlite_at_client_storage.dart
@@ -3,6 +3,7 @@ import 'package:at_client/src/storage/sqlite/sqlite_sync_queue_store.dart';
 import 'package:at_client/src/sync/at_sync_queue.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:at_persistence_secondary_server/sqlite.dart';
+import 'package:path/path.dart' as p;
 
 /// Keystore and sync queue in one SQLite database at [dbPath].
 ///
@@ -23,7 +24,20 @@ class SqliteAtClientStorage extends AtClientStorageBase {
   SqliteDatabase? _db;
   SqliteAtKeyValueStore? _keyStore;
   AtSyncQueue? _queue;
-  bool _closed = false;
+
+  /// The path SQLite treats as "not a file": a database private to its own
+  /// connection.
+  static const String inMemoryPath = ':memory:';
+
+  /// The store this points at: the canonicalised database file plus the atSign
+  /// its keystore is keyed by, since one file can hold more than one atSign.
+  /// An in-memory database is private to the connection that opened it, so it
+  /// reports a token unique to this instance instead — two of those share
+  /// nothing and must not be refused as one store.
+  @override
+  String get location => dbPath == inMemoryPath
+      ? '$inMemoryPath#${identityHashCode(this)}'
+      : '${p.canonicalize(dbPath)}::$atSign';
 
   @override
   AtKeyValueStore<String, AtData, AtMetaData?> get keyStore =>
@@ -35,7 +49,6 @@ class SqliteAtClientStorage extends AtClientStorageBase {
 
   @override
   Future<void> openBackend() async {
-    if (_closed) throw StateError('storage for $atSign has been closed');
     if (_db != null) return;
     final db = SqliteDatabase.open(atSign, dbPath);
     final keyStore = SqliteAtKeyValueStore(db, atSign);
@@ -55,10 +68,7 @@ class SqliteAtClientStorage extends AtClientStorageBase {
   }
 
   @override
-  Future<void> close() async {
-    if (_closed) return;
-    _closed = true;
-    dropClaim();
+  Future<void> closeBackend() async {
     await _queue?.close();
     await _keyStore?.close();
     _db?.close();
@@ -68,5 +78,6 @@ class SqliteAtClientStorage extends AtClientStorageBase {
 /// Keystore and sync queue in memory: a SQLite database that is never written
 /// to disk.
 class InMemoryAtClientStorage extends SqliteAtClientStorage {
-  InMemoryAtClientStorage({required super.atSign}) : super(dbPath: ':memory:');
+  InMemoryAtClientStorage({required super.atSign})
+      : super(dbPath: SqliteAtClientStorage.inMemoryPath);
 }

--- a/packages/at_client/lib/src/sync/at_sync_queue.dart
+++ b/packages/at_client/lib/src/sync/at_sync_queue.dart
@@ -94,6 +94,8 @@ class AtSyncQueue {
 
   bool _opened = false;
 
+  bool get isOpen => _opened;
+
   AtSyncQueue({required String atSign})
       : _atSign = atSign,
         _logger = AtSignLogger('AtSyncQueue ($atSign)');

--- a/packages/at_client/lib/src/sync/at_sync_queue.dart
+++ b/packages/at_client/lib/src/sync/at_sync_queue.dart
@@ -2,6 +2,7 @@ import 'dart:collection';
 import 'dart:convert';
 
 import 'package:at_client/src/sync/sync_queue_store.dart';
+import 'package:at_persistence_secondary_server/hive.dart';
 import 'package:at_utils/at_utils.dart';
 import 'package:hive/hive.dart';
 import 'package:meta/meta.dart';
@@ -74,9 +75,9 @@ class SyncQueueEntry {
 /// order across restarts.
 ///
 /// Lifecycle: construct → [open] → use → [close]. [open] is idempotent.
-/// Hive must already have been initialised (via the keystore's
-/// `HiveAtPersistenceFactory.initialize(...)`); this class never calls
-/// `Hive.init` itself.
+/// The box opens on the Hive instance owning this queue's `storagePath`, so
+/// two clients of one atSign in one process keep separate queues when given
+/// separate paths.
 class AtSyncQueue {
   static const String _boxNamePrefix = 'syncqueue_';
 
@@ -84,10 +85,9 @@ class AtSyncQueue {
   final AtSignLogger _logger;
 
   /// Test seam. Production callers should use the default constructor —
-  /// the box is opened against the global Hive instance via [open].
-  /// Tests can pass an already-opened `Box<String>` to bypass the
-  /// production `Hive.openBox` call (useful for in-memory test boxes
-  /// or to share a box across test fixtures).
+  /// [open] resolves the box on the instance owning this queue's
+  /// `storagePath`. Tests can pass an already-opened `Box<String>` to bypass
+  /// that (useful for in-memory test boxes or to share one across fixtures).
   SyncQueueStore? _store;
 
   final LinkedHashSet<String> _inMemoryQueue = LinkedHashSet<String>();
@@ -96,8 +96,16 @@ class AtSyncQueue {
 
   bool get isOpen => _opened;
 
-  AtSyncQueue({required String atSign})
+  /// The directory this queue's box lives in, or null for the package-global
+  /// Hive instance. Required so the compiler names every call site — a second
+  /// client of one atSign needs its own path and a default would be silently
+  /// wrong. Null keeps the legacy global-instance behaviour for a caller
+  /// (e.g. an injected keystore) that has no directory to name.
+  final String? _storagePath;
+
+  AtSyncQueue({required String atSign, String? storagePath})
       : _atSign = atSign,
+        _storagePath = storagePath,
         _logger = AtSignLogger('AtSyncQueue ($atSign)');
 
   /// Returns the Hive box name this queue uses, derived
@@ -112,10 +120,12 @@ class AtSyncQueue {
   /// in `ts`-ascending order. Idempotent — calling [open] twice is a
   /// no-op after the first.
   ///
-  /// Hive.init must already have been called by the surrounding
-  /// keystore initialisation. If [injectedBox] is supplied (test
-  /// seam), it is used instead of opening one via Hive — letting
-  /// tests provide an in-memory box without calling Hive.init at all.
+  /// The box opens on the instance owning this queue's `storagePath`, not on
+  /// the package-global `Hive`: the box name derives from the atSign alone and
+  /// Hive resolves open boxes by name within an instance, so opening on the
+  /// global meant two clients of one atSign shared one queue however different
+  /// their paths. A [store] from a storage bundle is used as is; an
+  /// [injectedBox] (test seam) is wrapped.
   Future<void> open({Box<String>? injectedBox, SyncQueueStore? store}) async {
     if (_opened) return;
     if (store != null) {
@@ -123,8 +133,10 @@ class AtSyncQueue {
     } else if (injectedBox != null) {
       _store = HiveBoxSyncQueueStore(injectedBox);
     } else {
+      final path = _storagePath;
+      final hive = path == null ? Hive : HiveInstances.forPath(path);
       _store = HiveBoxSyncQueueStore(
-          await Hive.openBox<String>(boxNameForAtSign(_atSign)));
+          await hive.openBox<String>(boxNameForAtSign(_atSign)));
     }
     _replayIntoMemory();
     _opened = true;

--- a/packages/at_client/lib/src/sync/at_sync_queue.dart
+++ b/packages/at_client/lib/src/sync/at_sync_queue.dart
@@ -29,13 +29,24 @@ class SyncQueueEntry {
   /// recent enqueue for [atKey]. Used for ordering on startup replay.
   final int ts;
 
+  /// Monotonic per-queue enqueue counter, stamped by [AtSyncQueue.enqueue].
+  ///
+  /// This is the identity a drain uses to remove exactly the version it
+  /// pushed. `ts` cannot serve: it is milliseconds, and an update followed by
+  /// a delete of the same key lands well inside one millisecond — the exact
+  /// pair the removal must tell apart. Entries persisted before this field
+  /// existed read back as 0.
+  final int seq;
+
   SyncQueueEntry({
     required this.atKey,
     required this.op,
     required this.ts,
+    this.seq = 0,
   });
 
-  Map<String, dynamic> _toJson() => <String, dynamic>{'op': op.name, 'ts': ts};
+  Map<String, dynamic> _toJson() =>
+      <String, dynamic>{'op': op.name, 'ts': ts, 'seq': seq};
 
   String _serialise() => jsonEncode(_toJson());
 
@@ -52,6 +63,7 @@ class SyncQueueEntry {
       atKey: atKey,
       op: op,
       ts: map['ts'] as int,
+      seq: (map['seq'] as int?) ?? 0,
     );
   }
 }
@@ -162,6 +174,11 @@ class AtSyncQueue {
     }
     entries.sort((a, b) => a.ts.compareTo(b.ts));
     for (final e in entries) {
+      // Seed the enqueue counter past everything persisted, so a restart
+      // cannot stamp a seq an in-flight drain from the previous process
+      // already read — removeIfUnchanged's comparison depends on seqs never
+      // being reissued.
+      if (e.seq >= _nextSeq) _nextSeq = e.seq + 1;
       _inMemoryQueue.add(e.atKey);
     }
   }
@@ -187,6 +204,10 @@ class AtSyncQueue {
   ///
   /// Use [DateTime.now().millisecondsSinceEpoch] as the timestamp
   /// unless [ts] is supplied (for tests).
+  /// Monotonic enqueue counter for this queue instance, seeded past the
+  /// highest persisted `seq` by [open] so a restart cannot reissue one.
+  int _nextSeq = 1;
+
   Future<void> enqueue(
     String atKey,
     SyncQueueOp op, {
@@ -197,6 +218,7 @@ class AtSyncQueue {
       atKey: atKey,
       op: op,
       ts: ts ?? DateTime.now().millisecondsSinceEpoch,
+      seq: _nextSeq++,
     );
     await _store!.put(atKey, entry._serialise());
     _inMemoryQueue.add(atKey);
@@ -221,6 +243,26 @@ class AtSyncQueue {
     _ensureOpen();
     _inMemoryQueue.remove(atKey);
     await _store!.delete(atKey);
+  }
+
+  /// Removes [atKey] only while its entry is still the one stamped [seq];
+  /// returns whether it removed.
+  ///
+  /// This is the drain's success-path removal. Between a drain reading an
+  /// entry and the server accepting the push, a new local write to the same
+  /// atKey replaces the entry — an update superseded by a delete, or by a
+  /// newer value. An unconditional remove at that point discards the newer
+  /// op with nothing left to retry it: the server keeps what was pushed, the
+  /// queue reads empty, and the client reports itself in sync. Removing only
+  /// the pushed version leaves a superseded entry queued for the next round.
+  Future<bool> removeIfUnchanged(String atKey, int seq) async {
+    _ensureOpen();
+    final raw = _store!.get(atKey);
+    if (raw == null) return false;
+    if (SyncQueueEntry._deserialise(atKey, raw).seq != seq) return false;
+    _inMemoryQueue.remove(atKey);
+    await _store!.delete(atKey);
+    return true;
   }
 
   /// Drops every entry, keeping the box open.

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   at_chops: ^3.3.0
   at_lookup: ^3.6.0
   at_auth: ^4.0.0-rc1
-  at_persistence_secondary_server: ^5.1.0
+  at_persistence_secondary_server: ^5.3.0
   hive: ^2.2.3
   meta: ^1.16.0
   version: ^3.0.2

--- a/packages/at_client/test/apkam_authorization_test.dart
+++ b/packages/at_client/test/apkam_authorization_test.dart
@@ -278,7 +278,7 @@ void main() {
           .executeVerb(verbBuilder, sync: false);
       expect(reservedKeyUpdateResult, isNotNull);
       expect(reservedKeyUpdateResult!.startsWith('data:'), true);
-      AtClientImpl.atClientInstanceMap.remove(atSign);
+      await (AtClientImpl.atClientInstanceMap[atSign] as AtClientImpl?)?.stop();
       // create an atClient for new enrollment
       var newEnrollmentId = 'abc123';
       var enrolledAtClient = await AtClientImpl.create(
@@ -505,7 +505,7 @@ void main() {
           await atClient.getLocalSecondary()!.executeVerb(verbBuilder);
       expect(updateReservedKeyResult, isNotNull);
       expect(updateReservedKeyResult!.startsWith('data:'), true);
-      AtClientImpl.atClientInstanceMap.remove(atSign);
+      await (AtClientImpl.atClientInstanceMap[atSign] as AtClientImpl?)?.stop();
       // create an atClient for new enrollment
       var newEnrollmentId = 'abc123';
       var enrolledAtClient = await AtClientImpl.create(
@@ -645,7 +645,7 @@ void main() {
       expect(scanJson.contains('@alice:location@alice'), true);
       expect(scanJson.contains('@alice:phone.wavi@alice'), true);
       expect(scanJson.contains('@bob:shared_key@alice'), true);
-      AtClientImpl.atClientInstanceMap.remove(atSign);
+      await (AtClientImpl.atClientInstanceMap[atSign] as AtClientImpl?)?.stop();
       // create an atClient for new enrollment
       var newEnrollmentId = 'abc123';
       var enrolledAtClient = await AtClientImpl.create(
@@ -689,6 +689,10 @@ Future<void> setupLocalStorage(String storageDir, String atSign) async {
 
 Future<void> tearDownLocalStorage(String storageDir) async {
   try {
+    for (final c
+        in List<AtClient>.from(AtClientImpl.atClientInstanceMap.values)) {
+      await c.stop();
+    }
     await Hive.close();
     AtClientImpl.atClientInstanceMap.clear();
     var isExists = await Directory(storageDir).exists();

--- a/packages/at_client/test/at_client_impl_test.dart
+++ b/packages/at_client/test/at_client_impl_test.dart
@@ -16,14 +16,24 @@ import 'test_utils/test_utils.dart';
 class MockRemoteSecondary extends Mock implements RemoteSecondary {}
 
 void main() {
+  tearDown(() async {
+    for (final c
+        in List<AtClient>.from(AtClientImpl.atClientInstanceMap.values)) {
+      await c.stop();
+    }
+  });
   group('A group of at client impl create tests', () {
     final String atSign = '@alice';
     setUp(() async {
-      AtClientImpl.atClientInstanceMap.remove(atSign);
+      await (AtClientImpl.atClientInstanceMap[atSign] as AtClientImpl?)?.stop();
       AtClientManager.getInstance().removeAllChangeListeners();
     });
     tearDown(() async {
-      AtClientImpl.atClientInstanceMap.remove(atSign);
+      for (final c
+          in List<AtClient>.from(AtClientImpl.atClientInstanceMap.values)) {
+        await c.stop();
+      }
+      await (AtClientImpl.atClientInstanceMap[atSign] as AtClientImpl?)?.stop();
       AtClientManager.getInstance().removeAllChangeListeners();
     });
 
@@ -65,12 +75,16 @@ void main() {
       ..commitLogPath = 'test/hive/path';
 
     setUp(() async {
-      AtClientImpl.atClientInstanceMap.remove(atSign);
+      await (AtClientImpl.atClientInstanceMap[atSign] as AtClientImpl?)?.stop();
       AtClientManager.getInstance().removeAllChangeListeners();
     });
 
     tearDown(() async {
-      AtClientImpl.atClientInstanceMap.remove(atSign);
+      for (final c
+          in List<AtClient>.from(AtClientImpl.atClientInstanceMap.values)) {
+        await c.stop();
+      }
+      await (AtClientImpl.atClientInstanceMap[atSign] as AtClientImpl?)?.stop();
       AtClientManager.getInstance().removeAllChangeListeners();
     });
 
@@ -352,7 +366,7 @@ void main() {
       expect(atResponse.response, 'ok');
     });
     tearDown(() async {
-      AtClientImpl.atClientInstanceMap.remove(atSign);
+      await (AtClientImpl.atClientInstanceMap[atSign] as AtClientImpl?)?.stop();
     });
   });
   group('A group of test to validate max length of a key', () {
@@ -381,8 +395,9 @@ void main() {
     MockRemoteSecondary mockRemoteSecondary = MockRemoteSecondary();
     MockLocalSecondary mockLocalSecondary = MockLocalSecondary();
     MockAtChopsKeys mockAtChopsKeys = MockAtChopsKeys();
-    setUp(() {
-      AtClientImpl.atClientInstanceMap.remove('@alice');
+    setUp(() async {
+      await (AtClientImpl.atClientInstanceMap['@alice'] as AtClientImpl?)
+          ?.stop();
       var key = 'REqkIcl9HPekt0T7+rZhkrBvpysaPOeC2QL1PVuWlus=';
       registerFallbackValue(FakeLookupVerbBuilder());
       when(() => mockLocalSecondary.executeVerb(any()))

--- a/packages/at_client/test/at_client_termination_test.dart
+++ b/packages/at_client/test/at_client_termination_test.dart
@@ -39,7 +39,8 @@ void main() {
   group('validate stop() behaviour', () {
     group('Client termination tests', () {
       test(
-        'close() should be idempotent and remove client from instance map',
+        'stop() is idempotent, releases storage, and removes the client from '
+        'the instance map',
         () async {
           final atSign = '@stop_integration';
           final atClient = await AtClientImpl.create(
@@ -49,14 +50,21 @@ void main() {
           ) as AtClientImpl;
 
           expect(AtClientImpl.atClientInstanceMap.containsKey(atSign), true);
+          final storage = atClient.storage as AtClientStorageBase;
+          expect(storage.isAttached, isTrue);
 
-          // Call close multiple times to verify idempotency
           await atClient.stop();
           await atClient.stop();
           await atClient.stop();
 
-          expect(AtClientImpl.atClientInstanceMap.containsKey(atSign), true);
+          expect(AtClientImpl.atClientInstanceMap.containsKey(atSign), false,
+              reason: 'a stopped client keeps nothing open, so nothing should '
+                  'hand it back; a later create() builds a fresh one');
+          expect(storage.isAttached, isFalse,
+              reason: 'stop() drops the claim on the storage it built');
           expect(atClient.isStopped, true);
+          expect(() => atClient.start(), throwsA(isA<StateError>()),
+              reason: 'a client whose storage is released cannot be restarted');
         },
       );
 
@@ -76,9 +84,11 @@ void main() {
             _createPreference('stop_errors'),
             remoteSecondary: mockRemoteSecondary,
           ) as AtClientImpl;
-
           await atClient.stop();
-          expect(AtClientImpl.atClientInstanceMap.containsKey(atSign), true);
+          expect(atClient.isStopped, true);
+          expect(AtClientImpl.atClientInstanceMap.containsKey(atSign), false,
+              reason: 'a failure closing the connection must not leave the '
+                  'client registered as live');
         },
       );
 
@@ -166,18 +176,18 @@ void main() {
         expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), true);
 
         await _initializeAtClient(secondAtSign);
-
-        expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), true);
+        expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), false,
+            reason: 'switching away stops the outgoing client, and a stopped '
+                'client releases its storage and leaves the map');
         expect(
           AtClientImpl.atClientInstanceMap.containsKey(secondAtSign),
           true,
         );
-
         expect(atClient1.isStopped, true);
-
-        // Verify switching back returns the same cached instance
-        final reusedAtClient = await _initializeAtClient(firstAtSign);
-        expect(identical(atClient1, reusedAtClient), true);
+        final rebuilt = await _initializeAtClient(firstAtSign);
+        expect(identical(atClient1, rebuilt), false,
+            reason: 'switching back opens storage afresh on a new client');
+        expect(rebuilt.isStopped, false);
       });
 
       test('switching to same atSign should handle correctly', () async {
@@ -205,10 +215,10 @@ void main() {
 
           final atClient1 = await _initializeAtClient(atSign);
           await atClient1.stop();
-
           final atClient2 = await _initializeAtClient(atSign);
-
-          expect(identical(atClient1, atClient2), true);
+          expect(identical(atClient1, atClient2), false,
+              reason: 'the stopped client released its storage; the manager '
+                  'builds and wires a new one');
 
           expect((atClient2.syncService as SyncServiceImpl).isStopped, false);
           expect(

--- a/packages/at_client/test/local_secondary_sync_queue_test.dart
+++ b/packages/at_client/test/local_secondary_sync_queue_test.dart
@@ -39,6 +39,7 @@ void main() {
     try {
       // Close every Hive box (including the sync-queue box) so the next
       // setUp doesn't reattach to leftover in-memory state.
+      await (AtClientImpl.atClientInstanceMap[atSign] as AtClientImpl?)?.stop();
       await Hive.close();
       AtClientImpl.atClientInstanceMap.remove(atSign);
       final dir = Directory(storageDir);

--- a/packages/at_client/test/local_secondary_test.dart
+++ b/packages/at_client/test/local_secondary_test.dart
@@ -85,6 +85,7 @@ void main() {
       await setupLocalStorage(storageDir, atSign);
     });
     tearDown(() async {
+      await (AtClientImpl.atClientInstanceMap[atSign] as AtClientImpl?)?.stop();
       AtClientImpl.atClientInstanceMap.remove(atSign);
       await tearDownLocalStorage(storageDir);
     });
@@ -175,7 +176,10 @@ void main() {
 
   group('A group of local secondary execute verb tests', () {
     setUp(() async => await setupLocalStorage(storageDir, atSign));
-    tearDown(() async => await tearDownLocalStorage(storageDir));
+    tearDown(() async {
+      await (AtClientImpl.atClientInstanceMap[atSign] as AtClientImpl?)?.stop();
+      await tearDownLocalStorage(storageDir);
+    });
 
     test('test update verb builder', () async {
       final atClientManager = AtClientManager(atSign);
@@ -342,7 +346,10 @@ void main() {
 
   group('writesInProgress tracker', () {
     setUp(() async => await setupLocalStorage(storageDir, atSign));
-    tearDown(() async => await tearDownLocalStorage(storageDir));
+    tearDown(() async {
+      await (AtClientImpl.atClientInstanceMap[atSign] as AtClientImpl?)?.stop();
+      await tearDownLocalStorage(storageDir);
+    });
 
     /// Builds a fresh LocalSecondary against the test Hive store. Each
     /// test gets its own AtClient instance (atClientInstanceMap is

--- a/packages/at_client/test/storage/at_client_storage_release_test.dart
+++ b/packages/at_client/test/storage/at_client_storage_release_test.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+
+import 'package:at_client/at_client.dart';
+import 'package:test/test.dart';
+
+import 'storage_contract.dart';
+
+void main() {
+  late Directory dir;
+  setUp(() => dir = Directory.systemTemp.createTempSync('at_client_release_'));
+  tearDown(() async {
+    for (final c
+        in List<AtClient>.from(AtClientImpl.atClientInstanceMap.values)) {
+      await c.stop();
+    }
+    dir.deleteSync(recursive: true);
+  });
+
+  AtClientPreference pref() => AtClientPreference()
+    ..hiveStoragePath = dir.path
+    ..commitLogPath = '${dir.path}/commit';
+
+  test(
+      'while a client holds an atSign\'s Hive storage, a second storage for '
+      'that atSign is refused; after stop() it is allowed', () async {
+    final first = await AtClientImpl.create('@releaseguard', 'wavi', pref())
+        as AtClientImpl;
+    final other = Directory.systemTemp.createTempSync('at_client_release_b_');
+    final second =
+        HiveAtClientStorage(atSign: '@releaseguard', storagePath: other.path);
+    await expectLater(
+        () => second.attach(FakeClient('@releaseguard', 'e2')),
+        throwsA(isA<StateError>().having((e) => e.message, 'message',
+            contains('already holds @releaseguard'))),
+        reason: 'every box is on the global Hive instance and named by atSign, '
+            'so a second path is not a second store');
+
+    await first.stop();
+    await second.attach(FakeClient('@releaseguard', 'e2'));
+    expect(second.isAttached, isTrue,
+        reason: 'stop() closed the first storage, so the atSign is free');
+    await second.close();
+    other.deleteSync(recursive: true);
+  });
+
+  test(
+      'a fresh create() after stop() gets a new client on freshly opened '
+      'storage', () async {
+    final first = await AtClientImpl.create('@releasefresh', 'wavi', pref())
+        as AtClientImpl;
+    final firstStorage = first.storage;
+    await first.stop();
+    final again = await AtClientImpl.create('@releasefresh', 'wavi', pref())
+        as AtClientImpl;
+    expect(identical(again, first), isFalse,
+        reason: 'the stopped client left the instance map');
+    expect(identical(again.storage, firstStorage), isFalse,
+        reason: 'and its storage was closed rather than handed on');
+    expect(again.isStopped, isFalse);
+  });
+
+  test('a client whose construction fails releases the storage it claimed',
+      () async {
+    final bad = pref()
+      ..crypto = const CryptoConfig(defaultProviderId: 'no-such-provider');
+    await expectLater(AtClientImpl.create('@releasefail', 'wavi', bad),
+        throwsA(isA<Exception>()),
+        reason: 'the default provider is not registered, so create() throws '
+            'after the storage was attached');
+    final ok = await AtClientImpl.create('@releasefail', 'wavi', pref())
+        as AtClientImpl;
+    expect(ok.storage, isNotNull,
+        reason: 'a failed build must not leave its claim behind, or no client '
+            'for that atSign could ever be built in this isolate again');
+  });
+}

--- a/packages/at_client/test/storage/at_client_storage_release_test.dart
+++ b/packages/at_client/test/storage/at_client_storage_release_test.dart
@@ -1,10 +1,43 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/sqlite.dart';
+import 'package:at_client/src/sync/at_sync_queue.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:test/test.dart';
 
 import 'storage_contract.dart';
+
+/// A storage whose [openBackend] can be held open on [gate], so a test can
+/// interleave a second [attach] while the first is still inside it.
+class _GatedStorage extends AtClientStorageBase {
+  _GatedStorage(this._location, {Completer<void>? gate}) : _gate = gate;
+  final String _location;
+  final Completer<void>? _gate;
+
+  @override
+  String get location => _location;
+
+  @override
+  Future<void> openBackend() async {
+    final gate = _gate;
+    if (gate != null) await gate.future;
+  }
+
+  @override
+  Future<void> closeBackend() async {}
+
+  @override
+  Future<void> clearData() async {}
+
+  @override
+  AtKeyValueStore<String, AtData, AtMetaData?> get keyStore =>
+      throw UnimplementedError();
+
+  @override
+  AtSyncQueue get syncQueue => throw UnimplementedError();
+}
 
 void main() {
   late Directory dir;
@@ -40,6 +73,32 @@ void main() {
     expect(sameStore.isAttached, isTrue,
         reason: 'stop() closed the first storage, releasing the store');
     await sameStore.close();
+  });
+
+  test(
+      'a second attach() racing the first cannot claim the same location '
+      'before the first finishes opening', () async {
+    final gate = Completer<void>();
+    final first = _GatedStorage('@race-loc', gate: gate);
+    final second = _GatedStorage('@race-loc');
+
+    final firstAttach = first.attach(FakeClient('@race', 'e1'));
+    // first is now suspended inside openBackend(), still awaiting gate.
+
+    await expectLater(
+        () => second.attach(FakeClient('@race', 'e2')),
+        throwsA(isA<StateError>()
+            .having((e) => e.message, 'message', contains('already open at'))),
+        reason: 'the claim must be visible to a second attach() as soon as '
+            'the first has passed its own checks, not only once the first '
+            'has finished opening its backend — otherwise both attach and '
+            'the loser\'s later close() tears down the backend the winner '
+            'still uses');
+
+    gate.complete();
+    await firstAttach;
+    expect(first.isAttached, isTrue);
+    await first.close();
   });
 
   test('two storages for one atSign at different locations both open',

--- a/packages/at_client/test/storage/at_client_storage_release_test.dart
+++ b/packages/at_client/test/storage/at_client_storage_release_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:at_client/at_client.dart';
+import 'package:at_client/sqlite.dart';
 import 'package:test/test.dart';
 
 import 'storage_contract.dart';
@@ -100,5 +101,41 @@ void main() {
     expect(ok.storage, isNotNull,
         reason: 'a failed build must not leave its claim behind, or no client '
             'for that atSign could ever be built in this isolate again');
+  });
+
+  test(
+      'a client uses the storage it is given, and stop() does not close what '
+      'it does not own', () async {
+    final injected = InMemoryAtClientStorage(atSign: '@injected');
+    // No hiveStoragePath: supplying storage picks the backend AND the
+    // location, so the preference no longer has to name one.
+    final client = await AtClientImpl.create(
+            '@injected', 'wavi', AtClientPreference(), storage: injected)
+        as AtClientImpl;
+
+    expect(identical(client.storage, injected), isTrue,
+        reason: 'the client used the storage it was handed rather than '
+            'building a Hive one from the preference');
+
+    await client.stop();
+
+    expect(injected.isAttached, isFalse, reason: 'stop() dropped the claim');
+    await injected.attach(FakeClient('@injected', null));
+    expect(injected.isAttached, isTrue,
+        reason: 'an injected store outlives the client that borrowed it - the '
+            'caller owns its lifetime, so stop() must not have closed it');
+    await injected.close();
+  });
+
+  test('a client with no injected storage still owns and closes its own',
+      () async {
+    final client =
+        await AtClientImpl.create('@ownsits', 'wavi', pref()) as AtClientImpl;
+    final own = client.storage!;
+    await client.stop();
+    await expectLater(() => own.attach(FakeClient('@ownsits', null)),
+        throwsA(isA<StateError>()),
+        reason: 'storage the client built itself is closed on release, and a '
+            'closed store cannot be reopened');
   });
 }

--- a/packages/at_client/test/storage/at_client_storage_release_test.dart
+++ b/packages/at_client/test/storage/at_client_storage_release_test.dart
@@ -21,26 +21,54 @@ void main() {
     ..commitLogPath = '${dir.path}/commit';
 
   test(
-      'while a client holds an atSign\'s Hive storage, a second storage for '
-      'that atSign is refused; after stop() it is allowed', () async {
+      'a second storage for one atSign at the same location is refused; '
+      'stop() releases it', () async {
     final first = await AtClientImpl.create('@releaseguard', 'wavi', pref())
         as AtClientImpl;
-    final other = Directory.systemTemp.createTempSync('at_client_release_b_');
-    final second =
-        HiveAtClientStorage(atSign: '@releaseguard', storagePath: other.path);
+    final sameStore =
+        HiveAtClientStorage(atSign: '@releaseguard', storagePath: dir.path);
     await expectLater(
-        () => second.attach(FakeClient('@releaseguard', 'e2')),
-        throwsA(isA<StateError>().having((e) => e.message, 'message',
-            contains('already holds @releaseguard'))),
-        reason: 'every box is on the global Hive instance and named by atSign, '
-            'so a second path is not a second store');
+        () => sameStore.attach(FakeClient('@releaseguard', 'e2')),
+        throwsA(isA<StateError>()
+            .having((e) => e.message, 'message', contains('already open at'))),
+        reason: 'one directory and one atSign resolve to one Hive box, so '
+            'these are one store however many objects point at it');
 
     await first.stop();
-    await second.attach(FakeClient('@releaseguard', 'e2'));
-    expect(second.isAttached, isTrue,
-        reason: 'stop() closed the first storage, so the atSign is free');
-    await second.close();
+    await sameStore.attach(FakeClient('@releaseguard', 'e2'));
+    expect(sameStore.isAttached, isTrue,
+        reason: 'stop() closed the first storage, releasing the store');
+    await sameStore.close();
+  });
+
+  test('two storages for one atSign at different locations both open',
+      () async {
+    final other = Directory.systemTemp.createTempSync('at_client_release_b_');
+    final here =
+        HiveAtClientStorage(atSign: '@twoplaces', storagePath: dir.path);
+    final there =
+        HiveAtClientStorage(atSign: '@twoplaces', storagePath: other.path);
+    await here.attach(FakeClient('@twoplaces', 'e1'));
+    await there.attach(FakeClient('@twoplaces', 'e2'));
+    expect(here.isAttached && there.isAttached, isTrue,
+        reason: 'different directories are different Hive instances, so two '
+            'enrollments of one atSign keep separate stores');
+    expect(here.location, isNot(equals(there.location)));
+    await here.close();
+    await there.close();
     other.deleteSync(recursive: true);
+  });
+
+  test('two atSigns sharing one directory both open', () async {
+    final a = HiveAtClientStorage(atSign: '@shareda', storagePath: dir.path);
+    final b = HiveAtClientStorage(atSign: '@sharedb', storagePath: dir.path);
+    await a.attach(FakeClient('@shareda', 'e1'));
+    await b.attach(FakeClient('@sharedb', 'e1'));
+    expect(a.isAttached && b.isAttached, isTrue,
+        reason: 'the box name derives from the atSign, so two atSigns under '
+            'one directory are two boxes and share nothing');
+    await a.close();
+    await b.close();
   });
 
   test(

--- a/packages/at_client/test/sync_stop_abandons_test.dart
+++ b/packages/at_client/test/sync_stop_abandons_test.dart
@@ -1,0 +1,93 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:at_client/at_client.dart';
+import 'package:at_client/src/service/sync_service_impl.dart';
+import 'package:at_client/src/sync/at_sync_queue.dart';
+import 'package:hive/hive.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class _MockNotificationService extends Mock implements NotificationService {}
+
+class _MockAtClient extends Mock implements AtClient {}
+
+class _MockLocalSecondary extends Mock implements LocalSecondary {}
+
+class _MockRemoteSecondary extends Mock implements RemoteSecondary {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(AtKey());
+  });
+
+  group('stop() during a round', () {
+    late _MockAtClient atClient;
+    late _MockLocalSecondary localSecondary;
+    late SyncServiceImpl sync;
+
+    setUp(() async {
+      atClient = _MockAtClient();
+      localSecondary = _MockLocalSecondary();
+      when(() => atClient.getCurrentAtSign()).thenReturn('@abandon');
+      when(() => atClient.getLocalSecondary()).thenReturn(localSecondary);
+      final notifications = _MockNotificationService();
+      when(() => notifications.subscribe(
+              regex: any(named: 'regex'),
+              shouldDecrypt: any(named: 'shouldDecrypt')))
+          .thenAnswer((_) => const Stream<AtNotification>.empty());
+      when(() => atClient.notificationService).thenReturn(notifications);
+      when(() => atClient.getPreferences()).thenReturn(AtClientPreference());
+      sync = await SyncServiceImpl.create(atClient,
+          remoteSecondary: _MockRemoteSecondary(),
+          warmStartSync: false) as SyncServiceImpl;
+    });
+
+    test('the round ends at its next step and touches nothing further',
+        () async {
+      final gate = Completer<List<String>>();
+      when(() => localSecondary.peekSyncQueue()).thenAnswer((_) => gate.future);
+      when(() => atClient.get(any())).thenAnswer((_) async => AtValue());
+
+      final round = sync.syncInternal(5, SyncRequest()..result = SyncResult(),
+          localCommitIdBeforeSync: 1);
+      await Future<void>.delayed(Duration.zero);
+      await sync.stop();
+      gate.complete(<String>[]);
+
+      await expectLater(round, throwsA(isA<Exception>()),
+          reason: 'a stopped service abandons the round rather than '
+              'finishing it against storage that may be closing');
+      verifyNever(() => atClient.get(any()));
+    });
+
+    test('the same round completes when not stopped (control)', () async {
+      when(() => localSecondary.peekSyncQueue())
+          .thenAnswer((_) async => <String>[]);
+      when(() => atClient.get(any())).thenAnswer((_) async => AtValue());
+
+      try {
+        await sync.syncInternal(5, SyncRequest()..result = SyncResult(),
+            localCommitIdBeforeSync: 1);
+      } catch (_) {}
+      verify(() => atClient.get(any())).called(greaterThan(0));
+    });
+  });
+
+  test(
+      'syncQueueSyncSnapshot is null for a closed queue, as for an unopened one',
+      () async {
+    final atClient = _MockAtClient();
+    when(() => atClient.getCurrentAtSign()).thenReturn('@snapshot');
+    final box =
+        await Hive.openBox<String>('snapshot_probe', bytes: Uint8List(0));
+    final queue = AtSyncQueue(atSign: '@snapshot');
+    await queue.open(injectedBox: box);
+    final ls = LocalSecondary(atClient, keyStore: null, syncQueue: queue);
+    expect(ls.syncQueueSyncSnapshot, 0);
+    await queue.close();
+    expect(ls.syncQueueSyncSnapshot, isNull,
+        reason: 'a closed queue has no size to report; null is what a caller '
+            'already handles for a queue that never opened');
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -120,3 +120,19 @@ dev_dependencies:
   plugin_platform_interface: ^2.1.6
   test: ^1.25.0
   test_process: ^2.1.0
+
+# TEMPORARY — comes out when at_persistence_secondary_server publishes a
+# release carrying PR #2776. Pins the merged at_server commit carrying
+# "a store honours the storagePath it is given": HiveInstances.forPath opens
+# each storage path on its own Hive instance. Without it, two clients of one
+# atSign share the keystore box (named sha(atSign) on the global instance)
+# whatever their paths, and the per-location storage guard is meaningless.
+# Published at_persistence_secondary_server tops out at 5.2.1 (2026-08-11),
+# which predates the fix. A SHA, not a branch: the branch was deleted when
+# #2776 merged, and a SHA cannot be deleted or drift.
+dependency_overrides:
+  at_persistence_secondary_server:
+    git:
+      url: https://github.com/atsign-foundation/at_server.git
+      ref: 5c0e603c02c438dcbdc0531717ebfd71f62a48ad
+      path: packages/at_persistence_secondary_server

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   async: ^2.9.0
   at_base2e15: ^1.0.0
   at_file_saver: ^0.1.2
-  at_persistence_secondary_server: ^5.1.0
+  at_persistence_secondary_server: ^5.3.0
   at_persistence_spec: ^3.0.0
   at_utf7: ^1.0.0
   basic_utils: ^5.6.1
@@ -120,19 +120,3 @@ dev_dependencies:
   plugin_platform_interface: ^2.1.6
   test: ^1.25.0
   test_process: ^2.1.0
-
-# TEMPORARY — comes out when at_persistence_secondary_server publishes a
-# release carrying PR #2776. Pins the merged at_server commit carrying
-# "a store honours the storagePath it is given": HiveInstances.forPath opens
-# each storage path on its own Hive instance. Without it, two clients of one
-# atSign share the keystore box (named sha(atSign) on the global instance)
-# whatever their paths, and the per-location storage guard is meaningless.
-# Published at_persistence_secondary_server tops out at 5.2.1 (2026-08-11),
-# which predates the fix. A SHA, not a branch: the branch was deleted when
-# #2776 merged, and a SHA cannot be deleted or drift.
-dependency_overrides:
-  at_persistence_secondary_server:
-    git:
-      url: https://github.com/atsign-foundation/at_server.git
-      ref: 5c0e603c02c438dcbdc0531717ebfd71f62a48ad
-      path: packages/at_persistence_secondary_server

--- a/tests/at_end2end_test/lib/src/at_encryption_key_initializers.dart
+++ b/tests/at_end2end_test/lib/src/at_encryption_key_initializers.dart
@@ -42,7 +42,8 @@ class AtEncryptionKeysLoader {
     result = await atClient.getLocalSecondary()!.putValue(
         encryptionPublicKeyAtKey,
         AtCredentials
-            .credentialsMap[atSign]![TestConstants.ENCRYPTION_PUBLIC_KEY].toString());
+            .credentialsMap[atSign]![TestConstants.ENCRYPTION_PUBLIC_KEY]
+            .toString());
     if (result) {
       _logger.info('encryption public key was set successfully.');
     } else {
@@ -57,6 +58,21 @@ class AtEncryptionKeysLoader {
       _logger.info('self encryption key was set successfully');
     } else {
       _logger.severe('failed to set self encryption key');
+    }
+
+    // set the PKAM pair. A client built without an AtChops of its own rebuilds
+    // one from the keystore, and cannot sign without these.
+    final pkam = atClient.atChops!.atChopsKeys.atPkamKeyPair!;
+    result = await atClient
+        .getLocalSecondary()!
+        .putValue(AtConstants.atPkamPublicKey, pkam.atPublicKey.publicKey);
+    result = result &&
+        await atClient.getLocalSecondary()!.putValue(
+            AtConstants.atPkamPrivateKey, pkam.atPrivateKey.privateKey);
+    if (result) {
+      _logger.info('pkam key pair was set successfully');
+    } else {
+      _logger.severe('failed to set the pkam key pair');
     }
   }
 }

--- a/tests/at_end2end_test/lib/src/test_initializers.dart
+++ b/tests/at_end2end_test/lib/src/test_initializers.dart
@@ -11,11 +11,24 @@ import 'package:at_utils/at_logger.dart';
 
 import 'at_credentials.dart';
 
+/// What an atSign's initial authentication produced, kept so that switching
+/// back to that atSign later can be given the same credentials again.
+class _AuthCredentials {
+  final AtChops atChops;
+  final String? enrollmentId;
+
+  _AuthCredentials(this.atChops, this.enrollmentId);
+}
+
 class TestSuiteInitializer {
   static final TestSuiteInitializer _singleton =
       TestSuiteInitializer._internal();
 
   static final AtSignLogger logger = AtSignLogger(' TestSuiteInitialized ');
+
+  /// The credentials [testInitializer] authenticated each atSign with, keyed
+  /// by atSign. Read by [switchToAtSign].
+  final Map<String, _AuthCredentials> _authCache = {};
 
   TestSuiteInitializer._internal() {
     AtSignLogger.root_level = 'info';
@@ -66,6 +79,11 @@ class TestSuiteInitializer {
 
       atClientPreference ??=
           TestPreferences.getInstance().getPreference(atSign);
+      // Remember what this atSign authenticated with. Switching away and back
+      // rebuilds the client, and a rebuild with no credentials cannot
+      // authenticate an APKAM enrollment - see [switchToAtSign].
+      _authCache[atSign] =
+          _AuthCredentials(atChops, atAuthResponse?.atAuthKeys?.enrollmentId);
       // Create the atClientManager for the atSign
       var atClientManager = await AtClientManager.getInstance()
           .setCurrentAtSign(atSign, namespace, atClientPreference,
@@ -100,6 +118,47 @@ class TestSuiteInitializer {
     } on Exception catch (e) {
       print('Exception in setting the encryption: $e');
       rethrow;
+    }
+  }
+
+  /// Makes [atSign] current again, re-supplying the credentials its initial
+  /// [testInitializer] authentication produced.
+  ///
+  /// **Why the credentials have to be repeated.** `setCurrentAtSign` for an
+  /// atSign other than the current one stops that client and builds a fresh
+  /// one, and it keeps no credentials of its own: called with only a
+  /// preference, it builds a client with no `AtChops` and a null
+  /// `enrollmentId`. Under `authType: apkam` the atKeys carry a real
+  /// enrollment id, the atServer expects PKAM to name it, and the rebuilt
+  /// client cannot - which is `AT0401 pkam authentication failed`, the whole
+  /// of `end2end_test_14`. It is invisible under `authType: pkam` and against
+  /// the local fixture, both of which authenticate with a null enrollment id.
+  ///
+  /// **Why only on a real switch.** `setCurrentAtSign`'s idempotency
+  /// short-circuit requires `atChops` and `enrollmentId` to be null, so
+  /// passing them for the atSign already current would force a stop/recreate
+  /// on every call - and a stopped client releases its storage, so each no-op
+  /// switch would reopen the store cold.
+  Future<AtClientManager> switchToAtSign(String atSign, String namespace,
+      {AtClientPreference? preference}) async {
+    final acm = AtClientManager.getInstance();
+    final pref =
+        preference ?? TestPreferences.getInstance().getPreference(atSign);
+    if (_currentAtSign() == atSign) {
+      return acm.setCurrentAtSign(atSign, namespace, pref);
+    }
+    final credentials = _authCache[atSign];
+    return acm.setCurrentAtSign(atSign, namespace, pref,
+        atChops: credentials?.atChops, enrollmentId: credentials?.enrollmentId);
+  }
+
+  /// The atSign the manager currently holds, or null if it holds no client.
+  /// `AtClientManager.atClient` throws rather than returning null.
+  String? _currentAtSign() {
+    try {
+      return AtClientManager.getInstance().atClient.getCurrentAtSign();
+    } on StateError {
+      return null;
     }
   }
 

--- a/tests/at_end2end_test/test/bypasscache_test.dart
+++ b/tests/at_end2end_test/test/bypasscache_test.dart
@@ -2,7 +2,6 @@ import 'package:at_client/at_client.dart';
 import 'package:at_end2end_test/config/config_util.dart';
 import 'package:at_end2end_test/src/sync_initializer.dart';
 import 'package:at_end2end_test/src/test_initializers.dart';
-import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:at_end2end_test/utils/test_constants.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
@@ -25,8 +24,8 @@ void main() async {
 
   Future<void> setAtSignOneAutoNotify(bool autoNotify) async {
     //  reset the autoNotify to true
-    await AtClientManager.getInstance().setCurrentAtSign(sharedByAtSign,
-        namespace, TestPreferences.getInstance().getPreference(sharedByAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(sharedByAtSign, namespace);
 
     var configResult = await AtClientManager.getInstance()
         .atClient
@@ -88,8 +87,8 @@ void main() async {
     await setAtSignOneAutoNotify(true);
 
     // Set sharedBy atSign as currentAtSign and Put the initial value
-    await AtClientManager.getInstance().setCurrentAtSign(sharedByAtSign,
-        namespace, TestPreferences.getInstance().getPreference(sharedByAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(sharedByAtSign, namespace);
 
     // Per-key gate: register the listener BEFORE the put so the
     // push event for this key can't fire before the listener is in
@@ -116,10 +115,8 @@ void main() async {
     await Future.delayed(Duration(seconds: 5));
 
     // Switch to sharedWithAtSign
-    await AtClientManager.getInstance().setCurrentAtSign(
-        sharedWithAtSign,
-        namespace,
-        TestPreferences.getInstance().getPreference(sharedWithAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(sharedWithAtSign, namespace);
 
     await E2ESyncService.getInstance()
         .syncData(AtClientManager.getInstance().atClient.syncService);
@@ -135,8 +132,8 @@ void main() async {
     expect(getResult.metadata!.isCached, true);
 
     // Switch back to sharedByAtSign to update the value of the key.
-    await AtClientManager.getInstance().setCurrentAtSign(sharedByAtSign,
-        namespace, TestPreferences.getInstance().getPreference(sharedByAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(sharedByAtSign, namespace);
 
     // Set autoNotify to false so that the update doesn't propagate to sharedWith AtSign automatically
     await setAtSignOneAutoNotify(false);
@@ -162,10 +159,8 @@ void main() async {
     await pushedUpdatedValue;
 
     // As atSignTwo
-    await AtClientManager.getInstance().setCurrentAtSign(
-        sharedWithAtSign,
-        namespace,
-        TestPreferences.getInstance().getPreference(sharedWithAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(sharedWithAtSign, namespace);
 
     // Sync - after this we still should have the old value
     await E2ESyncService.getInstance()

--- a/tests/at_end2end_test/test/deletion_key_test.dart
+++ b/tests/at_end2end_test/test/deletion_key_test.dart
@@ -183,7 +183,7 @@ void main() {
         .atClient;
     // notifying a key with ttr to shared with atSign
     await currentAtClient.put(atKey, value);
-    await E2ESyncService.getInstance().syncData(sharedByAtClient.syncService);
+    await E2ESyncService.getInstance().syncData(currentAtClient.syncService);
 
     var sharedWithAtClient = (await AtClientManager.getInstance()
             .setCurrentAtSign(sharedWithAtSign, namespace,

--- a/tests/at_end2end_test/test/deletion_key_test.dart
+++ b/tests/at_end2end_test/test/deletion_key_test.dart
@@ -2,7 +2,6 @@ import 'package:at_client/at_client.dart';
 import 'package:at_end2end_test/config/config_util.dart';
 import 'package:at_end2end_test/src/sync_initializer.dart';
 import 'package:at_end2end_test/src/test_initializers.dart';
-import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:at_end2end_test/utils/test_constants.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
@@ -52,8 +51,8 @@ Future<bool> _pollUntilCachedExistsMatches(
 /// to the receiver atServer, the receiver's cached entry is never
 /// created, and these tests hang forever waiting for it.
 Future<void> _ensurePublisherAutoNotifyTrue() async {
-  await AtClientManager.getInstance().setCurrentAtSign(sharedByAtSign,
-      namespace, TestPreferences.getInstance().getPreference(sharedByAtSign));
+  await TestSuiteInitializer.getInstance()
+      .switchToAtSign(sharedByAtSign, namespace);
   await AtClientManager.getInstance()
       .atClient
       .getRemoteSecondary()!
@@ -71,16 +70,12 @@ void main() {
     await TestSuiteInitializer.getInstance()
         .testInitializer(sharedWithAtSign, namespace, authType);
     // Initialize sharedWithAtSign
-    sharedWithAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
-            sharedWithAtSign,
-            namespace,
-            TestPreferences.getInstance().getPreference(sharedWithAtSign)))
+    sharedWithAtClient = (await TestSuiteInitializer.getInstance()
+            .switchToAtSign(sharedWithAtSign, namespace))
         .atClient;
     // Setting sharedByAtSign atClient instance to context.
-    sharedByAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
-            sharedByAtSign,
-            namespace,
-            TestPreferences.getInstance().getPreference(sharedByAtSign)))
+    sharedByAtClient = (await TestSuiteInitializer.getInstance()
+            .switchToAtSign(sharedByAtSign, namespace))
         .atClient;
     // Defensive: ensure auto-notify is on for the publisher atServer
     // before any TTR-using test runs.
@@ -102,20 +97,16 @@ void main() {
               ..cache(-1, true)
               ..timeToLive(5 * TestConstants.oneMinuteMillis))
             .build();
-    sharedByAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
-            sharedByAtSign,
-            namespace,
-            TestPreferences.getInstance().getPreference(sharedByAtSign)))
+    sharedByAtClient = (await TestSuiteInitializer.getInstance()
+            .switchToAtSign(sharedByAtSign, namespace))
         .atClient;
     final putResult = await sharedByAtClient.put(atKey, 'dummy_cached_value');
     assert(putResult == true);
     await E2ESyncService.getInstance().syncData(sharedByAtClient.syncService);
 
     // Switch to sharedWith AtSign and fetch the cached key
-    sharedWithAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
-            sharedWithAtSign,
-            namespace,
-            TestPreferences.getInstance().getPreference(sharedWithAtSign)))
+    sharedWithAtClient = (await TestSuiteInitializer.getInstance()
+            .switchToAtSign(sharedWithAtSign, namespace))
         .atClient;
     var cachedAtKey = AtKey()
       ..key = key
@@ -138,10 +129,8 @@ void main() {
     expect(getResponse.value, 'dummy_cached_value');
 
     // Switch back to sharedBy AtSign and delete the key
-    sharedByAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
-            sharedByAtSign,
-            namespace,
-            TestPreferences.getInstance().getPreference(sharedByAtSign)))
+    sharedByAtClient = (await TestSuiteInitializer.getInstance()
+            .switchToAtSign(sharedByAtSign, namespace))
         .atClient;
     await sharedByAtClient.delete(atKey);
     await E2ESyncService.getInstance().syncData(sharedByAtClient.syncService);
@@ -150,10 +139,8 @@ void main() {
     // of the cached entry from local hive. CCD=true means the
     // publisher's delete propagates a delete-the-cache directive to
     // the receiver's atServer; same cross-server-notify tail applies.
-    sharedWithAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
-            sharedWithAtSign,
-            namespace,
-            TestPreferences.getInstance().getPreference(sharedWithAtSign)))
+    sharedWithAtClient = (await TestSuiteInitializer.getInstance()
+            .switchToAtSign(sharedWithAtSign, namespace))
         .atClient;
     final cachedRemoved = await _pollUntilCachedExistsMatches(
         sharedWithAtClient, cachedAtKeyStr, false);
@@ -176,18 +163,15 @@ void main() {
             .build();
     var value = 'test_cached_value';
 
-    var currentAtClient = (await AtClientManager.getInstance().setCurrentAtSign(
-            sharedByAtSign,
-            namespace,
-            TestPreferences.getInstance().getPreference(sharedByAtSign)))
+    var currentAtClient = (await TestSuiteInitializer.getInstance()
+            .switchToAtSign(sharedByAtSign, namespace))
         .atClient;
     // notifying a key with ttr to shared with atSign
     await currentAtClient.put(atKey, value);
     await E2ESyncService.getInstance().syncData(currentAtClient.syncService);
 
-    var sharedWithAtClient = (await AtClientManager.getInstance()
-            .setCurrentAtSign(sharedWithAtSign, namespace,
-                TestPreferences.getInstance().getPreference(sharedWithAtSign)))
+    var sharedWithAtClient = (await TestSuiteInitializer.getInstance()
+            .switchToAtSign(sharedWithAtSign, namespace))
         .atClient;
     var cachedAtKey = AtKey()
       ..key = key

--- a/tests/at_end2end_test/test/encryption_test.dart
+++ b/tests/at_end2end_test/test/encryption_test.dart
@@ -47,12 +47,8 @@ void main() {
     // AtClientImpl.create() adopts this preference's crypto config onto it
     // (CryptoRuntime resolves against the live preference.crypto). This test
     // depends on that production behaviour.
-    final atClientManager =
-        await AtClientManager.getInstance().setCurrentAtSign(
-      atSign,
-      namespace,
-      preference,
-    );
+    final atClientManager = await TestSuiteInitializer.getInstance()
+        .switchToAtSign(atSign, namespace, preference: preference);
     return atClientManager.atClient;
   }
 
@@ -68,8 +64,8 @@ void main() {
         defaultProviderId: defaultProviderId,
         providers: providers,
       );
-    final atClientManager = await AtClientManager.getInstance()
-        .setCurrentAtSign(atSign, namespace, preference);
+    final atClientManager = await TestSuiteInitializer.getInstance()
+        .switchToAtSign(atSign, namespace, preference: preference);
     return atClientManager.atClient;
   }
 

--- a/tests/at_end2end_test/test/key_stream_test.dart
+++ b/tests/at_end2end_test/test/key_stream_test.dart
@@ -9,7 +9,6 @@ import 'package:at_client/src/key_stream/key_stream_map_base.dart';
 import 'package:at_client/src/key_stream/key_stream_mixin.dart';
 import 'package:at_end2end_test/config/config_util.dart';
 import 'package:at_end2end_test/src/test_initializers.dart';
-import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:at_end2end_test/utils/test_constants.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
@@ -85,20 +84,16 @@ void main() async {
     });
 
     test('getKeys', () async {
-      atClientManager = await AtClientManager.getInstance().setCurrentAtSign(
-          currentAtSign,
-          namespace,
-          TestPreferences.getInstance().getPreference(currentAtSign));
+      atClientManager = await TestSuiteInitializer.getInstance()
+          .switchToAtSign(currentAtSign, namespace);
       final pro = PutRequestOptions()..useRemoteAtServer = true;
       await Future.wait([
         atClientManager.atClient.put(key, randomValue, putRequestOptions: pro),
         atClientManager.atClient.put(key2, randomValue2, putRequestOptions: pro)
       ]);
 
-      await AtClientManager.getInstance().setCurrentAtSign(
-          sharedWithAtSign,
-          namespace,
-          TestPreferences.getInstance().getPreference(sharedWithAtSign));
+      await TestSuiteInitializer.getInstance()
+          .switchToAtSign(sharedWithAtSign, namespace);
       expect(AtClientManager.getInstance().atClient.getCurrentAtSign(),
           sharedWithAtSign);
       await keyStream.getKeys();
@@ -127,10 +122,8 @@ void main() async {
         ..sharedWith = sharedWithAtSign
         ..namespace = namespace
         ..sharedBy = currentAtSign;
-      await AtClientManager.getInstance().setCurrentAtSign(
-          sharedWithAtSign,
-          namespace,
-          TestPreferences.getInstance().getPreference(sharedWithAtSign));
+      await TestSuiteInitializer.getInstance()
+          .switchToAtSign(sharedWithAtSign, namespace);
       keyStream = KeyStreamImpl(
         regex: '$namespace@',
         convert: (key, value) => value.value ?? '',
@@ -173,10 +166,8 @@ void main() async {
         ..sharedWith = sharedWithAtSign
         ..namespace = namespace
         ..sharedBy = currentAtSign;
-      await AtClientManager.getInstance().setCurrentAtSign(
-          sharedWithAtSign,
-          namespace,
-          TestPreferences.getInstance().getPreference(sharedWithAtSign));
+      await TestSuiteInitializer.getInstance()
+          .switchToAtSign(sharedWithAtSign, namespace);
       keyStream = IterableKeyStream<String>(
         regex: '$namespace@',
         convert: (key, value) => value.value ?? '',
@@ -225,10 +216,8 @@ void main() async {
         ..sharedWith = sharedWithAtSign
         ..namespace = namespace
         ..sharedBy = currentAtSign;
-      await AtClientManager.getInstance().setCurrentAtSign(
-          sharedWithAtSign,
-          namespace,
-          TestPreferences.getInstance().getPreference(sharedWithAtSign));
+      await TestSuiteInitializer.getInstance()
+          .switchToAtSign(sharedWithAtSign, namespace);
       keyStream = MapKeyStream<String, String>(
         regex: '$namespace@',
         convert: (key, value) => MapEntry(key.key, value.value),
@@ -289,16 +278,12 @@ void main() async {
       currentAtSign = ConfigUtil.getYaml()['atSign']['firstAtSign'];
       sharedWithAtSign = ConfigUtil.getYaml()['atSign']['secondAtSign'];
       // Create atClient instance for currentAtSign
-      await AtClientManager.getInstance().setCurrentAtSign(
-          currentAtSign,
-          namespace,
-          TestPreferences.getInstance().getPreference(currentAtSign));
+      await TestSuiteInitializer.getInstance()
+          .switchToAtSign(currentAtSign, namespace);
 
       // Create atClient instance for atSign2
-      await AtClientManager.getInstance().setCurrentAtSign(
-          sharedWithAtSign,
-          namespace,
-          TestPreferences.getInstance().getPreference(sharedWithAtSign));
+      await TestSuiteInitializer.getInstance()
+          .switchToAtSign(sharedWithAtSign, namespace);
       // Set Encryption Keys for sharedWithAtSign
       keyStream = KeyStreamImpl(
         regex: '$namespace@',
@@ -315,10 +300,8 @@ void main() async {
       expect(keyStream, isA<KeyStreamMixin<String?>>());
       expect(keyStream.isPaused, false);
 
-      await AtClientManager.getInstance().setCurrentAtSign(
-          currentAtSign,
-          namespace,
-          TestPreferences.getInstance().getPreference(currentAtSign));
+      await TestSuiteInitializer.getInstance()
+          .switchToAtSign(currentAtSign, namespace);
       await Future.delayed(Duration(milliseconds: 1));
       expect(keyStream.controller.isClosed, true);
 
@@ -333,10 +316,8 @@ void main() async {
           key2, AtValue()..value = randomValue2, 'update');
       expect(keyStream2, emitsInOrder([randomValue2]));
 
-      await AtClientManager.getInstance().setCurrentAtSign(
-          sharedWithAtSign,
-          namespace,
-          TestPreferences.getInstance().getPreference(sharedWithAtSign));
+      await TestSuiteInitializer.getInstance()
+          .switchToAtSign(sharedWithAtSign, namespace);
       await Future.delayed(Duration(milliseconds: 1));
       expect(keyStream2.controller.isClosed, true);
       expect(keyStream.controller.isClosed, true);

--- a/tests/at_end2end_test/test/notify_test.dart
+++ b/tests/at_end2end_test/test/notify_test.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:at_client/at_client.dart';
 import 'package:at_end2end_test/config/config_util.dart';
 import 'package:at_end2end_test/src/test_initializers.dart';
-import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:at_end2end_test/utils/test_constants.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
@@ -41,9 +40,8 @@ void main() async {
     // for each run.
     var value = '+1 100 200 30';
     // Setting currentAtSign atClient instance to context.
-    currentAtClientManager = await AtClientManager.getInstance()
-        .setCurrentAtSign(currentAtSign, namespace,
-            TestPreferences.getInstance().getPreference(currentAtSign));
+    currentAtClientManager = await TestSuiteInitializer.getInstance()
+        .switchToAtSign(currentAtSign, namespace);
     final notificationResult = await currentAtClientManager
         .atClient.notificationService
         .notify(NotificationParams.forUpdate(phoneKey, value: value));
@@ -52,10 +50,8 @@ void main() async {
         NotificationStatusEnum.delivered);
 
     // Setting sharedWithAtSign atClient instance to context.
-    await AtClientManager.getInstance().setCurrentAtSign(
-        sharedWithAtSign,
-        namespace,
-        TestPreferences.getInstance().getPreference(sharedWithAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(sharedWithAtSign, namespace);
     var notificationListResult = await AtClientManager.getInstance()
         .atClient
         .notifyList(regex: 'phone$randomValue');
@@ -82,9 +78,8 @@ void main() async {
     // for each run.
     var value = '+1 100 200 30';
     // Setting currentAtSign atClient instance to context.
-    currentAtClientManager = await AtClientManager.getInstance()
-        .setCurrentAtSign(currentAtSign, namespace,
-            TestPreferences.getInstance().getPreference(currentAtSign));
+    currentAtClientManager = await TestSuiteInitializer.getInstance()
+        .switchToAtSign(currentAtSign, namespace);
     final notificationResult = await currentAtClientManager
         .atClient.notificationService
         .notify(NotificationParams.forUpdate(phoneKey, value: value),
@@ -94,10 +89,8 @@ void main() async {
         NotificationStatusEnum.delivered);
 
     // Setting sharedWithAtSign atClient instance to context.
-    await AtClientManager.getInstance().setCurrentAtSign(
-        sharedWithAtSign,
-        namespace,
-        TestPreferences.getInstance().getPreference(sharedWithAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(sharedWithAtSign, namespace);
     var notificationListResult = await AtClientManager.getInstance()
         .atClient
         .notifyList(regex: 'phone$randomValue');

--- a/tests/at_end2end_test/test/sharing_key_test.dart
+++ b/tests/at_end2end_test/test/sharing_key_test.dart
@@ -4,7 +4,6 @@ import 'package:at_client/at_client.dart';
 import 'package:at_end2end_test/config/config_util.dart';
 import 'package:at_end2end_test/src/sync_initializer.dart';
 import 'package:at_end2end_test/src/test_initializers.dart';
-import 'package:at_end2end_test/src/test_preferences.dart';
 import 'package:at_end2end_test/utils/test_constants.dart';
 import 'package:test/test.dart';
 import 'package:uuid/uuid.dart';
@@ -32,8 +31,8 @@ void main() async {
     // bypasscache_test may have left `autoNotify=false` persisted on
     // the server (its `finally`-based reset is unreliable on test
     // timeouts).
-    await acm.setCurrentAtSign(currentAtSign, namespace,
-        TestPreferences.getInstance().getPreference(currentAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(currentAtSign, namespace);
     await acm.atClient
         .getRemoteSecondary()!
         .executeCommand('config:set:autoNotify=true\n', auth: true);
@@ -46,8 +45,8 @@ void main() async {
   test('Share a key to sharedWith atSign and lookup from sharedWith atSign',
       () async {
     // Setting currentAtSign atClient instance to context.
-    await acm.setCurrentAtSign(currentAtSign, namespace,
-        TestPreferences.getInstance().getPreference(currentAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(currentAtSign, namespace);
     // Generate  uuid
     var uniqueId = uuid.v4().hashCode;
     var phoneNumberKey = AtKey()
@@ -64,8 +63,8 @@ void main() async {
     await E2ESyncService.getInstance().syncData(acm.atClient.syncService);
 
     // Setting sharedWithAtSign atClient instance to context.
-    await acm.setCurrentAtSign(sharedWithAtSign, namespace,
-        TestPreferences.getInstance().getPreference(sharedWithAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(sharedWithAtSign, namespace);
     var getResult = await acm.atClient.get(AtKey()
       ..key = 'phoneNumber-$uniqueId'
       ..sharedBy = currentAtSign);
@@ -84,8 +83,8 @@ void main() async {
       'Create a key to sharedWith atSign with ttr and verify sharedWith atSign has a cached_key',
       () async {
     // Setting currentAtSign atClient instance to context.
-    await acm.setCurrentAtSign(currentAtSign, namespace,
-        TestPreferences.getInstance().getPreference(currentAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(currentAtSign, namespace);
     var uniqueId = uuid.v4().hashCode;
     // TTL set to 5 minutes so the publisher's atServer doesn't
     // expire the key before our 60s cache-propagation polling
@@ -105,8 +104,8 @@ void main() async {
     await E2ESyncService.getInstance().syncData(acm.atClient.syncService);
 
     // Setting sharedWithAtSign atClient instance to context.
-    await acm.setCurrentAtSign(sharedWithAtSign, namespace,
-        TestPreferences.getInstance().getPreference(sharedWithAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(sharedWithAtSign, namespace);
     var cachedVerificationKey = AtKey()
       ..key = 'verificationnumber-$uniqueId'
       ..sharedWith = sharedWithAtSign
@@ -145,8 +144,8 @@ void main() async {
     var uniqueId = uuid.v4().hashCode;
     final value = 'New Jersey';
 
-    await acm.setCurrentAtSign(currentAtSign, namespace,
-        TestPreferences.getInstance().getPreference(currentAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(currentAtSign, namespace);
     await acm.atClient.put(
         AtKey()
           ..key = 'location-$uniqueId'
@@ -156,8 +155,8 @@ void main() async {
         value,
         putRequestOptions: PutRequestOptions()..useRemoteAtServer = true);
 
-    await acm.setCurrentAtSign(sharedWithAtSign, namespace,
-        TestPreferences.getInstance().getPreference(sharedWithAtSign));
+    await TestSuiteInitializer.getInstance()
+        .switchToAtSign(sharedWithAtSign, namespace);
     var getResult = await acm.atClient.get(AtKey()
       ..key = 'location-$uniqueId'
       ..sharedBy = currentAtSign);

--- a/tests/at_functional_test/test/at_client_lifecycle_functional_test.dart
+++ b/tests/at_functional_test/test/at_client_lifecycle_functional_test.dart
@@ -39,8 +39,8 @@ void main() {
       await (atClient as AtClientImpl).stop();
       expect(
         AtClientImpl.atClientInstanceMap.containsKey(firstAtSign),
-        true,
-        reason: 'Client instance should remain in map even after stop',
+        false,
+        reason: 'a stopped client releases its storage and leaves the map',
       );
     });
 
@@ -56,7 +56,8 @@ void main() {
       await atClient.stop();
       await atClient.stop();
 
-      expect(AtClientImpl.atClientInstanceMap.containsKey(secondAtSign), true);
+      expect(AtClientImpl.atClientInstanceMap.containsKey(secondAtSign), false,
+          reason: 'stop() is idempotent, and the first call already released');
     });
 
     test('stop with active notifications cleans up gracefully', () async {
@@ -82,20 +83,22 @@ void main() {
   });
 
   group('Implicit client caching behavior', () {
-    test('keeps both clients in cache when switching atSigns', () async {
-      final atClient1 = (await TestUtils.initAtClient(firstAtSign, namespace))
-          .atClient;
+    test('switching atSigns stops and releases the outgoing client', () async {
+      final atClient1 =
+          (await TestUtils.initAtClient(firstAtSign, namespace)).atClient;
       var atKey = AtKey()
         ..key = 'alice_data'
         ..namespace = namespace;
       await atClient1.put(atKey, 'Alice value');
 
-      final atClient2 = (await TestUtils.initAtClient(secondAtSign, namespace))
-          .atClient;
+      final atClient2 =
+          (await TestUtils.initAtClient(secondAtSign, namespace)).atClient;
       atKey = AtKey()..key = 'bob_data';
       await atClient2.put(atKey, 'Bob value');
 
-      expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), true);
+      expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), false,
+          reason: 'the outgoing client is stopped, and a stopped client leaves '
+              'the map');
       expect(AtClientImpl.atClientInstanceMap.containsKey(secondAtSign), true);
 
       // Verify current atSign is correct
@@ -107,27 +110,30 @@ void main() {
         ..key = 'verify_read'
         ..namespace = namespace;
       await AtClientManager.getInstance().atClient.put(verifyKey, 'test');
-      final result = await AtClientManager.getInstance().atClient.get(verifyKey);
+      final result =
+          await AtClientManager.getInstance().atClient.get(verifyKey);
       expect(result.value, 'test');
 
       await (atClient1 as AtClientImpl).stop();
       await (atClient2 as AtClientImpl).stop();
     });
 
-    test('reuses cached instance when switching back to same atSign', () async {
-      final atClient1 = (await TestUtils.initAtClient(firstAtSign, namespace))
-          .atClient;
+    test('switching back builds a fresh client on the same store', () async {
+      final atClient1 =
+          (await TestUtils.initAtClient(firstAtSign, namespace)).atClient;
       final key = AtKey()
         ..key = 'alice_reuse'
         ..namespace = namespace;
       await atClient1.put(key, 'Alice value');
 
       await TestUtils.initAtClient(secondAtSign, namespace);
-      final reusedAtClient = (await TestUtils.initAtClient(
-              firstAtSign, namespace))
-          .atClient;
+      final reusedAtClient =
+          (await TestUtils.initAtClient(firstAtSign, namespace)).atClient;
 
-      expect(identical(atClient1, reusedAtClient), true);
+      expect(identical(atClient1, reusedAtClient), false,
+          reason: 'the first client released its storage when the manager '
+              'switched away; the store itself persists, so the value below '
+              'is still there');
 
       final AtValue result = await reusedAtClient.get(key);
       expect(result.value, 'Alice value');
@@ -135,20 +141,21 @@ void main() {
       await (reusedAtClient as AtClientImpl).stop();
     });
 
-    test('soft-close stops services but keeps instance in cache', () async {
+    test('stop() on the outgoing client releases it from the cache', () async {
       final atClient1 = (await TestUtils.initAtClient(firstAtSign, namespace))
           .atClient as AtClientImpl;
-      final atClientManager = await TestUtils.initAtClient(
-          secondAtSign, namespace);
+      final atClientManager =
+          await TestUtils.initAtClient(secondAtSign, namespace);
 
-      expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), true);
+      expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), false);
       expect(atClient1.isStopped, true);
 
       await atClient1.stop();
       await (atClientManager.atClient as AtClientImpl).stop();
     });
 
-    test('rapid switching preserves all instances', () async {
+    test('rapid switching leaves only the current client in the cache',
+        () async {
       final atClientManager = AtClientManager.getInstance();
       final switchSequence = [
         firstAtSign,
@@ -169,9 +176,9 @@ void main() {
             'v');
       }
 
-      expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), true);
+      expect(AtClientImpl.atClientInstanceMap.containsKey(firstAtSign), false,
+          reason: 'every switch away released the outgoing client');
       expect(AtClientImpl.atClientInstanceMap.containsKey(secondAtSign), true);
-
       await (atClientManager.atClient as AtClientImpl).stop();
     });
   });

--- a/tests/at_functional_test/test/enrollment_test.dart
+++ b/tests/at_functional_test/test/enrollment_test.dart
@@ -54,7 +54,15 @@ void main() {
         aliceApkamSymmetricKey, encryptionPublicKeyMap[atSign]!);
   });
 
-  tearDown(() {
+  tearDown(() async {
+    for (final c
+        in List<AtClient>.from(AtClientImpl.atClientInstanceMap.values)) {
+      await c.stop();
+    }
+    for (final c
+        in List<AtClient>.from(AtClientImpl.atClientInstanceMap.values)) {
+      await c.stop();
+    }
     AtClientManager.getInstance().reset();
     AtClientImpl.atClientInstanceMap.clear();
   });
@@ -67,7 +75,8 @@ void main() {
       final onBoardingRequest = AtOnboardingRequest(apkamAtSign)
         ..appName = 'wavi'
         ..deviceName = 'pixel1'
-        ..rootDomain = AtRootDomain('vip.ve.atsign.zone', TestUtils.rootServerPort)
+        ..rootDomain =
+            AtRootDomain('vip.ve.atsign.zone', TestUtils.rootServerPort)
         ..atKeysIo =
             FileAtKeysIo(filePath: (atsign) => 'test/testData/$atsign.atKeys');
       // onboard with enable enrollment set
@@ -83,7 +92,8 @@ void main() {
         apkamAtSign,
         atKeysIo:
             FileAtKeysIo(filePath: (atsign) => 'test/testData/$atsign.atKeys'),
-      )..rootDomain = AtRootDomain('vip.ve.atsign.zone', TestUtils.rootServerPort));
+      )..rootDomain =
+          AtRootDomain('vip.ve.atsign.zone', TestUtils.rootServerPort));
       expect(atAuthResponse.isSuccessful, true);
       expect(atAuthResponse.atAuthKeys, isNotNull);
 
@@ -189,10 +199,8 @@ void main() {
       // an atServer that keeps the credential in an enrollment of its own the
       // same write is a no-op: it already holds this value.
       expect(
-          await atClientManager.atClient
-              .getRemoteSecondary()!
-              .executeCommand(
-                  'update:privatekey:at_pkam_publickey $alicePkamPublicKey\n'),
+          await atClientManager.atClient.getRemoteSecondary()!.executeCommand(
+              'update:privatekey:at_pkam_publickey $alicePkamPublicKey\n'),
           'data:-1',
           reason: 'the owner credential must be the demo keypair again before '
               'anything else authenticates as this atSign');
@@ -252,7 +260,8 @@ void main() {
           otp: 'a1b2c3',
           signingAlgo: SigningAlgoType.rsa2048); //random invalid OTP
       var atEnrollment = AtEnrollment.create();
-      var newAtLookup = AtLookupImpl(atSign, 'vip.ve.atsign.zone', TestUtils.rootServerPort);
+      var newAtLookup =
+          AtLookupImpl(atSign, 'vip.ve.atsign.zone', TestUtils.rootServerPort);
       expect(
           () async => atEnrollment.submit(enrollmentRequest, newAtLookup),
           throwsA(predicate((dynamic e) =>
@@ -275,7 +284,8 @@ void main() {
           otp: otp,
           signingAlgo: SigningAlgoType.rsa2048);
       var atEnrollment = AtEnrollment.create();
-      var newAtLookup = AtLookupImpl(atSign, 'vip.ve.atsign.zone', TestUtils.rootServerPort);
+      var newAtLookup =
+          AtLookupImpl(atSign, 'vip.ve.atsign.zone', TestUtils.rootServerPort);
       var enrollmentResponse =
           await atEnrollment.submit(enrollmentRequest, newAtLookup);
       expect(enrollmentResponse.enrollmentId, isNotEmpty);
@@ -415,6 +425,10 @@ void main() {
           approveEnrollmentResponse?.enrollStatus, EnrollmentStatus.approved);
 
       // Set AtClient to null and authenticate with the new auth keys generated for enrollment
+      for (final c
+          in List<AtClient>.from(AtClientImpl.atClientInstanceMap.values)) {
+        await c.stop();
+      }
       AtClientManager.getInstance().reset();
       AtClientImpl.atClientInstanceMap.clear();
 
@@ -442,7 +456,8 @@ void main() {
           AtBytes.fromString(encryptionPrivateKeyMap[atSign]!);
       atAuthRequest.atAuthKeys?.defaultSelfEncryptionKey =
           AtBytes.fromString(aesKeyMap[atSign]!);
-      atAuthRequest.rootDomain = AtRootDomain('vip.ve.atsign.zone', TestUtils.rootServerPort);
+      atAuthRequest.rootDomain =
+          AtRootDomain('vip.ve.atsign.zone', TestUtils.rootServerPort);
 
       AtAuthResponse atAuthResponse = await atAuth.authenticate(atAuthRequest);
       expect(atAuthResponse.isSuccessful, true);
@@ -514,6 +529,10 @@ void main() {
       expect(approveEnrollmentResponse?.enrollStatus, EnrollmentStatus.denied);
 
       // Set AtClient to null and authenticate with the new auth keys generated for enrollment
+      for (final c
+          in List<AtClient>.from(AtClientImpl.atClientInstanceMap.values)) {
+        await c.stop();
+      }
       AtClientManager.getInstance().reset();
       AtClientImpl.atClientInstanceMap.clear();
 
@@ -540,7 +559,8 @@ void main() {
           AtBytes.fromString(encryptionPrivateKeyMap[atSign]!);
       atAuthRequest.atAuthKeys?.defaultSelfEncryptionKey =
           AtBytes.fromString(aesKeyMap[atSign]!);
-      atAuthRequest.rootDomain = AtRootDomain('vip.ve.atsign.zone', TestUtils.rootServerPort);
+      atAuthRequest.rootDomain =
+          AtRootDomain('vip.ve.atsign.zone', TestUtils.rootServerPort);
 
       expect(
           () async => await atAuth.authenticate(atAuthRequest),
@@ -614,6 +634,10 @@ void main() {
       expect(putBuzzKeyResponse.response, isNotEmpty);
 
       // Set AtClient to null and authenticate with the new auth keys generated for enrollment
+      for (final c
+          in List<AtClient>.from(AtClientImpl.atClientInstanceMap.values)) {
+        await c.stop();
+      }
       AtClientManager.getInstance().reset();
       AtClientImpl.atClientInstanceMap.clear();
 
@@ -638,7 +662,8 @@ void main() {
           AtBytes.fromString(encryptionPrivateKeyMap[atSign]!);
       atAuthRequest.atAuthKeys?.defaultSelfEncryptionKey =
           AtBytes.fromString(aesKeyMap[atSign]!);
-      atAuthRequest.rootDomain = AtRootDomain('vip.ve.atsign.zone', TestUtils.rootServerPort);
+      atAuthRequest.rootDomain =
+          AtRootDomain('vip.ve.atsign.zone', TestUtils.rootServerPort);
 
       AtAuthResponse atAuthResponse = await atAuth.authenticate(atAuthRequest);
       expect(atAuthResponse.isSuccessful, true);
@@ -692,7 +717,8 @@ void main() {
         () async {
       String random = Uuid().v4().hashCode.toString();
       AtEnrollment atEnrollmentBase = AtEnrollment.create();
-      AtLookUp atLookUp = AtLookupImpl(atSign, 'vip.ve.atsign.zone', TestUtils.rootServerPort);
+      AtLookUp atLookUp =
+          AtLookupImpl(atSign, 'vip.ve.atsign.zone', TestUtils.rootServerPort);
 
       AtClientManager atClientManager =
           await TestUtils.initAtClient(atSign, namespace);
@@ -728,7 +754,7 @@ void main() {
             deviceName: 'device-$random',
             otp: (await atClientManager.atClient.getOTP()).response,
             namespaces: {'wavi': 'rw'},
-          signingAlgo: SigningAlgoType.rsa2048),
+            signingAlgo: SigningAlgoType.rsa2048),
         atLookUp,
       );
 
@@ -817,8 +843,8 @@ void main() {
       // generates a fresh APKAM keypair and wraps its apkamSymmetricKey with
       // the atSign's default encryption public key.
       final random = Uuid().v4().hashCode;
-      final enrolleeLookup =
-          AtLookupImpl(cramAtSign, 'vip.ve.atsign.zone', TestUtils.rootServerPort);
+      final enrolleeLookup = AtLookupImpl(
+          cramAtSign, 'vip.ve.atsign.zone', TestUtils.rootServerPort);
       final enrollResponse = await AtEnrollment.create().submit(
         AtEnrollmentRequest(
           atSign: cramAtSign,
@@ -852,6 +878,10 @@ void main() {
       // (e) Verify outcomes: the enrollee authenticates with its own APKAM
       // keypair plus the atSign's default encryption/self keys, then can act in
       // its granted namespace (buzz) but not in an ungranted one (wavi).
+      for (final c
+          in List<AtClient>.from(AtClientImpl.atClientInstanceMap.values)) {
+        await c.stop();
+      }
       AtClientManager.getInstance().reset();
       AtClientImpl.atClientInstanceMap.clear();
 

--- a/tests/at_onboarding_cli_functional_tests/runLocal.sh
+++ b/tests/at_onboarding_cli_functional_tests/runLocal.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the onboarding-CLI functional suite locally, the way CI runs it
+# (.github/workflows/at_libraries.yaml, functional_tests_at_onboarding_cli).
+#
+# Deliberately NOT a copy of tests/at_functional_test/runLocal.sh. Two
+# differences matter, and both cost time when rediscovered:
+#
+#  1. pkamLoad is NOT started. That script installs PKAM public keys for the
+#     demo atSigns, and these tests CRAM-onboard - they need atSigns holding
+#     no PKAM key yet. Starting it makes onboarding fail as "already
+#     activated", which reads like a product bug and is not.
+#  2. check_test_env.dart is NOT run. It polls `lookup:publickey@sitaram`
+#     until it answers - state only pkamLoad creates - so in a suite that runs
+#     without pkamLoad it can never pass: it hangs for its full timeout and
+#     then fails, which reads as a broken environment. CI does not call it
+#     either; it runs readiness, then a sleep, then the tests.
+#
+# This suite binds the same ports as tests/at_functional_test (64,
+# 25000-25999, 6379), so the two cannot run at the same time.
+#
+# CRAM secrets are one-shot: a second run against a virtualenv that already
+# onboarded these atSigns fails. The compose down below is what makes a re-run
+# work, so do not skip it.
+
+cd "$(dirname "$0")"
+
+echo "*** Getting dependencies" && dart pub get
+
+echo "*** docker compose down" && docker compose down
+echo "*** docker compose pull" && docker compose pull
+echo "*** docker compose up" && docker compose up -d
+
+echo "*** Checking docker readiness" && dart run check_docker_readiness.dart
+
+echo "*** Waiting 10s for the atSigns to come up" && sleep 10
+
+echo "*** Clearing client test storage"
+rm -rf test/hive
+find test -name '*.atKeys' -delete 2>/dev/null || true
+
+echo "*** Running tests"
+# Let the run fail through to cleanup, then propagate its code - otherwise
+# set -e aborts before teardown on the very failure this exists to catch.
+set +e
+dart test --concurrency=1 -r expanded
+TEST_EXIT=$?
+set -e
+
+echo "*** docker compose down" && docker compose down
+
+exit "$TEST_EXIT"

--- a/tests/at_onboarding_cli_functional_tests/runLocal.sh
+++ b/tests/at_onboarding_cli_functional_tests/runLocal.sh
@@ -40,11 +40,29 @@ echo "*** Clearing client test storage"
 rm -rf test/hive
 find test -name '*.atKeys' -delete 2>/dev/null || true
 
+# These tests onboard through at_onboarding_cli, which writes its keyfiles to
+# $HOME/.atsign/keys - the real one. Those keys are for virtualenv-only demo
+# atSigns; they outlive the container the compose down above just recycled, and
+# `onboard` refuses when a keyfile already exists. So the next local run fails
+# with "Keys file already exists" for atSigns the fresh virtualenv has never
+# onboarded, which reads as a product bug and is not. Give the run a throwaway
+# HOME instead: the keys land beside it and go when it does, and the real
+# ~/.atsign/keys is neither written nor read.
+#
+# Scoped to `dart test` deliberately - docker reads its context from the real
+# $HOME/.docker and pub its cache from $HOME/.pub-cache, so neither moves.
+REAL_HOME="$HOME"
+TEST_HOME="$(mktemp -d)"
+trap 'rm -rf "$TEST_HOME"' EXIT
+mkdir -p "$TEST_HOME/.atsign/keys"
+echo "*** Throwaway HOME for this run: $TEST_HOME"
+
 echo "*** Running tests"
 # Let the run fail through to cleanup, then propagate its code - otherwise
 # set -e aborts before teardown on the very failure this exists to catch.
 set +e
-dart test --concurrency=1 -r expanded
+HOME="$TEST_HOME" PUB_CACHE="${PUB_CACHE:-$REAL_HOME/.pub-cache}" \
+  dart test --concurrency=1 -r expanded
 TEST_EXIT=$?
 set -e
 


### PR DESCRIPTION
## Intro / context
What this series of PRs (this one, then #2210 and #2211 will deliver:
- at_client_web will be able to inject the storage  it needs (whatever that is - we’ll likely start with fully in memory, ephemeral for the session)
- CLI apps can have fully ephemeral local storage so they leave nothing on disk
- We can switch away from hive as the default on the client
- Basically a whole load of storage enhancements tech debt removal, and structural cleanup

Now on to this PR specifically - it is small in terms of lib code changes - just paving the way, and sorting out the test pack to match. the vast majority of the PR is the changes to the test pack to use the new api

## Why

Two enrollments of one atSign must not share local storage: an enrollment holds key material
only for its granted namespaces, so a shared store hands one enrollment another's records and
pending writes. Storage was keyed by the atSign alone.

Four holes had to close with it — a client must be able to release its storage; a store must
refuse a second opener rather than share silently; a caller must be able to say where its
storage lives and on which backend; and a queued write must not be lost when a later write
supersedes it.

## What

See commits & diffs. Storage is keyed by location (the directory plus the atSign), the base
refuses a second opener, `stop()` closes what the client owns and only detaches what it was
given, `create` / `setCurrentAtSign` / `AtServiceFactory.atClient` take `storage:`, and queue
entries carry a `seq` so the drain removes only the version it pushed.

⚠️ Behaviour change: a stopped client no longer stays cached with its store open.

## How to verify it

Tests pass. Locally functional +82, e2e +32, onboarding-CLI +15. In CI the onboarding-CLI job
went fail → pass, and `end2end_test_14` 11 passed/18 failed → green. (A `bypasscache` stale
read in that job is intermittent and independent of this branch: it also fails on the merge
base.)

## Description for the changelog

A client's local storage is isolated by location and released on `stop()`, a caller may supply
its own, and a delete that supersedes a queued update is no longer lost on push.
