### PR TITLE
docs(wasm): reconcile the browser lane onto the storage bundle (D-12)

### DIFF
--- a/docs/projects/wasm/acceptance.md
+++ b/docs/projects/wasm/acceptance.md
@@ -419,6 +419,62 @@ what crosses is what the TypeScript signature promised.
 
 ---
 
+## 9a. Gates added 2026-08-30
+
+These follow from D-13..D-19. Three of them close holes where the existing ladder measured
+**speed** on a concern named for **correctness** or **confidentiality**.
+
+### 9a.1 Confidentiality — key material *(new; the existing key gates measure only time)*
+
+The only key-material gates today paste an `.atKeys` file into a page and record Argon2id
+wall-clock. Nothing tests the property the concern is named for.
+
+| # | Gate | Proves |
+| --- | --- | --- |
+| X-K1 | After a key write, the IndexedDB record is **not plaintext** | the envelope is actually applied |
+| X-K2 | `exportKey` on the wrapping key **throws** | the key is genuinely non-extractable |
+| X-K3 | "Ciphertext present, wrapping key missing" raises a **distinct documented error code**, not a generic decrypt failure | the eviction case is handled, not merely survived |
+| X-K4 | Generate → store → reload → retrieve → decrypt round-trips in **Chrome *and* Safari** | Safari's storage policy is the risk; this gate blocks the key-storage design from being treated as approved |
+
+### 9a.2 Remote-only correctness *(new — D-13, D-14)*
+
+| # | Gate | Proves |
+| --- | --- | --- |
+| X-R1 | A client built on the **remote-only bundle** constructs with **no Hive box and no SQLite** in the process — including on the **write** path | the bundle supplies a no-op sync queue, so `LocalSecondary`'s lazily-opened Hive path is never entered. This is the D-14 regression. The gate is on *this bundle*, not on the process: a consumer who injects a SQLite bundle is expected to open one |
+| X-R2 | A remote-only client **reads data written by a local-storage client** | unstamped keys route to the legacy provider on read; without this the client writes fine and fails on pre-existing data |
+| X-R3 | A write is not acknowledged until the atServer accepts it | write-through, not write-back — no reintroduced durability question |
+| X-R4 | Notification resume across two sequential clients does not replay | under D-14 the checkpoint read **silently succeeds and returns nothing**, so this is a correctness bug rather than a crash. If in-memory is chosen instead, the gate is an explicit test *documenting* the replay |
+| X-R5 | Two clients for two different atSigns coexist in one process with independent caches | D-19 multi-tenancy, demonstrated rather than promised |
+
+### 9a.3 Deployment contract *(new — the environment the other gates assume)*
+
+| # | Gate | Proves |
+| --- | --- | --- |
+| X-D1 | The host page is served over **HTTPS or localhost** | `crypto.subtle` exists. Every crypto and key-storage measurement is invalid without it — on plain http they would report the design as broken and every primitive as pure Dart |
+| X-D2 | Response headers include `script-src 'wasm-unsafe-eval'` and `application/wasm`, verified against the deployed artifact | the contract is executable, not aspirational |
+| X-D3 | `COOP`/`COEP` are **absent** | D-18 — cross-origin isolation would break popup OIDC, and nothing in V1 needs it |
+
+### 9a.4 Surface stability *(new — D-16)*
+
+| # | Gate | Proves |
+| --- | --- | --- |
+| X-S1 | Every method on the JS/TS surface returns a `Promise` — a **surface** test, not a behaviour test | the V2 storage upgrade cannot become a breaking npm change (D-16) |
+| X-S2 | `dist/index.js` and `dist/index.d.ts` are **generated**, and a clean rebuild produces no diff | D-20 — the shipped behaviour and the published types cannot drift, because neither is hand-maintained |
+| X-S3 | A **timeout-bounded** Node smoke test resolves a real call | the shim ordering trap is a silent hang, not an error; a bare `await` cannot tell a hang from slowness |
+
+### 9a.5 A standing rule for every tier
+
+**Classify each failure before acting on it:**
+
+- **bucket (a)** — harness or platform artefact
+- **bucket (b)** — genuine algorithm or protocol output mismatch
+
+**Bucket (b) is a stop condition.** Without this triage, `@TestOn('vm')` annotations
+silently convert evidence into exclusions, and a `continue-on-error` tier reports green
+while the thing it was built to detect goes unrecorded.
+
+---
+
 ## 10. The honest limit
 
 **No gate here proves "zero runtime failures".** Stating otherwise would be the same

--- a/docs/projects/wasm/decisions.md
+++ b/docs/projects/wasm/decisions.md
@@ -1,7 +1,7 @@
 # decisions.md — Rulings, measured findings & open questions
 
 **Status:** decision record (binding).
-**Scope:** the rulings D-1..D-9 that govern the implementation-neutral `AtClient`
+**Scope:** the rulings D-1..D-20 that govern the implementation-neutral `AtClient`
 work, the measurements that drove them, the superseded positions from the predecessor
 `plan.md`, the open questions, and a dated log.
 **Lane:** this doc owns *why*, not *how* or *when*. Mechanics live in
@@ -17,6 +17,9 @@ non-Dart consumer story in [`js-api.md`](js-api.md).
 - [4. Corrections to the predecessor doc](#4-corrections-to-the-predecessor-doc)
 - [5. Open questions](#5-open-questions)
 - [6. Decision log](#6-decision-log)
+
+Companion: [`enterprise-identity.md`](enterprise-identity.md) — IdP integration, enrollment
+lifecycle, and the registrar asks (D-17 and OQ-14 live there).
 
 ---
 
@@ -173,6 +176,13 @@ than a library; packages ship entry points routinely. It is reachable only from 
 `main()`, so it tree-shakes out of any Dart app importing `at_client_web` as a library —
 Dart consumers pay nothing.
 
+**Amended 2026-09-02 — see D-20.** The clause *"hand-written `index.js`/`index.d.ts`"* is
+**superseded**. D-20 rules that the JS surface is authored **once in TypeScript**, with both
+`.js` and `.d.ts` **generated**; neither output is hand-edited. Everything else in D-8 stands
+— the facade is still a build artifact of `at_client_web`, not a pub package. This pointer
+exists because a faithful reading of D-8 alone regenerates the hand-written position, and
+has already done so at least once.
+
 ### D-9 — Keys cross the JS boundary as strings; events as callbacks (2026-08-13)
 
 `AtKey` and `AtValue` are never materialised in JavaScript.
@@ -220,7 +230,7 @@ structured, typed records.
 ### D-11 — The Dart gear is typed via a declared `typeTag`; app types are never compiled into `at_client_web` (2026-08-18)
 
 The JS and Dart gears mesh at exactly one point: the wire `typeTag`, a plain `String`.
-Layer B (`plans/wasm/api-designing.md` §2.3) holds the machinery for declaring and
+Layer B (§2.3 of the Layer A/B/C design note) holds the machinery for declaring and
 honouring tags; it never contains an app-specific collection type (`Todo`, `BlogPost`).
 
 **Why.** Measured (§2.6 below): `_rehydrate` looks up factories by the tag stored on the
@@ -298,6 +308,235 @@ manager's same-atSign short-circuit already refuses one, and nothing else in pro
 reaches a cached client; X1 pins that guard before X4 changes `stop()`, since the guard is
 what a released client's safety then rests on. (Amended 2026-09-05: first written as "two
 paths hand back a stopped client" — one was already guarded, the other has no caller.)
+
+**Amended 2026-09-06 — the gateway must admit a remote-only bundle.** D-13 ships the
+browser lane on a bundle that keeps no durable records, and D-14 makes that bundle the
+*only* injection route rather than a second one alongside it. Four things this interface
+must therefore permit. None is a change of direction; each is the difference between *"one
+bundle owns the keystore and the queue"* and *"one bundle is the only way storage is
+supplied"*, which is the property the browser lane needs.
+
+1. **A no-op sync queue is legal.** A remote-only bundle has nothing to enqueue: its writes
+   are already at the atServer when `put` returns. `syncQueue` should stay non-nullable —
+   nullability pushes a `?` through every call site for one caller's benefit — but the
+   contract must *say* that a queue which never enqueues and always reports empty satisfies
+   it. Otherwise the first invariant written as "a write leaves the queue non-empty"
+   silently outlaws the browser.
+2. **A keystore that is not durable is legal.** `keyStore` is typed to `AtKeyValueStore`,
+   which is already enough; what is missing is the statement that a **write-through**
+   implementation, whose misses go to the atServer, satisfies it. The seam exists —
+   `LocalSecondary` takes both halves as constructor parameters (`local_secondary.dart:101-102`)
+   — only the contract is silent.
+3. **No `isLocalStoreRequired` gate on the bundle path.** `at_client_impl.dart:380` throws
+   when a keystore is injected while `preference.isLocalStoreRequired` is false. Under a
+   bundle that question stops being meaningful: the bundle *is* the store, and whether it
+   happens to be durable is its own business. **X4 must not carry this guard onto the
+   factory it introduces.**
+4. **`clear()` and the principal guard must survive a store with no durable half.** Both
+   stay meaningful — an in-memory cache is still principal-specific, and `AT0009` is still
+   the failure being designed out — but neither may assume there are records on disk to
+   empty, nor that `close()` has a file to close.
+
+**And the three backends stay open.** D-13 fixes the browser *default*, not the capability:
+the Hive, SQLite and `:memory:` bundles this decision ships remain injectable everywhere,
+including in a browser that chooses to pay for one. Keeping `package:at_client/sqlite.dart`
+a separate barrel is what makes that a consumer's choice rather than a payload tax.
+
+---
+
+### D-13 — V1 **ships** remote-only; the local store is a bundle choice, not a removed capability (2026-08-30, amended 2026-09-06)
+
+The first browser release ships a **remote-only storage bundle** as its default: no
+SQLite, no VFS, no `sqlite3.wasm`, no Hive in the shipped browser payload. A local store
+becomes the default in V2, as a speed optimisation.
+
+> **Amended 2026-09-06.** This was first written as *"there is no local store in the
+> browser"*, which over-claimed. D-12 makes client storage an injected bundle, so
+> remote-only is **one implementation of that interface** — not a mode, and not a removed
+> capability. SQLite (including the `:memory:` backend D-12 ships), Hive, and any other
+> backend stay injectable through the same gateway, in the browser as anywhere else. What
+> V1 fixes is the **default and the shipped payload**, not what a consumer may supply.
+> Nothing here forecloses a browser app choosing a SQLite bundle; it just does not pay for
+> one it did not ask for.
+
+**Why this is the default.** The browser lane had two independently hard problems: a
+durable local database and a secure key store. Defaulting to remote-only takes the first
+off V1's critical path without closing it, and the survivor is already designed. The
+default bundle also touches neither `Hive`'s global nor `sqlite3`'s open-override global,
+the two pieces of process-global state we do not own.
+
+**Bound.** The mode is not new or speculative: it is already exercised in
+`at_contact/test/test_util.dart:7`, `at_client/test/samples/test_util.dart:11`, and
+`put_request_test.dart:150`.
+
+**Cost, stated plainly — and it is the *default's* cost, not the platform's:** every `get`
+is a network round-trip. `AtCollection` and bulk reads become N round-trips. This must
+appear in published consumer docs, or it will be met as a surprise. A consumer who cannot
+accept it injects a different bundle, which is the point of D-12.
+
+---
+
+### D-14 — Remote-only is delivered as an **`AtClientStorage` implementation**, not by making `localSecondary` nullable (2026-08-30, amended 2026-09-06)
+
+`at_client` does not learn about a "no local store" mode. It receives a bundle whose
+keystore is a write-through cache — misses and writes go to the atServer — and whose sync
+queue is a no-op.
+
+> **Amended 2026-09-06.** First written as *"an injected write-through `Secondary`"*,
+> decided before D-12. D-12's bundle is now the injection gateway, so remote-only ships as
+> a `RemoteOnlyAtClientStorage implements AtClientStorage` rather than as a second,
+> parallel injection route. **One gateway, not two** — that is the whole substance of the
+> amendment; the reasoning below is unchanged.
+
+**Why not nullable `localSecondary`.** It would mean patching 12 `localSecondary!` sites
+in `EncryptionService` and 9 `getLocalSecondary()!` sites in `LegacyCryptoProvider`, then
+keeping every future call site aware of the mode. The Null Object costs one class.
+
+It also avoids a trap that the patch-the-call-sites approach walks straight into:
+`CryptoRuntime._provider` (`crypto_runtime.dart:84-95`) routes every **unstamped** key to
+`LegacyCryptoProvider`, and `defaultProviderId` is consulted on the **write** path only. A
+client that merely registered a new remote-capable provider would write new data correctly
+and **crash reading any pre-existing data**.
+
+**Bound by source facts, re-measured 2026-09-06 against trunk `cd0327479` (after X1–X3).**
+`Secondary` is a one-method interface (`client/secondary.dart`) and both secondaries
+implement it as peers; `LocalSecondary` takes its keystore as an injectable constructor
+parameter typed to an interface and, **since X2/X3, an injectable `syncQueue` beside it**
+(`local_secondary.dart:101-102`); and `AtClientImpl.create` already accepts
+`localSecondaryKeyStore`. X2/X3 moved the sync-queue half of this from *"must never be
+reached"* to *"is supplied"*, which is strictly better for this design.
+
+**Three consequences that must be built, not assumed:**
+
+1. **The no-op queue is supplied, not evaded.** Before X3 the plan was to keep the
+   implementation away from `LocalSecondary`'s lazily-opened Hive queue
+   (`_ensureSyncQueueOpen`, `local_secondary.dart:120`), leaning on
+   `Secondary.executeVerb`'s `cameFromServer` flag to bypass enqueuing. With the bundle the
+   queue is injected instead, so the lazy path is never entered at all. The `cameFromServer`
+   route stays valid but is no longer load-bearing.
+2. **The `isLocalStoreRequired` guard must not reach the bundle path.**
+   `at_client_impl.dart:380` currently throws when a keystore is injected while
+   `preference.isLocalStoreRequired` is false — exactly backwards for this design. Under a
+   bundle the flag stops being the right question, so X4's factory must not inherit the
+   guard. This is D-12's amendment item 3, stated from this side.
+3. **`AtChops` must not be rebuilt from a store that never held the keys.** X4's
+   measurement found 14 e2e tests dying with *"PKAM Keypair required for signing"* when a
+   client was rebuilt on a reopened keystore. A remote-only bundle has no durable keystore
+   at all, so key material must come from `AtKeysIo` and must never be inferred from
+   storage. This is a constraint on the browser lane, not a defect in X4.
+
+*(Note: `executeVerb`'s `sync:` parameter is already documented as ignored, so
+`_saveSharedKey`'s `sync: true` is not a problem.)*
+
+---
+
+### D-15 — Dart runs on the **main thread** in V1 (2026-08-30)
+
+Not a default — a decision, taken because it resolves four problems at once and costs
+nothing while there is no VFS.
+
+| Trap | Resolved because |
+| --- | --- |
+| `package:cryptography`'s WebCrypto gate is a literal `window` dereference | `window` exists on the main thread |
+| `SimpleOpfsFileSystem` is dedicated-worker-only | no VFS in V1 |
+| Cross-origin isolation (COOP/COEP) | no `SharedArrayBuffer` |
+| `postMessage` marshalling to the JS facade | the facade calls Dart directly |
+
+⚠️ **This does not make crypto acceleration free.** It holds under **dart2js** only; under
+dart2wasm the default AES path resolves to pure Dart regardless of thread. See
+[`design.md`](design.md) §C1.
+
+---
+
+### D-16 — The JS/TS surface is **`Promise`-returning for every protocol operation**; no synchronous escape hatch (2026-08-30)
+
+Even where remote-only plus an in-memory cache would permit a synchronous return.
+
+**Why.** This is the single highest-value forward-compatibility rule in the programme. V2
+moves storage into SQLite, and possibly into a Worker — both asynchronous. If any V1
+operation is synchronous, V2 becomes a **breaking change to a published npm surface** for
+every consumer. Async from day one makes V2 a purely internal refactor the host page never
+observes.
+
+**Bound.** No `getSync`-style API may ship, at any version, for any operation that could
+later touch storage or the network.
+
+---
+
+### D-17 — **Redirect-based OIDC only.** Popup flows are not shipped (2026-08-30)
+
+**Why.** Popups work today, because V1 requires no cross-origin isolation — so this costs
+nothing now. But if V2 ever needs COOP `same-origin` (for `SharedArrayBuffer`-based OPFS
+or Dart isolates), it severs `window.opener` and **every popup integration breaks
+simultaneously**. Redirect flows survive COOP natively.
+
+This is deliberate insurance on a decision we have chosen to defer (D-18). Cheap now,
+expensive to retrofit.
+
+---
+
+### D-18 — Do not adopt a VFS requiring cross-origin isolation; and do not settle the VFS choice on a benchmark (2026-08-30)
+
+Supersedes the conditional phrasing in earlier drafts. The VFS choice is **pick-two**:
+
+| | crash consistency | multi-atSign | no cross-origin isolation |
+| --- | --- | --- | --- |
+| `IndexedDbFileSystem` | ❌ (`xSync` is a documented no-op, `vfs/indexed_db.dart:646-649`) | ✅ | ✅ |
+| `SimpleOpfsFileSystem` | ✅ | ❌ — exactly two files, `/database` and `/database-journal` | ✅ |
+| `WasmVfs` (async_opfs) | ✅ | ✅ | ❌ — SAB + `Atomics` ⇒ COOP+COEP |
+
+**Bound.** `WasmVfs` is rejected: it is the only option that forces COOP `same-origin`.
+Choosing it on latency would mean **a storage benchmark silently deciding the enterprise
+identity integration** — the same failure shape OQ-5 was written to prevent, in a new form.
+
+Escalate the remaining trade as a **product** decision before V2 needs it.
+
+---
+
+### D-19 — No new process-global state; one client per atSign, created explicitly (2026-08-30)
+
+New code — the entire browser lane included — constructs its own `AtClientManager` and
+never calls `getInstance()`.
+
+**Why.** `AtClientManager.getInstance()` appears 22× in `at_client/lib` and across 34
+files in 14 downstream packages, so the singleton must be **demoted over a major**, not
+deleted. But the browser lane can simply not use it, which costs nothing and satisfies the
+constraint immediately.
+
+**Bound.** Storage and crypto take the atSign **explicitly**; nothing infers it from
+ambient state. Under D-13 the per-atSign state is an in-memory map rather than a database,
+so multi-tenancy can be *demonstrated* in V1 rather than promised — which is what the
+enterprise concern actually requires. This resolves OQ-11 in the instance-based direction.
+
+---
+
+### D-20 — The JS facade is authored **once, in TypeScript**; the `.js` and `.d.ts` are both generated (2026-08-30)
+
+`src/index.ts` is the single source of truth for the npm surface. `tsc` (or `tsup`/`rollup`)
+emits `dist/index.js` for vanilla-JS consumers and `dist/index.d.ts` for TypeScript
+consumers. **Neither output is hand-edited or hand-reviewed.**
+
+**Why.** The previous specification in [`js-api.md`](js-api.md) §4/§8 called for a
+hand-written `index.js` *and* a hand-written `index.d.ts`, with the `.d.ts` justified as
+having "documentation value, not generated." That is two hand-maintained descriptions of
+one surface: double the maintenance, and drift between the shipped behaviour and the
+published types is a matter of when, not whether. Generating both from one file makes
+misalignment structurally impossible rather than merely discouraged.
+
+A vanilla-JavaScript consumer is unaffected — they execute `dist/index.js` and their editor
+reads the `.d.ts` regardless of the authoring language.
+
+**Bound.** The Dart-generated `at_client.js` is **strictly internal**: not a documented
+entry point, and not exposed through `package.json`'s `exports`.
+
+**One implementation trap, and it is this package's own.** The Node shim
+(`globalThis.self = globalThis`) must execute **before** the compiled Dart bundle loads, and
+ES module imports are hoisted above the importing module's body. A naive TypeScript port
+therefore reintroduces the silent-hang failure the shim exists to prevent. Put the
+assignment in a side-effect module imported first, and cover it with a **timeout-bounded**
+test — a bare `await` cannot distinguish a hang from slowness.
+
+This pairs with D-16: the async-only surface is what the generated `.d.ts` must express.
 
 ---
 
@@ -573,6 +812,42 @@ covered by T3.1 and X1. Note D-7 makes this the *less* critical of the two paths
 
 ---
 
+### Status changes, 2026-08-30
+
+| Question | Now |
+| --- | --- |
+| **OQ-5** — which VFS | **Deferred by D-13** (the default V1 bundle needs no VFS; a consumer injecting a SQLite bundle does, which is why this is deferred rather than closed) and **constrained by D-18** (`WasmVfs` rejected; the remaining trade is a product decision, not a benchmark) |
+| **OQ-11** — instance-based `AtClientManager` | **Resolved by D-19** in the instance-based direction. The browser lane constructs its own manager; `getInstance()` is demoted over a major rather than deleted |
+| **OQ-12** — process-global factory registry | **Resolved by D-19** — instance-per-client |
+| **Argon2id / WebCrypto** | **Settled statically** — `cryptography` 2.9.0 has no Argon2id override and Argon2id is absent from the WebCrypto spec, so it always resolves to `DartArgon2id`. The deferred Argon2id UX work stands. See [`design.md`](design.md) §C1 |
+
+### OQ-13 — Where does the monitor resume checkpoint live in remote-only?
+
+`notification_service_impl.dart:130` reads `lastReceivedNotificationAtKey` from
+`getLocalSecondary()!.keyStore!`. Under D-14 that call **silently succeeds and returns
+nothing** after every reload, replaying all notifications with no error — a correctness bug
+rather than a crash, which is worse.
+
+Options: accept the replay (in-memory), or give it a small IndexedDB record beside the key
+envelope. **Recommend the latter**; it reuses the browser-storage layer the key store
+already builds. Must be decided before the browser lane ships notifications.
+
+### OQ-14 — Do the registrar asks land?
+
+Unattended enterprise provisioning needs a machine-to-machine credential and a
+deprovisioning endpoint from the **registrar**, which is another team. Interactive web
+activation is unaffected and works today. Tracked in
+[`enterprise-identity.md`](enterprise-identity.md); lead time is the risk.
+
+### OQ-15 — What is the payload budget, and who owns it?
+
+Open in every lineage; owner assigned in none. D-13 keeps `sqlite3.wasm` (~1 MB+) out of
+the **default** V1 payload, which relieves the pressure but does not answer the question —
+and a consumer who injects a SQLite bundle pays it back in full. Escalate rather than
+invent a number.
+
+---
+
 ## 6. Decision log
 
 | Date       | Entry                                                                                                                                                                                               |
@@ -588,10 +863,13 @@ covered by T3.1 and X1. Note D-7 makes this the *less* critical of the two paths
 | 2026-08-13 | **D-7..D-9 ruled.** dart2js is the JS/TS compile target; the facade lives in `at_client_web` with D-4 unamended; keys cross as strings and events as callbacks. `js-api.md` added as the sixth doc. |
 | 2026-08-18 | Added JS-6 (throw vs. return-tuple, supabase-js precedent) to `js-api.md` §11. |
 | 2026-09-05 | **D-12 ruled.** Client storage becomes one injected bundle owning the keystore and the sync queue; S3 and §2.3's separate queue interface are superseded. `hiveStoragePath` deprecated; `stop()` releases storage. OQ-3 resolved for storage. |
-| 2026-08-18 | `plans/wasm/api-designing.md` written: the three-layer Dart facade split (Layer A/B/C) and the Axis A/B/C reference-SDK survey. `plans/wasm/key-storage.md` written, depending on the split. |
+| 2026-08-18 | The Layer A/B/C design note written: the three-layer Dart facade split and the Axis A/B/C reference-SDK survey. The browser key-storage note written, depending on the split. |
 | 2026-08-18 | Measured the collections API's write/read asymmetry (§2.6, F1–F12) against `packages/at_client/lib/src/collections/collections.dart`. |
-| 2026-08-18 | **D-9 amended, D-10 and D-11 ruled.** Collections (`AtCollection<T>`) become the sole JS/TS data plane; the flat key/value plane from the original §5.2 is removed, not deprecated in place. The Dart gear is typed via a declared `typeTag`; app types are never compiled into `at_client_web`. Write-compatibility with typed Dart peers is left open pending an upstream `writeTypeTag` or a bounded carrier-class shim (JS-7). `js-api.md` §5–§11 rewritten to match; `plans/wasm/api-designing.md` §2.3/§2.4/§2.6 rewritten for the collections-shaped Layer B. JS-2 resolved; JS-8 (the `AtClientManager` singleton blocking multi-instance clients) recorded. |
+| 2026-08-18 | **D-9 amended, D-10 and D-11 ruled.** Collections (`AtCollection<T>`) become the sole JS/TS data plane; the flat key/value plane from the original §5.2 is removed, not deprecated in place. The Dart gear is typed via a declared `typeTag`; app types are never compiled into `at_client_web`. Write-compatibility with typed Dart peers is left open pending an upstream `writeTypeTag` or a bounded carrier-class shim (JS-7). `js-api.md` §5–§11 rewritten to match; the Layer A/B/C design note §2.3/§2.4/§2.6 rewritten for the collections-shaped Layer B. JS-2 resolved; JS-8 (the `AtClientManager` singleton blocking multi-instance clients) recorded. |
 | 2026-08-24 | **Phase 0 landed** ([#2149](https://github.com/atsign-foundation/at_client_sdk/pull/2149)). The dependency-tree walk ships as `tools/wasm_shakedown` — a standalone CLI with its own test suite, not a per-package test as R1 specified — wired into `.github/workflows/at_libraries.yaml` as a hard gate. `at_chops` gated first. |
 | 2026-08-25 | at_auth 4.0.0-rc1 ([#2179](https://github.com/atsign-foundation/at_client_sdk/pull/2179)), the PQ program's S-5: the `at_auth_io.dart` barrel split, `FileAtKeysIo` default dropped, registrar onto `package:http`. Ships one conditional export (`probe_default.dart`). |
 | 2026-08-27 | **Phase 0 matured** ([#2183](https://github.com/atsign-foundation/at_client_sdk/pull/2183)). Gate config extracted to `.github/wasm_gates.yaml`; `controls` made mandatory; `at_auth` gated. **T0.2's two-way ratchet withdrawn** for one-way baselines, **T0.3's no-conditionals ban withdrawn** and restated as a both-branches-walked requirement (D-1 amended, OQ-1 resolved), **R5 withdrawn** — T2 cannot run on a hosted runner (§2.7). T0.4 remains unimplemented. |
 | 2026-08-27 | Phase 1 in review as a three-PR stack: [#2162](https://github.com/atsign-foundation/at_client_sdk/pull/2162) (S4–S6) ready, [#2163](https://github.com/atsign-foundation/at_client_sdk/pull/2163) (S1, S2) and [#2164](https://github.com/atsign-foundation/at_client_sdk/pull/2164) (S3) draft. `plan.md` deleted, as §3 had asserted since 2026-08-13. |
+| 2026-08-30 | D-20 ruled: the JS facade is authored once in TypeScript; `.js` and `.d.ts` are both generated. Corrects `js-api.md` §4/§8, which specified hand-writing both. |
+| 2026-08-30 | D-13..D-19 ruled: remote-only V1; injected write-through `Secondary`; Dart on the main thread; async-only JS surface; redirect-only OIDC; no cross-origin-isolated VFS; no new process globals. `design.md`'s `cryptography`/`better_cryptography` claims corrected. OQ-5/11/12 closed or constrained; OQ-13..15 opened. |
+| 2026-09-06 | **Reconciled with D-12.** The browser lane's rulings, first written 2026-08-30 as D-12..D-19, **renumber to D-13..D-20** — D-12 was taken by the storage bundle, which is the older claim on trunk. **D-13 amended:** V1 *ships* remote-only; it is a default and a payload budget, not a removed capability — the Hive, SQLite and `:memory:` bundles stay injectable. **D-14 amended:** remote-only is delivered as an `AtClientStorage` implementation (write-through keystore, no-op sync queue), not as a second injection route beside X4's factory — one gateway, not two. **D-12 amended** with the four things its interface must permit for that to hold. D-14's source facts re-measured against trunk `cd0327479`; X2/X3 made `LocalSecondary`'s sync queue injectable, which this design now uses instead of avoiding. Committed docs no longer cite the untracked working-notes directory. |

--- a/docs/projects/wasm/design.md
+++ b/docs/projects/wasm/design.md
@@ -472,27 +472,66 @@ these are the algorithms it must use:
 | `pqcrypto`            | `ml_kem_768_pure_dart.dart`, `ml_dsa_65_pure_dart.dart`                                                                              |
 | `better_cryptography` | `aes.dart`, `aes_ctr_factory.dart`, `ed25519.dart`, `at_chops_util.dart`                                                             |
 
-`cryptography` 2.x's browser path uses Web Crypto via `dart:html`. `pqcrypto` is
-additionally fragile: `ml_kem_768_pure_dart.dart` reaches into
+> **Corrected 2026-08-30.** The two claims previously in this block — that `cryptography`
+> reaches Web Crypto "via `dart:html`", and that `better_cryptography` has "unknown web
+> status" — were both wrong. They are replaced below. The `dart:html` claim was inherited
+> verbatim from the predecessor `plan.md`; it is right about a package, but **the wrong
+> package**.
+
+`pqcrypto` is fragile in its own way: `ml_kem_768_pure_dart.dart` reaches into
 `package:pqcrypto/src/…` for `KyberLevel`, a private-path import that can break on any
-upstream release. `better_cryptography` is a `cryptography` fork with unknown web status.
+upstream release. That risk is unchanged.
 
-**The compile target changes what this question even asks.** Under dart2wasm,
-`dart:html` is rejected, so `cryptography` *must* fall back to pure Dart — and pure-Dart
-Argon2id is the reason `.atKeys` decryption was expected to be slow enough to need
-deferred UX work ([`acceptance.md`](acceptance.md) T4.6). Under **dart2js**, which
-[`decisions.md`](decisions.md) D-7 selects, `dart:html` compiles — so the Web Crypto path
-is reachable and may activate automatically.
+**The two crypto packages resolve their browser backends by different mechanisms and fail
+differently. They must be tracked as separate rows, never merged.**
 
-So C1 is no longer "will it compile?" but:
+| | `cryptography` 2.9.0 | `better_cryptography` 1.0.0+1 |
+| --- | --- | --- |
+| Selection mechanism | **runtime probe** — `isWebCryptoAvailable = crypto.subtle.isDefinedAndNotNull && window.isSecureContext` | **compile-time** — `if (dart.library.html)` in `lib/browser.dart:24` |
+| Web interop | `dart:js_interop` — **no `dart:html` anywhere in `lib/`** | **`dart:html` + `package:js`** (`src/browser/javascript_bindings.dart:19,24`; `src/browser/aes_ctr.dart:18`) |
+| Secure-context gate | yes — the `window.isSecureContext` probe above | **none.** `BrowserCryptography extends DartCryptography` performs no availability check |
+| Behaviour outside a secure context | falls back to pure Dart | **expected to throw on every operation** — `BrowserAesMixin` calls `crypto.subtle` unconditionally, with no try/catch and no `Dart*` delegate |
+| In a dedicated Worker | ⚠️ the gate is a literal `window` dereference, so it fails | 🔴 `dart:html` is unusable in a Worker at all |
 
-1. Which implementation does `cryptography` select under dart2js?
-2. If it is Web Crypto, how much faster are Argon2id and AES?
-3. Does that remove the deferred Argon2id work outright?
+**`better_cryptography` is on the default AES path — the hot path.** `AESEncryptionAlgo` →
+`aes.dart` → `aes_ctr_factory.dart` → `package:better_cryptography`. `BrowserCryptography`
+returns a pure-Dart `AesCtr` only for 24-byte keys; 16- and 32-byte keys get
+`BrowserAesCtr`. So every data encrypt/decrypt in a dart2js browser build goes through
+`dart:html`.
 
-**Measure before assuming either way** — and note that a dependency silently relying on
-the deprecated `dart:html` is a risk to track, not a licence for our own code to use it
-(T0.1 keeps it on the forbidden list for package-owned sources).
+**What the compile target actually decides:**
+
+| Compiler | `dart.library.html` | AES-CTR resolves to | Consequence |
+| --- | --- | --- | --- |
+| **dart2js** (D-7's shipping artifact) | true | `BrowserAesCtr` → `crypto.subtle` | accelerated, **main thread only** |
+| **dart2wasm** | false | `DartAesCtr`, pure Dart | **never accelerated**, any context |
+
+### C1 is re-specified
+
+Two of its three questions are now answerable **from source, with no browser**:
+
+1. *Which implementation does `cryptography` select under dart2js?* — `browser_cryptography.dart`,
+   always. Selection is by `dart.library.js_interop`, true under **both** web targets. Which
+   *primitive* backs it is then a **runtime** decision, so Node, Chrome-on-localhost and
+   plain-http Chrome take **three different paths** — and neither T0 nor T1 can see the
+   difference.
+2. *How much faster are Argon2id and AES?* — still needs measurement, for AES.
+3. *Does that remove the deferred Argon2id work?* — **No, and this is now settled.**
+   `cryptography` 2.9.0's `browser_cryptography.dart` has **no Argon2id override**, so
+   `argon2id.dart` always resolves to `DartArgon2id`. Argon2id is not in the WebCrypto spec
+   at all, so no browser can supply one. Re-check only on a `cryptography` major bump — and
+   state the version when doing so.
+
+**The task this block previously specified was mis-aimed:** "confirm `cryptography`
+resolves to its pure-Dart implementation" cannot be confirmed, because the branch selected
+is the browser branch either way. The real question is which primitives that branch
+accelerates at runtime, which is a T3 measurement, not a T0/T1 graph property.
+
+A dependency silently relying on the deprecated `dart:html` remains a risk to track, not a
+licence for our own code to use it (T0.1 keeps it on the forbidden list for package-owned
+sources). `better_cryptography` is additionally a **`1.0.0+1` fork on the hot path** — a
+maintenance cliff, and the strongest argument for replacing it with a WebCrypto AES-CTR
+implementation we own.
 
 All three packages are verifiable **by execution** rather than by compile — the at_chops
 suite runs under [`acceptance.md`](acceptance.md) T2.3. That is a strictly better answer

--- a/docs/projects/wasm/enterprise-identity.md
+++ b/docs/projects/wasm/enterprise-identity.md
@@ -1,0 +1,133 @@
+# enterprise-identity.md — atSigns behind a customer's identity provider
+
+**Status:** design doc (proposed). Lives in `docs/projects/wasm/`.
+**Purpose:** what it takes for an enterprise customer to manage atSigns from **their own**
+identity provider (Microsoft Entra, Okta) — the lifecycle mapping, what already exists,
+what is missing, and which constraints the browser lane must not violate while the answer
+is outstanding.
+**Why it is here:** this is an **adoption** blocker, not a program blocker. Nothing below
+prevents the WASM work from shipping; all of it prevents an enterprise from adopting it.
+
+---
+
+## 0. The requirement in one line
+
+> An enterprise wants their directory to be the system of record: a SCIM *create user*
+> event provisions an atSign, a *disable* or *delete user* event deprovisions it, with no
+> human in the loop — and they want the credentials stored where they already store
+> secrets.
+
+---
+
+## 1. Lifecycle mapping
+
+The protocol is closer to ready than any earlier doc suggested. Mapping IdP events onto
+what `at_auth` and the atServer actually expose:
+
+| IdP event | atProtocol primitive | State |
+| --- | --- | --- |
+| SCIM **create user** | registrar → CRAM key → `AtAuth.onboard` → first enrollment (auto-approved, server grants `__manage`) | ⛔ **the activation OTP goes to a human mailbox** — §3 |
+| **New device / app** for an existing user | `AtEnrollment.submit(EnrollmentRequest, otp)` → `approve` | ✅ fully machine-drivable — the enrollment OTP is minted **programmatically** (`otp:get`), and `setSpp` gives a semi-permanent passcode |
+| **Webhook-driven bulk approval** | an `autoApprove` daemon subscribing `.*\.new\.enrollments\.__manage`, regex-matching app/device | ⚠️ **already written**, but reachable only through `auth_cli.dart` — not exported from the barrel |
+| SCIM **disable user** | per-enrollment `AtEnrollment.revoke(enrollmentId)` | ⚠️ per-enrollment only; **no atSign-level primitive** — §2 |
+| SCIM **re-enable user** | `unrevoke` | ⚠️ exists on the wire and in the server handler; **no library API** |
+| **Reconcile** directory ↔ atSigns | `AtEnrollment.list(statusFilters)` | ✅ |
+| **Policy** — who may hold an atSign in this tenant | `packages/at_policy` | ✅ right home, unused for this |
+
+**Two structural facts make this tractable:**
+
+1. **The enrollment lifecycle is storage-free.** Every `AtEnrollment` method takes only an
+   `AtLookUp` — no `AtClient`, no keystore (`at_enrollment.dart:73,107,126,145,152,159,166,189`).
+   It works in a browser under D-13 with no local store.
+2. **The handoff already exists.** An approved enrollment yields an `AtAuthSession`, and
+   `AtClientManager.fromAuthSession` (`at_client_manager.dart:193-211`) already consumes it.
+
+---
+
+## 2. What the atServer is missing: an atSign-level disable
+
+Per-enrollment `revoke` exists. There is **no primitive that disables the identity's own
+access**. Composing one as `list(approved) → revoke each` is **racy** (a new enrollment can
+land between the calls) and **non-atomic** (a partial failure leaves the identity
+half-disabled).
+
+**There is an adjacent atSign-level control, and it points the wrong way.**
+
+| | `config:block` | what is needed |
+| --- | --- | --- |
+| Grammar | `config:block:add:@alice @bob` / `:remove:` / `:show` | — |
+| Enforced at | `from` verb — `checkInBlockList(fromAtSign)` → `BlockedConnectionException` | the owner's own authentication |
+| Direction | **inbound** — stops *other* atSigns reaching my atServer | **the identity itself** must stop working |
+| Self-disable | **explicitly foreclosed in code** — the handler strips `currentAtSign` from the list | required |
+
+That last row matters: self-blocking is excluded **deliberately**, which is what makes this
+a genuine gap rather than a search that missed something.
+
+**The ask.** One operation that suspends an atSign as a unit — reject new enrollment
+requests, suspend all approved enrollments atomically, close live connections — with a
+reversible counterpart mirroring `revoke`/`unrevoke`. It needs a **status distinct from
+`EnrollmentStatus.revoked`**, so per-enrollment state survives and re-enable does not
+wrongly restore individually-revoked enrollments.
+
+This is atServer work, owned in-house, tracked in the atServer plan.
+
+---
+
+## 3. What the registrar is missing: unattended provisioning
+
+**This is the only genuinely external dependency in the whole programme.**
+
+Important scoping correction: the registrar **is** browser-reachable over HTTPS today, and
+a web app can complete an interactive activation — OTP to email, exchanged for a CRAM key.
+**That path works and is not in question.**
+
+What does not exist, on the surface our own client consumes:
+
+| # | Ask | Priority |
+| --- | --- | --- |
+| R-1 | A machine-to-machine credential, so a backend can create an atSign with no human reading an OTP email. Today the credential is a single shared `Authorization` header value with no per-tenant scoping | **blocker** |
+| R-2 | A deprovisioning endpoint, with agreed reversibility semantics against §2's suspend/restore | **blocker** |
+| R-3 | A tenant reconciliation / list endpoint, so an integration can detect and heal drift | wanted |
+
+**Raise these now**, in parallel with the browser work — lead time is the risk, not
+difficulty. The full hand-off document is maintained separately and states each item as
+"here is the surface we consume; confirm or correct it," because our evidence is our own
+client wrapper rather than the registrar's API documentation.
+
+---
+
+## 4. Two defects on the onboarding path, unrelated to WASM
+
+Both pre-date this programme. Both will surface in the first enterprise security review, so
+they are recorded here rather than buried under a WASM ticket.
+
+| Defect | Why it matters here |
+| --- | --- |
+| The default registrar client installs a `badCertificateCallback` accepting **any** certificate — on the channel carrying the activation OTP and returning the CRAM key | A browser **cannot** do this, so the web client already verifies properly. The port fixes it as a side effect; that is an argument for the port, not an excuse for the line |
+| Onboarding writes `atAuthKeys` JSON — **private key material** — into `Directory.current.path` as a checkpoint file | A server-side webhook handler would leave private keys in its working directory. Fatal in exactly the deployment this document describes |
+
+---
+
+## 5. Constraints the browser lane must not violate
+
+These are *don't-close-this-door* rules. None requires the IdP integration to be built now.
+
+| # | Constraint | Why |
+| --- | --- | --- |
+| **E1** | **Onboard the web app as an APKAM enrollment, never as a new atSign.** | Enrollment is machine-drivable today; atSign creation is not (§3). It also makes browser-storage eviction **non-fatal** — the atSign's keys still live on the user's other device, so losing the browser key store means *re-enroll*, not lockout. **This holds only while the browser never mints keys of its own** — a web app that *creates* an atSign becomes the sole custodian of that master key, and eviction is then unrecoverable. Creation, if it ever lands in the browser, ships with a mandatory escrow or export step **in the same change** |
+| **E2** | Build the sealed key envelope as a **reusable, pure-Dart component**, not welded inside the IndexedDB implementation | An IdP directory attribute (Entra schema extensions, Okta Universal Directory) is a plausible host-supplied key store. If sealing is reusable, that store inherits it. If not, writing plaintext atKeys into a directory attribute would be a serious regression — note that a host-supplied store receives **plaintext** across the port, and owns its own at-rest protection |
+| **E3** | **Redirect-based OIDC only** (D-17) | Popups work today but break the moment any V2 storage option requires COOP `same-origin` |
+| **E4** | **No new process-global state**; one client per atSign, explicitly (D-19) | An IdP integration is inherently multi-identity: one service holding many users' atSigns. Under D-13 this can be *demonstrated* now, not merely promised |
+| **E5** | Export the enrollment lifecycle that already exists — `unrevoke`, `delete`, single `fetch`, and the `autoApprove` daemon | Cheap, non-breaking, additive. These are **library-API gaps, not server gaps**: all of them exist on the wire and in the atServer's enroll handler. The webhook-driven approval daemon is already written |
+| **E6** | Make HTTP-client injection mandatory on the onboarding path | Needed for the browser anyway; it is also what lets §4's two defects be fixed independently |
+| **E7** | **Zero vendor-specific IdP code in the core SDK.** Expose generic SCIM/OIDC lifecycle hooks and build IdP integrations as pluggable adapters. | Hardcoding Microsoft Entra or Okta APIs creates massive technical debt. The SDK must remain provider-agnostic, relying on standard protocols so any IdP (Ping, Auth0, custom) can be plugged in without touching `at_client` or `at_auth`. |
+
+---
+
+## 6. What this document does **not** claim
+
+- It does not assume a flow shape. Whether the customer's OIDC leg is redirect or popup,
+  and whether provisioning is SCIM or webhook, is **assumed, not verified** — the reference
+  specification was not readable. E3 is deliberately written as the conservative branch,
+  which is correct under either shape, so learning more can only *relax* a constraint.
+- It does not schedule the IdP integration. It records what would foreclose it.

--- a/docs/projects/wasm/implementation-plan.md
+++ b/docs/projects/wasm/implementation-plan.md
@@ -29,6 +29,30 @@ for the trajectory see [`roadmap.md`](roadmap.md); for the non-Dart consumer sto
 
 ---
 
+> ## ⚠️ Scope change, 2026-08-30 (amended 2026-09-06) — V1 ships remote-only
+>
+> The first browser release **ships** a remote-only storage bundle as its default: no
+> SQLite, no VFS, no `sqlite3.wasm`, no Hive in the shipped payload. It is a default, not a
+> prohibition — under D-12 storage is an injected bundle, so the SQLite, `:memory:` and Hive
+> bundles stay injectable for a consumer who wants one. See [`decisions.md`](decisions.md)
+> D-13.
+>
+> **What this does to the backlog below:**
+>
+> | Group | Status |
+> | --- | --- |
+> | Transport tasks | **unchanged, and now the critical path.** Also cheaper than assumed: the atServer already speaks WebSocket natively and the WSS proxy is built, so there is **no server-side transport work** |
+> | Storage / persistence / sync-queue tasks | **deferred to V2** *as browser-lane work*. Correct as written; not withdrawn. `decisions.md` D-18 constrains the VFS choice for when they resume. **The X series below is not deferred** — it is `at_client`-side and lands on its own merits; it is what makes the browser's remote-only bundle injectable at all |
+> | Crypto tasks | **re-specified** — see [`design.md`](design.md) §C1. The `dart:html` claim was right about `better_cryptography`, not `cryptography`, and the Argon2id question is now settled statically |
+> | Key-storage tasks | **unchanged, and now the whole storage story** |
+> | JS packaging tasks | **re-specified by D-20** — author the facade once in TypeScript; generate both `.js` and `.d.ts` |
+>
+> A new task group is implied and not yet written up here: the **remote-only
+> `AtClientStorage`** that delivers remote-only (D-14) — a write-through keystore and a
+> no-op sync queue, injected through the X-series gateway rather than as a second route. It
+> replaces what would otherwise have been a sweep through 21 null-assertion call sites.
+
+
 ## 0. How to read this plan
 
 Task ids are stable and referenced from the other docs. Each carries a goal, the
@@ -320,8 +344,10 @@ measurement is against `d13516d95`, after them.
 **Found 2026-09-05 by the wrap-up's cold read and done the same day:** the X3 merge-back
 had been skipped. It landed as `51bdb6230`; `at_sync_queue.dart` kept trunk's `SyncQueueStore`
 abstraction and the spike's `HiveInstances.forPath(path)` default together, and the queue's
-`storagePath` became optional so trunk's SQLite storage compiles on the spike. Also owed: nine dangling links to a `plans/wasm/`
-directory that does not exist (`implementation-plan.md`, `js-api.md`, `decisions.md`).
+`storagePath` became optional so trunk's SQLite storage compiles on the spike. **Cleared
+2026-09-06:** the ten citations of a personal, untracked working-notes directory in
+`implementation-plan.md`, `js-api.md` and `decisions.md` now name the note without a path,
+so every link in the committed set resolves inside the repo.
 
 **Deferred to the major:** deprecating `AtClientManager`. Its `AtSignChangeListener`
 capability exists only because there is a global current atSign, and where that goes is
@@ -386,15 +412,30 @@ count is sound for at_client's own sync service, and the extension seam is fine 
 
 Now verified **by execution** under T2.3 rather than by compile.
 
-- **C1 — `cryptography`** must resolve to its pure-Dart implementation; its 2.x browser
-  path uses Web Crypto via `dart:html`, which dart2wasm rejects. Critical path — it
-  backs X-Wing, X25519, AES-GCM, the X25519 key pair, Argon2id and `at_chops_util`.
+- **C1 — `cryptography`** — ⚠️ **re-specified 2026-08-30; see [`design.md`](design.md)
+  §C1.** The former wording ("must resolve to its pure-Dart implementation; its browser
+  path uses Web Crypto via `dart:html`") was wrong on both halves. The package has **no
+  `dart:html` anywhere in `lib/`** — it uses `dart:js_interop` with a **runtime**
+  `window.isSecureContext` probe — so the browser branch is selected under *both* web
+  targets and "resolves to pure Dart" is not a checkable property. The real question is
+  which primitives that branch accelerates at runtime, which is a T3 measurement, not a
+  T0/T1 graph property. Still critical path: it backs X-Wing, X25519, AES-GCM, the X25519
+  key pair, Argon2id and `at_chops_util`.
+  **Argon2id is already settled** — no override in 2.9.0, and Argon2id is absent from the
+  WebCrypto spec, so it always resolves to `DartArgon2id`. The deferred Argon2id UX work
+  stands.
 - **C2 — `pqcrypto: ^0.3.0`.** Backs `ml_kem_768_pure_dart.dart` and
   `ml_dsa_65_pure_dart.dart` — the algorithms a WASM build must use. Note
   `ml_kem_768_pure_dart.dart` imports `package:pqcrypto/src/…` for `KyberLevel`, a
   private-path import that can break on any upstream release.
 - **C3 — `better_cryptography`.** Backs `aes.dart`, `aes_ctr_factory.dart`,
-  `ed25519.dart`, `at_chops_util.dart`. A `cryptography` fork with unknown WASM status.
+  `ed25519.dart`, `at_chops_util.dart`. ⚠️ **Status is no longer unknown, and this is the
+  higher-risk row of the two.** It is a `1.0.0+1` fork whose browser backend imports
+  **`dart:html` + `package:js`**, selected at compile time by `dart.library.html`, with
+  **no secure-context gate at all** — so outside a secure context the expected outcome is
+  a throw on every encrypt, not a fallback. It sits on the **default AES path**, i.e. the
+  hot path. Tracked separately from C1: the two packages resolve by different mechanisms
+  and fail differently, and must not be merged into one row.
 - **C4 — Measure Argon2id in pure Dart under WASM.** The number is the deferred UX
   input for `.atKeys` passphrase decryption. → X3
 
@@ -418,8 +459,9 @@ Now verified **by execution** under T2.3 rather than by compile.
 
 ## 8. Phase 6 — the JS/TS facade (J)
 
-Design in [`js-api.md`](js-api.md) and [`plans/wasm/api-designing.md`](../../../plans/wasm/api-designing.md)
-(the Dart-side Layer A/B/C split); rulings D-7..D-11 in [`decisions.md`](decisions.md).
+Design in [`js-api.md`](js-api.md) and in the Layer A/B/C design note (the Dart-side
+facade split, held as working notes outside this repo); rulings D-7..D-11 in
+[`decisions.md`](decisions.md).
 Builds on W1. Adds no Dart package — everything lands inside `at_client_web`.
 
 **Rewritten 2026-08-18 for the collections pivot (D-10, D-11).** J1 previously described
@@ -454,7 +496,7 @@ a flat ~25-method surface; that surface is removed, not extended. `AtCollection<
   `'unknown'` event, never drop it or throw. → T6.5
 - **J4 — The TS-supplied `KeyStore` seam.** Adapt a JS object behind the Dart storage
   interface, so Node consumers supply storage without a Dart package. Owned jointly with
-  [`plans/wasm/key-storage.md`](../../../plans/wasm/key-storage.md). → T6.6
+  the browser key-storage design note. → T6.6
 - **J5 — Entry point.** `packages/at_client_web/web/at_client_js.dart` — the `main()`
   that installs the facade on the global scope. Compiled with `dart compile js`; keep the
   dart2wasm build green in CI to preserve the option.

--- a/docs/projects/wasm/js-api.md
+++ b/docs/projects/wasm/js-api.md
@@ -13,7 +13,7 @@ sequencing see [`implementation-plan.md`](implementation-plan.md); for the gates
 (D-10) and `AtCollection<T>` (`packages/at_client/lib/src/collections/collections.dart`)
 is the sole JS/TS data plane (D-9 amended, D-11 added). §6, §8, §9, §10 and §11 updated to
 match; see `decisions.md` §2.6 for the measured findings this rewrite is based on and
-`plans/wasm/api-designing.md` §2.3–§2.4 for the Dart-side (Layer B/C) shape.
+the Layer A/B/C design note §2.3–§2.4 for the Dart-side (Layer B/C) shape.
 
 ## Table of contents
 
@@ -139,7 +139,7 @@ Measured by compiling the same facade both ways:
 | Loading                      | `require` / `<script>`; runs `main()` on load                                           | fetch → `compile` → `instantiate` → `invoke`                                             |
 | Bundlers                     | **trivial — it is just JavaScript**                                                     | manual `.wasm` asset handling, per bundler                                               |
 | Browsers                     | **universal**                                                                           | Chrome 119+ / Firefox 120+ / Safari 18.2+                                                |
-| CSP                          | **nothing special**                                                                     | requires `script-src 'wasm-unsafe-eval'`                                                 |
+| CSP                          | ⚠️ **not "nothing special"** — see §8a                                                   | requires `script-src 'wasm-unsafe-eval'`                                                 |
 | Node                         | works; needs the shim in [§7](#7-typescript-supplied-implementations-and-node)          | works unmodified                                                                         |
 | `is` / `as` on interop types | **correct**                                                                             | **broken** — all interop types share one `externref` representation                      |
 | Promises                     | **real native `Promise`**                                                               | `JSPromise` (also awaitable)                                                             |
@@ -183,12 +183,17 @@ that here rather than letting it erode silently.
 2. **"No `dart:html` / `dart:js`" becomes self-imposed.** Under dart2wasm it was
    compiler-enforced. Under dart2js it is a policy kept in order to leave dart2wasm open
    — so it moves into [`acceptance.md`](acceptance.md) T0.1 as an explicit rule.
-3. **`cryptography`'s Web Crypto path becomes reachable.** Open question C1 exists
-   because `cryptography` 2.x's browser path uses `dart:html`, which dart2wasm rejects.
-   Under dart2js that path *works*. The question changes from "will it compile?" to
-   "which path does it select, and is it faster?" — and a Web Crypto-backed Argon2id and
-   AES could remove the deferred performance work entirely. See
-   [§11](#11-open-questions).
+3. **The Web Crypto path becomes reachable — for `better_cryptography`, not
+   `cryptography`.** *(Corrected 2026-08-30; the original claim here misattributed the
+   dependency.)* `cryptography` uses `dart:js_interop` and a **runtime**
+   `window.isSecureContext` probe, so its branch is selected under *both* web targets and
+   the compiler does not decide it. The package that genuinely requires `dart:html` is
+   **`better_cryptography`**, which backs the **default AES path** and selects its backend
+   at compile time via `dart.library.html`. So under dart2js, AES becomes Web
+   Crypto-backed; under dart2wasm it stays pure Dart.
+   Argon2id is **not** affected either way: `cryptography` 2.9.0 has no Argon2id override
+   and Argon2id is absent from the WebCrypto spec, so the deferred Argon2id work stands.
+   See [`design.md`](design.md) §C1 and [§11](#11-open-questions).
 4. **Storage gets safer, not riskier.** `package:sqlite3`'s web support was originally
    built for dart2js — `common.dart` documents interfaces implemented by "the `dart:ffi`
    and the `dart:js` WASM version". The validated dart2wasm compile was the *less*
@@ -206,9 +211,10 @@ product; the compiler is a packaging decision.*
 **Inside `at_client_web`.** No new Dart package;
 [`decisions.md`](decisions.md) D-4 stands unamended.
 
-1. **The npm package is not a Dart package.** It is a build artifact — the compiled
-   `.js`, a hand-written `index.js` wrapper, and a hand-written `index.d.ts`. Publishing
-   to npm implies no pub package.
+1. **The npm package is not a Dart package.** It is a build artifact — the compiled Dart
+   `.js` engine plus a wrapper **authored once in TypeScript**, from which both the
+   shipped `.js` and the `.d.ts` are generated (§8, D-20). Publishing to npm implies no
+   pub package.
 2. **The facade is an entry point, not a library.** `dart compile js` compiles a
    *program*. The facade only exists because a `main()` calls `createJSInteropWrapper`
    and installs the result. Packages ship entry points routinely without being split.
@@ -221,7 +227,9 @@ packages/at_client_web/
   lib/at_client_web.dart        # Dart-facing platform impls — unchanged by this doc
   lib/src/js/                   # the @JSExport facade, marshalling, error mapping
   web/at_client_js.dart         # main() that installs the facade  ← dart compile js
-  npm/                          # package.json, index.js, index.d.ts (hand-written)
+  npm/src/                      # index.ts + shim.ts — hand-written TypeScript, the ONLY
+                                #   hand-maintained facade source
+  npm/dist/                     # index.js + index.d.ts — GENERATED by tsc, never edited
 ```
 
 **Recorded wrinkle:** `at_client_web` then does two jobs, and its name says "web" while
@@ -240,6 +248,33 @@ is **removed**, not deprecated in place. `AtCollection<T>`
 `at_client.dart:28`) is the **sole** JS/TS data plane. The older `at_collection/` tree
 (`AtCollectionModel`, `AtJsonCollectionModel`, factories) is `@Deprecated` at
 `at_client.dart:31-38` in favour of it and is never bound — see [§9](#9-deliberately-excluded).
+
+### 5.0 Binding rule: every protocol operation returns a `Promise`
+
+**No synchronous escape hatch may ship, for any operation that could later touch storage or
+the network.** No `getSync`, no synchronous getter that reads data.
+
+```ts
+// NEVER
+const value = client.getSync('key.atsign');
+
+// ALWAYS
+const value = await client.get('key.atsign');
+```
+
+**Why this is a rule and not a style preference.** The first browser release is remote-only
+with an in-memory cache ([`decisions.md`](decisions.md) D-13), and Dart runs on the main
+thread (D-15). Some operations *could* therefore return synchronously today. If any of them
+does, the V2 storage upgrade — SQLite, possibly in a Worker, both asynchronous — becomes a
+**breaking change to a published npm surface** for every consumer that adopted the
+synchronous form.
+
+Holding the surface async from day one makes V2 a purely internal refactor that the host
+page never observes. It costs nothing now and cannot be retrofitted later.
+
+Recorded as D-16.
+
+---
 
 ### 5.1 Why no raw key plane is exposed at all
 
@@ -455,15 +490,61 @@ bare `await`.
 
 ## 8. npm packaging
 
+> **Corrected 2026-08-30 (D-20).** An earlier version of this section specified a
+> hand-written `index.js` *and* a hand-written `index.d.ts`. That is two hand-maintained
+> descriptions of one surface, and they will drift. **Author the wrapper once, in
+> TypeScript; generate both outputs from it.**
+
 ```
-@atsign/at-client
-  package.json        # GENERATED by build tooling, not hand-committed — see below
-  index.js            # sets globalThis.self on Node, loads the bundle, wraps the raw
-                       # facade in a real ES class, re-exports it
-  index.d.ts          # hand-written; documentation value, not generated (see below)
-  at_client.js        # dart compile js output
-  at_client.js.map
+src/                  # hand-written — the only facade source
+  shim.ts             # Node globals; MUST be imported before the engine (see below)
+  index.ts            # imports the internal engine, wraps it in a real ES class,
+                      #   enforces the Promise-only surface (§5.0), maps errors
+
+dist/                 # GENERATED by tsc — never hand-edited, never reviewed for style
+  index.js            # what a vanilla-JS consumer executes
+  index.d.ts          # what gives TS consumers autocomplete
+  index.js.map
+
+at_client.js          # dart compile js output — internal engine, not a public entry point
+at_client.js.map
+package.json          # GENERATED by build tooling, not hand-committed — see below
 ```
+
+**Why this and not hand-written JS:**
+
+- **The behaviour and the types cannot misalign**, because they are emitted from the same
+  file. Drift is not managed, it is impossible.
+- **One bug surface.** Changing how the facade talks to the Dart engine is one edit.
+- **Vanilla-JS consumers are unaffected.** They import `dist/index.js` and neither know nor
+  care that it was authored in TypeScript — while their editor quietly reads the `.d.ts`
+  and gives them autocomplete anyway.
+
+The Dart-generated `at_client.js` stays **strictly internal**: it is not a documented entry
+point, and `package.json`'s `exports` must not expose it.
+
+⚠️ **One trap, created by this package's own Node shim.** §7 requires
+`globalThis.self = globalThis` to run **before** the compiled Dart bundle loads. ES module
+imports are hoisted and evaluated before the importing module's body, so the obvious
+TypeScript is silently wrong:
+
+```ts
+// BROKEN — the import is evaluated first; every Promise then hangs, with no error
+globalThis.self = globalThis;
+import './at_client.js';
+```
+
+Put the assignment in its own module and import it first, since imports evaluate in order:
+
+```ts
+// index.ts
+import './shim.js';        // side-effect module — sets globalThis.self
+import './at_client.js';   // now safe
+```
+
+A dynamic `await import('./at_client.js')` after the assignment also works. **Whichever is
+chosen, it needs a timeout-bounded test** — the failure mode is a silent hang, not an
+error, which is exactly the class of bug this programme exists to remove.
 
 Notes:
 
@@ -512,14 +593,72 @@ Notes:
 
   This is where a `@JSExport`-produced object becomes a real, `instanceof`-checkable,
   autocomplete-friendly class — the compiled facade cannot do this on its own, and no
-  amount of Layer B design (`plans/wasm/api-designing.md`) fixes it, because the
+  amount of Layer B design (see the Layer A/B/C design note) fixes it, because the
   limitation is in `@JSExport` itself.
 - **The `.d.ts` stays hand-written.** Sass keeps its `.d.ts` in a *separate repo*
   (`sass/sass` → `js-api-doc/index.d.ts`), framed explicitly as user-facing documentation
-  rather than generated types. `plans/wasm/api-designing.md` §2.6 (re-costed 2026-08-18
+  rather than generated types. The Layer A/B/C design note §2.6 (re-costed 2026-08-18
   for Layer B's generics) recommends **drift detection** — a CI diff of generated-vs-committed
   — over full generation, for the same reason: a hand-authored `.d.ts` carries
   documentation value generated output loses. See [§11](#11-open-questions) JS-5.
+
+---
+
+## 8a. The deployment contract
+
+**What the host must provide.** This section exists because the three browser concerns —
+serving the build, storing keys, and integrating an identity provider — all meet here, and
+no earlier document owned it.
+
+### 8a.1 Hard requirements
+
+| # | Requirement | Consequence if omitted |
+| --- | --- | --- |
+| 1 | **A secure context** — HTTPS, or `localhost` | `crypto.subtle` is **absent, not degraded**. The non-extractable key-wrapping key cannot be generated at all, so the browser key store fails outright |
+| 2 | `script-src 'wasm-unsafe-eval'` | Required for **any** Dart web build. See 8a.2 — the "dart2js needs nothing" row above is wrong |
+| 3 | `application/wasm` MIME on `.wasm` responses | Streaming instantiation fails |
+| 4 | `worker-src blob:` | Needed if any part of the stack moves off the main thread |
+
+**Requirement 1 is functional, not hygiene.** A spike served over plain http measures a
+configuration that cannot ship: it would report the key-storage design as broken and every
+accelerable crypto primitive as pure Dart. **Serve the host page over HTTPS or localhost
+from the first commit.**
+
+Absence of `crypto.subtle` must **fail loudly** and must never silently degrade to
+plaintext storage.
+
+### 8a.2 Why "dart2js needs nothing" was wrong
+
+The compile-target table above credits dart2js with requiring no CSP allowance. That holds
+for the *Dart bundle* alone, and only while nothing else in the stack is WebAssembly.
+
+It stops holding the moment a local store returns: SQLite-wasm is fetched from a URL at
+runtime, ~1 MB+, **regardless of which Dart compiler produced the bundle**. The serving
+requirement is therefore **compiler-independent** — which is precisely what the dart2js
+framing hid.
+
+Under D-13 the default V1 payload carries no such asset, which is a real payload win. It
+becomes the default in V2 — and a consumer who injects a SQLite bundle before then takes on
+the serving requirement with it.
+**Whoever owns the deployment contract must own that asset: its origin, its MIME type, and
+whether the npm package ships it.**
+
+### 8a.3 Explicitly *not* required
+
+| Header | Status |
+| --- | --- |
+| `COOP: same-origin` / `COEP: require-corp` | **Not required, and deliberately avoided.** Only a `SharedArrayBuffer`-based VFS would need them, and D-18 rejects that option. Cross-origin isolation severs `window.opener`, which would break popup OIDC flows |
+
+### 8a.4 Keep asset locations configurable
+
+Do not hard-code same-origin paths for the `.wasm` bundle or any runtime-fetched asset.
+CDN and sub-path deployments are normal, and under any future `COEP: require-corp` a
+cross-origin asset additionally needs CORP/CORS headers from the CDN.
+
+### 8a.5 Release ownership
+
+The `.d.ts` and npm release path has no CI, no versioning convention, and no named owner.
+Serving is not only headers — it is a release pipeline. This blocks any non-`0.x` publish.
 
 ---
 
@@ -574,7 +713,7 @@ Notes:
   project's own T6/T4 gates exercise it against a live atServer — the marker reflects a
   gap in *our* boundary validation, not upstream's contract.
 - **No `dispose()` on `AtCollection`, at all.** Every reference SDK in Axis C
-  (§1 of `plans/wasm/api-designing.md`) has an explicit cleanup call
+  (§1 of the Layer A/B/C design note) has an explicit cleanup call
   (`removeChannel`, `stopClient`). Upstream's own comments (`collections.dart:439`/`:447`)
   acknowledge the gap ("Held so a future `dispose()` can cancel cleanly"), and
   `availableEvents`' scheduler runs for the collection's lifetime regardless
@@ -641,7 +780,7 @@ change; document the gap and ship read-compatibility in the meantime.**
 `static final AtClientManager _singleton` driven by `setCurrentAtSign(...)`. A JS
 consumer calling `AtClient.create({atSign: '@alice'})` then `AtClient.create({atSign:
 '@bob'})` expects two independent clients — every reference SDK in Axis C
-(`plans/wasm/api-designing.md` §1) is multi-instance by construction — but today the
+(Layer A/B/C design note §1) is multi-instance by construction — but today the
 second call mutates global state under the first. **Interim: ship documented as one
 atSign per page/process, plus a facade-level `AtFailure.alreadyInitialised` thrown on a
 second *distinct* atSign** (converts silent corruption into a clear error, ~10 lines in

--- a/docs/projects/wasm/roadmap.md
+++ b/docs/projects/wasm/roadmap.md
@@ -18,6 +18,7 @@ implementations, so that a browser WasmGC build runs without runtime failures. T
 ## Table of contents
 
 - [Document map](#document-map)
+- [Scope note: V1 is remote-only](#scope-note-v1-is-remote-only)
 - [1. The thesis](#1-the-thesis)
 - [2. Why the compiler cannot be the gate](#2-why-the-compiler-cannot-be-the-gate)
 - [3. The tier model](#3-the-tier-model)
@@ -25,9 +26,31 @@ implementations, so that a browser WasmGC build runs without runtime failures. T
 - [5. Ownership boundary against the PQ program](#5-ownership-boundary-against-the-pq-program)
 - [6. The phase trajectory at a glance](#6-the-phase-trajectory-at-a-glance)
 
+## Scope note: V1 is remote-only
+
+**Added 2026-08-30, amended 2026-09-06.** The first browser release **ships** a
+remote-only storage bundle as its default: no SQLite, no VFS, no `sqlite3.wasm`, no Hive
+in the shipped payload. A local store becomes the default in V2, as a speed optimisation.
+See `decisions.md` D-13.
+
+**This is a default, not a prohibition.** Under `decisions.md` D-12 client storage is an
+injected bundle, so remote-only is one implementation of that interface and the SQLite,
+`:memory:` and Hive bundles stay injectable — in the browser too, for a consumer willing to
+pay for one. What V1 fixes is what we ship by default.
+
+That takes an entire hard problem off V1's critical path: the browser lane had two
+independently difficult pieces — a durable local database and a secure key store — and only
+the second is on the path to first release. The default bundle also touches neither of the
+two process globals we do not own.
+
+Everything in the storage lane below remains correct; it is **deferred, not withdrawn**, and
+`decisions.md` D-18 constrains the VFS choice for when it resumes.
+
+---
+
 ## Document map
 
-This is one of **six** docs. Each keeps to its lane; cross-references point at the
+This is one of **seven** docs. Each keeps to its lane; cross-references point at the
 canonical home rather than duplicating it.
 
 | Doc                                                | What lives there                                                                                                                                                                                                                                                                                           |
@@ -35,9 +58,10 @@ canonical home rather than duplicating it.
 | **roadmap.md** (this doc)                          | The WHY + WHAT — the neutrality thesis, the compiler-blindness finding, the three-tier model, goals/non-goals, the PQ ownership boundary, the phase trajectory.                                                                                                                                            |
 | [`design.md`](design.md)                           | The per-capability seam designs — transport, storage bootstrap, sync queue, keys, HTTP, connectivity, logging, filesystem, process/env. Current call sites with `file:line`, the proposed interface, and who implements it on each platform. Plus the dead-end seams and the `AtClientPreference` reframe. |
 | [`implementation-plan.md`](implementation-plan.md) | The build sequence — phases, the task backlog (P/T/I/C/G/D groups), dependency order, and the publish ladder.                                                                                                                                                                                              |
-| [`acceptance.md`](acceptance.md)                   | The gates, tiered T0–T6, with the measured evidence for each and an explicit statement of what each tier does *not* prove.                                                                                                                                                                                 |
-| [`decisions.md`](decisions.md)                     | The decision log — the binding rulings (D-1..D-11), their rationale, the measured findings that drove them, and the open questions.                                                                                                                                                                        |
-| [`js-api.md`](js-api.md)                           | The non-Dart consumer story — the dart2js compile target, the measured JS/TS language boundary, the TypeScript surface, error mapping, TS-supplied implementations, Node, and npm packaging.                                                                                                               |
+| [`acceptance.md`](acceptance.md)                   | The gates, tiered T0–T6, with the measured evidence for each and an explicit statement of what each tier does *not* prove. Plus §9a: confidentiality, remote-only, deployment and surface-stability gates.                                                                                                  |
+| [`decisions.md`](decisions.md)                     | The decision log — the binding rulings (D-1..D-20), their rationale, the measured findings that drove them, and the open questions.                                                                                                                                                                        |
+| [`js-api.md`](js-api.md)                           | The non-Dart consumer story — the dart2js compile target, the measured JS/TS language boundary, the TypeScript surface, error mapping, TS-supplied implementations, Node, npm packaging, and **the deployment contract** (§8a).                                                                              |
+| [`enterprise-identity.md`](enterprise-identity.md) | **New 2026-08-30.** atSigns behind a customer's IdP (Entra/Okta) — the SCIM lifecycle mapping, the atSign-level disable gap, the registrar asks, and the constraints the browser lane must not violate. An *adoption* blocker, not a program blocker.                                                       |
 
 ---
 
@@ -64,9 +88,15 @@ at_client / at_lookup / at_utils / at_auth / at_chops     ← interfaces only
         ▲                    ▲                    ▲
 at_client_web           *_io barrels         at_client_flutter
 (WebSocket,            (SecureSocket,        (keychain, app dirs)
- SQLite-wasm,           file keystore,       — a consumer today,
- IndexedDB keys)        file logging)          an implementer later
+ IndexedDB keys)        file keystore,       — a consumer today,
+                        file logging)          an implementer later
 ```
+
+`SQLite-wasm` was listed in `at_client_web` until 2026-09-02. **D-13 took it out of the
+default**, and did not remove the capability: V1 ships a remote-only bundle, so nothing in
+the default payload needs a local store to back. A consumer may still inject a SQLite
+bundle (`package:at_client/sqlite.dart`, D-12); it becomes the browser default in V2, as a
+*speed* optimisation rather than a correctness one.
 
 **Why not conditional imports.** A conditional import is a compile-time answer to a
 runtime question. It leaves platform knowledge inside the neutral layer, it makes the
@@ -134,9 +164,14 @@ neutral barrel's import graph. Consumers add one import.
 
 ### Tier 3 — platform implementers
 
-- **`at_client_web`** — new, built by this project. WebSocket transport, SQLite-wasm
-  storage, IndexedDB-backed key store, `navigator.onLine` connectivity, console
-  logging.
+- **`at_client_web`** — new, built by this project. WebSocket transport,
+  IndexedDB-backed key store, `navigator.onLine` connectivity, console logging.
+  *(SQLite-wasm storage left this list 2026-09-02 as the **default**: **D-13** ships V1
+  remote-only. It is not withdrawn. The **backend** ruling in [`design.md`](design.md) §5 —
+  SQLite-wasm over IndexedDB — stands, and under **D-12** a SQLite bundle stays injectable
+  today for anyone who wants one; it becomes the default in V2. Its **VFS** half is a
+  separate and still-open question: **D-18** makes it pick-two, so nothing in §5 settles
+  which VFS V2 gets.)*
 - **`at_client_flutter`** — exists, but is **not** a platform implementer today. It
   implements exactly one abstraction (`KeychainAtKeysIo extends WrittenAtKeysIo`,
   `packages/at_client_flutter/lib/src/keychain/keychain_io_impl.dart:10`); all path


### PR DESCRIPTION
Reconciles the browser-lane doc set onto the storage-bundle ruling that landed in **#2207**. Docs only — no code.

Rebased onto trunk now that #2207 has merged. This composes with what landed rather than competing with it.

## What this reconciles

Trunk now carries **D-12** from #2207 (`AtClientStorage` — one injected bundle owning keystore and sync queue). Our browser-lane doc set was written against a *different* D-12 and ran to D-19.

**gkc's D-12 keeps its number.** Ours renumbers **D-12..D-19 → D-13..D-20**, across 56 citation sites. D-12 and its five anchors were held fixed and verified intact, so the mechanical churn needs no auditing — only the substance below.

## What changed in substance

**1. We adopt the bundle direction.** Our old D-12/D-13 injected a write-through `Secondary` as a parallel route into `AtClientImpl`. That competed with the new factory. It is gone. Remote-only is now **an `AtClientStorage` implementation** — one gateway, not two.

**2. Our old ruling over-claimed and is corrected.** It said "no SQLite, no Hive in the browser," full stop. That was wrong. Amended D-13 now says V1 **ships** remote-only as a *default and payload budget*, not a removed capability. SQLite (including the `:memory:` backend D-12 ships), Hive, and other backends stay injectable through the same interface. We do not want that path closed.

**3. Four requirements added under D-12 — these are asks on a ruling that has already merged.** They could not be folded into #2207, so they land here as constraints on the implementation still to come:

| # | Ask |
| --- | --- |
| 1 | A **no-op sync queue** is legal. Remote-only has nothing to sync; the contract should say so before an invariant assert forecloses it |
| 2 | `keyStore` may be **write-through / remote-backed**, not assumed durable |
| 3 | **No `isLocalStoreRequired` gate on the bundle path.** Under a bundle, "is a local store required" stops being the right question |
| 4 | `clear()` and the principal guard stay meaningful for a store with no durable half |

**Item 3 constrains X4.** `at_client_impl.dart:380` on current trunk throws when a keystore is injected with `isLocalStoreRequired == false`. X4 rewrites exactly that construction path. If it carries the guard onto the new factory, the browser lane loses its entry point.

Worth noting X2/X3 already helped here: `LocalSecondary` takes an injectable `syncQueue` at `local_secondary.dart:102` alongside its keystore at `:101`. Our old "must never be reached" becomes "is supplied."

## Also in this branch

- Crypto correction in `design.md` §C1 — the `cryptography` vs `better_cryptography` distinction, and which one the Web Crypto path actually reaches.
- `enterprise-identity.md`, new.
- Removed citations to an untracked personal working-notes directory. **Known gap:** those now read as "the Layer A/B/C design note," which cites a document a reader cannot reach. Deliberate trade against inlining ~23KB. Flagging so the dangling reference is not a surprise.
- The broken `../pq/detail/implementation-plan.md` link is a pre-existing forward reference into the PQ branch, not introduced here. Left alone.

## Verification

Structural, since there is no code:

- D-1..D-20, each heading exactly once
- 0 dangling `D-NN` citations
- 0 references to the personal notes directory under `docs/`
- 0 unresolved heading anchors
- diff touches only `docs/projects/wasm/`

## Supersedes

**#2193** carried this same content under the old numbering, which would have put a second `### D-12` on trunk alongside the one #2207 landed. Closed as superseded by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
