### PR TITLE
test(functional): isolate each test file's storage, on a selectable backend

### DIFF
--- a/.github/workflows/at_client_sdk.yaml
+++ b/.github/workflows/at_client_sdk.yaml
@@ -164,6 +164,54 @@ jobs:
         working-directory: tests/at_functional_test/test
         run: docker compose down
 
+  # The same functional pack again on the two storage backends the default run
+  # does not exercise. Beta only: this proves the backends, not the SDK matrix,
+  # and the pack above already covers both channels on Hive.
+  functional_tests_storage:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        storage: [sqlite, memory]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: ./actions/setup-flutter-and-dart
+        with:
+          dart-channel: beta
+
+      - name: Install dependencies in at_functional_test
+        working-directory: tests/at_functional_test
+        run: dart pub get
+
+      - name: Add entry to hosts file
+        run: echo "127.0.0.1    vip.ve.atsign.zone" | sudo tee -a /etc/hosts
+
+      - name: Start docker instance
+        working-directory: tests/at_functional_test/test
+        run: docker compose pull && docker compose up -d
+
+      - name: Check for docker container readiness
+        working-directory: tests/at_functional_test
+        run: dart run test/check_docker_readiness.dart
+
+      - name: Run PKAM
+        run: docker exec test-virtualenv-1 supervisorctl start pkamLoad
+
+      - name: Check test environment readiness
+        working-directory: tests/at_functional_test
+        run: dart run test/check_test_env.dart
+
+      - name: Run functional tests on ${{ matrix.storage }} storage
+        working-directory: tests/at_functional_test
+        env:
+          AT_FUNCTIONAL_STORAGE: ${{ matrix.storage }}
+        run: dart test --concurrency=1
+
+      - name: stop docker containers
+        working-directory: tests/at_functional_test/test
+        run: docker compose down
+
   end2end_tests_prep:
     # Don't run on PRs from a fork as the secrets aren't available
     if: ${{ github.event.pull_request.head.repo.fork == false }}

--- a/docs/projects/wasm/implementation-plan.md
+++ b/docs/projects/wasm/implementation-plan.md
@@ -312,7 +312,11 @@ D-12. Independent of the P series, which is `at_server`-side.
   only; the existing job's matrix is untouched, so nothing is renamed.
   **Measured against `at_virtual_env:local`, 82 tests each: hive 82, sqlite 82, memory 82,
   all passing.** That is the first time either SQLite-backed bundle has carried a live put,
-  get, sync drain or notification rather than only the unit contract tests.
+  get, sync drain or notification rather than only the unit contract tests. ✅ **CI agrees:
+  on [#2210](https://github.com/atsign-foundation/at_client_sdk/pull/2210) both new jobs
+  passed first time, and the run is 11 of 11 green** — `end2end_test_14` needed one re-run
+  for `bypasscache_test`, the intermittent that has its own row and fails pre-X4a. Re-derive
+  rather than quoting: `gh run list --branch gkc-x5-functional-storage`.
   ⚠️ **"A bundle per file" was not buildable as written.** A bundle is bound to one atSign
   at construction and several files drive two, so the unit is per *(file, atSign)*. Three
   things the build found, none of them visible by reading:

--- a/docs/projects/wasm/implementation-plan.md
+++ b/docs/projects/wasm/implementation-plan.md
@@ -293,14 +293,50 @@ D-12. Independent of the P series, which is `at_server`-side.
   established. And trunk's `AtClient.stop()` dartdoc *promises* resurrection: "Local
   storage is NOT closed. The instance remains in the internal cache and reuses its
   still-open local keystore when resumed". X4's storage release therefore changes a
-  documented contract, and the packs (X5) and that dartdoc move with it. The storage-release
-  work is parked as a git stash named `x4-release-wip` on the repository's stash stack
-  (its label names a branch since deleted; resume by branching from trunk and popping it)
-  until then.
-- **X5 — Move the functional pack onto an in-memory bundle per file.** The named consumer:
-  `test_utils.dart` shares `test/hive/client/$atsign` across every file, so one file
-  inherits the next's pending sync queue and the next client's scoped enrollment is refused
-  `AT0009` pushing keys it did not write. Depends on X3.
+  documented contract, and the packs (X5) and that dartdoc move with it. ⚠️ **This said the
+  storage-release work was parked as a git stash named `x4-release-wip` until 2026-09-06.**
+  It is not: it is [#2208](https://github.com/atsign-foundation/at_client_sdk/pull/2208) on
+  branch `gkc-at-client-storage-release`, which X5 is stacked on. Resume by checking that
+  branch out, never from a stash.
+- **X5 — Each functional test file gets its own storage, on a selectable backend.**
+  ✅ **Built 2026-09-06.** The consumer was real: `test_utils.dart` gave every file
+  `test/hive/client/$atsign`, the runner clears that directory once per run and never
+  between files, and CI never clears it at all. Each file now names itself
+  (`TestUtils.isolateStorage('<file>')`) and gets one bundle per atSign, at a location no
+  other file opens.
+  **Which backend is built comes from `AT_FUNCTIONAL_STORAGE`** (gkc, 2026-09-06):
+  `hive` by default — what the pack has always run on, so the default run's behaviour is
+  unchanged — or `sqlite` or `memory`. An unrecognised value is refused rather than
+  defaulted, so a typo cannot quietly run the backend it was meant to replace. A second CI
+  job, `functional_tests_storage`, runs the same pack again on the other two, beta channel
+  only; the existing job's matrix is untouched, so nothing is renamed.
+  **Measured against `at_virtual_env:local`, 82 tests each: hive 82, sqlite 82, memory 82,
+  all passing.** That is the first time either SQLite-backed bundle has carried a live put,
+  get, sync drain or notification rather than only the unit contract tests.
+  ⚠️ **"A bundle per file" was not buildable as written.** A bundle is bound to one atSign
+  at construction and several files drive two, so the unit is per *(file, atSign)*. Three
+  things the build found, none of them visible by reading:
+  - **The claim guard caught nine tests sharing one atSign's store across principals.**
+    `enrollment_test` re-authenticates as its own enrolment and reads what the owner wrote
+    locally, so it hands the store over explicitly at the five points where it stops every
+    client. The guard firing is the evidence that the sharing was real and unnoticed.
+  - **A child isolate is a separate heap**, so `sync_multiple_client_test`'s two clients
+    cannot be handed a bundle at all — that isolate builds its own from the path string it
+    is sent. The third client in that file sets `isLocalStoreRequired` false and opens no
+    local store.
+  - **`setCurrentAtSign` treated any storage argument as a change** and took the
+    destructive stop/recreate path, which would have altered the client lifecycle at every
+    site the pack touches. Re-offering the bundle a client already holds is now not a
+    change; a different bundle still rebuilds.
+  Two `at_client` changes ride with it: `fromAuthSession` accepts a `storage` bundle, being
+  the one door that could not take one; and `commitLogPath` came off the pack's preferences,
+  it being read nowhere in `at_client`. A preference now carries no storage path at all, so
+  a call site that forgets a bundle fails loudly instead of opening the shared directory.
+  ⚠️ **Owed, found while scoping and not fixed:** `InMemoryAtClientStorage` distinguishes
+  instances by `identityHashCode`, which is a hash and not an identity, so two live
+  in-memory storages whose hashes collided would be refused as one store. Negligible at the
+  handful per test process this pack opens; wrong in principle.
+  Depends on X3.
 - **X6 — Consumers.** `at_client_flutter` and `at_onboarding_cli` move onto the factory, so
   both are WASM-ready ahead of the next major. Whether they move in this major or the next
   is open.

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 3.14.1
+- fix: `setCurrentAtSign` no longer rebuilds the client when it is handed the
+  storage that client already holds. Offering the same bundle is not a
+  change, and the rebuild it used to force stopped a working client and its
+  services for nothing. A different bundle still rebuilds, as it must.
 - feat: `AtClientManager.fromAuthSession` accepts a `storage` bundle and
   passes it to the client it builds, as `setCurrentAtSign` already did. A
   caller handing storage in no longer has to avoid the auth hand-off to do

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## 3.14.1
+- feat: `AtClientManager.fromAuthSession` accepts a `storage` bundle and
+  passes it to the client it builds, as `setCurrentAtSign` already did. A
+  caller handing storage in no longer has to avoid the auth hand-off to do
+  it. The bundle is borrowed, not owned: `stop()` detaches without closing.
 - build: require `at_persistence_secondary_server` ^5.3.0. This package's
   keystore and sync queue open on `HiveInstances`, which 5.3.0 is the first
   release to carry; the floor still said ^5.1.0, so a consumer could resolve

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 3.14.1
+- feat: `AtClientStorage.isHeldBy` says whether a given client is the one
+  currently holding the storage.
 - fix: `setCurrentAtSign` no longer rebuilds the client when it is handed the
   storage that client already holds. Offering the same bundle is not a
   change, and the rebuild it used to force stopped a working client and its

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -192,7 +192,7 @@ class AtClientManager {
   bool _storageIsUnchanged(AtClientStorage? storage) {
     if (storage == null) return true;
     final current = _currentAtClient;
-    return current is AtClientImpl && identical(current.storage, storage);
+    return current != null && storage.isHeldBy(current);
   }
 
   /// Explicit, typed hand-off from auth to client.

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -193,9 +193,13 @@ class AtClientManager {
   /// Set [reuse] to adopt auth's already-authenticated connection
   /// ([session.atLookUp]) and skip the second handshake — the perf escape hatch.
   /// When false (default) the client opens its own fresh socket.
+  ///
+  /// [storage] is borrowed rather than owned, exactly as on [setCurrentAtSign].
   Future<AtClientManager> fromAuthSession(
       AtAuthSession session, AtClientPreference preference,
-      {AtServiceFactory? serviceFactory, bool reuse = false}) async {
+      {AtServiceFactory? serviceFactory,
+      bool reuse = false,
+      AtClientStorage? storage}) async {
     // Destructure rootDomain onto the preference for now. A follow-up will add
     // an AtRootDomain-typed accessor to AtClientPreference so this can stop.
     preference.rootDomain = session.rootDomain.rootDomain;
@@ -210,7 +214,8 @@ class AtClientManager {
         serviceFactory: serviceFactory,
         atKeysIo: session.atKeysIo,
         atLookUp: reuse ? session.atLookUp : null,
-        enrollmentId: session.enrollmentId);
+        enrollmentId: session.enrollmentId,
+        storage: storage);
   }
 
   void listenToAtSignChange(AtSignChangeListener listener) {

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -105,6 +105,11 @@ class AtClientManager {
     // Callers needing a forced reset for a SAME-atSign change of
     // preferences / atChops / enrollmentId still get one — we only
     // skip when nothing in the request changed.
+    //
+    // Re-offering the storage the current client already holds is not a
+    // change either: it is what a caller that owns one bundle for the whole
+    // of its work does on every call, and rebuilding on it would tear the
+    // client down for nothing.
     final currentAtSign = _currentAtClient?.getCurrentAtSign();
     if (currentAtSign != null &&
         currentAtSign == atSign &&
@@ -112,7 +117,7 @@ class AtClientManager {
         atKeysIo == null &&
         atLookUp == null &&
         enrollmentId == null &&
-        storage == null &&
+        _storageIsUnchanged(storage) &&
         _currentAtClient!.isStopped == false) {
       // The full stop/recreate path below recreates via AtClientImpl.create(),
       // which adopts the supplied preference's crypto config onto a re-used
@@ -180,6 +185,14 @@ class AtClientManager {
     _logger.info("setCurrentAtSign complete");
 
     return this;
+  }
+
+  /// Whether [storage] would leave the current client's storage as it is:
+  /// either none was offered, or it is the object that client already holds.
+  bool _storageIsUnchanged(AtClientStorage? storage) {
+    if (storage == null) return true;
+    final current = _currentAtClient;
+    return current is AtClientImpl && identical(current.storage, storage);
   }
 
   /// Explicit, typed hand-off from auth to client.

--- a/packages/at_client/lib/src/storage/at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/at_client_storage.dart
@@ -15,6 +15,9 @@ abstract class AtClientStorage {
   /// Drops [owner]'s claim, keeping the backend open.
   Future<void> detach(AtClient owner);
 
+  /// Whether [client] is the one currently holding this storage.
+  bool isHeldBy(AtClient client);
+
   AtKeyValueStore<String, AtData, AtMetaData?> get keyStore;
 
   AtSyncQueue get syncQueue;
@@ -54,6 +57,9 @@ abstract class AtClientStorageBase implements AtClientStorage {
       '${client.getCurrentAtSign()}|${client.enrollmentId ?? 'legacy'}';
 
   bool get isAttached => _owner != null;
+
+  @override
+  bool isHeldBy(AtClient client) => identical(_owner, client);
 
   /// The store this points at, in a form two storages over the same records
   /// report identically — everything that decides which records they resolve

--- a/packages/at_client/test/storage/at_client_storage_release_test.dart
+++ b/packages/at_client/test/storage/at_client_storage_release_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:at_auth/at_auth.dart';
 import 'package:at_client/at_client.dart';
 import 'package:at_client/sqlite.dart';
 import 'package:at_client/src/sync/at_sync_queue.dart';
@@ -186,6 +187,31 @@ void main() {
     await injected.close();
   });
 
+  test('fromAuthSession hands its storage to the client it builds', () async {
+    final injected = InMemoryAtClientStorage(atSign: '@handoff');
+    final keysIo = _AttachWatchingKeysIo(injected);
+    final session = AtAuthSession(
+        atSign: '@handoff',
+        rootDomain: const AtRootDomain('root.atsign.org', 64),
+        namespace: 'wavi',
+        atKeysIo: keysIo);
+
+    // The client derives its AtChops from the session's key source, and this
+    // one refuses - but only after _init has attached whatever storage it was
+    // given, which is the moment the watcher records.
+    await expectLater(
+        () => AtClientManager('@handoff')
+            .fromAuthSession(session, AtClientPreference(), storage: injected),
+        throwsA(anything));
+
+    expect(keysIo.storageWasAttached, isTrue,
+        reason: 'fromAuthSession must pass storage down to '
+            'AtClientImpl.create. Without it the client builds its own from '
+            'hiveStoragePath, which this preference does not set, so it fails '
+            'before ever reading a key');
+    await injected.close();
+  });
+
   test('a client with no injected storage still owns and closes its own',
       () async {
     final client =
@@ -197,4 +223,24 @@ void main() {
         reason: 'storage the client built itself is closed on release, and a '
             'closed store cannot be reopened');
   });
+}
+
+/// Records whether [_storage] was already attached when the client asked this
+/// source for key material, then refuses: attachment happens in `_init`, so
+/// reading `true` here proves the storage reached the client.
+class _AttachWatchingKeysIo extends WrittenAtKeysIo {
+  _AttachWatchingKeysIo(this._storage);
+
+  final AtClientStorageBase _storage;
+  bool storageWasAttached = false;
+
+  @override
+  Future<AtKeys> read(String atSign) {
+    storageWasAttached = _storage.isAttached;
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<void> write(String atSign, AtKeys atKeys) =>
+      throw UnimplementedError();
 }

--- a/packages/at_client/test/storage/at_client_storage_release_test.dart
+++ b/packages/at_client/test/storage/at_client_storage_release_test.dart
@@ -187,6 +187,29 @@ void main() {
     await injected.close();
   });
 
+  test(
+      're-offering the storage a client already holds does not rebuild the '
+      'client', () async {
+    final storage = InMemoryAtClientStorage(atSign: '@sticky');
+    final manager = AtClientManager('@sticky');
+    await manager.setCurrentAtSign('@sticky', 'wavi', AtClientPreference(),
+        storage: storage);
+    final first = manager.atClient;
+
+    await manager.setCurrentAtSign('@sticky', 'wavi', AtClientPreference(),
+        storage: storage);
+
+    expect(first.isStopped, isFalse,
+        reason: 'the second call offered nothing that changed, so it must '
+            'have taken the idempotency short-circuit. The rebuild path stops '
+            'the outgoing client first, so a stopped one means it rebuilt');
+    expect(identical(manager.atClient, first), isTrue,
+        reason: 'and the same client must still be current');
+
+    await first.stop();
+    await storage.close();
+  });
+
   test('fromAuthSession hands its storage to the client it builds', () async {
     final injected = InMemoryAtClientStorage(atSign: '@handoff');
     final keysIo = _AttachWatchingKeysIo(injected);

--- a/tests/at_functional_test/lib/src/functional_storage.dart
+++ b/tests/at_functional_test/lib/src/functional_storage.dart
@@ -1,0 +1,87 @@
+import 'dart:io';
+
+import 'package:at_client/at_client.dart';
+import 'package:at_client/sqlite.dart';
+
+/// A storage backend the functional pack can run its clients on.
+enum FunctionalStorageBackend { hive, sqlite, memory }
+
+/// The local storage the clients of one test file use: one bundle per atSign,
+/// at a location no other test file opens.
+///
+/// Every file shared one directory before this existed, so a file inherited
+/// whatever keystore entries and unpushed sync-queue entries the previous one
+/// left behind. Each file now names itself and gets its own.
+///
+/// The backend comes from [environmentVariable] — Hive by default, which is
+/// what the pack has always run on; `sqlite` and `memory` let the same tests
+/// prove the other two implementations.
+class FunctionalStorage {
+  FunctionalStorage(this.testFile, {FunctionalStorageBackend? backend})
+      : backend = backend ?? backendFromEnvironment();
+
+  /// Names the backend to build. Unset means [FunctionalStorageBackend.hive].
+  static const String environmentVariable = 'AT_FUNCTIONAL_STORAGE';
+
+  /// Throws on a value that is not a backend name rather than falling back to
+  /// Hive, so a typo cannot quietly run the backend it was meant to replace.
+  static FunctionalStorageBackend backendFromEnvironment() {
+    final raw = Platform.environment[environmentVariable];
+    if (raw == null || raw.isEmpty) return FunctionalStorageBackend.hive;
+    final wanted = raw.toLowerCase();
+    return FunctionalStorageBackend.values.firstWhere(
+        (backend) => backend.name == wanted,
+        orElse: () => throw ArgumentError('$environmentVariable=$raw is not '
+            'one of ${FunctionalStorageBackend.values.map((b) => b.name).join(', ')}'));
+  }
+
+  /// This test file's name, which is what keeps its on-disk backends apart
+  /// from every other file's.
+  final String testFile;
+
+  final FunctionalStorageBackend backend;
+
+  final Map<String, AtClientStorage> _byAtSign = {};
+
+  /// Where this file's on-disk backends live, under the directory the pack's
+  /// runner already clears before a run.
+  String get storagePath => 'test/hive/$testFile';
+
+  /// The bundle every client this file builds for [atSign] shares.
+  ///
+  /// Built once and kept, so a client stopped and rebuilt mid-file reads back
+  /// what its predecessor wrote — which several tests assert.
+  AtClientStorage forAtSign(String atSign) =>
+      _byAtSign.putIfAbsent(atSign, () => _build(atSign));
+
+  /// Lets the next client attach under a different enrollment while keeping
+  /// the data.
+  ///
+  /// The claim guard otherwise refuses a second principal, which is right for
+  /// an application and wrong for a fixture that deliberately re-authenticates
+  /// as one of the atSign's own enrolments and expects to read what the owner
+  /// wrote. Every client must be stopped first, or `forgetPrincipal` throws.
+  Future<void> allowPrincipalChange() async {
+    for (final storage in _byAtSign.values) {
+      await storage.forgetPrincipal();
+    }
+  }
+
+  AtClientStorage _build(String atSign) => switch (backend) {
+        FunctionalStorageBackend.hive => HiveAtClientStorage(
+            atSign: atSign, storagePath: '$storagePath/$atSign'),
+        FunctionalStorageBackend.sqlite =>
+          SqliteAtClientStorage.under(atSign: atSign, storagePath: storagePath),
+        FunctionalStorageBackend.memory =>
+          InMemoryAtClientStorage(atSign: atSign),
+      };
+
+  /// Closes every bundle this file opened. Nothing else does: a client only
+  /// borrows the storage it is given, and detaches from it on `stop()`.
+  Future<void> closeAll() async {
+    for (final storage in _byAtSign.values) {
+      await storage.close();
+    }
+    _byAtSign.clear();
+  }
+}

--- a/tests/at_functional_test/runLocal.sh
+++ b/tests/at_functional_test/runLocal.sh
@@ -41,6 +41,7 @@ echo "*** Checking test environment" && dart run test/check_test_env.dart
 
 echo "*** Clearing client test storage" && rm -rf test/hive && rm -f test/testData/@srie.atKeys
 
+echo "*** Storage backend: ${AT_FUNCTIONAL_STORAGE:-hive (default)}"
 echo "*** Running tests"
 # Let the test run fail through to cleanup (so a flake doesn't leave the
 # container up), then propagate its exit code.

--- a/tests/at_functional_test/test/at_client_delete_test.dart
+++ b/tests/at_functional_test/test/at_client_delete_test.dart
@@ -4,6 +4,7 @@ import 'package:at_functional_test/src/config_util.dart';
 import 'test_utils.dart';
 
 void main() async {
+  TestUtils.isolateStorage('at_client_delete_test');
   late String currentAtSign;
   late String sharedWithAtSign;
   final namespace = 'wavi';

--- a/tests/at_functional_test/test/at_client_lifecycle_functional_test.dart
+++ b/tests/at_functional_test/test/at_client_lifecycle_functional_test.dart
@@ -4,6 +4,7 @@ import 'package:test/test.dart';
 import 'test_utils.dart';
 
 void main() {
+  TestUtils.isolateStorage('at_client_lifecycle_functional_test');
   late String firstAtSign;
   late String secondAtSign;
   final namespace = 'lifecycletest';

--- a/tests/at_functional_test/test/at_client_sync_test.dart
+++ b/tests/at_functional_test/test/at_client_sync_test.dart
@@ -14,6 +14,7 @@ import 'test_utils.dart';
 import 'package:at_functional_test/src/config_util.dart';
 
 void main() {
+  TestUtils.isolateStorage('at_client_sync_test');
   late String atSign;
   late String sharedWithAtSign;
   final namespace = 'wavi';

--- a/tests/at_functional_test/test/at_exception_test.dart
+++ b/tests/at_functional_test/test/at_exception_test.dart
@@ -8,6 +8,7 @@ import 'package:test/test.dart';
 import 'test_utils.dart';
 
 void main() {
+  TestUtils.isolateStorage('at_exception_test');
   late AtClientManager atClientManager;
   late AtClient atClient;
   late String atSign;

--- a/tests/at_functional_test/test/at_lookup_race_test.dart
+++ b/tests/at_functional_test/test/at_lookup_race_test.dart
@@ -14,6 +14,7 @@ import 'test_utils.dart';
 late AtSignLogger logger;
 
 void main() {
+  TestUtils.isolateStorage('at_lookup_race_test');
   late String atSign;
   late AtClientManager atClientManager;
   late AtClient atClient;

--- a/tests/at_functional_test/test/atclient_notify_test.dart
+++ b/tests/at_functional_test/test/atclient_notify_test.dart
@@ -11,6 +11,7 @@ import 'test_utils.dart';
 
 // ignore_for_file: deprecated_member_use
 void main() {
+  TestUtils.isolateStorage('atclient_notify_test');
   late AtClientManager atClientManager;
   late String currentAtSign;
   late String sharedWithAtSign;
@@ -33,7 +34,8 @@ void main() {
   setUp(() async {
     // Invoking 'setCurrentAtSign' in setUp method to set currentAtSign before each test.
     atClientManager = await AtClientManager.getInstance().setCurrentAtSign(
-        currentAtSign, 'wavi', TestUtils.getPreference(currentAtSign));
+        currentAtSign, 'wavi', TestUtils.getPreference(currentAtSign),
+        storage: TestUtils.storageFor(currentAtSign));
   });
 
   test('notify updating of a key to sharedWith atSign - using await', () async {
@@ -196,7 +198,8 @@ void main() {
     // for the receiving atSign
     logger.info('Switching to $sharedWithAtSign');
     atClientManager = await atClientManager.setCurrentAtSign(
-        sharedWithAtSign, 'wavi', TestUtils.getPreference(sharedWithAtSign));
+        sharedWithAtSign, 'wavi', TestUtils.getPreference(sharedWithAtSign),
+        storage: TestUtils.storageFor(sharedWithAtSign));
     atClientManager.atClient.notificationService.subscribe(regex: 'nothing');
 
     int? lnt;
@@ -216,7 +219,8 @@ void main() {
     logger.info('Switching to $currentAtSign');
     // Switch to the sending atSign
     atClientManager = await atClientManager.setCurrentAtSign(
-        currentAtSign, 'wavi', TestUtils.getPreference(currentAtSign));
+        currentAtSign, 'wavi', TestUtils.getPreference(currentAtSign),
+        storage: TestUtils.storageFor(currentAtSign));
 
     logger.info('Sending notification');
     // And send a notification
@@ -233,7 +237,8 @@ void main() {
     logger.info('Switching to $sharedWithAtSign');
     // Switch to the receiving atSign
     atClientManager = await atClientManager.setCurrentAtSign(
-        sharedWithAtSign, 'wavi', TestUtils.getPreference(sharedWithAtSign));
+        sharedWithAtSign, 'wavi', TestUtils.getPreference(sharedWithAtSign),
+        storage: TestUtils.storageFor(sharedWithAtSign));
 
     logger.info('Subscribing to notifications');
     // and subscribe to notifications
@@ -260,7 +265,8 @@ void main() {
   group('A group of tests for notification fetch', () {
     test('A test to verify non existent notification', () async {
       await AtClientManager.getInstance().setCurrentAtSign(
-          currentAtSign, namespace, TestUtils.getPreference(currentAtSign));
+          currentAtSign, namespace, TestUtils.getPreference(currentAtSign),
+          storage: TestUtils.storageFor(currentAtSign));
       var notificationResult = await AtClientManager.getInstance()
           .atClient
           .notificationService
@@ -271,7 +277,8 @@ void main() {
 
     test('A test to verify the notification expiry', () async {
       await AtClientManager.getInstance().setCurrentAtSign(
-          currentAtSign, namespace, TestUtils.getPreference(currentAtSign));
+          currentAtSign, namespace, TestUtils.getPreference(currentAtSign),
+          storage: TestUtils.storageFor(currentAtSign));
       for (int i = 0; i < 10; i++) {
         logger.info('Testing notification expiry - test run #$i');
         var atKey = (AtKey.shared('test-notification-expiry',

--- a/tests/at_functional_test/test/atclient_pkam_auth_test.dart
+++ b/tests/at_functional_test/test/atclient_pkam_auth_test.dart
@@ -13,6 +13,7 @@ import 'test_utils.dart';
 late String atSign;
 
 void main() {
+  TestUtils.isolateStorage('atclient_pkam_auth_test');
   String namespace = 'wavi';
   late AtClientManager atClientManager;
 

--- a/tests/at_functional_test/test/atclient_put_test.dart
+++ b/tests/at_functional_test/test/atclient_put_test.dart
@@ -10,6 +10,7 @@ import 'test_utils.dart';
 /// The tests verify the put and get functionality where key is created using AtKey concrete
 /// class
 void main() {
+  TestUtils.isolateStorage('atclient_put_test');
   late AtClientManager atClientManager;
   late String atSign;
   final namespace = 'wavi';

--- a/tests/at_functional_test/test/atclient_put_text_test.dart
+++ b/tests/at_functional_test/test/atclient_put_text_test.dart
@@ -6,6 +6,7 @@ import 'test_utils.dart';
 /// The tests verify the put and get functionality where key is created using AtKey
 /// static factory methods
 void main() {
+  TestUtils.isolateStorage('atclient_put_text_test');
   late AtClientManager atClientManager;
   late String atSign;
   final namespace = 'wavi';

--- a/tests/at_functional_test/test/atclient_remote_secondary_test.dart
+++ b/tests/at_functional_test/test/atclient_remote_secondary_test.dart
@@ -7,6 +7,7 @@ import 'package:test/test.dart';
 import 'test_utils.dart';
 
 void main() {
+  TestUtils.isolateStorage('atclient_remote_secondary_test');
   late AtClientManager atClientManager;
   late String atSign;
   final namespace = 'wavi';

--- a/tests/at_functional_test/test/atclient_sharedkey_test.dart
+++ b/tests/at_functional_test/test/atclient_sharedkey_test.dart
@@ -6,6 +6,7 @@ import 'package:test/test.dart';
 import 'test_utils.dart';
 
 void main() {
+  TestUtils.isolateStorage('atclient_sharedkey_test');
   late AtClientManager atClientManager;
   late AtClient atClient;
   late String currentAtSign;

--- a/tests/at_functional_test/test/atclient_sync_callback_test.dart
+++ b/tests/at_functional_test/test/atclient_sync_callback_test.dart
@@ -14,6 +14,7 @@ import 'package:uuid/uuid.dart';
 import 'test_utils.dart';
 
 void main() {
+  TestUtils.isolateStorage('atclient_sync_callback_test');
   late AtClientManager atClientManager;
   late String atSign;
   var uniqueId = Uuid().v4();

--- a/tests/at_functional_test/test/atclient_sync_conflict_test.dart
+++ b/tests/at_functional_test/test/atclient_sync_conflict_test.dart
@@ -10,6 +10,7 @@ import 'package:test/test.dart';
 import 'test_utils.dart';
 
 void main() async {
+  TestUtils.isolateStorage('atclient_sync_conflict_test');
   late AtClientManager atClientManager;
   late String atSign;
   String namespace = 'wavi';

--- a/tests/at_functional_test/test/atkey_static_test.dart
+++ b/tests/at_functional_test/test/atkey_static_test.dart
@@ -6,6 +6,7 @@ import 'test_utils.dart';
 /// The tests verify the put and get functionality where key is created using AtKey
 /// static factory methods
 void main() {
+  TestUtils.isolateStorage('atkey_static_test');
   late String atSign;
   late String sharedWithAtSign;
   String namespace = 'wavi';

--- a/tests/at_functional_test/test/auth_session_handoff_test.dart
+++ b/tests/at_functional_test/test/auth_session_handoff_test.dart
@@ -15,6 +15,7 @@ import 'test_utils.dart';
 /// and no `AtLookUp` are injected from auth. If the client's derived `AtChops`
 /// PKAMs on its fresh socket, a put/get round-trip succeeds.
 void main() {
+  TestUtils.isolateStorage('auth_session_handoff_test');
   late String atSign;
   final namespace = 'wavi';
 
@@ -49,8 +50,9 @@ void main() {
     //    client must derive its own AtChops from session.atKeysIo and PKAM on a
     //    fresh socket.
     final preference = TestUtils.getPreference(atSign);
-    final atClientManager = await AtClientManager.getInstance()
-        .fromAuthSession(authResponse.session!, preference);
+    final atClientManager = await AtClientManager.getInstance().fromAuthSession(
+        authResponse.session!, preference,
+        storage: TestUtils.storageFor(atSign));
     final atClient = atClientManager.atClient;
 
     // The client built its own crypto context (not one injected by auth).

--- a/tests/at_functional_test/test/encryption_test.dart
+++ b/tests/at_functional_test/test/encryption_test.dart
@@ -5,6 +5,7 @@ import 'test_utils.dart';
 import 'package:test/test.dart';
 
 void main() {
+  TestUtils.isolateStorage('encryption_test');
   late String atSign_1;
   final namespace = 'functional_encryption_test';
 
@@ -24,7 +25,8 @@ void main() {
 
   Future<AtClient> getAtClient(String atSign) async {
     return (await AtClientManager.getInstance().setCurrentAtSign(
-            atSign, namespace, TestUtils.getPreference(atSign_1)))
+            atSign, namespace, TestUtils.getPreference(atSign),
+            storage: TestUtils.storageFor(atSign)))
         .atClient;
   }
 

--- a/tests/at_functional_test/test/enrollment_test.dart
+++ b/tests/at_functional_test/test/enrollment_test.dart
@@ -18,6 +18,7 @@ import 'sync_multiple_client_test.dart';
 import 'test_utils.dart';
 
 void main() {
+  TestUtils.isolateStorage('enrollment_test');
   late AtClientManager atClientManager;
   late String atSign;
   String namespace = 'wavi';
@@ -65,6 +66,9 @@ void main() {
     }
     AtClientManager.getInstance().reset();
     AtClientImpl.atClientInstanceMap.clear();
+    // Every client is stopped, and what comes next authenticates as a
+    // different enrollment of the same atSign on the same store.
+    await TestUtils.storage.allowPrincipalChange();
   });
 
   group('A group of tests for APKAM scenarios using at_auth', () {
@@ -99,8 +103,6 @@ void main() {
 
       // create atclient instance
       var atClientPreference = AtClientPreference()
-        ..commitLogPath = 'test/hive/commit/'
-        ..hiveStoragePath = 'test/hive/client'
         ..rootDomain = 'vip.ve.atsign.zone'
         ..rootPort = TestUtils.rootServerPort;
 
@@ -113,7 +115,8 @@ void main() {
       final atClientManager = await AtClientManager(apkamAtSign)
           .setCurrentAtSign(apkamAtSign, namespace, atClientPreference,
               atChops: atAuth.atChops,
-              enrollmentId: atOnboardingResponse.enrollmentId);
+              enrollmentId: atOnboardingResponse.enrollmentId,
+              storage: TestUtils.storageFor(apkamAtSign));
       //var scanResult = await atClientManager.atClient.getKeys();
       var scanResult = await atClientManager.atClient
           .getRemoteSecondary()
@@ -431,6 +434,9 @@ void main() {
       }
       AtClientManager.getInstance().reset();
       AtClientImpl.atClientInstanceMap.clear();
+      // Every client is stopped, and what comes next authenticates as a
+      // different enrollment of the same atSign on the same store.
+      await TestUtils.storage.allowPrincipalChange();
 
       // Get AtChops from the AtAuthKeys
       AtEncryptionKeyPair atEncryptionKeyPair = AtEncryptionKeyPair.create(
@@ -466,6 +472,7 @@ void main() {
       // to perform put operation.
       await AtClientManager.getInstance().setCurrentAtSign(
           atSign, namespace, TestUtils.getPreference(atSign),
+          storage: TestUtils.storageFor(atSign),
           atChops: atChops, enrollmentId: atEnrollmentResponse.enrollmentId);
 
       // Insert key which has access to namespace authorized by enrollment.
@@ -535,6 +542,9 @@ void main() {
       }
       AtClientManager.getInstance().reset();
       AtClientImpl.atClientInstanceMap.clear();
+      // Every client is stopped, and what comes next authenticates as a
+      // different enrollment of the same atSign on the same store.
+      await TestUtils.storage.allowPrincipalChange();
 
       // Get AtChops from the AtAuthKeys
       AtEncryptionKeyPair atEncryptionKeyPair = AtEncryptionKeyPair.create(
@@ -640,6 +650,9 @@ void main() {
       }
       AtClientManager.getInstance().reset();
       AtClientImpl.atClientInstanceMap.clear();
+      // Every client is stopped, and what comes next authenticates as a
+      // different enrollment of the same atSign on the same store.
+      await TestUtils.storage.allowPrincipalChange();
 
       // Get AtChops from the AtAuthKeys
       AtEncryptionKeyPair atEncryptionKeyPair = AtEncryptionKeyPair.create(
@@ -672,6 +685,7 @@ void main() {
       // to perform put operation.
       await AtClientManager.getInstance().setCurrentAtSign(
           atSign, namespace, TestUtils.getPreference(atSign),
+          storage: TestUtils.storageFor(atSign),
           atChops: atChops, enrollmentId: atEnrollmentResponse.enrollmentId);
 
       // Insert key which has access to namespace authorized by enrollment.
@@ -817,6 +831,7 @@ void main() {
 
       final ownerManager = await AtClientManager.getInstance().setCurrentAtSign(
           cramAtSign, namespace, TestUtils.getPreference(cramAtSign),
+          storage: TestUtils.storageFor(cramAtSign),
           atChops: ownerAuth.atChops,
           enrollmentId: onboardResponse.enrollmentId);
       final ownerClient = ownerManager.atClient;
@@ -884,6 +899,9 @@ void main() {
       }
       AtClientManager.getInstance().reset();
       AtClientImpl.atClientInstanceMap.clear();
+      // Every client is stopped, and what comes next authenticates as a
+      // different enrollment of the same atSign on the same store.
+      await TestUtils.storage.allowPrincipalChange();
 
       final enrolleeChopsKeys = AtChopsKeys.create(
           AtEncryptionKeyPair.create(encryptionKeyPair.atPublicKey.publicKey,
@@ -910,6 +928,7 @@ void main() {
 
       await AtClientManager.getInstance().setCurrentAtSign(
           cramAtSign, 'buzz', TestUtils.getPreference(cramAtSign),
+          storage: TestUtils.storageFor(cramAtSign),
           atChops: enrolleeChops, enrollmentId: enrollResponse.enrollmentId);
       final enrolleeClient = AtClientManager.getInstance().atClient;
 
@@ -933,10 +952,10 @@ void main() {
   });
 }
 
+/// Only ever handed to a [RemoteSecondary], which opens no local store, so
+/// this carries no storage path.
 AtClientPreference getClient2Preferences() {
   return AtClientPreference()
-    ..commitLogPath = 'test/hive/client_2/commit'
-    ..hiveStoragePath = 'test/hive/client_2'
     ..rootDomain = 'vip.ve.atsign.zone'
     ..rootPort = TestUtils.rootServerPort;
 }

--- a/tests/at_functional_test/test/stats_notification_sync_test.dart
+++ b/tests/at_functional_test/test/stats_notification_sync_test.dart
@@ -8,6 +8,7 @@ import 'test_utils.dart';
 const notificationIdKey = '_latestNotificationIdv2';
 
 void main() {
+  TestUtils.isolateStorage('stats_notification_sync_test');
   late String atSign;
   late String atSign2;
   late AtClientManager atClientManager;

--- a/tests/at_functional_test/test/sync_multiple_client_test.dart
+++ b/tests/at_functional_test/test/sync_multiple_client_test.dart
@@ -54,6 +54,10 @@ final _childIsolateLogger = AtSignLogger('ChildIsolate')..level = 'warning';
 var isolateResponseQueue = Queue();
 
 var childIsolateSendPortMap = <ClientId, SendPort>{};
+// This file's two clients run in child isolates, which are separate heaps: a
+// storage bundle built here could not be reached from there, and the isolates
+// are handed path strings instead. These two paths are this file's own and no
+// other file opens them.
 final String clientOneHiveKeyStorePath = 'test/hive/client1';
 final String clientTwoHiveKeyStorePath = 'test/hive/client2';
 late Isolate clientOneIsolate;
@@ -63,6 +67,7 @@ late Completer clientOneAck;
 late Completer clientTwoAck;
 
 void main() async {
+  TestUtils.isolateStorage('sync_multiple_client_test');
   AtSignLogger.root_level = 'shout';
   var mainIsolateReceivePort = ReceivePort('MainIsolateReceivePort');
   SyncServiceImpl.queueSize = 1;
@@ -325,8 +330,13 @@ Future<void> startClient(ChildIsolatePreferences clientParameters) async {
       currentAtSign, clientParameters.clientId.name,
       hiveStoragePath: clientParameters.hiveStoragePath,
       commitLogPath: clientParameters.commitLogPath);
+  // This isolate has no file-level fixture - TestUtils' static is null in a
+  // fresh heap - so it builds its bundle from the path the main isolate sent.
   atClientManager = await TestUtils.initAtClient(currentAtSign, namespace,
-      preference: atClientPreferences);
+      preference: atClientPreferences,
+      storage: HiveAtClientStorage(
+          atSign: currentAtSign,
+          storagePath: clientParameters.hiveStoragePath));
 }
 
 Future<void> updateOrDeleteKey(AtKey atKey, int randomValueForOperation,
@@ -354,6 +364,8 @@ Future<dynamic> _getServerCommitEntries(String regex) async {
           demo_credentials.pkamPrivateKeyMap[currentAtSign]!));
 
   AtChops atChops = AtChopsImpl(atChopsKeys);
+  // No storage bundle: this client sets isLocalStoreRequired false and opens
+  // no local store at all.
   atClientManager = await AtClientManager.getInstance().setCurrentAtSign(
       currentAtSign,
       namespace,

--- a/tests/at_functional_test/test/test_utils.dart
+++ b/tests/at_functional_test/test/test_utils.dart
@@ -2,12 +2,14 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 import 'package:at_functional_test/src/at_keys_initializer.dart';
+import 'package:at_functional_test/src/functional_storage.dart';
 import 'package:at_utils/at_logger.dart';
 import 'package:crypton/crypton.dart';
 import 'package:crypto/crypto.dart';
 import 'package:at_client/at_client.dart';
 
 import 'package:at_demo_data/at_demo_data.dart';
+import 'package:test/test.dart';
 
 class TestUtils {
   static final ObjectLifeCycleOptions optionsTtlOneMinute =
@@ -21,10 +23,39 @@ class TestUtils {
   static int get rootServerPort =>
       int.tryParse(Platform.environment['VIRTUALENV_BASE_PORT'] ?? '') ?? 64;
 
+  static FunctionalStorage? _storage;
+
+  /// Names this test file, giving its clients storage no other file opens.
+  ///
+  /// Call once, first thing in `main()`. Every bundle it hands out is closed
+  /// in a `tearDownAll` registered here, since a client only borrows the
+  /// storage it is given.
+  static void isolateStorage(String testFile) {
+    final storage = FunctionalStorage(testFile);
+    _storage = storage;
+    tearDownAll(() async {
+      await storage.closeAll();
+      if (identical(_storage, storage)) _storage = null;
+    });
+  }
+
+  /// This file's storage. Throws rather than falling back to a shared one:
+  /// silently sharing is what [isolateStorage] exists to stop.
+  static FunctionalStorage get storage =>
+      _storage ??
+      (throw StateError('this test file has not called '
+          'TestUtils.isolateStorage(<file name>) at the top of main(), so it '
+          'has no storage of its own'));
+
+  /// The bundle every client this file builds for [atSign] shares.
+  static AtClientStorage storageFor(String atSign) =>
+      storage.forAtSign(atSign);
+
+  /// A preference carrying no storage path: what opens the store is the
+  /// bundle passed to `setCurrentAtSign`, and a call site that forgets one
+  /// fails loudly here rather than quietly opening the shared directory.
   static AtClientPreference getPreference(String atsign) {
     var preference = AtClientPreference();
-    preference.hiveStoragePath = 'test/hive/client/$atsign';
-    preference.commitLogPath = 'test/hive/client/$atsign';
     preference.rootDomain = 'vip.ve.atsign.zone';
     preference.rootPort = rootServerPort;
     preference.decryptPackets = false;
@@ -51,15 +82,19 @@ class TestUtils {
     return digest.toString();
   }
 
+  /// [storage] overrides this file's bundle, for a caller that has none —
+  /// a child isolate is a fresh heap, so [isolateStorage]'s static is null
+  /// there and the isolate has to build its own from what it was handed.
   static Future<AtClientManager> initAtClient(
       String currentAtSign, String namespace,
-      {AtClientPreference? preference}) async {
+      {AtClientPreference? preference, AtClientStorage? storage}) async {
     AtSignLogger.root_level = 'shout';
     preference ??= TestUtils.getPreference(currentAtSign);
     final encryptionKeysLoader = AtEncryptionKeysLoader.getInstance();
     var atClientManager = await AtClientManager.getInstance().setCurrentAtSign(
         currentAtSign, namespace, preference,
-        atChops: encryptionKeysLoader.createAtChopsFromDemoKeys(currentAtSign));
+        atChops: encryptionKeysLoader.createAtChopsFromDemoKeys(currentAtSign),
+        storage: storage ?? storageFor(currentAtSign));
     // Set the preferences again because (1) setCurrentAtSign might do nothing
     // because currentAtSign is the same, and (2) some other test may have messed
     // with the preferences


### PR DESCRIPTION
Stacked on #2208 (`gkc-at-client-storage-release`). Retarget to trunk once that merges.

**Note:** Because the full CI doesn't trigger on PRs against non-trunk branches, I triggered it manually for the [at_client_sdk](https://github.com/atsign-foundation/at_client_sdk/actions/runs/34030126138) and [at_libraries](https://github.com/atsign-foundation/at_client_sdk/actions/runs/34030127317) workflows - all green. In particular note that the existing functional tests continue to execute as normal (using the Hive storage) there are now additional functional test runs which use SQLIte storage and InMemory storage.

Once again, like #2208, there are very few lib changes; most of the PR is new tests and some one-line test changes to a whole load of tests.

## What

Every functional test file shared `test/hive/client/$atsign`, so a file inherited whatever keystore entries and unpushed sync-queue entries the previous one left behind. The runner clears that directory once per run and never between files; CI never clears it at all.

Each file now names itself and gets one storage bundle per atSign, at a location no other file opens. `AT_FUNCTIONAL_STORAGE` picks the backend — `hive` by default, so the existing runs are unchanged — and a new CI job runs the same pack again on `sqlite` and `memory`, beta channel only.

## How

Most of the diff is one line per test file. The four places worth reading:

| File | What to decide |
| --- | --- |
| `tests/at_functional_test/lib/src/functional_storage.dart` | New. Backend selection and the per-(file, atSign) bundle. Refuses an unrecognised `AT_FUNCTIONAL_STORAGE` rather than defaulting |
| `packages/at_client/lib/src/manager/at_client_manager.dart` | `fromAuthSession` gains `storage:`; the idempotency short-circuit no longer treats re-offering a client's own bundle as a change |
| `packages/at_client/lib/src/storage/at_client_storage.dart` | `isHeldBy` added to the interface |
| `tests/at_functional_test/test/enrollment_test.dart` | Hands one atSign's store between principals at five points, deliberately |

Safe to skim: the other 17 test files gain a single `TestUtils.isolateStorage('<file>')` line and, where they build a client outside `TestUtils`, a `storage:` argument.

Three things the build found that reading would not have:

- **The claim guard caught nine tests sharing one atSign's store across principals.** `enrollment_test` re-authenticates as its own enrolment and reads what the owner wrote locally, so it now hands the store over explicitly rather than tripping the guard.
- **A child isolate is a separate heap**, so `sync_multiple_client_test`'s two clients cannot be handed a bundle at all — that isolate builds its own from the path string it is sent. The third client in that file opens no local store.
- **`setCurrentAtSign` treated any `storage` argument as a change** and took the destructive stop/recreate path, which would have altered the client lifecycle at every site touched here.

⚠️ `commitLogPath` comes off the pack's preferences — it is read nowhere in `at_client`. A preference now carries no storage path at all, so a call site that forgets a bundle fails loudly instead of quietly opening the shared directory.

## How to verify

Local, against `at_virtual_env:local`, 82 tests each:

1. `cd tests/at_functional_test && ./runLocal.sh` — **82 passed, 0 failed**
2. `AT_FUNCTIONAL_STORAGE=sqlite ./runLocal.sh` — **82 passed, 0 failed**
3. `AT_FUNCTIONAL_STORAGE=memory ./runLocal.sh` — **82 passed, 0 failed**
4. `cd packages/at_client && dart test --concurrency=1` — **694 passed, 39 skipped**

Runs 2 and 3 are the first time either SQLite-backed bundle has carried a live put, get, sync drain or notification, rather than only the unit contract tests.

Both `at_client` behaviour changes are mutation-proven: reverting each reddens exactly one assertion, quoting its reason.

## Skills impact

- [ ] No public API change — skill unaffected
- [x] Public API changed — I have opened or will open an `at_client_skills` PR to reflect this

Both API changes are additive (`fromAuthSession(storage:)`, `AtClientStorage.isHeldBy`), and nothing in `packages/at_client_skills/` is falsified — `14-multi-agent.md`'s "one process, one storage path" guidance and every `hiveStoragePath` example still hold. No follow-up release is needed.
