### PR TITLE
feat: move the CLI and Flutter consumers onto a client factory they own

### DIFF
--- a/docs/projects/wasm/decisions.md
+++ b/docs/projects/wasm/decisions.md
@@ -398,7 +398,7 @@ confirmed correct and is the only one recorded below.
 `final` event subclasses, pre-allocated enum slack); there is no `@experimental`. Against
 that: the API is roughly four months old (born `df1272374`, 2026-04-27), took a breaking
 change 2 days after introduction (`fb4c96587`, mandatory `typeTag`), reworked
-`EventSource` semantics since, ships 7 correctness fixes in the current 3.14.1, and has
+`EventSource` semantics since, ships 7 correctness fixes in the current 3.15.0-rc1, and has
 **zero functional/e2e coverage** — all 209 tests in `packages/at_client/test/` are
 mocktail unit tests against `MockAtClient`; nothing in `tests/at_functional_test/` or
 `tests/at_end2end_test/` references it. `js-api.md` §10 marks the JS-side collections

--- a/docs/projects/wasm/design.md
+++ b/docs/projects/wasm/design.md
@@ -155,7 +155,6 @@ default.
 | `at_lookup/lib/src/util/secure_socket_util.dart:12,23,25,29,35,43,49,54,55` | `SecurityContext.defaultContext`, cert `File`, `setTrustedCertificates`, `SecureSocket.connect` ×2, `setOption(tcpNoDelay)` ×2, TLS-keylog `File` + append-write. **Every connection in every package ends here.** |
 | `at_lookup/lib/src/monitor_client.dart:63`                                  | `SecureSocket.connect(host, int.parse(port))` — raw, bypasses even `SecureSocketUtil`.                                                                                                                             |
 | `at_client/lib/src/stream/stream_notification_handler.dart:27`              | `SecureSocket.connect(host, port)` — raw.                                                                                                                                                                          |
-| `at_client/lib/src/manager/monitor.dart:539`                                | `SecureSocketUtil.createSecureSocket(...)` inside the default `MonitorOutboundConnectionFactory`.                                                                                                                  |
 | `at_lookup/lib/src/cache/cacheable_secondary_address_finder.dart:209,222`   | raw TLS socket to `root.atsign.org:64` for directory lookup.                                                                                                                                                       |
 | `at_auth/lib/src/at_auth_impl.dart:396`                                     | `_defaultProbeSocket` → `SecureSocket.connect`. **Owned by the PQ program's S-5**, not here.                                                                                                                       |
 
@@ -181,9 +180,14 @@ return type is the entire blocker.
 `wss://<host>:<port>/ws`. Framing is unchanged, so the response parser is reused as-is.
 
 **Breaking-change blast radius.** `Socket getSocket()` is on a public interface;
-external `implements AtConnection` users are unknown. In-repo callers are
-`at_client/lib/src/client/remote_secondary.dart` and
-`at_client/lib/src/manager/monitor.dart`. Enumerate before changing.
+external `implements AtConnection` users are unknown. The one in-repo caller is
+`at_client/lib/src/client/remote_secondary.dart`; `monitor.dart` stopped being one
+when Monitor gave up its socket. Enumerate before changing.
+
+⚠️ **The line numbers in this section predate that change** and have not been
+re-derived. `at_client` now reaches the atServer through `AtLookUp.withSecureSocket`
+and a transport, so the inventory above understates how much is already injectable.
+Re-derive it before scoping the transport work.
 
 **Directory lookup.** `root.atsign.org:64` is a raw TLS socket with no browser
 equivalent. Two escape hatches already exist — `SecondaryAddressFinder` is an abstract
@@ -523,8 +527,7 @@ changes no interface, breaks nothing, and shrinks every later diff.
 
 | Seam                                                                                                      | Defined at                                                                            | Never passed by                                                                                                                      |
 | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `AtLookupSecureSocketFactory`, `AtLookupSecureSocketListenerFactory`, `AtLookupOutboundConnectionFactory` | `at_lookup/lib/src/at_lookup_impl.dart:740,749,756`, constructor params at `:108-131` | `RemoteSecondary` — `at_client/lib/src/client/remote_secondary.dart:44-56` builds `AtLookupImpl` without any of them                 |
-| `MonitorOutboundConnectionFactory`                                                                        | `at_client/lib/src/manager/monitor.dart:531`, constructor param at `:93`              | `NotificationServiceImpl._` — `notification_service_impl.dart:76-84`; `create` exposes only `monitor:` and `secondaryAddressFinder:` |
+| `AtLookupSecureSocketFactory`, `AtLookupSecureSocketListenerFactory`, `AtLookupOutboundConnectionFactory` | `at_lookup/lib/src/at_lookup_impl.dart:740,749,756`, constructor params at `:108-131` | Now PASSED: `RemoteSecondary` builds through `AtLookUp.withSecureSocket` with a `transport:`. The three factories remain for callers building `AtLookupImpl` directly |
 | `AtSyncQueue.open({injectedBox})`                                                                         | `at_client/lib/src/sync/at_sync_queue.dart:116`                                       | Not reachable from `AtClientImpl.create`                                                                                             |
 | `http.Client`                                                                                             | `at_auth/lib/src/registrar/registrar_service.dart:26`                                 | Plumbed — listed for completeness; the default is the only native part                                                               |
 

--- a/docs/projects/wasm/implementation-plan.md
+++ b/docs/projects/wasm/implementation-plan.md
@@ -188,7 +188,9 @@ The largest item, and the one breaking change with an unknown external blast rad
 Design in [`design.md`](design.md) §2.1.
 
 - **T1 — Audit `implements AtConnection` and `getSocket()` callers.** In-repo:
-  `remote_secondary.dart`, `monitor.dart`. External implementors are unknown
+  `remote_secondary.dart` — and only that one now. ⚠️ This row said
+  `monitor.dart` too; `Monitor` gave up its socket in X6 and calls `getSocket`
+  zero times. External implementors are unknown
   ([`decisions.md`](decisions.md) OQ-8). **Do this before writing the interface** —
   enumerate the blast radius first.
 - **T2 — Define `AtTransport`.** Inbound `Stream<List<int>>`, a sink,
@@ -199,9 +201,18 @@ Design in [`design.md`](design.md) §2.1.
   through in `base_connection.dart:10,14,50` (`late final Socket _socket`,
   `socket.destroy()`, `socket.remoteAddress`), `outbound_connection.dart` and
   `outbound_connection_impl.dart`.
-- **T4 — Retype the three factories** at `at_lookup_impl.dart:740,749,756` from
-  `SecureSocket` onto `AtTransport`. They are already injectable and already plumbed by
-  S1; the return type is the whole blocker.
+- **T4 — Retype the three factories** — `AtLookupSecureSocketFactory`,
+  `AtLookupSecureSocketListenerFactory`, `AtLookupOutboundConnectionFactory`, at
+  `at_lookup_impl.dart:1312,1323,1332` (this row cited `:740,749,756`, which is stale) —
+  from `SecureSocket` onto `AtTransport`. They are already injectable and already plumbed
+  by S1; the return type is the whole blocker.
+  ⚠️ **`AtLookupImpl`'s `dart:io` binding is five occurrences, not a rewrite** (measured
+  2026-09-06): those three factory classes, which are the io implementations co-located at
+  the foot of the file, plus `createOutBoundConnection` at `:834`, whose local is typed
+  `SecureSocket` and which catches `SocketException` — io-typed only because the factory's
+  return type is. Retype the three, move their bodies to `_io`, and the core is io-free
+  with no logic change. `at_lookup.dart`, where `withSecureSocket` lives, imports no
+  `dart:io` at all today.
 - **T5 — `at_lookup_io.dart`.** Native transport wrapping `SecureSocket`; absorb
   `src/util/secure_socket_util.dart` whole (certs, `SecurityContext`, TLS keylog) as
   native-only.
@@ -214,6 +225,33 @@ Design in [`design.md`](design.md) §2.1.
   the two existing escape hatches — the abstract interface, or the `proxy:<host>`
   convention. The production answer is OQ-7.
 - **T8 — Publish `at_lookup` 4.0.0.** → T0 green for at_lookup, T2.2
+- **T9 — Let the APP inject the transport, and thread it to every construction site**
+  (gkc, 2026-09-06). This is the structural gap the rest of phase T does not close:
+  retyping the factories makes a web transport *possible*, but nothing lets an app
+  *supply* one. `at_client_web` needs every `AtLookUp` its process builds to sit on a
+  WebSocket, so the transport joins [`AtClientStorage`](#5a-client-storage-bundle-x) and
+  `AtKeysIo` as a thing the app hands in.
+  **Six production sites hardcode `secureSocketTransport(...)`, in three packages**
+  (measured 2026-09-06): at_client `client/remote_secondary.dart:150` and
+  `service/notification_service_impl.dart:92` — the only two files in at_client importing
+  `at_lookup_io.dart`, and the sync service inherits the first through its own
+  `RemoteSecondary`; at_auth `at_auth_impl.dart:151` and `:259` and
+  `enroll/enrollment_handshake.dart:61`; at_server_status `at_status_impl.dart:115`.
+  ⚠️ **at_auth is not optional here.** A web app authenticates *before* it has an
+  `AtClient`, so an injection that reaches only at_client still drags `dart:io` through
+  onboarding, `authenticate` and the enrollment handshake. The transport is an
+  ecosystem-level injection, not an at_client parameter.
+  ⚠️ **The factory is nearer neutral than "not yet built":** `withSecureSocket` already
+  takes an `AtLookupTransport`, so what is missing is a neutral NAME and an io-free
+  `AtLookupImpl` for it to construct (T4). Its own dartdoc anticipates the sibling:
+  "Named for its transport, so a differently-transported factory can join it later rather
+  than this one growing a mode flag."
+  **Open: where the injected transport lives.** `AtClientPreference` is the wrong home —
+  it is a data bag, the transport is a live object carrying three factories, and
+  `setPreferences` would make it swappable mid-life. Reading it off `AtClient` matches
+  `atKeysIo` exactly and reaches `NotificationServiceImpl` and `SyncServiceImpl`, which
+  build their own connections; a shared platform bundle carrying transport + storage +
+  keysIo is the other shape. Not settled.
 
 ---
 
@@ -416,6 +454,25 @@ D-12. Independent of the P series, which is `at_server`-side.
     ⚠️ **The "back-pressure seam is unreachable" half of this row was WRONG.** The seam is
     explicit on `AtLookupMuxable.notifications`, wired to `pauseDelivery()` and pinned by
     at_lookup's own tests — at_client simply never reached it. One pause fixes both halves.
+  ⛔ **THREE connections to the atServer is the default, and stays** (gkc, 2026-09-06): the
+  verb processor, the monitor, and the sync service. That has been at_client's behaviour all
+  along and nothing here changes it — `AtClientImpl._init` builds the first through
+  `buildRemoteSecondary`, `NotificationServiceImpl` hands `Monitor` a FRESH lookup, and
+  `SyncServiceImpl.create` builds its own `RemoteSecondary`. The `monitor:` and
+  `remoteSecondary:` injection points are test-only; at_auth's `reuse: true` supplies the verb
+  connection rather than adding a fourth, so the count is three either way.
+  ⚠️ **Nothing pins this**, and `Monitor`'s dartdoc still offers the collapse to two ("or the
+  one `RemoteSecondary` already holds"). It carries two reasons against — no atServer
+  implements `monitor:multiplexed`, and `_onNotification` pauses the connection while a
+  handler runs, which on a shared socket would deadlock the handler's own put — but it reads
+  as an option rather than a ruling. A test asserting the three lookups are distinct instances
+  would need a `@visibleForTesting` getter for sync's, which is private. Owed, not done.
+  ⚠️ **Sync's promptness rides on the MONITOR connection, not its own.**
+  `statsServiceListener` subscribes to `statsNotification` through the notification service
+  and enqueues a system sync on each one; its own connection carries only `sync:`, `batch:`
+  and `stats:3`. So a monitor that goes silently deaf costs sync its trigger and drops it to
+  the 30-second `_periodicSyncInterval` safety net — which is what the watchdog above now
+  catches.
   - **The socket-alive-but-silent watchdog is back**, as `AtClientPreference.
     monitorSilenceTimeout` (default 60s, `Duration.zero` off) driving a timer in `Monitor`
     that rebuilds through `stopNotifications`/`startNotifications`.

--- a/docs/projects/wasm/implementation-plan.md
+++ b/docs/projects/wasm/implementation-plan.md
@@ -384,8 +384,12 @@ D-12. Independent of the P series, which is `at_server`-side.
   in-memory storages whose hashes collided would be refused as one store. Negligible at the
   handful per test process this pack opens; wrong in principle.
   Depends on X3.
-- **X6 — Consumers.** ✅ **Built 2026-09-06** on `gkc-x6-consumers`, stacked on
-  [#2210](https://github.com/atsign-foundation/at_client_sdk/pull/2210). **Ruled: they move
+- **X6 — Consumers.** ✅ **Built 2026-09-06** on `gkc-x6-consumers` as
+  [#2211](https://github.com/atsign-foundation/at_client_sdk/pull/2211), which **targets trunk
+  directly** — it was stacked on [#2210](https://github.com/atsign-foundation/at_client_sdk/pull/2210)
+  until that merged and was retargeted. ⚠️ This row said "stacked" until 2026-09-07, and that
+  word carries a consequence: a stacked PR gets no real CI, so it would have a reader discount
+  #2211's checks. They are real. **Ruled: they move
   in THIS major** (gkc, 2026-09-06), and `AtClient.create` has nothing to do with
   `AtClientManager` — future apps, once the manager is gone, manage their clients'
   lifecycles explicitly, so the job now is to make that *possible* while apps using the
@@ -417,10 +421,12 @@ D-12. Independent of the P series, which is `at_server`-side.
   per-service builder callbacks instead, which covers the only override anyone uses.
   ⚠️ **Owed.** `at_onboarding_cli` and `at_cli_commons` still set `hiveStoragePath` as their
   default (eleven analyzer infos); moving them onto client-closed bundles changes when the
-  client's store closes, so it wants all three live packs rather than riding in on unit
+  client's store closes, so it wants the live packs rather than riding in on unit
   green. Eleven example apps in the other widget packages still set `commitLogPath`, each
   needing its own version decision. **X6 itself changes storage ownership semantics, so the
-  three live packs are owed before its PR is ready.**
+  live packs are owed before its PR is ready — all FOUR of them, not three. The fourth is
+  the onboarding-CLI **proxy** pack, which cannot run on this Mac at all (see the X6 review
+  notes below), so on this machine "all four" means three run plus one delegated to CI.**
   Depends on X4.
 
   **Adversarial review of [#2211](https://github.com/atsign-foundation/at_client_sdk/pull/2211),
@@ -505,6 +511,31 @@ D-12. Independent of the P series, which is `at_server`-side.
     `deprecated_member_use` from at_chops/at_auth plus 3 `unnecessary_import` this PR did
     add; those three are removed. `--fatal-infos` is not a CI gate — CI runs bare
     `dart analyze` and `flutter analyze --no-fatal-infos`.
+  **Raised while building X6, tracked nowhere else:**
+  - **The monitor connection advertises nothing.** `RemoteSecondary` passes
+    `clientConfig: _getClientConfig()` — version, clientId, appName, appVersion, platform —
+    and `NotificationServiceImpl` passes none, so that parameter takes its `const {}`
+    default. `AtClientConfig.atClientVersion` therefore reaches the atServer over the verb
+    connection only. Whether that is deliberate is unknown: the socket-owning Monitor built
+    its own connection, so there was nothing to inherit. Worth settling if the atServer logs
+    or branches on client version per connection.
+  - **`Monitor` is arguably no longer required.** It is not exported from at_client's barrel,
+    has exactly one consumer, and that consumer uses five members — `currentState`,
+    `targetState`, `currentStateStream`, `start()`, `stop()`. What is left in it is
+    `NotificationServiceImpl`'s own concern, and `Monitor.lastReceipt` is already dead:
+    written once, read only by a test, while the public `NotificationService.lastReceipt` is
+    served by a second copy. A fold-in would move the watchdog and the retry with it. Not
+    started; it is a second structural change and X6 was already large.
+  - **`buildRemoteSecondary` is not the only construction site.** `SyncServiceImpl.create`
+    builds a `RemoteSecondary` directly rather than through it — functionally equivalent, it
+    omits `privateKey` which the constructor recovers from the preference. #2211's own
+    description calls `buildRemoteSecondary` "the one place a connection is built", which
+    overstates it. Either route sync through it or correct the sentence.
+  **Considered and rejected (gkc, 2026-09-06):** a rail asserting
+  `AtClientConfig.atClientVersion` matches `pubspec.yaml`. Its dartdoc says the two "must
+  always be the same" and nothing enforces it, and the value is sent to the atServer — but
+  the bump is a deliberate, infrequent act and the twin stays manual. Do not re-propose
+  without new evidence of drift.
   ⚠️ **Merge-back note for the spike:** three sites now read `preference.signingAlgoType`
   directly (`sync_service_impl.dart`, `notification_service_impl.dart`, `remote_secondary.dart`)
   where the spike calls `signingAlgoOf(atClient)`. They must go back to `signingAlgoOf` when PQ
@@ -529,8 +560,13 @@ measurement is against `d13516d95`, after them.
 **Found 2026-09-05 by the wrap-up's cold read and done the same day:** the X3 merge-back
 had been skipped. It landed as `51bdb6230`; `at_sync_queue.dart` kept trunk's `SyncQueueStore`
 abstraction and the spike's `HiveInstances.forPath(path)` default together, and the queue's
-`storagePath` became optional so trunk's SQLite storage compiles on the spike. Also owed: nine dangling links to a `plans/wasm/`
-directory that does not exist (`implementation-plan.md`, `js-api.md`, `decisions.md`).
+`storagePath` became optional so trunk's SQLite storage compiles on the spike. Also owed:
+references to a `plans/wasm/` directory that does not exist. ⚠️ **Recorded as "nine dangling
+links" until 2026-09-07, and both halves of that were wrong** (corrected on the spike
+2026-09-06, and this copy had not caught up): it is ten lines, one of which names two files,
+and only **two** of the ten are markdown links — in `implementation-plan.md`'s T-series rows.
+The other eight are prose references that no link checker sees: `decisions.md` ×3,
+`js-api.md` ×5.
 
 **Deferred to the major:** deprecating `AtClientManager`. Its `AtSignChangeListener`
 capability exists only because there is a global current atSign, and where that goes is

--- a/docs/projects/wasm/implementation-plan.md
+++ b/docs/projects/wasm/implementation-plan.md
@@ -385,6 +385,54 @@ D-12. Independent of the P series, which is `at_server`-side.
   three live packs are owed before its PR is ready.**
   Depends on X4.
 
+  **Adversarial review of [#2211](https://github.com/atsign-foundation/at_client_sdk/pull/2211),
+  2026-09-06** (13 agents, six dimensions, every finding attacked by a skeptic). Five
+  high-severity defects were confirmed in source and **fixed on the branch** at `100e73b9d`:
+  a permanently deaf notification listener after one failed first connect; two documented
+  preferences (`monitorHeartbeatInterval`, `monitorHeartbeatResponseTimeout`) gone dead with
+  the effective interval halved 59s → 30s; `at_onboarding_cli`'s and `at_cli_commons`' floors
+  unable to supply what their `lib/` now calls; and `AtClient.create`'s dartdoc asserting the
+  opposite of what the code does.
+  ⚠️ **The retry for the first defect belongs in at_client, NOT at_lookup.**
+  `startNotifications` deliberately *surfaces* a failed start — three at_lookup tests pin
+  that, one reasoning "failing loudly beats a connection that silently never receives
+  anything". Fixing it in at_lookup reddened all three; `Monitor` retries instead.
+  ⚠️ **One of the six author claims was FALSE: "deleting monitor_test.dart's 13 tests is
+  safe".** Eleven are covered by at_lookup's 26 muxable tests; **two are not** — the heartbeat
+  *cadence* tests, which set the preference and asserted the resulting interval, where
+  at_lookup's replacements set `AtLookupImpl.heartbeatInterval` directly and cannot see an
+  `AtClientPreference` at all. They were unportable while the wiring was missing; **the fix at
+  `100e73b9d` restores that wiring, so porting them is now possible and owed.**
+  **Still owed on this branch, none of them fixed:**
+  - **A half-built client is filed and handed out.** `AtClient.create` writes to
+    `atClientInstanceMap` before its service wiring can throw, so a failure leaves a poisoned
+    entry with storage attached and no caller reference; a later `setCurrentAtSign` adopts it
+    and stops it, closing a `closedByClient` bundle the app still believes it owns. Fix is
+    `try { … } catch (_) { await client.stop(); rethrow; }` around the wiring.
+  - **Four dartdocs still say storage is "borrowed" unconditionally**, which `closedByClient:
+    true` falsifies. One search-and-replace.
+  - **Notification handling is no longer serialised** and the back-pressure seam is
+    unreachable; and the socket-alive-but-silent watchdog was deleted with nothing equivalent.
+    With the two fixed defects these are four independent weakenings of notification liveness
+    in one PR, against a public contract (`notification_service.dart:47-51`) that still
+    promises the old behaviour.
+  - **The Flutter app-owned path is a trap end to end.** `EnrollmentRequestList` reaches
+    `AtClientManager.getInstance().atClient` at five sites, which throws for a create-only
+    app — so an app following the new CHANGELOG advice *and* using the enrollment UI this
+    package ships must call `setCurrentAtSign`, which then adopts and later stops its client.
+  - **`at_onboarding_cli` semver**: three `feat:` entries shipped under a patch bump
+    (1.16.1-rc1 → rc2); semver wants 1.17.0. Gary's call.
+  - **`dart analyze --fatal-infos` is not clean**: ~145 lines in at_client still touch the two
+    newly-`@Deprecated` fields with no `// ignore:`. Not a CI gate today.
+  ⚠️ **Merge-back note for the spike:** three sites now read `preference.signingAlgoType`
+  directly (`sync_service_impl.dart`, `notification_service_impl.dart`, `remote_secondary.dart`)
+  where the spike calls `signingAlgoOf(atClient)`. They must go back to `signingAlgoOf` when PQ
+  algorithm resolution lands, or a per-enrollment ML-DSA enrollment signs with the preference's
+  algorithm instead of its own.
+  ⚠️ **This row previously said "at_cli_commons needed no change".** A later commit on the same
+  branch changed it, and its floors were not re-derived afterwards — which is how two of the
+  five defects arrived.
+
 **Sequencing.** Each X item lands as its own PR on **trunk** and is merged back into
 `gkc-pq-d1-spike` before the next starts, so the drift never accumulates into one large
 reconciliation. The one reconciliation worth writing down rather than discovering at

--- a/docs/projects/wasm/implementation-plan.md
+++ b/docs/projects/wasm/implementation-plan.md
@@ -280,7 +280,12 @@ D-12. Independent of the P series, which is `at_server`-side.
 - **X4 — Inject it, and release it.** A new static factory on `AtClient` that builds *and*
   wires the services, taking a bundle; `stop()` releases the claim and closes what the
   bundle opened. Deprecate `AtClientPreference.hiveStoragePath` with a migration note.
-  Depends on X1. **Measured 2026-09-05 on trunk `d13516d95` (the X3 merge), storage-release
+  Depends on X1.
+  ⚠️ **What #2208 actually shipped is narrower than this sentence.** It added `storage:` to
+  the doors that already existed (`AtClientImpl.create`, `setCurrentAtSign`, and via X5
+  `fromAuthSession`) and the release semantics, and left the static factory and the
+  deprecation unbuilt. Both landed in X6 instead, the deprecation only once
+  `AtClientStorage.closedByClient` made a bundle able to be closed by the client. **Measured 2026-09-05 on trunk `d13516d95` (the X3 merge), storage-release
   semantics built and run against the packs before landing anything:** 69 tests red across three causes —
   (a) 38 fixtures that rebuild a client for one atSign without stopping the previous one,
   which the per-atSign Hive guard now refuses; (b) a sync round outliving `stop()` and
@@ -341,9 +346,44 @@ D-12. Independent of the P series, which is `at_server`-side.
   in-memory storages whose hashes collided would be refused as one store. Negligible at the
   handful per test process this pack opens; wrong in principle.
   Depends on X3.
-- **X6 — Consumers.** `at_client_flutter` and `at_onboarding_cli` move onto the factory, so
-  both are WASM-ready ahead of the next major. Whether they move in this major or the next
-  is open.
+- **X6 — Consumers.** ✅ **Built 2026-09-06** on `gkc-x6-consumers`, stacked on
+  [#2210](https://github.com/atsign-foundation/at_client_sdk/pull/2210). **Ruled: they move
+  in THIS major** (gkc, 2026-09-06), and `AtClient.create` has nothing to do with
+  `AtClientManager` — future apps, once the manager is gone, manage their clients'
+  lifecycles explicitly, so the job now is to make that *possible* while apps using the
+  manager see no change.
+  ⚠️ **The row's premise was wrong in both directions.** `at_client_flutter`'s `lib/` had
+  nothing to move: zero references to `AtClientPreference`, `AtClientImpl` or
+  `AtClientStorage`; it wraps `AtAuth` and reads `AtClientManager.getInstance().atClient`,
+  and only its example apps set storage paths. Meanwhile `at_cli_commons`, which the row
+  never named, was one of only three production `lib/` sites setting `hiveStoragePath` —
+  though it reaches the client through `AtOnboardingServiceImpl`, so there is one seam, not
+  two.
+  **What landed.** `AtClient.create` — X4's promised static factory, never built by #2208,
+  which added `storage:` to the existing doors instead. It builds a client and wires its
+  three services, taking `storage` alongside `atKeysIo`, registers nothing, and refuses an
+  atSign whose client is already live rather than handing back one the caller does not own.
+  `AtOnboardingPreference.storage` carries a bundle through to `setCurrentAtSign`;
+  `at_cli_commons` needed no change, because `CLIBase` already passes the caller's own
+  preference object through untouched. `AuthService.createClient` turns a completed
+  authentication into a client the app owns, and `FlutterEnrollmentService` takes an
+  optional client so it can work against one.
+  **`AtClientStorage.closedByClient`** (gkc's idea, 2026-09-06) moves lifetime ownership onto
+  the bundle instead of inferring it from how the storage arrived. That removed the last
+  argument for `hiveStoragePath`, which is now deprecated along with `commitLogPath` — the
+  latter read by nothing anywhere, so every caller setting it was setting a value with no
+  effect.
+  ⚠️ **`AtServiceFactory` cannot go manager-free in 3.x**: every method takes an
+  `AtClientManager` positionally and non-nullably, and relaxing that makes the three
+  existing `ServiceFactoryWithNoOpSyncService` overrides illegal. `AtClient.create` takes
+  per-service builder callbacks instead, which covers the only override anyone uses.
+  ⚠️ **Owed.** `at_onboarding_cli` and `at_cli_commons` still set `hiveStoragePath` as their
+  default (eleven analyzer infos); moving them onto client-closed bundles changes when the
+  client's store closes, so it wants all three live packs rather than riding in on unit
+  green. Eleven example apps in the other widget packages still set `commitLogPath`, each
+  needing its own version decision. **X6 itself changes storage ownership semantics, so the
+  three live packs are owed before its PR is ready.**
+  Depends on X4.
 
 **Sequencing.** Each X item lands as its own PR on **trunk** and is merged back into
 `gkc-pq-d1-spike` before the next starts, so the drift never accumulates into one large

--- a/docs/projects/wasm/implementation-plan.md
+++ b/docs/projects/wasm/implementation-plan.md
@@ -403,27 +403,51 @@ D-12. Independent of the P series, which is `at_server`-side.
   at_lookup's replacements set `AtLookupImpl.heartbeatInterval` directly and cannot see an
   `AtClientPreference` at all. They were unportable while the wiring was missing; **the fix at
   `100e73b9d` restores that wiring, so porting them is now possible and owed.**
-  **Still owed on this branch, none of them fixed:**
-  - **A half-built client is filed and handed out.** `AtClient.create` writes to
-    `atClientInstanceMap` before its service wiring can throw, so a failure leaves a poisoned
-    entry with storage attached and no caller reference; a later `setCurrentAtSign` adopts it
-    and stops it, closing a `closedByClient` bundle the app still believes it owns. Fix is
-    `try { … } catch (_) { await client.stop(); rethrow; }` around the wiring.
-  - **Four dartdocs still say storage is "borrowed" unconditionally**, which `closedByClient:
-    true` falsifies. One search-and-replace.
-  - **Notification handling is no longer serialised** and the back-pressure seam is
-    unreachable; and the socket-alive-but-silent watchdog was deleted with nothing equivalent.
-    With the two fixed defects these are four independent weakenings of notification liveness
-    in one PR, against a public contract (`notification_service.dart:47-51`) that still
-    promises the old behaviour.
-  - **The Flutter app-owned path is a trap end to end.** `EnrollmentRequestList` reaches
-    `AtClientManager.getInstance().atClient` at five sites, which throws for a create-only
-    app — so an app following the new CHANGELOG advice *and* using the enrollment UI this
-    package ships must call `setCurrentAtSign`, which then adopts and later stops its client.
-  - **`at_onboarding_cli` semver**: three `feat:` entries shipped under a patch bump
-    (1.16.1-rc1 → rc2); semver wants 1.17.0. Gary's call.
-  - **`dart analyze --fatal-infos` is not clean**: ~145 lines in at_client still touch the two
-    newly-`@Deprecated` fields with no `// ignore:`. Not a CI gate today.
+  **The rest of that list was worked 2026-09-06 and is now DONE**, each fix pinned by a test
+  whose break-it mutation reddens the assertion and quotes its own reason string:
+  - **A half-built client is no longer filed and handed out.** `AtClient.create` wraps its
+    service wiring in `try { … } catch (_) { await client.stop(); rethrow; }`, which unfiles
+    the client and releases its claim on the storage location.
+  - **The four unconditional "borrowed" dartdocs** are corrected, plus two in the functional
+    pack that stated the rule as a general claim about clients and four more in the
+    CHANGELOGs.
+  - **Notification handling is serialised again.** `Monitor._onNotification` pauses the
+    subscription for the duration of the handler, exactly as the socket-owning Monitor did.
+    ⚠️ **The "back-pressure seam is unreachable" half of this row was WRONG.** The seam is
+    explicit on `AtLookupMuxable.notifications`, wired to `pauseDelivery()` and pinned by
+    at_lookup's own tests — at_client simply never reached it. One pause fixes both halves.
+  - **The socket-alive-but-silent watchdog is back**, as `AtClientPreference.
+    monitorSilenceTimeout` (default 60s, `Duration.zero` off) driving a timer in `Monitor`
+    that rebuilds through `stopNotifications`/`startNotifications`.
+    ⚠️ **Ruled: at_client, not at_lookup** (gkc, 2026-09-06). The argument for putting it in
+    at_lookup mis-cited `at_lookup_impl.dart:914-922`, which argues against Monitor owning
+    the reconnect BACKOFF and is conditioned on "a connection that also carries verb
+    traffic" — Monitor's is dedicated. This PR changes at_lookup by zero lines and at_lookup
+    is ahead of at_client on the release train.
+    **It has a live test as well as three unit tests**, and it needed no test hook: the
+    atServer writes a stats notification to every monitor connection every 15s by default
+    (`at_secondary_config.dart:63` on at_server `origin/trunk`), which is a real clock to
+    bracket the budget around. `tests/at_functional_test/test/monitor_silence_test.dart`
+    runs two 45-second arms differing only in the budget — 3s must rebuild, 40s must not —
+    observed through the public `currentListenerStateStream`, with the stats-arrive premise
+    asserted first so a server that stopped sending them fails as itself. ⚠️ What no test
+    here does is wedge a real atServer into answering heartbeats while delivering nothing;
+    the arms reproduce the condition the watchdog keys on, not the fault that causes it.
+  - **The Flutter app-owned path works end to end.** `EnrollmentRequestList` takes an
+    optional `enrollmentService` and every client read goes through it.
+    ⚠️ **It was six reaches, not five, and the sixth fires first**: the service's constructor
+    wires `onListen` to a method whose first statement touches `atClient`, which runs
+    synchronously inside the widget's own `.listen`. Swapping only the five named sites would
+    not have fixed it. The widget now disposes only a service it built itself.
+  - **`at_onboarding_cli` is 1.17.0-rc1** (gkc, 2026-09-06), and `at_cli_commons` floors it
+    there — it had pinned `^1.16.1-rc2`, which resolves a version without `storagePath`.
+  - **`dart analyze --fatal-infos`**: ⚠️ **that row's diagnosis was WRONG.** None of the 143
+    same-package uses of the two deprecated fields produces a diagnostic, because
+    `deprecated_member_use_from_same_package` is not in `package:lints/recommended.yaml`,
+    which is all this package includes. The 289 infos were 286 pre-existing
+    `deprecated_member_use` from at_chops/at_auth plus 3 `unnecessary_import` this PR did
+    add; those three are removed. `--fatal-infos` is not a CI gate — CI runs bare
+    `dart analyze` and `flutter analyze --no-fatal-infos`.
   ⚠️ **Merge-back note for the spike:** three sites now read `preference.signingAlgoType`
   directly (`sync_service_impl.dart`, `notification_service_impl.dart`, `remote_secondary.dart`)
   where the spike calls `signingAlgoOf(atClient)`. They must go back to `signingAlgoOf` when PQ

--- a/docs/projects/wasm/js-api.md
+++ b/docs/projects/wasm/js-api.md
@@ -569,7 +569,7 @@ Notes:
   unit tests against `MockAtClient`; nothing in `tests/at_functional_test/` or
   `tests/at_end2end_test/` references it. The API also took a breaking change 2 days
   after introduction (`fb4c96587`, mandatory `typeTag`), reworked `EventSource`
-  semantics since, and ships 7 correctness fixes in the current 3.14.1. **Ruling: the
+  semantics since, and ships 7 correctness fixes in the current 3.15.0-rc1. **Ruling: the
   JS-side collections surface ships marked unstable/0.x in the npm package** until this
   project's own T6/T4 gates exercise it against a live atServer — the marker reflects a
   gap in *our* boundary validation, not upstream's contract.

--- a/packages/at_cli_commons/CHANGELOG.md
+++ b/packages/at_cli_commons/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 3.1.2
 
+- chore: set `AtOnboardingPreference.storagePath` rather than the now-deprecated
+  `AtClientPreference.hiveStoragePath`. The store lands in the same place; the
+  bundle is built by at_onboarding_cli and closed by the client, so `CLIBase`
+  still has nothing to tear down.
 - chore: stop setting `AtClientPreference.commitLogPath`, which at_client reads
   nowhere, so the value had no effect. No behaviour changes.
 

--- a/packages/at_cli_commons/CHANGELOG.md
+++ b/packages/at_cli_commons/CHANGELOG.md
@@ -6,6 +6,8 @@
   still has nothing to tear down.
 - chore: stop setting `AtClientPreference.commitLogPath`, which at_client reads
   nowhere, so the value had no effect. No behaviour changes.
+- build: require `at_onboarding_cli` ^1.17.0-rc1, the first version carrying
+  `AtOnboardingPreference.storagePath`.
 
 ## 3.1.1
 

--- a/packages/at_cli_commons/CHANGELOG.md
+++ b/packages/at_cli_commons/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.2
+
+- chore: stop setting `AtClientPreference.commitLogPath`, which at_client reads
+  nowhere, so the value had no effect. No behaviour changes.
+
 ## 3.1.1
 
 - fix: `getUserName` now resolves via `USER` → `LOGNAME` → `USERNAME` → `whoami`

--- a/packages/at_cli_commons/example/pubspec.yaml
+++ b/packages/at_cli_commons/example/pubspec.yaml
@@ -12,6 +12,25 @@ dependencies:
   at_client: ^3.8.0
   args: ^2.7.0
 
+# at_cli_commons is a path dependency, so its own floors must resolve locally
+# too - a published at_client cannot satisfy them while the versions they need
+# are still unreleased. Transitive overrides are not automatic.
+dependency_overrides:
+  at_client:
+    path: ../../at_client
+  at_onboarding_cli:
+    path: ../../at_onboarding_cli
+  at_auth:
+    path: ../../at_auth
+  at_chops:
+    path: ../../at_chops
+  at_commons:
+    path: ../../at_commons
+  at_lookup:
+    path: ../../at_lookup
+  at_utils:
+    path: ../../at_utils
+
 dev_dependencies:
   lints: ^2.1.1
   test: ^1.24.4

--- a/packages/at_cli_commons/lib/src/cli_base.dart
+++ b/packages/at_cli_commons/lib/src/cli_base.dart
@@ -322,8 +322,6 @@ class CLIBase {
       ..hiveStoragePath = localStoragePathToUse
       ..namespace = nameSpace
       ..downloadPath = downloadPathToUse
-      ..commitLogPath = '$localStoragePathToUse/commitLog'
-          .replaceAll('/', Platform.pathSeparator)
       ..rootDomain = atRootDomain.rootDomain
       ..rootPort = atRootDomain.rootPort
       ..fetchOfflineNotifications = true

--- a/packages/at_cli_commons/lib/src/cli_base.dart
+++ b/packages/at_cli_commons/lib/src/cli_base.dart
@@ -319,7 +319,7 @@ class CLIBase {
     final AtOnboardingPreference atOnboardingConfig =
         preference ?? AtOnboardingPreference();
     atOnboardingConfig
-      ..hiveStoragePath = localStoragePathToUse
+      ..storagePath = localStoragePathToUse
       ..namespace = nameSpace
       ..downloadPath = downloadPathToUse
       ..rootDomain = atRootDomain.rootDomain

--- a/packages/at_cli_commons/pubspec.yaml
+++ b/packages/at_cli_commons/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   args: ^2.6.0
   at_client: ^3.14.1
   at_commons: ^5.6.0
-  at_onboarding_cli: ^1.16.1-rc2
+  at_onboarding_cli: ^1.17.0-rc1
   at_utils: ^3.0.19
   chalkdart: ">=2.0.9<4.0.0" # no breaking changes in 3.0.0
   version: ^3.0.2

--- a/packages/at_cli_commons/pubspec.yaml
+++ b/packages/at_cli_commons/pubspec.yaml
@@ -12,9 +12,9 @@ resolution: workspace
 
 dependencies:
   args: ^2.6.0
-  at_client: ^3.7.0
+  at_client: ^3.14.1
   at_commons: ^5.6.0
-  at_onboarding_cli: ^1.8.0
+  at_onboarding_cli: ^1.16.1-rc2
   at_utils: ^3.0.19
   chalkdart: ">=2.0.9<4.0.0" # no breaking changes in 3.0.0
   version: ^3.0.2

--- a/packages/at_cli_commons/pubspec.yaml
+++ b/packages/at_cli_commons/pubspec.yaml
@@ -12,7 +12,7 @@ resolution: workspace
 
 dependencies:
   args: ^2.6.0
-  at_client: ^3.14.1
+  at_client: ^3.15.0-rc1
   at_commons: ^5.6.0
   at_onboarding_cli: ^1.17.0-rc1
   at_utils: ^3.0.19

--- a/packages/at_cli_commons/pubspec.yaml
+++ b/packages/at_cli_commons/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_cli_commons
 description: Library of useful stuff when building cli programs which use the AtClient SDK
-version: 3.1.1
+version: 3.1.2
 
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_cli_commons
 homepage: https://atsign.com

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -9,11 +9,27 @@
   the file-stream path used to build its own with neither enrollment nor
   credentials. The sync service's own connection now gets the client's key
   material.
+- feat: `AtClientPreference.monitorSilenceTimeout` (default 60s) rebuilds a
+  notification connection that answers heartbeats while delivering nothing. A
+  heartbeat proves the socket is alive, not that notifications still arrive on
+  it, so without this a client can report `listening` while permanently deaf.
+  `Duration.zero` turns it off, which an atServer configured to send no stats
+  notifications needs.
+- fix: the notification monitor handles one notification at a time again,
+  pausing the connection while it does. The pause reaches the socket, so a
+  backlog after a reconnect arrives at the rate the client can absorb, and the
+  last-notification watermark is written in arrival order rather than
+  whichever `put` happens to land last.
+- fix: `AtClient.create` no longer leaves a part-built client behind when
+  wiring its services throws. The client is filed before the services are
+  wired, so a failure used to strand an entry no caller held a reference to,
+  still claiming its storage; it is now stopped, which unfiles it and releases
+  that claim.
 - refactor: `Monitor` no longer opens, authenticates, frames, heartbeats or
   reconnects its own socket - all of it moved into `AtLookupMuxable`, where
   at_lookup's own 26 notification tests cover it, including reconnect inside
   the backoff window and asking the caller for its CURRENT watermark. The class
-  is 213 lines where it was 543. `Monitor`'s constructor now takes a required
+  is 327 lines where it was 543. `Monitor`'s constructor now takes a required
   `lookUp` and no longer takes `atChops`, `enrollmentId`,
   `secondaryAddressFinder`, `connectDelays` or
   `monitorOutboundConnectionFactory`; `onSocketDataReceipt` is gone, the
@@ -33,10 +49,13 @@
   be removed in the next major release.
 - feat: `AtClient.create` builds a client and wires its notification, sync and
   enrollment services, taking `storage` as a named parameter alongside
-  `atKeysIo`. It registers nothing: the client is unknown to `AtClientManager`
-  and the caller owns its lifetime, which is what an app managing its own
-  clients needs. `AtClientManager` is unchanged, so code using it sees no
-  difference. A service builder replaces any of the three services. The
+  `atKeysIo`. The caller owns its lifetime, which is what an app managing its
+  own clients needs. `AtClientManager` is unchanged, so code using it sees no
+  difference. ⚠️ The client is not invisible to `AtClientManager`: it is filed
+  in the instance map like any other, so a later `setCurrentAtSign` for the
+  same atSign adopts it, replaces its services and stops it on the next
+  switch. Do not mix the two for one atSign in one process.
+  A service builder replaces any of the three services. The
   factory refuses an atSign whose client is already live rather than handing
   back one the caller does not own, and refuses a `storage` that
   `isLocalStoreRequired: false` would never open.
@@ -49,7 +68,8 @@
 - feat: `AtClientManager.fromAuthSession` accepts a `storage` bundle and
   passes it to the client it builds, as `setCurrentAtSign` already did. A
   caller handing storage in no longer has to avoid the auth hand-off to do
-  it. The bundle is borrowed, not owned: `stop()` detaches without closing.
+  it. The bundle is borrowed unless built with `closedByClient: true`, in
+  which case the client closes it on `stop()`.
 - build: require `at_persistence_secondary_server` ^5.3.0. This package's
   keystore and sync queue open on `HiveInstances`, which 5.3.0 is the first
   release to carry; the floor still said ^5.1.0, so a consumer could resolve
@@ -88,9 +108,10 @@
   caller that supplies storage picks both the backend and where it lives, so
   `AtClientPreference.hiveStoragePath` no longer has to name a location; omit it
   and the client builds the Hive store under that path exactly as before. The
-  client only borrows storage it was given: `stop()` detaches without closing,
-  so one store can be handed to a later client, while storage the client built
-  itself is still closed on release.
+  client borrows storage it was given by default: `stop()` detaches without
+  closing, so one store can be handed to a later client. A bundle built with
+  `closedByClient: true` is closed by the client instead, and storage the
+  client built itself is always closed on release.
 - fix: a delete that supersedes a queued update is no longer lost on push. Queue
   entries carry a monotonic `seq`, and the drain removes only the version it
   actually pushed, so a write that replaced the entry mid-flight stays queued for

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,23 @@
 ## 3.14.1
+- feat: at_client builds its connections through `AtLookUp.withSecureSocket`,
+  which returns the muxable that owns reconnect, reauth and heartbeat. Requires
+  `at_lookup` ^3.7.0-rc1. Credentials travel as an `AtAuthenticator` built from
+  whichever of four shapes the client holds - a keystore, chops, a private key,
+  a cram secret - rather than being parked on the lookup, so every connection a
+  client opens is configured alike instead of assembled independently at each
+  site. `AtClientImpl.buildRemoteSecondary` is the single place that builds one;
+  the file-stream path used to build its own with neither enrollment nor
+  credentials. The sync service's own connection now gets the client's key
+  material.
+- refactor: `Monitor` no longer opens, authenticates, frames, heartbeats or
+  reconnects its own socket - all of it moved into `AtLookupMuxable`, where
+  at_lookup's own 26 notification tests cover it, including reconnect inside
+  the backoff window and asking the caller for its CURRENT watermark. The class
+  is 213 lines where it was 543. `Monitor`'s constructor now takes a required
+  `lookUp` and no longer takes `atChops`, `enrollmentId`,
+  `secondaryAddressFinder`, `connectDelays` or
+  `monitorOutboundConnectionFactory`; `onSocketDataReceipt` is gone, the
+  framing it did being at_lookup's now.
 - feat: `AtClientStorage.closedByClient` lets a bundle say that the client
   closes it on `stop()`, instead of ownership being inferred from how the
   storage reached the client. False by default, which is the borrowed

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 3.14.1
+- feat: `AtClientStorage.closedByClient` lets a bundle say that the client
+  closes it on `stop()`, instead of ownership being inferred from how the
+  storage reached the client. False by default, which is the borrowed
+  behaviour every existing caller already gets. Passing true lets an app with
+  no teardown of its own still choose the backend and the location without
+  having to close anything.
 - **DEPRECATED:** `AtClientPreference.commitLogPath`. Nothing reads it — the
   client is commit-log-free — so whatever is set there has no effect. It will
   be removed in the next major release.

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## 3.14.1
+- feat: `AtClient.create` builds a client and wires its notification, sync and
+  enrollment services, taking `storage` as a named parameter alongside
+  `atKeysIo`. It registers nothing: the client is unknown to `AtClientManager`
+  and the caller owns its lifetime, which is what an app managing its own
+  clients needs. `AtClientManager` is unchanged, so code using it sees no
+  difference. A service builder replaces any of the three services. The
+  factory refuses an atSign whose client is already live rather than handing
+  back one the caller does not own, and refuses a `storage` that
+  `isLocalStoreRequired: false` would never open.
 - feat: `AtClientStorage.isHeldBy` says whether a given client is the one
   currently holding the storage.
 - fix: `setCurrentAtSign` no longer rebuilds the client when it is handed the

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.14.1
+## 3.15.0-rc1
 - feat: at_client builds its connections through `AtLookUp.withSecureSocket`,
   which returns the muxable that owns reconnect, reauth and heartbeat. Requires
   `at_lookup` ^3.7.0-rc1. Credentials travel as an `AtAuthenticator` built from

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 3.14.1
+- **DEPRECATED:** `AtClientPreference.commitLogPath`. Nothing reads it — the
+  client is commit-log-free — so whatever is set there has no effect. It will
+  be removed in the next major release.
 - feat: `AtClient.create` builds a client and wires its notification, sync and
   enrollment services, taking `storage` as a named parameter alongside
   `atKeysIo`. It registers nothing: the client is unknown to `AtClientManager`

--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -5,6 +5,10 @@
   behaviour every existing caller already gets. Passing true lets an app with
   no teardown of its own still choose the backend and the location without
   having to close anything.
+- **DEPRECATED:** `AtClientPreference.hiveStoragePath`. Supply an
+  `AtClientStorage` instead: it chooses the backend as well as the location,
+  and `closedByClient: true` keeps the client closing the store, so nothing is
+  given up by moving. Still honoured until the next major release.
 - **DEPRECATED:** `AtClientPreference.commitLogPath`. Nothing reads it — the
   client is commit-log-free — so whatever is set there has no effect. It will
   be removed in the next major release.

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -432,7 +432,7 @@ class AtClientImpl implements AtClient {
         final AtClientStorage storage;
         if (injected != null) {
           storage = injected;
-          _ownsStorage = false;
+          _ownsStorage = injected.closedByClient;
         } else {
           final storagePath = preference!.hiveStoragePath;
           if (storagePath == null) {

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -102,6 +102,24 @@ class AtClientImpl implements AtClient {
   @override
   AtKeysIo? get atKeysIo => _atKeysIo;
 
+  /// Builds a [RemoteSecondary] carrying this client's identity and
+  /// credentials, so every one this client opens is configured alike rather
+  /// than assembled independently at each site.
+  ///
+  /// [atLookUp] injects an already-built lookup; passing none lets
+  /// [RemoteSecondary] open its own connection, which is what a site wanting a
+  /// connection separate from the client's shared one does.
+  @visibleForTesting
+  RemoteSecondary buildRemoteSecondary({AtLookUp? atLookUp}) => RemoteSecondary(
+        _atSign,
+        _preference!,
+        atChops: atChops,
+        atLookUp: atLookUp,
+        privateKey: _preference!.privateKey,
+        enrollmentId: enrollmentId,
+        atKeysIo: _atKeysIo,
+      );
+
   /// Keeps track of CryptoProviders registered with this AtClient
   // ---------------------------------------------------------------------------
   // DataEvent stream — fires on every successful keystore mutation that
@@ -486,14 +504,7 @@ class AtClientImpl implements AtClient {
     }
 
     // Using ??= because we may be injecting a RemoteSecondary
-    _remoteSecondary ??= RemoteSecondary(
-      _atSign,
-      _preference!,
-      atChops: atChops,
-      atLookUp: atLookUp,
-      privateKey: _preference!.privateKey,
-      enrollmentId: enrollmentId,
-    );
+    _remoteSecondary ??= buildRemoteSecondary(atLookUp: atLookUp);
 
     // Using ??= because we may be injecting an EncryptionService
     _encryptionService ??= EncryptionService(_atSign);
@@ -1303,11 +1314,7 @@ class AtClientImpl implements AtClient {
     var command =
         'stream:init$sharedWith namespace:$namespace $streamId $fileName ${encryptedData.length}\n';
     _logger.finer('sending stream init:$command');
-    var remoteSecondary = RemoteSecondary(
-      _atSign,
-      _preference!,
-      atChops: atChops,
-    );
+    var remoteSecondary = buildRemoteSecondary();
     var result = await remoteSecondary.executeCommand(command, auth: true);
     _logger.finer('ack message:$result');
     if (result != null && result.startsWith('stream:ack')) {

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -257,6 +257,13 @@ class AtClientImpl implements AtClient {
   @visibleForTesting
   static final Map atClientInstanceMap = <String, AtClient>{};
 
+  /// Whether a live client is already filed for [atSign].
+  ///
+  /// [atClientInstanceMap] is keyed by atSign, so two enrollments of one
+  /// atSign share an entry. [stop] removes the entry, freeing the atSign.
+  static bool holdsLiveClient(String atSign) =>
+      atClientInstanceMap.containsKey(AtUtils.fixAtSign(atSign));
+
   static final Finalizer<String> _finalizer = Finalizer((service) {
     _logger.finer('Outgoing $service has been garbage collected');
   });

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -442,10 +442,9 @@ class AtClientImpl implements AtClient {
     if (_preference!.isLocalStoreRequired) {
       AtSyncQueue? syncQueue;
       if (_localSecondaryKeyStore == null) {
-        // A caller that supplied storage picked the backend and the location;
-        // this client only borrows it, so `stop()` detaches without closing.
-        // Otherwise build the default Hive store under the preference's path
-        // and own it.
+        // A caller that supplied storage picked the backend and the location,
+        // and the bundle itself says whether `stop()` closes it. Otherwise
+        // build the default Hive store under the preference's path and own it.
         final injected = _injectedStorage;
         final AtClientStorage storage;
         if (injected != null) {

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -1315,9 +1315,12 @@ class AtClientImpl implements AtClient {
       result = result.trim();
       _logger.finer('ack received for streamId:$streamId');
       remoteSecondary.atLookUp.connection!.getSocket().add(encryptedData);
-      var streamResult = await (remoteSecondary.atLookUp as AtLookupImpl)
-          .messageListener
-          .read(maxWaitMilliSeconds: _preference!.outboundConnectionTimeout);
+      // `readResponse` rather than reaching through to the listener: this
+      // path has already written the bytes to the socket itself, so it needs
+      // the read half alone. The listener is not in at_lookup's barrel.
+      var streamResult = await (remoteSecondary.atLookUp as AtLookupMuxable)
+          .readResponse(
+              maxWaitMilliSeconds: _preference!.outboundConnectionTimeout);
       if (streamResult.startsWith('stream:done')) {
         await remoteSecondary.atLookUp.connection!.close();
         streamResponse.status = AtStreamStatus.complete;

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -25,10 +25,11 @@ abstract class AtClient {
   /// [stop]. Code that wants the shared current-atSign client goes on calling
   /// [AtClientManager.setCurrentAtSign], whose behaviour is unchanged.
   ///
-  /// [storage] is borrowed rather than owned, so [stop] detaches from it
-  /// without closing it and the caller closes it when done. Supply none and
-  /// the client opens a Hive store under `preference.hiveStoragePath` and
-  /// closes that itself.
+  /// [storage] is borrowed by default, so [stop] detaches from it without
+  /// closing it and the caller closes it when done; a bundle built with
+  /// `closedByClient: true` is closed by the client instead, which is what an
+  /// app with no teardown of its own wants. Supplying none falls back to a Hive
+  /// store under the deprecated `preference.hiveStoragePath`.
   ///
   /// Each builder replaces one service with the caller's own; by default each
   /// service is the real one.

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -20,10 +20,17 @@ abstract class AtClient {
   /// Builds a client for [atSign] and wires its notification, sync and
   /// enrollment services.
   ///
-  /// Nothing registers the client this returns. It is unknown to
-  /// [AtClientManager], and the caller owns its lifetime, ending it with
-  /// [stop]. Code that wants the shared current-atSign client goes on calling
+  /// The caller owns the client's lifetime and ends it with [stop]. Code that
+  /// wants the shared current-atSign client goes on calling
   /// [AtClientManager.setCurrentAtSign], whose behaviour is unchanged.
+  ///
+  /// ⚠️ The client is NOT invisible to [AtClientManager]. It is filed in
+  /// `AtClientImpl.atClientInstanceMap` like any other, so a later
+  /// [AtClientManager.setCurrentAtSign] for the same atSign adopts THIS client
+  /// rather than building its own — and adopting it replaces its notification,
+  /// sync and enrollment services without stopping the ones it had, then stops
+  /// it on the next atSign switch. Until that is separated, do not mix this
+  /// factory and the manager for one atSign in one process.
   ///
   /// [storage] is borrowed by default, so [stop] detaches from it without
   /// closing it and the caller closes it when done; a bundle built with

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -1,17 +1,89 @@
+import 'dart:async';
 import 'dart:io';
 
-import 'package:at_auth/at_auth.dart' show AtKeysIo;
+import 'package:at_auth/at_auth.dart' show AtEnrollment, AtKeysIo;
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/response/response.dart';
 import 'package:at_client/src/service/encryption_service.dart';
+import 'package:at_client/src/service/enrollment_service_impl.dart';
+import 'package:at_client/src/service/notification_service_impl.dart';
+import 'package:at_client/src/service/sync_service_impl.dart';
 import 'package:at_client/src/stream/at_stream_response.dart';
 import 'package:at_client/src/stream/file_transfer_object.dart';
+import 'package:at_lookup/at_lookup.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:meta/meta.dart';
 
 /// Interface for a client application that can communicate with a secondary server.
 abstract class AtClient {
+  /// Builds a client for [atSign] and wires its notification, sync and
+  /// enrollment services.
+  ///
+  /// Nothing registers the client this returns. It is unknown to
+  /// [AtClientManager], and the caller owns its lifetime, ending it with
+  /// [stop]. Code that wants the shared current-atSign client goes on calling
+  /// [AtClientManager.setCurrentAtSign], whose behaviour is unchanged.
+  ///
+  /// [storage] is borrowed rather than owned, so [stop] detaches from it
+  /// without closing it and the caller closes it when done. Supply none and
+  /// the client opens a Hive store under `preference.hiveStoragePath` and
+  /// closes that itself.
+  ///
+  /// Each builder replaces one service with the caller's own; by default each
+  /// service is the real one.
+  ///
+  /// Throws a [StateError] when a client for [atSign] is already live, rather
+  /// than handing back one this caller does not own. [stop] releases it.
+  static Future<AtClient> create({
+    required String atSign,
+    required AtClientPreference preference,
+    String? namespace,
+    AtClientStorage? storage,
+    AtKeysIo? atKeysIo,
+    String? enrollmentId,
+    AtLookUp? atLookUp,
+    SecondaryAddressFinder? secondaryAddressFinder,
+    FutureOr<NotificationService> Function(AtClient)?
+        notificationServiceBuilder,
+    FutureOr<SyncService> Function(AtClient)? syncServiceBuilder,
+    FutureOr<EnrollmentService> Function(AtClient)? enrollmentServiceBuilder,
+  }) async {
+    if (AtClientImpl.holdsLiveClient(atSign)) {
+      throw StateError(
+          'A client for $atSign is already live. AtClient.create builds a '
+          'client the caller owns, so it will not hand back one owned '
+          'elsewhere; stop() the existing client first.');
+    }
+    if (storage != null && !preference.isLocalStoreRequired) {
+      throw ArgumentError.value(
+          storage,
+          'storage',
+          'preference.isLocalStoreRequired is false for $atSign, so this '
+              'storage would never be opened');
+    }
+    final client = await AtClientImpl.create(
+      atSign,
+      namespace,
+      preference,
+      atKeysIo: atKeysIo,
+      atLookUp: atLookUp,
+      enrollmentId: enrollmentId,
+      storage: storage,
+    );
+    client.notificationService = notificationServiceBuilder == null
+        ? await NotificationServiceImpl.create(client,
+            secondaryAddressFinder: secondaryAddressFinder)
+        : await notificationServiceBuilder(client);
+    client.syncService = syncServiceBuilder == null
+        ? await SyncServiceImpl.create(client)
+        : await syncServiceBuilder(client);
+    client.enrollmentService = enrollmentServiceBuilder == null
+        ? EnrollmentServiceImpl(client, AtEnrollment.create())
+        : await enrollmentServiceBuilder(client);
+    return client;
+  }
+
   @experimental
   set telemetry(AtTelemetryService? telemetryService);
 

--- a/packages/at_client/lib/src/client/at_client_spec.dart
+++ b/packages/at_client/lib/src/client/at_client_spec.dart
@@ -43,6 +43,9 @@ abstract class AtClient {
   ///
   /// Throws a [StateError] when a client for [atSign] is already live, rather
   /// than handing back one this caller does not own. [stop] releases it.
+  ///
+  /// A failure while building leaves nothing behind: the part-built client is
+  /// stopped, which unfiles it and releases its claim on [storage].
   static Future<AtClient> create({
     required String atSign,
     required AtClientPreference preference,
@@ -79,16 +82,25 @@ abstract class AtClient {
       enrollmentId: enrollmentId,
       storage: storage,
     );
-    client.notificationService = notificationServiceBuilder == null
-        ? await NotificationServiceImpl.create(client,
-            secondaryAddressFinder: secondaryAddressFinder)
-        : await notificationServiceBuilder(client);
-    client.syncService = syncServiceBuilder == null
-        ? await SyncServiceImpl.create(client)
-        : await syncServiceBuilder(client);
-    client.enrollmentService = enrollmentServiceBuilder == null
-        ? EnrollmentServiceImpl(client, AtEnrollment.create())
-        : await enrollmentServiceBuilder(client);
+    // The client is already filed in `AtClientImpl.atClientInstanceMap` by the
+    // time the services are wired, so a throw here would leave an entry no
+    // caller holds a reference to, still claiming its storage. `stop()`
+    // unfiles it and releases that claim.
+    try {
+      client.notificationService = notificationServiceBuilder == null
+          ? await NotificationServiceImpl.create(client,
+              secondaryAddressFinder: secondaryAddressFinder)
+          : await notificationServiceBuilder(client);
+      client.syncService = syncServiceBuilder == null
+          ? await SyncServiceImpl.create(client)
+          : await syncServiceBuilder(client);
+      client.enrollmentService = enrollmentServiceBuilder == null
+          ? EnrollmentServiceImpl(client, AtEnrollment.create())
+          : await enrollmentServiceBuilder(client);
+    } catch (_) {
+      await client.stop();
+      rethrow;
+    }
     return client;
   }
 

--- a/packages/at_client/lib/src/client/remote_secondary.dart
+++ b/packages/at_client/lib/src/client/remote_secondary.dart
@@ -1,6 +1,13 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:at_auth/at_auth.dart'
+    show
+        AtKeysIo,
+        authenticatorFor,
+        authenticatorForChops,
+        authenticatorForCramSecret,
+        authenticatorForPrivateKey;
 import 'package:at_chops/at_chops.dart';
 import 'package:at_client/src/client/secondary.dart';
 import 'package:at_client/src/manager/at_client_manager.dart';
@@ -9,7 +16,7 @@ import 'package:at_client/src/preference/at_client_preference.dart';
 import 'package:at_client/src/util/at_client_util.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_commons/at_commons.dart';
-import 'package:at_lookup/at_lookup.dart';
+import 'package:at_lookup/at_lookup_io.dart';
 import 'package:at_utils/at_utils.dart';
 import 'package:internet_connection_checker/internet_connection_checker.dart';
 
@@ -30,13 +37,96 @@ class RemoteSecondary implements Secondary {
   set atChops(AtChops? value) {
     _atChops = value;
     atLookUp.atChops = value;
+    _installAuthenticator();
+  }
+
+  /// The keystore an authenticator reads, when this client was given one.
+  AtKeysIo? _atKeysIo;
+
+  /// The legacy credential, for a client that was given no keystore.
+  String? _privateKey;
+  String? _cramSecret;
+
+  /// Hands the lookup an authenticator, so authentication is decided from the
+  /// keystore rather than from credentials parked on at_lookup.
+  ///
+  /// Called from the constructor as well as the [atChops] setter, because the
+  /// constructor sets `atLookUp.atChops` directly - hooking only the setter
+  /// installs nothing on the path that matters.
+  ///
+  /// Installed beside `atChops`, not instead of it: at_auth's
+  /// `EnrollmentApprover` reads that field for enrollment crypto, which is not
+  /// authentication.
+  void _installAuthenticator() {
+    final lookUp = atLookUp;
+    // `AtLookUp` does not declare the seam - that interface is frozen because
+    // mocks implement it - so any other implementation keeps its behaviour.
+    if (lookUp is! AtLookupMuxable) {
+      return;
+    }
+
+    final io = _atKeysIo;
+    if (io != null) {
+      lookUp.authenticator = authenticatorFor(
+        io,
+        _atSign,
+        enrollmentId: lookUp.enrollmentId,
+        chops: _atChops,
+      );
+      return;
+    }
+
+    // No keystore. The order from here is the ladder's own - atChops, then
+    // privateKey, then cramSecret - so a client holding more than one
+    // authenticates with the same credential it did before. That precedence is
+    // stated rather than fallen into.
+    final chops = _atChops;
+    if (chops != null) {
+      lookUp.authenticator = authenticatorForChops(
+        _atSign,
+        chops,
+        enrollmentId: lookUp.enrollmentId,
+        signingAlgo: _preference.signingAlgoType,
+        // The same preference fields the constructor stamps on the lookup, so
+        // the authenticator and the ladder it replaces read them alike.
+        hashingAlgo: _preference.hashingAlgoType,
+      );
+      return;
+    }
+
+    // The legacy credential, and precisely the caller the ladder existed for.
+    // Without this, deleting the ladder would make a keystore mandatory.
+    final privateKey = _privateKey;
+    if (privateKey != null) {
+      lookUp.authenticator = authenticatorForPrivateKey(
+        _atSign,
+        privateKey,
+        enrollmentId: lookUp.enrollmentId,
+      );
+      return;
+    }
+
+    // Nothing in this tree sets `preference.cramSecret` - every in-tree CRAM
+    // goes through onboarding, which builds its own lookup - but the field is
+    // public API, so a consumer that set it kept working through the ladder
+    // and must keep working through the seam.
+    final cramSecret = _cramSecret;
+    if (cramSecret != null) {
+      lookUp.authenticator = authenticatorForCramSecret(_atSign, cramSecret);
+      return;
+    }
+
+    // None of the four: nothing to authenticate with, so nothing is
+    // installed. That is a real mode - at_server_status holds no key material
+    // at all, and an OTP enrollment submit routes through auth: false.
   }
 
   RemoteSecondary(String atSign, AtClientPreference preference,
       {String? privateKey,
       AtChops? atChops,
       AtLookUp? atLookUp,
-      String? enrollmentId}) {
+      String? enrollmentId,
+      AtKeysIo? atKeysIo}) {
     _atSign = AtUtils.fixAtSign(atSign);
     logger = AtSignLogger('RemoteSecondary ($_atSign)');
     _preference = preference;
@@ -46,20 +136,30 @@ class RemoteSecondary implements Secondary {
       ..pathToCerts = preference.pathToCerts
       ..tlsKeysSavePath = preference.tlsKeysSavePath;
     _atChops = atChops;
+    _atKeysIo = atKeysIo;
+    _privateKey = privateKey;
+    _cramSecret = preference.cramSecret;
+    // privateKey and cramSecret are no longer set ON the lookup: both are
+    // credentials, and credentials now travel as an authenticator, which
+    // _installAuthenticator supplies below from whichever of the four shapes
+    // this client actually holds.
     this.atLookUp = atLookUp ??
-        AtLookupImpl(atSign, preference.rootDomain, preference.rootPort,
-            privateKey: privateKey,
-            cramSecret: preference.cramSecret,
-            secondaryAddressFinder:
-                AtClientManager.getInstance().secondaryAddressFinder,
-            secureSocketConfig: secureSocketConfig,
-            clientConfig: _getClientConfig());
+        AtLookUp.withSecureSocket(
+          atSign: atSign,
+          rootDomain: AtRootDomain(preference.rootDomain, preference.rootPort),
+          transport: secureSocketTransport(secureSocketConfig),
+          authenticator: null,
+          secondaryAddressFinder:
+              AtClientManager.getInstance().secondaryAddressFinder,
+          clientConfig: _getClientConfig(),
+        );
     this.atLookUp.enrollmentId = enrollmentId;
     logger.finer(
         'signingAlgoType: ${preference.signingAlgoType} hashingAlgoType: ${preference.hashingAlgoType}');
     this.atLookUp.signingAlgoType = preference.signingAlgoType;
     this.atLookUp.hashingAlgoType = preference.hashingAlgoType;
     this.atLookUp.atChops = atChops;
+    _installAuthenticator();
   }
 
   Map<String, String> _getClientConfig() {

--- a/packages/at_client/lib/src/manager/at_client_manager.dart
+++ b/packages/at_client/lib/src/manager/at_client_manager.dart
@@ -207,7 +207,9 @@ class AtClientManager {
   /// ([session.atLookUp]) and skip the second handshake — the perf escape hatch.
   /// When false (default) the client opens its own fresh socket.
   ///
-  /// [storage] is borrowed rather than owned, exactly as on [setCurrentAtSign].
+  /// [storage] is borrowed unless it was built with `closedByClient: true`, in
+  /// which case the client closes it on [AtClient.stop]. Same rule as on
+  /// [setCurrentAtSign].
   Future<AtClientManager> fromAuthSession(
       AtAuthSession session, AtClientPreference preference,
       {AtServiceFactory? serviceFactory,

--- a/packages/at_client/lib/src/manager/monitor.dart
+++ b/packages/at_client/lib/src/manager/monitor.dart
@@ -23,8 +23,9 @@ import 'package:at_utils/at_logger.dart';
 /// this file, with a comment explaining why.
 ///
 /// All of it now lives once, in [AtLookupMuxable]. What remains here is what
-/// was only ever Monitor's: the watermark, the notification callback, and the
-/// two states.
+/// only this class can do: the watermark, the notification callback, the two
+/// states, the retry of a first connect that failed, and the check for a
+/// connection that is up and answering but delivering nothing.
 class Monitor {
   NotificationListenerState _currentState =
       NotificationListenerState.notConnected;
@@ -51,21 +52,40 @@ class Monitor {
   ///
   /// Hand this a **fresh** instance to keep today's two-connection
   /// arrangement, or the one `RemoteSecondary` already holds to collapse them
-  /// into one. ⚠️ Sharing is not safe yet, and that is not a matter of taste:
-  /// no atServer implements `monitor:multiplexed`, so nothing holds a
+  /// into one. ⚠️ Sharing is not safe yet, and that is not a matter of taste.
+  /// No atServer implements `monitor:multiplexed`, so nothing holds a
   /// notification back while a verb response is in flight, and one written
-  /// into the middle of a response is absorbed into it.
+  /// into the middle of a response is absorbed into it. Second reason:
+  /// [_onNotification] pauses this connection while it hands a notification
+  /// on, so on a shared one the handler's own put would wait for a response
+  /// on the socket it has just paused.
   final AtLookupMuxable lookUp;
 
   Future<void> Function(String jsonEncoded) handleNotification;
 
   Future<int?> Function() getLastNotificationTime;
 
-  /// When the last notification arrived. Read by callers checking liveness.
+  /// When the last notification arrived, or null before the first.
   DateTime? lastReceipt;
 
   StreamSubscription<String>? _notificationSubscription;
   StreamSubscription<bool>? _connectionSubscription;
+
+  /// Rebuilds a connection that answers heartbeats while delivering nothing.
+  ///
+  /// [lookUp] recovers a connection that DROPS - the socket ends, or a
+  /// heartbeat goes unanswered - and that is the whole of what it can see. A
+  /// socket that stays up and answers every noop while the atServer has
+  /// stopped delivering on it looks healthy from there, and the client sits
+  /// reporting `listening` while permanently deaf. Only this class knows when
+  /// a notification last arrived, so only this class can tell the difference.
+  ///
+  /// Rebuilding means [stopNotifications] then [startNotifications] through
+  /// the same seam [start] uses; the reconnect backoff stays at_lookup's.
+  Timer? _silenceTimer;
+
+  /// When the connection last came up, or null while it is down.
+  DateTime? _connectedAt;
 
   /// Serialises [start] and [stop] so their bodies cannot interleave.
   ///
@@ -185,6 +205,7 @@ class Monitor {
         return;
       }
       _startRetryIx = 0;
+      _armSilenceTimer();
       logger.info('monitor started');
     } catch (e) {
       logger.warning('Failed to start notifications: $e');
@@ -208,17 +229,62 @@ class Monitor {
   }
 
   void _onConnectionState(bool up) {
+    // The budget restarts with the connection: a reconnect that has delivered
+    // nothing yet is not evidence of silence.
+    _connectedAt = up ? DateTime.now().toUtc() : null;
+    if (up) lastReceipt = null;
     _setCurrentState(up
         ? NotificationListenerState.listening
         : NotificationListenerState.notConnected);
   }
 
+  void _armSilenceTimer() {
+    _silenceTimer?.cancel();
+    final budget = atClientPreference.monitorSilenceTimeout;
+    if (budget <= Duration.zero) return;
+    _silenceTimer = Timer.periodic(budget, (_) => _checkSilence());
+  }
+
+  void _checkSilence() {
+    if (_targetState != NotificationListenerState.listening) return;
+    final connectedAt = _connectedAt;
+    // Down is at_lookup's to recover, and it is already doing so.
+    if (connectedAt == null) return;
+    final budget = atClientPreference.monitorSilenceTimeout;
+    final now = DateTime.now().toUtc();
+    if (now.difference(connectedAt) <= budget) return;
+    final last = lastReceipt;
+    if (last != null && now.difference(last) <= budget) return;
+    logger.warning('nothing received for $budget on a connection that is up '
+        '- rebuilding it');
+    _enqueue(_rebuild);
+  }
+
+  Future<void> _rebuild() async {
+    await _teardown();
+    await _start();
+  }
+
   Future<void> _onNotification(String notification) async {
     lastReceipt = DateTime.now().toUtc();
+    // Paused for the duration of the handler, as the socket-owning Monitor
+    // was. `listen` discards the future an async callback returns, so without
+    // this two notifications are handled at once: the watermark is written out
+    // of arrival order, and a reconnect's retained backlog arrives as fast as
+    // the atServer can send rather than as fast as this client can absorb.
+    // at_lookup carries the pause down to the socket.
+    //
+    // NOTE Safe only while [lookUp] is this monitor's own: on one shared with
+    // RemoteSecondary the handler's own put would wait for a response on the
+    // socket it has just paused.
+    final subscription = _notificationSubscription;
+    subscription?.pause();
     try {
       await handleNotification(notification);
     } catch (e, st) {
       logger.shout('Caught $e while handling $notification\n$st');
+    } finally {
+      subscription?.resume();
     }
   }
 
@@ -238,10 +304,14 @@ class Monitor {
     _startRetry?.cancel();
     _startRetry = null;
     _startRetryIx = 0;
+    _silenceTimer?.cancel();
+    _silenceTimer = null;
     _enqueue(_stop);
   }
 
-  Future<void> _stop() async {
+  Future<void> _stop() => _teardown();
+
+  Future<void> _teardown() async {
     // Stop first, then cancel. `stopNotifications` closes the notification
     // stream, and a subscriber that has already gone gets no done event -
     // harmless here, but the order also means the muxable emits its final
@@ -251,6 +321,7 @@ class Monitor {
     _notificationSubscription = null;
     await _connectionSubscription?.cancel();
     _connectionSubscription = null;
+    _connectedAt = null;
     _setCurrentState(NotificationListenerState.notConnected);
   }
 }

--- a/packages/at_client/lib/src/manager/monitor.dart
+++ b/packages/at_client/lib/src/manager/monitor.dart
@@ -1,34 +1,31 @@
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-import 'dart:typed_data';
 
-import 'package:at_chops/at_chops.dart';
-import 'package:at_client/at_client.dart';
-import 'package:at_client/src/response/default_response_parser.dart';
-import 'package:at_client/src/response/response.dart' show AtResponse;
-import 'package:at_commons/at_builders.dart';
+import 'package:at_client/src/preference/at_client_preference.dart';
+import 'package:at_client/src/service/notification_service.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:at_utils/at_logger.dart';
-import 'package:meta/meta.dart';
-import 'package:mutex/mutex.dart';
 
+/// Receives notifications from the atServer.
 ///
-/// A [Monitor] object is used to receive notifications from the secondary server.
+/// [start] runs until [stop] is called, surviving network weather. Two
+/// statuses are surfaced: [currentState] (what is true now) and [targetState]
+/// (what was asked for).
 ///
-/// When [start] is called, the expectation is that the Monitor will run
-/// constantly, reconnecting as required by network weather, until [stop] is
-/// called.
+/// ## What this class no longer does
 ///
-/// There are two statuses:
-/// [currentState] : the current status (listening / notConnected)
-/// [targetState] : the target status (listening / notConnected)
+/// It used to open its own socket, authenticate it with PKAM, buffer the
+/// bytes, frame them, strip prompts, check for overflow, heartbeat the
+/// connection and reconnect it on an
+/// `[1, 2, 3, 5, 8, 13, 21, 34]`-second backoff. Every one of those existed
+/// twice - once here and once in at_lookup - and the duplication was being
+/// paid for in current work, not historical work: at_lookup's own
+/// `authenticatedAsEnrollmentId` change had to be written a second time in
+/// this file, with a comment explaining why.
+///
+/// All of it now lives once, in [AtLookupMuxable]. What remains here is what
+/// was only ever Monitor's: the watermark, the notification callback, and the
+/// two states.
 class Monitor {
-  /// Capacity is represented in bytes.
-  /// Throws [BufferOverFlowException] if data size exceeds 10MB.
-  final _buffer = ByteBuffer(capacity: 10240000);
-
-  // Monitor connection status
   NotificationListenerState _currentState =
       NotificationListenerState.notConnected;
   NotificationListenerState _targetState =
@@ -43,501 +40,174 @@ class Monitor {
 
   Stream<NotificationListenerState> get currentStateStream =>
       currentStateStreamController.stream;
+
   late final AtSignLogger logger;
 
   final String atSign;
+
+  final AtClientPreference atClientPreference;
+
+  /// The connection, and everything that keeps it alive.
+  ///
+  /// Hand this a **fresh** instance to keep today's two-connection
+  /// arrangement, or the one `RemoteSecondary` already holds to collapse them
+  /// into one. ⚠️ Sharing is not safe yet, and that is not a matter of taste:
+  /// no atServer implements `monitor:multiplexed`, so nothing holds a
+  /// notification back while a verb response is in flight, and one written
+  /// into the middle of a response is absorbed into it.
+  final AtLookupMuxable lookUp;
 
   Future<void> Function(String jsonEncoded) handleNotification;
 
   Future<int?> Function() getLastNotificationTime;
 
-  SecondaryAddressFinder secondaryAddressFinder;
-
-  late AtClientPreference atClientPreference;
-
-  OutboundConnection? _monitorConnection;
-  StreamSubscription<Uint8List>? _monitorSocketSubscription;
-  Completer? _connectionDoneCompleter;
-
-  final DefaultResponseParser _defaultResponseParser = DefaultResponseParser();
-
-  late final MonitorOutboundConnectionFactory monitorOutboundConnectionFactory;
-
-  final AtChops? atChops;
-
-  final String? enrollmentId;
-
-  final int newLineCodeUnit = 10;
-  final int atCharCodeUnit = 64;
-
-  Timer? heartbeatTimer;
+  /// When the last notification arrived. Read by callers checking liveness.
   DateTime? lastReceipt;
-  DateTime? connectedAt;
 
-  static const defaultCommandTimeout = Duration(milliseconds: 2500);
+  StreamSubscription<String>? _notificationSubscription;
+  StreamSubscription<bool>? _connectionSubscription;
 
-  static const List<Duration> defaultConnectDelays = [
-    Duration(seconds: 1),
-    Duration(seconds: 2),
-    Duration(seconds: 3),
-    Duration(seconds: 5),
-    Duration(seconds: 8),
-    Duration(seconds: 13),
-    Duration(seconds: 21),
-    Duration(seconds: 34),
-  ];
+  /// Serialises [start] and [stop] so their bodies cannot interleave.
+  ///
+  /// Both are fire-and-forget to the caller and both await at_lookup partway
+  /// through, so without this a `stop()` immediately followed by a `start()`
+  /// runs the subscribe step of one while the teardown of the other is still
+  /// in flight. `stopNotifications` closes at_lookup's controllers and builds
+  /// fresh ones on next use, so the interleaving left this class holding
+  /// subscriptions to the CLOSED pair while at_lookup connected and notified
+  /// into the new ones - a monitor that is connected at one end and deaf at
+  /// the other, reporting `notConnected` for ever.
+  ///
+  /// `NotificationService.stopListening()`/`startListening()` expose exactly
+  /// that pair to application code, and the failure is silent: it looks like
+  /// an atServer with nothing to say.
+  Future<void> _lifecycle = Future<void>.value();
 
-  List<Duration> connectDelays;
-  int delayIx = 0;
+  void _enqueue(Future<void> Function() step) {
+    _lifecycle =
+        _lifecycle.then((_) => step()).catchError((Object e, StackTrace st) {
+      logger.shout('Monitor lifecycle step failed: $e\n$st');
+    });
+  }
 
   Monitor({
     required this.atSign,
     required this.atClientPreference,
-    required this.atChops,
-    required this.enrollmentId,
-    required this.secondaryAddressFinder,
+    required this.lookUp,
     required this.handleNotification,
     required this.getLastNotificationTime,
-    this.connectDelays = defaultConnectDelays,
-    MonitorOutboundConnectionFactory? monitorOutboundConnectionFactory,
   }) {
     logger = AtSignLogger('Monitor ($atSign)');
-    logger.finer('enrollmentId: $enrollmentId');
-    this.monitorOutboundConnectionFactory =
-        monitorOutboundConnectionFactory ?? MonitorOutboundConnectionFactory();
   }
 
-  /// - Sets [targetState] to `listening`. Throws a [StateError] if
-  /// [targetState] is already `listening`, or [currentState] is already `listening`
+  /// Sets [targetState] to `listening` and asks the atServer to start sending.
   ///
-  /// - Start a keep alive loop as follows:
-  /// - while [targetState] is `listening`
-  ///   - connect
-  ///   - startHeartbeat
-  ///   - wait for done
-  ///   - stopHeartbeat
-  ///   - if [targetState] is still `listening`, wait for a little time, with
-  ///     exponential backoff 1, 2, 3, 5, 8, 13, 21, 34 seconds and then 34
-  ///     seconds each time, resetting to 1 once a connection is successful.
+  /// Reconnection is [lookUp]'s, so this does not loop: it subscribes once and
+  /// the connection state arrives as events.
   void start() {
     if (targetState == NotificationListenerState.listening) {
       logger.shout('start() called, but targetState is already "listening"');
       return;
     }
-
     _targetState = NotificationListenerState.listening;
-
-    Future.delayed(Duration(milliseconds: 0), () {
-      stayConnected();
-    });
+    _enqueue(_start);
   }
 
-  /// - If there's a heartbeatTimer running, cancel it
-  /// - close the [_monitorConnection]
-  /// - set [currentState] to `notConnected`
-  Future<void> closeConnection() async {
-    logger.finer('closeConnection called');
-    // stop heartbeat
-    stopHeartbeat();
-
-    if (_monitorConnection != null) {
-      logger.finer('closeConnection: closing non-null _monitorConnection');
-      await _monitorConnection!.close();
-
-      _monitorConnection = null;
-    } else {
-      logger.finer(
-          'closeConnection: _monitorConnection is null, no need to close');
-    }
-
-    if (_connectionDoneCompleter != null &&
-        !_connectionDoneCompleter!.isCompleted) {
-      logger.finer('closeConnection: Completing _connectionDoneCompleter');
-      _connectionDoneCompleter!.complete();
-    } else {
-      logger.finer(
-          'closeConnection: _connectionDoneCompleter is null or already complete,'
-          ' no need to complete');
-    }
-
-    logger.finer('closeConnection: Setting currentState notConnected');
-    _currentState = NotificationListenerState.notConnected;
-    currentStateStreamController.add(_currentState);
-    connectedAt = null;
-  }
-
-  /// Stops the monitor. Call [Monitor.start] to start it again.
-  /// - set [targetState] to `notConnected`
-  /// - calls [closeConnection]
-  void stop() {
-    logger.info('stop() called. Setting targetState to notConnected,'
-        ' and calling closeConnection()');
-    _targetState = NotificationListenerState.notConnected;
-
-    closeConnection();
-  }
-
-  void startHeartbeat() {
-    if (heartbeatTimer != null) {
-      logger.warning('startHeartbeat called but heartbeatTimer exists');
-      logger.warning('cancelling timer and restarting');
-      stopHeartbeat();
-    }
-    logger.info('Starting heartbeat');
-
-    heartbeatTimer = Timer(
-      atClientPreference.monitorHeartbeatInterval,
-      _heartbeat,
+  Future<void> _start() async {
+    // Subscribed before `monitor:` goes out, not after. The notification
+    // stream buffers, so nothing is lost either way, but the connection-state
+    // stream is broadcast and does not replay - attaching afterwards would
+    // miss the very "up" this call is about to cause.
+    _connectionSubscription ??=
+        lookUp.notificationConnectionUp.listen(_onConnectionState);
+    _notificationSubscription ??= lookUp.notifications.listen(
+      _onNotification,
+      onError: (Object e) =>
+          logger.warning('Error on the notification stream: $e'),
     );
-  }
 
-  void stopHeartbeat() {
-    if (heartbeatTimer != null) {
-      logger.info('Stopping heartbeat');
-      heartbeatTimer!.cancel();
-      heartbeatTimer = null;
-    }
-  }
-
-  /// - while [targetState] is `listening`
-  ///   - connect, authenticate, issue monitor command
-  ///   - startHeartbeat
-  ///   - wait for done
-  ///   - stopHeartbeat
-  ///   - if [targetState] is still `listening`, wait for a little time, with
-  ///     exponential backoff 1, 2, 3, 5, 8, 13, 21, 34 seconds and then 34
-  ///     seconds each time, resetting to 1 once a connection is successful.
-  @visibleForTesting
-  Future<void> stayConnected() async {
-    while (targetState == NotificationListenerState.listening) {
-      if (_monitorConnection != null) {
-        throw StateError('_monitorConnection should be null');
-      }
-      if (_connectionDoneCompleter != null) {
-        throw StateError('_connectionDoneCompleter should be null');
-      }
+    // Its own guard: reading the watermark is a local keystore operation, not
+    // part of connecting, so a failure here must neither be reported as nor
+    // abort a failed connection. Starting without one costs a replayed window.
+    //
+    // Handed down as the FUNCTION, not as a value read once here. The muxable
+    // owns reconnection now, and it asks again on every reconnect - so the
+    // command carries where this client has actually got to. Reading it here
+    // and passing the number would pin every later reconnect to the position
+    // held at start, re-requesting the whole retained backlog each time.
+    Future<int?> currentWatermark() async {
       try {
-        logger.info('Connecting');
-        _connectionDoneCompleter = Completer();
-        // connect
-        _monitorConnection =
-            await monitorOutboundConnectionFactory.createConnection(
-                await secondaryAddressFinder.findSecondary(atSign),
-                decryptPackets: atClientPreference.decryptPackets,
-                pathToCerts: atClientPreference.pathToCerts,
-                tlsKeysSavePath: atClientPreference.tlsKeysSavePath);
-
-        logger.finer('Connection created');
-        runZonedGuarded(() {
-          logger.finer('Calling listen');
-          _monitorSocketSubscription = _monitorConnection!.getSocket().listen(
-            onSocketDataReceipt,
-            onDone: () {
-              if (_connectionDoneCompleter != null &&
-                  !_connectionDoneCompleter!.isCompleted) {
-                _connectionDoneCompleter!.complete();
-              }
-            },
-            onError: (e) {
-              if (_connectionDoneCompleter != null &&
-                  !_connectionDoneCompleter!.isCompleted) {
-                _connectionDoneCompleter!.complete();
-              }
-            },
-          );
-        }, (Object error, StackTrace st) {
-          logger.shout('runZonedGuarded onError $error\nStack Trace:\n$st');
-          if (_connectionDoneCompleter != null &&
-              !_connectionDoneCompleter!.isCompleted) {
-            logger.shout('runZonedGuarded onError - completing doneCompleter');
-            _connectionDoneCompleter!.complete();
-          }
-        });
-
-        int? lastNotificationTime = await getLastNotificationTime();
-
-        // authenticate
-        await _authenticateConnection();
-
-        // issue monitor command
-        var cmd = (MonitorVerbBuilder()
-              ..selfNotificationsEnabled = (true)
-              ..regex = (null)
-              ..lastNotificationTime = lastNotificationTime)
-            .buildCommand();
-        logger.info('SENDING: ${cmd.trim()}');
-        await _monitorConnection!.write(cmd);
-
-        logger.info(
-            'monitor started, last notification time: $lastNotificationTime');
-
-        logger.finer('stayConnected: Setting currentState listening');
-        _currentState = NotificationListenerState.listening;
-        currentStateStreamController.add(_currentState);
-        connectedAt = DateTime.now();
-      } on SocketException catch (e) {
-        logger.info('Failed to connect: ${e.message}');
-        await closeConnection();
-        _connectionDoneCompleter = null;
+        return await getLastNotificationTime();
       } catch (e) {
-        logger.info('Failed to connect: $e');
-        await closeConnection();
-        _connectionDoneCompleter = null;
+        logger.warning('Could not read the last-notification watermark, so the '
+            'monitor is (re)starting without one: $e');
+        return null;
       }
-
-      if (currentState == NotificationListenerState.listening) {
-        delayIx = 0;
-
-        // start heartbeat
-        startHeartbeat();
-
-        // wait for connection done
-        logger.info('stayConnected(): Waiting for Socket done');
-        await _connectionDoneCompleter!.future;
-        _connectionDoneCompleter = null;
-        logger.info('stayConnected() : Socket done');
-
-        await closeConnection(); // also stops heartbeat
-      }
-
-      // if [targetStatus] is still `listening`, wait before continuing
-      if (targetState == NotificationListenerState.listening) {
-        logger.info('Will attempt reconnect in ${connectDelays[delayIx]}');
-        await Future.delayed(connectDelays[delayIx]);
-        if (delayIx < (connectDelays.length - 1)) {
-          delayIx++;
-        }
-      } else {
-        logger.info('targetState is $targetState - will not auto reconnect');
-      }
-    }
-
-    logger.info('stayConnected() complete - monitor stopped');
-  }
-
-  final Duration aMinute = const Duration(seconds: 60);
-
-  /// Heartbeat checking
-  ///
-  /// - Send a heartbeat on the connection, wait for response
-  /// - If response received
-  ///   - if we've been connected for >= 60 seconds, verify we've received a
-  ///   notification within that time. (Server currently always sends
-  ///   statsNotifications - in future it will send small heartbeat
-  ///   notifications once every 30 seconds)
-  ///   - set the Timer for the next heartbeat
-  /// - else
-  ///   - close the connection
-  void _heartbeat() async {
-    if (currentState != NotificationListenerState.listening) {
-      logger.info("status is $currentState : heartbeat will not be sent");
-    } else {
-      logger.finer("sending heartbeat");
-      try {
-        final AtResponse r = await sendCommand(
-          "noop:0\n",
-          timeout: atClientPreference.monitorHeartbeatResponseTimeout,
-          logInfo: false,
-        );
-        logger.finer('Received heartbeat response: ${r.response}');
-
-        DateTime now = DateTime.now().toUtc();
-        // if we've been connected for over a minute
-        if (connectedAt != null && now.difference(connectedAt!) > aMinute) {
-          // and we've either received no notification, or last notification
-          // was received over a minute ago
-          if (lastReceipt == null || now.difference(lastReceipt!) > aMinute) {
-            throw Exception('No notification received in past minute');
-          } else {
-            logger.info('Heartbeat OK: lastReceipt $lastReceipt');
-          }
-        }
-        heartbeatTimer = Timer(
-          atClientPreference.monitorHeartbeatInterval,
-          _heartbeat,
-        );
-      } on TimeoutException {
-        logger.info('No heartbeat response after'
-            ' ${atClientPreference.monitorHeartbeatResponseTimeout}'
-            ' - closing unresponsive connection to atServer');
-        await closeConnection();
-      } catch (e) {
-        logger.info('Heartbeat exception $e - closing connection to atServer');
-        await closeConnection();
-      }
-    }
-  }
-
-  Future<void> _authenticateConnection() async {
-    logger.finer('Authenticating');
-    if (atChops == null) {
-      throw AtClientException.message(
-          'cannot authenticate monitor connection without at_chops set');
-    }
-    AtResponse fromResponse =
-        await sendCommand('from:$atSign\n', logInfo: true);
-
-    if (fromResponse.isError) {
-      throw UnAuthenticatedException('Bad "from" response: $fromResponse');
-    }
-
-    final atSigningInput = AtSigningInput(fromResponse.response)
-      ..signingAlgoType = atClientPreference.signingAlgoType
-      ..hashingAlgoType = atClientPreference.hashingAlgoType
-      ..signingMode = AtSigningMode.pkam;
-
-    var signingResult = atChops!.sign(atSigningInput);
-
-    var pkamBuilder = PkamVerbBuilder()
-      ..signingAlgo = atClientPreference.signingAlgoType.name
-      ..hashingAlgo = atClientPreference.hashingAlgoType.name
-      ..enrollmentlId = enrollmentId
-      ..signature = signingResult.result;
-
-    AtResponse pkamResponse = await sendCommand(
-      pkamBuilder.buildCommand(),
-      logInfo: true,
-    );
-    if (pkamResponse.isError || pkamResponse.response != 'success') {
-      throw UnAuthenticatedException('Bad "pkam" response: $fromResponse');
-    }
-
-    logger.info('Monitor connection authentication successful');
-  }
-
-  @visibleForTesting
-  Completer<AtResponse>? requestCompleter;
-
-  Mutex sendCommandMutex = Mutex();
-
-  @visibleForTesting
-  Future<AtResponse> sendCommand(
-    String command, {
-    Duration timeout = defaultCommandTimeout,
-    required bool logInfo,
-  }) async {
-    if (_monitorConnection == null) {
-      throw StateError('No connection, cannot send command');
-    }
-    if (!command.endsWith('\n')) {
-      throw ArgumentError('Commands must be terminated with \\n');
-    }
-    if (logInfo) {
-      logger.info('Sending: ${command.trim()}');
-    } else {
-      logger.finer('Sending: ${command.trim()}');
     }
 
     try {
-      await sendCommandMutex.acquire();
-      requestCompleter = Completer();
-
-      await _monitorConnection!.write(command);
-
-      return await requestCompleter!.future.timeout(timeout);
-    } finally {
-      sendCommandMutex.release();
-      requestCompleter = null;
+      await lookUp.startNotifications(
+          getLastNotificationTime: currentWatermark);
+      // Re-checked AFTER the await, not only before it. stop() can land while
+      // this is in flight - it sets targetState and tears down, and then this
+      // await completes and puts the connection straight back up. The old
+      // implementation needed a done-completer to close the same race; here it
+      // is one comparison, but it is just as necessary.
+      if (_targetState != NotificationListenerState.listening) {
+        logger.info('stop() arrived while starting - tearing down again');
+        await lookUp.stopNotifications();
+        return;
+      }
+      logger.info('monitor started');
+    } catch (e) {
+      // Not fatal, and deliberately not retried here: the muxable reconnects
+      // on its own backoff, and a second retry loop on top of it would
+      // compound the delays rather than shorten them.
+      logger.warning('Failed to start notifications: $e');
     }
   }
 
-  Future<void> handleAtServerResponse(String response) async {
+  void _onConnectionState(bool up) {
+    _setCurrentState(up
+        ? NotificationListenerState.listening
+        : NotificationListenerState.notConnected);
+  }
+
+  Future<void> _onNotification(String notification) async {
+    lastReceipt = DateTime.now().toUtc();
     try {
-      logger.finer('received response on monitor: $response');
-      if (response.toString().startsWith('notification:')) {
-        lastReceipt = DateTime.now().toUtc();
-        await handleNotification(response);
-      } else {
-        if (requestCompleter != null && !requestCompleter!.isCompleted) {
-          requestCompleter!.complete(_defaultResponseParser.parse(response));
-        } else {
-          logger.shout('Received response on monitor: $response'
-              ' but have nowhere to send it');
-        }
-      }
+      await handleNotification(notification);
     } catch (e, st) {
-      logger.shout('Caught $e while handling received message $response');
-      logger.shout('Stack Trace:\n$st');
+      logger.shout('Caught $e while handling $notification\n$st');
     }
   }
 
-  /// Handles messages on the inbound client's connection.
-  /// Closes the inbound connection in case of any error.
-  /// Throw a [BufferOverFlowException] if buffer is unable to hold incoming data
-  @visibleForTesting
-  Future<void> onSocketDataReceipt(dynamic data) async {
-    _monitorSocketSubscription?.pause();
-    try {
-      // check buffer overflow
-      _checkBufferOverFlow(data);
-
-      // Loop from last index to until the end of data.
-      // If a new line character is found, then it is end
-      // of server response. process the data.
-      // Else add the byte to buffer.
-      for (int element = 0; element < data.length; element++) {
-        // If it's a '\n' then complete data has been received. process it.
-        if (data[element] == newLineCodeUnit) {
-          String result = '';
-          String doing = '';
-          try {
-            doing = '_messageHandler:utf8.decode data';
-            result = utf8.decode(_buffer.getData().toList());
-
-            doing = '_messageHandler:_stripPrompt';
-            result = _stripPrompt(result);
-            logger.finer('RECEIVED $result');
-
-            doing = '_messageHandler:_handleResponse';
-            await handleAtServerResponse(result);
-          } catch (e) {
-            logger.shout('$e from $doing while handling $result');
-          } finally {
-            _buffer.clear();
-          }
-        } else {
-          _buffer.addByte(data[element]);
-        }
-      }
-    } finally {
-      _monitorSocketSubscription?.resume();
+  void _setCurrentState(NotificationListenerState state) {
+    if (_currentState == state) return;
+    logger.finer('currentState: $_currentState -> $state');
+    _currentState = state;
+    if (!currentStateStreamController.isClosed) {
+      currentStateStreamController.add(_currentState);
     }
   }
 
-  void _checkBufferOverFlow(dynamic data) {
-    if (_buffer.isOverFlow(data)) {
-      int bufferLength = (_buffer.length() + data.length) as int;
-      _buffer.clear();
-      throw BufferOverFlowException(
-          'data length exceeded the buffer limit. Data length : $bufferLength and Buffer capacity ${_buffer.capacity}');
-    }
+  /// Stops the monitor. Call [start] to start it again.
+  void stop() {
+    logger.info('stop() called. Setting targetState to notConnected');
+    _targetState = NotificationListenerState.notConnected;
+    _enqueue(_stop);
   }
 
-  String _stripPrompt(String result) {
-    var colonIndex = result.indexOf(':');
-    if (colonIndex == -1) {
-      return result;
-    }
-    var responsePrefix = result.substring(0, colonIndex);
-    var response = result.substring(colonIndex);
-    if (responsePrefix.contains('@')) {
-      responsePrefix =
-          responsePrefix.substring(responsePrefix.lastIndexOf('@') + 1);
-    }
-    return '$responsePrefix$response';
-  }
-}
-
-class MonitorOutboundConnectionFactory {
-  Future<OutboundConnection> createConnection(SecondaryAddress address,
-      {decryptPackets, pathToCerts, tlsKeysSavePath}) async {
-    SecureSocketConfig secureSocketConfig = SecureSocketConfig();
-    secureSocketConfig.decryptPackets = decryptPackets;
-    secureSocketConfig.pathToCerts = pathToCerts;
-    secureSocketConfig.tlsKeysSavePath = tlsKeysSavePath;
-
-    SecureSocket secureSocket = await SecureSocketUtil.createSecureSocket(
-        address.host, address.port.toString(), secureSocketConfig);
-    return OutboundConnectionImpl(secureSocket);
+  Future<void> _stop() async {
+    // Stop first, then cancel. `stopNotifications` closes the notification
+    // stream, and a subscriber that has already gone gets no done event -
+    // harmless here, but the order also means the muxable emits its final
+    // `false` while this is still listening for it.
+    await lookUp.stopNotifications();
+    await _notificationSubscription?.cancel();
+    _notificationSubscription = null;
+    await _connectionSubscription?.cancel();
+    _connectionSubscription = null;
+    _setCurrentState(NotificationListenerState.notConnected);
   }
 }

--- a/packages/at_client/lib/src/manager/monitor.dart
+++ b/packages/at_client/lib/src/manager/monitor.dart
@@ -83,6 +83,32 @@ class Monitor {
   /// an atServer with nothing to say.
   Future<void> _lifecycle = Future<void>.value();
 
+  /// Retry of the FIRST connect only.
+  ///
+  /// Once [lookUp] is notifying it owns reconnection, but until then it does
+  /// not: `startNotifications` deliberately SURFACES a failure rather than
+  /// retrying it - three of at_lookup's own tests pin that, on the grounds that
+  /// failing loudly beats a connection that silently never receives anything.
+  /// So the caller has to retry, and this is the caller. Without it one failed
+  /// start - offline at `subscribe()`, or an atServer briefly unreachable -
+  /// left the client deaf for the life of the process, because `start()`
+  /// short-circuits on a `targetState` that is already `listening`.
+  Timer? _startRetry;
+  int _startRetryIx = 0;
+
+  /// The same backoff at_lookup uses for a lost connection, so a failed first
+  /// connect and a dropped one recover on one schedule rather than two.
+  static const List<Duration> _startRetryDelays = [
+    Duration(seconds: 1),
+    Duration(seconds: 2),
+    Duration(seconds: 3),
+    Duration(seconds: 5),
+    Duration(seconds: 8),
+    Duration(seconds: 13),
+    Duration(seconds: 21),
+    Duration(seconds: 34),
+  ];
+
   void _enqueue(Future<void> Function() step) {
     _lifecycle =
         _lifecycle.then((_) => step()).catchError((Object e, StackTrace st) {
@@ -158,13 +184,27 @@ class Monitor {
         await lookUp.stopNotifications();
         return;
       }
+      _startRetryIx = 0;
       logger.info('monitor started');
     } catch (e) {
-      // Not fatal, and deliberately not retried here: the muxable reconnects
-      // on its own backoff, and a second retry loop on top of it would
-      // compound the delays rather than shorten them.
       logger.warning('Failed to start notifications: $e');
+      _scheduleStartRetry();
     }
+  }
+
+  /// Tries the first connect again, while the caller still wants to listen.
+  void _scheduleStartRetry() {
+    _startRetry?.cancel();
+    if (_targetState != NotificationListenerState.listening) return;
+    final delay =
+        _startRetryDelays[_startRetryIx.clamp(0, _startRetryDelays.length - 1)];
+    _startRetryIx++;
+    logger.info('retrying the notification start in ${delay.inSeconds}s');
+    _startRetry = Timer(delay, () {
+      if (_targetState == NotificationListenerState.listening) {
+        _enqueue(_start);
+      }
+    });
   }
 
   void _onConnectionState(bool up) {
@@ -195,6 +235,9 @@ class Monitor {
   void stop() {
     logger.info('stop() called. Setting targetState to notConnected');
     _targetState = NotificationListenerState.notConnected;
+    _startRetry?.cancel();
+    _startRetry = null;
+    _startRetryIx = 0;
     _enqueue(_stop);
   }
 

--- a/packages/at_client/lib/src/preference/at_client_config.dart
+++ b/packages/at_client/lib/src/preference/at_client_config.dart
@@ -10,5 +10,5 @@ class AtClientConfig {
 
   /// Represents the at_client version.
   /// Must always be the same as the actual version in pubspec.yaml
-  final String atClientVersion = '3.14.1';
+  final String atClientVersion = '3.15.0-rc1';
 }

--- a/packages/at_client/lib/src/preference/at_client_preference.dart
+++ b/packages/at_client/lib/src/preference/at_client_preference.dart
@@ -6,10 +6,20 @@ import 'package:version/version.dart';
 /// Class to hold attributes for client preferences.
 /// Set the preferences for your application and pass it to [AtClientManager.setCurrentAtSign].
 class AtClientPreference {
-  /// Local device path of hive storage
+  /// Local device path of hive storage, used when no [AtClientStorage] is
+  /// supplied to [AtClient.create] or [AtClientManager.setCurrentAtSign].
+  ///
+  /// Setting this leaves the client owning its store: it opens the store and
+  /// closes it again when it stops. Supplying a bundle instead chooses the
+  /// backend as well as the location, and hands the caller the lifetime.
   String? hiveStoragePath;
 
-  /// Local device path of commit log
+  /// Local device path of commit log.
+  ///
+  /// Read by nothing: the client keeps no commit log of its own, so whatever
+  /// is set here has no effect.
+  @Deprecated('Nothing reads this; the client is commit-log-free. Will be '
+      'removed in the next major release.')
   String? commitLogPath;
 
   /// Syncing strategy of the client [SyncStrategy]

--- a/packages/at_client/lib/src/preference/at_client_preference.dart
+++ b/packages/at_client/lib/src/preference/at_client_preference.dart
@@ -11,7 +11,11 @@ class AtClientPreference {
   ///
   /// Setting this leaves the client owning its store: it opens the store and
   /// closes it again when it stops. Supplying a bundle instead chooses the
-  /// backend as well as the location, and hands the caller the lifetime.
+  /// backend as well as the location, and can hand the lifetime back with
+  /// `closedByClient: true`, so nothing is given up by supplying one.
+  @Deprecated('Supply an AtClientStorage instead, which chooses the backend as '
+      'well as the location; pass closedByClient: true to keep having the '
+      'client close it. Will be removed in the next major release.')
   String? hiveStoragePath;
 
   /// Local device path of commit log.

--- a/packages/at_client/lib/src/preference/at_client_preference.dart
+++ b/packages/at_client/lib/src/preference/at_client_preference.dart
@@ -105,6 +105,20 @@ class AtClientPreference {
   /// See also [monitorHeartbeatInterval]
   Duration monitorHeartbeatResponseTimeout = Duration(seconds: 10);
 
+  /// How long the notifications monitor tolerates a connection that answers
+  /// heartbeats while delivering nothing, before rebuilding it.
+  ///
+  /// A heartbeat proves the socket is alive, not that notifications are still
+  /// arriving on it; without this a client can sit reporting
+  /// [NotificationListenerState.listening] while permanently deaf. The
+  /// atServer writes a stats notification to every monitor connection on its
+  /// own timer, so a healthy connection is never silent for long.
+  ///
+  /// [Duration.zero] turns the check off, which is what an atServer
+  /// configured to send no stats notifications needs - against one of those,
+  /// silence is normal and this would rebuild a healthy connection.
+  Duration monitorSilenceTimeout = Duration(seconds: 60);
+
   /// - when true, then the notifications monitor will be started either the
   /// first time that [NotificationService.subscribe] is called by the
   /// application code, or 30 seconds after creation of the

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -109,7 +109,14 @@ class NotificationServiceImpl extends NotificationService {
                     hashingAlgo: preference.hashingAlgoType,
                   ),
             secondaryAddressFinder: this.secondaryAddressFinder,
-          ),
+          )
+            // The muxable heartbeats now, so the preference has to reach it or
+            // it is silently ignored - and at_lookup's own default is 30s
+            // against this preference's documented 59s, so leaving it unset
+            // would halve the interval for every caller that never touched it.
+            ..heartbeatInterval = preference.monitorHeartbeatInterval
+            ..heartbeatResponseTimeout =
+                preference.monitorHeartbeatResponseTimeout,
           handleNotification: handleNotificationReceipt,
           getLastNotificationTime: getLastNotificationTime,
         );

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -14,7 +14,6 @@ import 'package:at_client/src/transformer/response_transformer/notification_resp
 import 'package:at_client/src/util/at_client_validation.dart';
 import 'package:at_client/src/util/regex_match_util.dart';
 import 'package:at_commons/at_builders.dart';
-import 'package:at_lookup/at_lookup.dart';
 import 'package:at_lookup/at_lookup_io.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart'
     as at_persistence_secondary_server;

--- a/packages/at_client/lib/src/service/notification_service_impl.dart
+++ b/packages/at_client/lib/src/service/notification_service_impl.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 
+import 'package:at_auth/at_auth.dart' show authenticatorForChops;
 import 'package:at_client/at_client.dart' hide StringBuffer;
 import 'package:at_client/src/crypto/crypto_runtime.dart';
 import 'package:at_client/src/manager/monitor.dart';
@@ -14,6 +15,7 @@ import 'package:at_client/src/util/at_client_validation.dart';
 import 'package:at_client/src/util/regex_match_util.dart';
 import 'package:at_commons/at_builders.dart';
 import 'package:at_lookup/at_lookup.dart';
+import 'package:at_lookup/at_lookup_io.dart';
 import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart'
     as at_persistence_secondary_server;
 import 'package:at_utils/at_utils.dart';
@@ -72,15 +74,44 @@ class NotificationServiceImpl extends NotificationService {
         CacheableSecondaryAddressFinder(atClient.getPreferences()!.rootDomain,
             atClient.getPreferences()!.rootPort);
 
+    final preference = atClient.getPreferences()!;
+    final chops = atClient.atChops;
     this.monitor = monitor ??
         Monitor(
           atSign: atSign,
-          atClientPreference: atClient.getPreferences()!,
-          atChops: atClient.atChops,
-          enrollmentId: atClient.enrollmentId,
+          atClientPreference: preference,
+          // A FRESH lookup, so the connection count is unchanged. Passing
+          // `atClient.getRemoteSecondary()!.atLookUp` here instead would
+          // collapse the two sockets into one - a one-line change, and NOT
+          // safe yet: no atServer implements `monitor:multiplexed`, so
+          // nothing holds a notification back while a verb response is in
+          // flight.
+          lookUp: AtLookUp.withSecureSocket(
+            atSign: atSign,
+            rootDomain:
+                AtRootDomain(preference.rootDomain, preference.rootPort),
+            transport: secureSocketTransport(SecureSocketConfig()
+              ..decryptPackets = preference.decryptPackets
+              ..pathToCerts = preference.pathToCerts
+              ..tlsKeysSavePath = preference.tlsKeysSavePath),
+            // Reproduces exactly what Monitor's own PKAM did: the same
+            // AtChops, the same signing and hashing algorithms, the same
+            // enrollment id. `null` when there is no signer, which fails the
+            // same way the old code did - it threw at connect time rather
+            // than authenticating with nothing.
+            authenticator: chops == null
+                ? null
+                : authenticatorForChops(
+                    atSign,
+                    chops,
+                    enrollmentId: atClient.enrollmentId,
+                    signingAlgo: preference.signingAlgoType,
+                    hashingAlgo: preference.hashingAlgoType,
+                  ),
+            secondaryAddressFinder: this.secondaryAddressFinder,
+          ),
           handleNotification: handleNotificationReceipt,
           getLastNotificationTime: getLastNotificationTime,
-          secondaryAddressFinder: this.secondaryAddressFinder,
         );
 
     lastReceivedNotificationAtKey = AtKey.local(

--- a/packages/at_client/lib/src/service/sync_service_impl.dart
+++ b/packages/at_client/lib/src/service/sync_service_impl.dart
@@ -139,7 +139,12 @@ class SyncServiceImpl implements SyncService {
       bool warmStartSync = true}) async {
     remoteSecondary ??= RemoteSecondary(
         atClient.getCurrentAtSign()!, atClient.getPreferences()!,
-        atChops: atClient.atChops, enrollmentId: atClient.enrollmentId);
+        atChops: atClient.atChops,
+        enrollmentId: atClient.enrollmentId,
+        // Sync's own connection, built with the same key material the client
+        // holds, so its authenticator matches the client's rather than
+        // falling to a different credential.
+        atKeysIo: atClient.atKeysIo);
     final syncService = SyncServiceImpl._(atClient, remoteSecondary);
     await syncService.statsServiceListener();
     syncService._startPeriodicSyncTimer();

--- a/packages/at_client/lib/src/storage/at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/at_client_storage.dart
@@ -34,11 +34,24 @@ abstract class AtClientStorage {
 
   /// Closes the backend. Idempotent.
   Future<void> close();
+
+  /// Whether the client that attaches to this storage closes it on [AtClient.stop].
+  ///
+  /// False by default: the storage is borrowed, the client only detaches, and
+  /// closing it is the caller's job. True hands the lifetime to the client,
+  /// which is what an app with no teardown of its own wants — it still chooses
+  /// the backend and the location, without having to close anything.
+  bool get closedByClient;
 }
 
 /// The claim rules every [AtClientStorage] shares; a backend supplies
 /// [location], [openBackend], [closeBackend] and [clearData].
 abstract class AtClientStorageBase implements AtClientStorage {
+  AtClientStorageBase({this.closedByClient = false});
+
+  @override
+  final bool closedByClient;
+
   AtClient? _owner;
   String? _lastPrincipal;
   bool _closed = false;

--- a/packages/at_client/lib/src/storage/hive_at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/hive_at_client_storage.dart
@@ -7,7 +7,8 @@ import 'package:at_persistence_secondary_server/hive.dart';
 
 /// The default storage: a Hive keystore and sync queue under [storagePath].
 class HiveAtClientStorage extends AtClientStorageBase {
-  HiveAtClientStorage({required this.atSign, required this.storagePath});
+  HiveAtClientStorage(
+      {required this.atSign, required this.storagePath, super.closedByClient});
 
   final String atSign;
   final String storagePath;

--- a/packages/at_client/lib/src/storage/sqlite/sqlite_at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/sqlite/sqlite_at_client_storage.dart
@@ -9,11 +9,12 @@ import 'package:path/path.dart' as p;
 ///
 /// [dbPath] may be `:memory:`, which is what [InMemoryAtClientStorage] passes.
 class SqliteAtClientStorage extends AtClientStorageBase {
-  SqliteAtClientStorage({required this.atSign, required this.dbPath});
+  SqliteAtClientStorage(
+      {required this.atSign, required this.dbPath, super.closedByClient});
 
   /// The database under [storagePath] laid out as the upstream factory does.
   SqliteAtClientStorage.under(
-      {required this.atSign, required String storagePath})
+      {required this.atSign, required String storagePath, super.closedByClient})
       : dbPath =
             SqlitePersistenceConfig.clientDefaults(storagePath: storagePath)
                 .dbPathFor(atSign);
@@ -78,6 +79,6 @@ class SqliteAtClientStorage extends AtClientStorageBase {
 /// Keystore and sync queue in memory: a SQLite database that is never written
 /// to disk.
 class InMemoryAtClientStorage extends SqliteAtClientStorage {
-  InMemoryAtClientStorage({required super.atSign})
+  InMemoryAtClientStorage({required super.atSign, super.closedByClient})
       : super(dbPath: SqliteAtClientStorage.inMemoryPath);
 }

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -4,7 +4,7 @@ description: The at_client library is the non-platform specific Client SDK which
 ##
 ##
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
-version: 3.14.1
+version: 3.15.0-rc1
 ## NB: When incrementing the version, please also increment the version in AtClientConfig file
 ##
 

--- a/packages/at_client/pubspec.yaml
+++ b/packages/at_client/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   at_commons: ^5.13.0
   at_utils: ^3.2.0
   at_chops: ^3.3.0
-  at_lookup: ^3.6.0
+  at_lookup: ^3.7.0-rc1
   at_auth: ^4.0.0-rc1
   at_persistence_secondary_server: ^5.3.0
   hive: ^2.2.3

--- a/packages/at_client/test/at_client_create_test.dart
+++ b/packages/at_client/test/at_client_create_test.dart
@@ -166,8 +166,8 @@ void main() {
             preference: pref(),
             storage: first,
             syncServiceBuilder: (_) => throw StateError('builder exploded')),
-        throwsA(isA<StateError>()
-            .having((e) => e.message, 'message', contains('builder exploded'))));
+        throwsA(isA<StateError>().having(
+            (e) => e.message, 'message', contains('builder exploded'))));
 
     // The client is filed before its services are wired, so a throw here can
     // strand an entry nothing holds a reference to. Asserted directly, before

--- a/packages/at_client/test/at_client_create_test.dart
+++ b/packages/at_client/test/at_client_create_test.dart
@@ -1,0 +1,122 @@
+import 'dart:io';
+
+import 'package:at_client/at_client.dart';
+import 'package:test/test.dart';
+
+import 'test_utils/no_op_services.dart';
+
+void main() {
+  late Directory dir;
+
+  setUp(() {
+    dir = Directory.systemTemp.createTempSync('at_client_create_');
+    AtClientManager.getInstance().reset();
+  });
+
+  tearDown(() async {
+    for (final c
+        in List<AtClient>.from(AtClientImpl.atClientInstanceMap.values)) {
+      await c.stop();
+    }
+    AtClientManager.getInstance().reset();
+    dir.deleteSync(recursive: true);
+  });
+
+  AtClientPreference pref() => AtClientPreference()..hiveStoragePath = dir.path;
+
+  test('the client holds the storage it was given', () async {
+    final storage =
+        HiveAtClientStorage(atSign: '@factoryheld', storagePath: dir.path);
+    final client = await AtClient.create(
+        atSign: '@factoryheld',
+        namespace: 'wavi',
+        preference: pref(),
+        storage: storage);
+
+    expect(storage.isHeldBy(client), isTrue,
+        reason: 'the bundle the caller supplied is the one the client opened, '
+            'not a Hive store built from preference.hiveStoragePath');
+
+    await client.stop();
+    await storage.close();
+  });
+
+  test('nothing is registered with AtClientManager', () async {
+    final client = await AtClient.create(
+        atSign: '@factorysolo', namespace: 'wavi', preference: pref());
+
+    expect(client.getCurrentAtSign(), '@factorysolo');
+    expect(() => AtClientManager.getInstance().atClient, throwsStateError,
+        reason: 'the factory builds a client the caller owns; only '
+            'setCurrentAtSign fills in the shared current-atSign client');
+
+    await client.stop();
+  });
+
+  test('the services are wired', () async {
+    final client = await AtClient.create(
+        atSign: '@factorywired', namespace: 'wavi', preference: pref());
+
+    expect(() => client.syncService, returnsNormally);
+    expect(() => client.notificationService, returnsNormally);
+    expect(client.enrollmentService, isNotNull);
+
+    await client.stop();
+  });
+
+  test('a builder replaces the service it names', () async {
+    final noOp = NoOpSyncService();
+    final client = await AtClient.create(
+        atSign: '@factorybuilder',
+        namespace: 'wavi',
+        preference: pref(),
+        syncServiceBuilder: (_) => noOp);
+
+    expect(client.syncService, same(noOp),
+        reason: 'the caller\'s builder is what supplied the service, rather '
+            'than SyncServiceImpl.create');
+
+    await client.stop();
+  });
+
+  test('an atSign whose client is live is refused; stop() releases it',
+      () async {
+    final first = await AtClient.create(
+        atSign: '@factorytwice', namespace: 'wavi', preference: pref());
+
+    await expectLater(
+        () => AtClient.create(
+            atSign: '@factorytwice', namespace: 'wavi', preference: pref()),
+        throwsA(isA<StateError>()
+            .having((e) => e.message, 'message', contains('already live'))),
+        reason: 'handing back a client this caller does not own would discard '
+            'every argument it passed');
+
+    await first.stop();
+    final second = await AtClient.create(
+        atSign: '@factorytwice', namespace: 'wavi', preference: pref());
+    expect(second, isNot(same(first)),
+        reason: 'stop() frees the atSign, so the refusal is about a LIVE '
+            'client rather than the atSign having been used once');
+
+    await second.stop();
+  });
+
+  test('storage the preference would never open is refused', () async {
+    final storage =
+        HiveAtClientStorage(atSign: '@factorynolocal', storagePath: dir.path);
+
+    await expectLater(
+        () => AtClient.create(
+            atSign: '@factorynolocal',
+            namespace: 'wavi',
+            preference: pref()..isLocalStoreRequired = false,
+            storage: storage),
+        throwsA(isA<ArgumentError>().having(
+            (e) => e.message, 'message', contains('isLocalStoreRequired'))),
+        reason: 'a caller that named its own backend must not be told it took '
+            'effect when the client opens no local store at all');
+
+    await storage.close();
+  });
+}

--- a/packages/at_client/test/at_client_create_test.dart
+++ b/packages/at_client/test/at_client_create_test.dart
@@ -152,4 +152,51 @@ void main() {
 
     await storage.close();
   });
+
+  test('a client that fails to build is not left behind', () async {
+    final first = HiveAtClientStorage(
+        atSign: '@factoryhalfbuilt',
+        storagePath: dir.path,
+        closedByClient: true);
+
+    await expectLater(
+        () => AtClient.create(
+            atSign: '@factoryhalfbuilt',
+            namespace: 'wavi',
+            preference: pref(),
+            storage: first,
+            syncServiceBuilder: (_) => throw StateError('builder exploded')),
+        throwsA(isA<StateError>()
+            .having((e) => e.message, 'message', contains('builder exploded'))));
+
+    // The client is filed before its services are wired, so a throw here can
+    // strand an entry nothing holds a reference to. Asserted directly, before
+    // the second create below - which would otherwise trip over the stranded
+    // entry and fail on a bare StateError instead of on this reason.
+    expect(AtClientImpl.atClientInstanceMap.containsKey('@factoryhalfbuilt'),
+        isFalse,
+        reason: 'a client whose build threw is unfiled, rather than sitting in '
+            'the instance map where the next setCurrentAtSign adopts and later '
+            'stops it - while the caller that asked for it holds no reference '
+            'and cannot stop it itself');
+
+    final second = HiveAtClientStorage(
+        atSign: '@factoryhalfbuilt',
+        storagePath: dir.path,
+        closedByClient: true);
+    final client = await AtClient.create(
+        atSign: '@factoryhalfbuilt',
+        namespace: 'wavi',
+        preference: pref(),
+        storage: second);
+
+    expect(second.isHeldBy(client), isTrue,
+        reason: 'the same stop() that unfiled it also released its claim on '
+            'the location, so a later client can open a store there - '
+            'otherwise one failed build makes that directory unusable for the '
+            'life of the process');
+
+    await client.stop();
+    expect(first.isHeldBy(client), isFalse);
+  });
 }

--- a/packages/at_client/test/at_client_create_test.dart
+++ b/packages/at_client/test/at_client_create_test.dart
@@ -42,14 +42,22 @@ void main() {
     await storage.close();
   });
 
-  test('nothing is registered with AtClientManager', () async {
+  test('the client is filed in the instance map, though not as the current one',
+      () async {
     final client = await AtClient.create(
         atSign: '@factorysolo', namespace: 'wavi', preference: pref());
 
     expect(client.getCurrentAtSign(), '@factorysolo');
+    expect(AtClientImpl.atClientInstanceMap['@factorysolo'], same(client),
+        reason: 'AtClientImpl.create files every client it builds, this one '
+            'included - so a later setCurrentAtSign for this atSign adopts '
+            'THIS client rather than building its own. Asserting only that the '
+            'manager has no current client passes before create() is ever '
+            'called, which is what made the previous version of this test '
+            'vacuous');
     expect(() => AtClientManager.getInstance().atClient, throwsStateError,
-        reason: 'the factory builds a client the caller owns; only '
-            'setCurrentAtSign fills in the shared current-atSign client');
+        reason: 'the manager\'s current client is still unset: create() does '
+            'not make this the process-wide current atSign');
 
     await client.stop();
   });

--- a/packages/at_client/test/at_client_create_test.dart
+++ b/packages/at_client/test/at_client_create_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:at_client/at_client.dart';
+import 'package:at_lookup/at_lookup.dart';
 import 'package:test/test.dart';
 
 import 'test_utils/no_op_services.dart';
@@ -100,6 +101,30 @@ void main() {
             'client rather than the atSign having been used once');
 
     await second.stop();
+  });
+
+  test('buildRemoteSecondary carries the client identity a preference cannot',
+      () async {
+    final client = await AtClient.create(
+        atSign: '@buildsecondary',
+        namespace: 'wavi',
+        preference: pref()..privateKey = 'dummy_private_key',
+        enrollmentId: 'enrollment-under-test') as AtClientImpl;
+
+    final built = client.buildRemoteSecondary();
+
+    // enrollmentId, not the credential: RemoteSecondary recovers privateKey
+    // from the preference on its own (`privateKey ??= preference.privateKey`),
+    // so asserting on the authenticator passes whether or not the factory
+    // threaded anything. The enrollment id is held by the client alone.
+    expect(built.atLookUp.enrollmentId, 'enrollment-under-test',
+        reason: 'every RemoteSecondary this client opens is configured FROM '
+            'the client, so a second connection acts as the same enrollment '
+            'rather than being assembled independently');
+    expect((built.atLookUp as AtLookupMuxable).authenticator, isNotNull,
+        reason: 'and it authenticates through the seam, not the ladder');
+
+    await client.stop();
   });
 
   test('storage the preference would never open is refused', () async {

--- a/packages/at_client/test/at_client_termination_test.dart
+++ b/packages/at_client/test/at_client_termination_test.dart
@@ -4,6 +4,7 @@ import 'package:at_client/at_client.dart';
 import 'package:at_client/src/listener/at_sign_change_listener.dart';
 import 'package:at_client/src/listener/switch_at_sign_event.dart';
 import 'package:at_client/src/manager/monitor.dart';
+import 'package:at_lookup/at_lookup.dart';
 import 'package:at_client/src/service/notification_service_impl.dart';
 import 'package:at_client/src/service/sync_service_impl.dart';
 import 'package:mocktail/mocktail.dart';
@@ -113,21 +114,17 @@ void main() {
     group('Monitor lifecycle tests', () {
       late Monitor monitor;
       late MockAtLookup mockAtLookup;
-      late MockAtChops mockAtChops;
-      late MockSecondaryAddressFinder mockAddressFinder;
+      late _StubMuxable stubMuxable;
 
       setUp(() {
         mockAtLookup = MockAtLookup();
-        mockAtChops = MockAtChops();
-        mockAddressFinder = MockSecondaryAddressFinder();
+        stubMuxable = _StubMuxable();
         when(() => mockAtLookup.close()).thenAnswer((_) async => {});
 
         monitor = Monitor(
           atSign: '@test',
           atClientPreference: AtClientPreference(),
-          atChops: mockAtChops,
-          enrollmentId: null,
-          secondaryAddressFinder: mockAddressFinder,
+          lookUp: stubMuxable,
           handleNotification: (String jsonEncoded) async {},
           getLastNotificationTime: () async => null,
         );
@@ -353,4 +350,28 @@ class _CapturingAtSignChangeListener implements AtSignChangeListener {
 
   @override
   void listenToAtSignChange(SwitchAtSignEvent event) => _onEvent(event);
+}
+
+/// Stands in for the muxable the Monitor now drives, so these tests exercise
+/// Monitor's own state handling rather than a socket.
+class _StubMuxable extends Fake implements AtLookupMuxable {
+  final _notifications = StreamController<String>.broadcast();
+  final _up = StreamController<bool>.broadcast();
+
+  @override
+  Stream<String> get notifications => _notifications.stream;
+
+  @override
+  Stream<bool> get notificationConnectionUp => _up.stream;
+
+  @override
+  Future<void> startNotifications({
+    String? regex,
+    Future<int?> Function()? getLastNotificationTime,
+    bool selfNotificationsEnabled = true,
+  }) async =>
+      _up.add(true);
+
+  @override
+  Future<void> stopNotifications() async => _up.add(false);
 }

--- a/packages/at_client/test/monitor_test.dart
+++ b/packages/at_client/test/monitor_test.dart
@@ -213,6 +213,46 @@ void main() {
               'every notification');
     });
 
+    test('a start that fails is retried, not abandoned', () async {
+      // at_lookup SURFACES a failed start rather than retrying it - three of
+      // its own tests pin that - so the retry has to live here. Before this,
+      // one failed start left the client deaf for the life of the process:
+      // start() short-circuits on a targetState that is already listening, so
+      // nothing could ask again.
+      muxable.startError = AtConnectException('mock - connection failed');
+
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+      expect(muxable.startCalls, 1);
+      expect(monitor.currentState, NotificationListenerState.notConnected);
+
+      // The first backoff step is 1s; clear the fault and let it come round.
+      muxable.startError = null;
+      await Future.delayed(const Duration(milliseconds: 1400));
+
+      expect(muxable.startCalls, greaterThan(1),
+          reason: 'the monitor asked again on its own, which is what the '
+              'public contract promises: reconnect until successful or until '
+              'stopListening');
+      expect(monitor.currentState, NotificationListenerState.listening,
+          reason: 'and once the fault cleared it actually got there');
+    }, timeout: Timeout(Duration(seconds: 15)));
+
+    test('a retry stops when stop() arrives', () async {
+      muxable.startError = AtConnectException('mock - connection failed');
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      monitor.stop();
+      muxable.startError = null;
+      final callsAtStop = muxable.startCalls;
+      await Future.delayed(const Duration(milliseconds: 1400));
+
+      expect(muxable.startCalls, callsAtStop,
+          reason: 'a pending retry must not resurrect a monitor the caller '
+              'has stopped');
+    }, timeout: Timeout(Duration(seconds: 15)));
+
     test('a start that fails leaves it notConnected', () async {
       // Ported in spirit from "secondary not available" and "secondary
       // reachable but rejecting commands", both of which now fail inside the

--- a/packages/at_client/test/monitor_test.dart
+++ b/packages/at_client/test/monitor_test.dart
@@ -1,524 +1,363 @@
 import 'dart:async';
-import 'dart:convert';
-import 'dart:io';
-import 'dart:typed_data';
 
-import 'package:at_chops/at_chops.dart';
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/manager/monitor.dart';
+import 'package:at_client/src/service/notification_service.dart';
+import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
 
-import 'package:mocktail/mocktail.dart';
+/// Monitor's own concerns, and only those.
+///
+/// This file used to hold eighteen tests, most of them about a socket, a byte
+/// buffer, PKAM authentication, a heartbeat and an
+/// `[1,2,3,5,8,13,21,34]`-second backoff that Monitor no longer has - all of
+/// that moved into at_lookup's `AtLookupMuxable`, where it exists once and is
+/// covered by `muxable_notifications_test.dart` and `socket_delivery_test.dart`.
+///
+/// Two of those tests had no equivalent there and were **ported before being
+/// deleted here**: a failure to connect, and a reachable atServer that rejects
+/// the write. They are now
+/// `muxable_notifications_test.dart`'s "a connection that cannot be
+/// established" group.
+///
+/// What is left is what was always Monitor's: the watermark, the notification
+/// callback, and the two states.
+class FakeMuxable extends Fake implements AtLookupMuxable {
+  // Recreated on demand, exactly as AtLookupImpl does: stopNotifications()
+  // nulls AND closes both controllers, so the next read of `notifications` or
+  // `notificationConnectionUp` builds a fresh one. A fake that reused a single
+  // controller could not reproduce a stop-then-start race at all - the
+  // subscriptions would keep working and the bug would be invisible.
+  StreamController<String> _notifications = StreamController<String>();
+  StreamController<bool> _up = StreamController<bool>.broadcast();
 
-import 'test_utils/mocks.dart';
+  bool started = false;
+  int? startedWithWatermark;
+  int startCalls = 0;
 
-class MockSecureSocket extends Mock implements SecureSocket {}
+  /// The function Monitor handed down, kept so a test can invoke it AGAIN —
+  /// which is what a reconnect does. Holding only the value it first returned
+  /// cannot tell a live callback from one that captured a stale number.
+  Future<int?> Function()? heldWatermarkSource;
 
-class MockStreamSubscription<T> extends Mock implements StreamSubscription<T> {}
+  /// Set to make [startNotifications] fail, as an unreachable or rejecting
+  /// atServer does.
+  Object? startError;
 
-class MockOutboundConnection extends Mock implements OutboundConnection {}
+  @override
+  Stream<String> get notifications => _notifications.stream;
 
-class MockMonitorOutboundConnectionFactory extends Mock
-    implements MonitorOutboundConnectionFactory {}
+  @override
+  Stream<bool> get notificationConnectionUp => _up.stream;
 
-class FakeAtSigningInput extends Fake implements AtSigningInput {}
+  @override
+  bool get isNotifying => started;
 
-/// Note: The test code here prioritizes brevity over isolation
-/// So while, right now, the tests are all passing despite sharing their mock objects, at some point
-/// we will add a test where that assumption doesn't hold any more, and the tests will start failing
-void main() {
-  SecondaryAddressFinder mockSecondaryAddressFinder =
-      MockSecondaryAddressFinder();
-  MonitorOutboundConnectionFactory mockMonitorOutboundConnectionFactory =
-      MockMonitorOutboundConnectionFactory();
-  OutboundConnection mockOutboundConnection = MockOutboundConnection();
-  SecureSocket mockSocket = MockSecureSocket();
-  AtChops mockAtChops = MockAtChops();
-  late Function(dynamic data) socketOnDataFn;
-  late Function() socketOnDoneFn;
-  // ignore: unused_local_variable
-  late Function(Exception e) socketOnErrorFn;
-  int? lastNotificationTime;
-  Future<int?> getLastNotificationTime() async {
-    return lastNotificationTime;
+  @override
+  Future<void> startNotifications({
+    String? regex,
+    Future<int?> Function()? getLastNotificationTime,
+    bool selfNotificationsEnabled = true,
+  }) async {
+    startCalls++;
+    if (startError != null) throw startError!;
+    started = true;
+    // Invoked, as the real muxable does on every (re)connect - so these
+    // assertions also prove the callback the Monitor hands down is callable.
+    heldWatermarkSource = getLastNotificationTime;
+    startedWithWatermark = await getLastNotificationTime?.call();
+    _up.add(true);
   }
 
-  var atSign = '@monitor_test';
-  var fakeSecondaryAddress = SecondaryAddress("monitor_test", 12345);
-  var fakeCertsLocation = '/home/ubuntu/Desktop/cert.pem';
-  var fakeTlsKeysSavePath = '/home/ubuntu/Desktop/cert.pem';
-  AtClientPreference atClientPreference = AtClientPreference();
-  atClientPreference.decryptPackets = true;
-  atClientPreference.tlsKeysSavePath = fakeTlsKeysSavePath;
-  atClientPreference.pathToCerts = fakeCertsLocation;
-  late AtSigningResult mockSigningResult;
+  @override
+  Future<void> stopNotifications() async {
+    started = false;
+    if (!_up.isClosed) _up.add(false);
+    // Closed and replaced, as the real one does.
+    final n = _notifications;
+    final u = _up;
+    _notifications = StreamController<String>();
+    _up = StreamController<bool>.broadcast();
+    unawaited(n.close());
+    unawaited(u.close());
+  }
 
-  List<(DateTime, NotificationListenerState)> monitorStateHistory = [];
+  /// The atServer sends one.
+  void deliver(String notification) => _notifications.add(notification);
 
+  /// The connection drops under us - the muxable reports it and reconnects.
+  void dropConnection() => _up.add(false);
+
+  void reconnected() => _up.add(true);
+
+  Future<void> dispose() async {
+    // NOT awaited: close() on a single-subscription controller returns a
+    // `done` that only completes once a subscriber has taken the event, and
+    // after stopNotifications these are fresh controllers with no listener.
+    // Awaiting hangs forever - the same trap that made the real
+    // stopNotifications hang before it was fixed.
+    if (!_notifications.isClosed) unawaited(_notifications.close());
+    if (!_up.isClosed) unawaited(_up.close());
+  }
+}
+
+void main() {
+  late FakeMuxable muxable;
   late Monitor monitor;
-  String allFromMonitor = '';
-
-  late Completer doneCompleter;
-  late StreamSubscription currentStateSubscription;
+  late List<String> received;
+  late List<NotificationListenerState> states;
+  int? watermark;
+  Object? watermarkError;
 
   setUp(() {
-    reset(mockSecondaryAddressFinder);
-    reset(mockSocket);
-    reset(mockOutboundConnection);
-    reset(mockMonitorOutboundConnectionFactory);
-    reset(mockAtChops);
-
-    when(() => mockSecondaryAddressFinder.findSecondary(any()))
-        .thenAnswer((_) async => fakeSecondaryAddress);
-    when(() => mockOutboundConnection.getSocket())
-        .thenAnswer((_) => mockSocket);
-    when(() => mockMonitorOutboundConnectionFactory.createConnection(
-            fakeSecondaryAddress,
-            decryptPackets: true,
-            tlsKeysSavePath: fakeTlsKeysSavePath,
-            pathToCerts: fakeCertsLocation))
-        .thenAnswer((_) async => mockOutboundConnection);
-    when(() => mockOutboundConnection.close()).thenAnswer((_) async => {});
-    when(() => mockSocket.listen(any(),
-        onError: any(named: "onError"),
-        onDone: any(named: "onDone"))).thenAnswer((Invocation invocation) {
-      socketOnDataFn = invocation.positionalArguments[0];
-      socketOnDoneFn = invocation.namedArguments[#onDone];
-      socketOnErrorFn = invocation.namedArguments[#onError];
-
-      return MockStreamSubscription<Uint8List>();
-    });
-    doneCompleter = Completer();
-    when(() => mockSocket.done).thenAnswer((_) => doneCompleter.future);
-
-    when(() => mockOutboundConnection.write('from:$atSign\n'))
-        .thenAnswer((Invocation invocation) async {
-      socketOnDataFn("@data:server challenge\n"
-          .codeUnits); // actual challenge is different, of course, but not important for unit tests
-    });
-    when(() => mockOutboundConnection.write(any(that: startsWith('pkam:'))))
-        .thenAnswer((Invocation invocation) async {
-      socketOnDataFn("success\n".codeUnits);
-    });
-    when(() => mockOutboundConnection.write(any(that: startsWith('monitor'))))
-        .thenAnswer((Invocation invocation) async {});
-    mockSigningResult = AtSigningResult()..result = 'mock_signing_result';
-    registerFallbackValue(FakeAtSigningInput());
-    when(() => mockAtChops.sign(any())).thenAnswer((_) => mockSigningResult);
-
-    const List<Duration> testConnectDelays = [
-      Duration(milliseconds: 100),
-      Duration(milliseconds: 200),
-      Duration(milliseconds: 300),
-      Duration(milliseconds: 500),
-      Duration(milliseconds: 800),
-      Duration(milliseconds: 1300),
-      Duration(milliseconds: 2100),
-      Duration(milliseconds: 3400),
-    ];
-    allFromMonitor = '';
+    muxable = FakeMuxable();
+    received = [];
+    states = [];
+    watermark = null;
+    watermarkError = null;
     monitor = Monitor(
-      atSign: atSign,
-      atClientPreference: atClientPreference,
-      atChops: mockAtChops,
-      enrollmentId: null,
-      secondaryAddressFinder: mockSecondaryAddressFinder,
-      handleNotification: (String received) async {
-        allFromMonitor += '$received\n';
+      atSign: '@alice',
+      atClientPreference: AtClientPreference(),
+      lookUp: muxable,
+      handleNotification: (String n) async => received.add(n),
+      getLastNotificationTime: () async {
+        if (watermarkError != null) throw watermarkError!;
+        return watermark;
       },
-      getLastNotificationTime: getLastNotificationTime,
-      connectDelays: testConnectDelays,
-      monitorOutboundConnectionFactory: mockMonitorOutboundConnectionFactory,
     );
-    monitor.logger.level = 'warning';
-    lastNotificationTime = null;
-    monitorStateHistory.clear();
-    currentStateSubscription = monitor.currentStateStream.listen((s) {
-      final d = DateTime.now().toUtc();
-      monitorStateHistory.add((d, s));
+    monitor.logger.level = 'severe';
+    monitor.currentStateStream.listen(states.add);
+  });
+
+  tearDown(() async => muxable.dispose());
+
+  group('start', () {
+    test('reaches listening, and passes a null watermark through', () async {
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      expect(monitor.targetState, NotificationListenerState.listening);
+      expect(monitor.currentState, NotificationListenerState.listening);
+      expect(states, [NotificationListenerState.listening]);
+      expect(muxable.started, isTrue);
+      expect(muxable.startedWithWatermark, isNull);
+    });
+
+    test('passes a real watermark through', () async {
+      watermark = 1755600000000;
+
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      expect(muxable.startedWithWatermark, 1755600000000,
+          reason: 'the watermark is what stops the atServer replaying every '
+              'notification it has ever held');
+    });
+
+    test('hands down a LIVE watermark source, not a value read once', () async {
+      // The muxable owns reconnection, so it asks this function again on every
+      // reconnect. Monitor must therefore pass the function itself: reading
+      // the number here and passing that pins every later reconnect to the
+      // position held at start, which is the frozen-watermark defect. Every
+      // other test in this group would pass with that defect present, because
+      // they only ever look at the FIRST call.
+      watermark = 1755600000000;
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+      expect(muxable.startedWithWatermark, 1755600000000);
+
+      // The client consumes notifications and its stored watermark advances.
+      watermark = 1755600009999;
+
+      expect(muxable.heldWatermarkSource, isNotNull,
+          reason: 'Monitor must hand a function down at all - without one the '
+              'muxable has nothing to re-ask and every reconnect goes out '
+              'with no watermark');
+      expect(await muxable.heldWatermarkSource!(), 1755600009999,
+          reason: 'invoking it again - which is exactly what a reconnect '
+              'does - must read the CURRENT watermark, not the number that '
+              'was current when notifications started');
+    });
+
+    /// Reading the watermark is a local keystore operation, not part of
+    /// connecting, so its failure must not abort the connect. When such an
+    /// exception reached the connect handler, the monitor retried with backoff
+    /// for as long as the cause persisted - and a cause that is a local
+    /// configuration rather than network weather persists forever. The client
+    /// was silently deaf and the only symptom was the absence of `listening`.
+    test('a watermark read that throws does not stop it connecting', () async {
+      watermarkError =
+          Exception('the keystore refused the lastreceivednotification read');
+
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      expect(monitor.currentState, NotificationListenerState.listening,
+          reason: 'a failed watermark read must not abort the connect');
+      expect(muxable.startedWithWatermark, isNull,
+          reason: 'and it starts with NO watermark rather than a stale one: '
+              'starting without one replays a window, which is recoverable, '
+              'where starting from a wrong one loses notifications');
+    });
+
+    test('a second start is refused rather than doubling up', () async {
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      expect(muxable.startCalls, 1,
+          reason: 'a second monitor: on the same connection would duplicate '
+              'every notification');
+    });
+
+    test('a start that fails leaves it notConnected', () async {
+      // Ported in spirit from "secondary not available" and "secondary
+      // reachable but rejecting commands", both of which now fail inside the
+      // muxable. What matters HERE is only that Monitor does not claim to be
+      // listening when the start did not succeed.
+      muxable.startError = AtConnectException('mock - connection failed');
+
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      expect(monitor.currentState, NotificationListenerState.notConnected);
+      expect(states, isEmpty,
+          reason: 'no state change was published, because none happened - a '
+              'listener that saw `listening` here would wait forever');
     });
   });
 
-  tearDown(() async {
-    await currentStateSubscription.cancel();
-    monitor.stop();
-    monitorStateHistory.clear();
-  });
+  group('notifications', () {
+    test('reach handleNotification, and stamp lastReceipt', () async {
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+      expect(monitor.lastReceipt, isNull);
 
-  group('Monitor socket response handling', () {
-    test('Multiple response lines in single call to socket messageHandler',
-        () async {
-      List<String> fromServerList = [
-        'notification:{"id":"1"}\ndata:ok\nnotification:{"id":',
-        '"2"}\nnotification:{"id:"3"}\ndata:',
-        'ok\nnoti',
-        'fication:{"id":"4"}\n'
-      ];
+      muxable.deliver('notification: {"id":"abc"}');
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      expect(received, ['notification: {"id":"abc"}']);
+      expect(monitor.lastReceipt, isNotNull);
+    });
+
+    test('a handler that throws does not kill the stream', () async {
+      monitor = Monitor(
+        atSign: '@alice',
+        atClientPreference: AtClientPreference(),
+        lookUp: muxable,
+        handleNotification: (String n) async {
+          received.add(n);
+          throw StateError('handler blew up on $n');
+        },
+        getLastNotificationTime: () async => null,
+      );
+      monitor.logger.level = 'severe';
 
       monitor.start();
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.listening);
+      await Future.delayed(const Duration(milliseconds: 20));
+      muxable.deliver('notification: {"id":"one"}');
+      await Future.delayed(const Duration(milliseconds: 20));
+      muxable.deliver('notification: {"id":"two"}');
+      await Future.delayed(const Duration(milliseconds: 20));
 
-      String allFromServer = '';
-      for (String fromServer in fromServerList) {
-        await socketOnDataFn(utf8.encode(fromServer));
-        allFromServer += fromServer;
-      }
-      // The Monitor response handler should filter out data:ok\n responses (heartbeat responses)
-      // and send only notifications to the Monitor's owner's response handler.
-      allFromServer = allFromServer.replaceAll('data:ok\n', '');
-      expect(allFromMonitor, allFromServer);
+      expect(received, hasLength(2),
+          reason: 'one bad notification must not deafen the client to every '
+              'notification after it');
     });
   });
 
-  group('Monitor constructor and start tests', () {
-    /// Create a Monitor with our mock connectivity checker, remote secondary and outbound connection factory.
-    /// Start the monitor with a NULL last notification time
-    /// Check that the monitor has started and has written the correct things to the socket
-    test('Monitor start, secondary OK, NULL lastNotificationTime', () async {
+  group('connection state', () {
+    test('a dropped connection surfaces, and so does the recovery', () async {
       monitor.start();
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.listening);
-      final writesToSocket =
-          verify(() => mockOutboundConnection.write(captureAny())).captured;
-      expect(writesToSocket.length, 3);
-      // We've created a monitor with a null lastNotificationTime - expect the command sent to the server to be simply 'monitor\n'
-      expect(writesToSocket.last, 'monitor:selfNotifications\n');
-    });
+      await Future.delayed(const Duration(milliseconds: 20));
 
-    /// Create a Monitor with our mock connectivity checker, remote secondary and outbound connection factory.
-    /// Start the monitor with a REAL last notification time
-    /// Check that the monitor has started and has written the correct things to the socket
-    test('Monitor start, secondary OK, with a real lastNotificationTime',
-        () async {
-      lastNotificationTime =
-          DateTime.now().subtract(Duration(days: 1)).millisecondsSinceEpoch;
-      monitor.start();
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.listening);
-      final writesToSocket =
-          verify(() => mockOutboundConnection.write(captureAny())).captured;
-      expect(writesToSocket.length, 3);
-      // We've created a monitor with a real lastNotificationTime
-      expect(writesToSocket.last,
-          'monitor:selfNotifications:$lastNotificationTime\n');
-    });
-
-    test('Monitor start, secondary not available', () async {
-      when(() => mockMonitorOutboundConnectionFactory.createConnection(
-          fakeSecondaryAddress,
-          decryptPackets: true,
-          tlsKeysSavePath: fakeTlsKeysSavePath,
-          pathToCerts: fakeCertsLocation)).thenAnswer((_) async {
-        throw AtConnectException('Mock - connection failed');
-      });
-
-      monitor.start();
-
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.notConnected);
-    });
-
-    test('Monitor start, secondary reachable but rejecting commands', () async {
-      when(() => mockOutboundConnection.write(any()))
-          .thenAnswer((Invocation invocation) async {
-        throw Exception('mockOutboundConnection.write() throwing exception');
-      });
-
-      monitor.start();
-
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.notConnected);
-    });
-
-    test('start, secondary reachable but rejecting commands', () async {
-      when(() => mockOutboundConnection.write(any()))
-          .thenAnswer((Invocation invocation) async {
-        throw Exception('mockOutboundConnection.write() throwing exception');
-      });
-
-      monitor.start();
-
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.notConnected);
-    });
-
-    test('start, secondary reachable but pkam failure', () async {
-      when(() => mockOutboundConnection.write(any(that: startsWith('pkam:'))))
-          .thenAnswer((Invocation invocation) async {
-        throw Exception('mockOutboundConnection.write() throwing exception');
-      });
-
-      monitor.start();
-
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.notConnected);
-    });
-
-    test(
-        'start, secondary OK, socket OK, socket closed, reconnects immediately',
-        () async {
-      monitor.start();
-
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.listening);
-
-      socketOnDoneFn();
-
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.notConnected);
-
-      // should reconnect after the initial reconnectDelay
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.listening);
-    });
-
-    test(
-        'start, secondary OK, socket OK, socket closed, reconnects on third attempt',
-        () async {
-      monitor.start();
-
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.listening);
-
-      socketOnDoneFn();
-
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.notConnected);
-
-      // make connections fail
-      when(() => mockMonitorOutboundConnectionFactory.createConnection(
-          fakeSecondaryAddress,
-          decryptPackets: true,
-          tlsKeysSavePath: fakeTlsKeysSavePath,
-          pathToCerts: fakeCertsLocation)).thenAnswer((_) async {
-        throw AtConnectException('Mock - connection failed');
-      });
-
-      await Future.delayed(monitor.connectDelays[0]);
-      await Future.delayed(monitor.connectDelays[1]);
-      await Future.delayed(Duration(milliseconds: 50)); // fudge factor
-
-      // make connections succeed again
-      when(() => mockMonitorOutboundConnectionFactory.createConnection(
-              fakeSecondaryAddress,
-              decryptPackets: true,
-              tlsKeysSavePath: fakeTlsKeysSavePath,
-              pathToCerts: fakeCertsLocation))
-          .thenAnswer((_) async => mockOutboundConnection);
-
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.listening);
-    });
-
-    test('Monitor heartbeat sending regularly', () async {
-      atClientPreference.monitorHeartbeatInterval = Duration(milliseconds: 20);
-      Duration waitTime = Duration(milliseconds: 25);
-
-      int numHeartbeatsSent = 0;
-      when(() => mockOutboundConnection.write("noop:0\n"))
-          .thenAnswer((Invocation invocation) async {
-        numHeartbeatsSent++;
-        sleep(Duration(milliseconds: 1));
-        socketOnDataFn("@ok\n".codeUnits);
-      });
-
-      monitor.start();
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.listening);
-
-      // We expect the first heartbeat to be sent heartbeatIntervalMillis from now
-      await Future.delayed(waitTime);
-
-      // we should have sent one heartbeat so far
-      expect(numHeartbeatsSent, 1);
-      // and the monitor status is still 'started'
-      expect(monitor.currentState, NotificationListenerState.listening);
-
-      // Now let's wait long enough for some heartbeats to be sent, check they have all been sent,
-      // and check that the monitor status is still 'started'
-      int additionalHeartbeatsToSend = 3;
-      int expectedHeartbeatCount =
-          numHeartbeatsSent + additionalHeartbeatsToSend;
-      await Future.delayed(waitTime);
-      await Future.delayed(waitTime);
-      await Future.delayed(waitTime);
-      // We're expecting three more to have been sent
-      expect(numHeartbeatsSent, expectedHeartbeatCount);
-      expect(monitor.currentState, NotificationListenerState.listening);
-
-      // Now let's simulate the socket is calling 'onDone'
-      // The monitor's status should go to `notConnected`
-      socketOnDoneFn();
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.notConnected);
-      expect(monitor.currentState, NotificationListenerState.notConnected);
-      expect(monitor.heartbeatTimer, null);
-      expect(numHeartbeatsSent, expectedHeartbeatCount);
-    });
-
-    test('Test that heartbeat exceptions are caught gracefully', () async {
-      atClientPreference.monitorHeartbeatInterval = Duration(milliseconds: 100);
-
-      int numHeartbeatAttempts = 0;
-      when(() => mockOutboundConnection.write("noop:0\n"))
-          .thenAnswer((Invocation invocation) async {
-        numHeartbeatAttempts++;
-        throw Exception('mockOutboundConnection.write() throwing exception');
-      });
-
-      monitor.start();
-
-      await Future.delayed(atClientPreference.monitorHeartbeatInterval +
-          Duration(milliseconds: 10));
-
-      // If there's an unhandled exception, this next assertion will not be made
-      expect(numHeartbeatAttempts, 1);
-    });
-
-    test('Test when monitor heartbeat response not received', () async {
-      // Do one successful heartbeat
-      // Then fake a timeout on the next one
-      // When the timeout occurs, socket as marked done
-      // When the socket is marked done, monitor state changes
-      // There is then a brief delay before the next connect attempt
-      // We will make the first reconnect attempt fail
-      // We will make the second reconnect attempt succeed
-      // So we need to verify (1) monitor state changes to "notConnected"
-      // and then (2) monitor state changes back to "connected" after the
-      // reconnect, and then (3) we get another heartbeat
-      int numHeartbeatsSent = 0;
-      bool sendHeartbeatResponse = true;
-      when(() => mockOutboundConnection.write("noop:0\n"))
-          .thenAnswer((Invocation invocation) async {
-        numHeartbeatsSent++;
-        if (sendHeartbeatResponse) {
-          sleep(Duration(milliseconds: 1));
-          socketOnDataFn("@ok\n".codeUnits);
-        }
-      });
-
-      atClientPreference.monitorHeartbeatResponseTimeout =
-          Duration(milliseconds: 20);
-      atClientPreference.monitorHeartbeatInterval = Duration(milliseconds: 60);
-
-      monitor.start();
-      expect(await monitor.currentStateStream.first,
-          NotificationListenerState.listening);
-      expect(monitor.currentState, NotificationListenerState.listening);
-
-      // Wait for two heartbeat successes
-      await Future.delayed(atClientPreference.monitorHeartbeatInterval * 2.2);
-      expect(numHeartbeatsSent, 2);
-
-      // Let's make reconnects fail, then stop heartbeat responses
-      when(() => mockMonitorOutboundConnectionFactory.createConnection(
-          fakeSecondaryAddress,
-          decryptPackets: true,
-          tlsKeysSavePath: fakeTlsKeysSavePath,
-          pathToCerts: fakeCertsLocation)).thenAnswer((_) async {
-        throw AtConnectException('Mock - connection failed');
-      });
-
-      // Let's NOT send a response to the next heartbeat(s).
-      sendHeartbeatResponse = false;
-
-      // Wait for the heartbeat timeout
-      await Future.delayed((atClientPreference.monitorHeartbeatResponseTimeout +
-              atClientPreference.monitorHeartbeatInterval) *
-          1.2);
-
-      // Status should be "notConnected"
+      muxable.dropConnection();
+      await Future.delayed(const Duration(milliseconds: 20));
       expect(monitor.currentState, NotificationListenerState.notConnected);
 
-      // Wait for the first delay timeout
-      await Future.delayed(monitor.connectDelays[0] * 1.1);
-
-      expect(monitor.currentState, NotificationListenerState.notConnected);
-
-      // let's start sending responses to heartbeats again
-      sendHeartbeatResponse = true;
-
-      // and let's make creating new connections succeed again
-      when(() => mockMonitorOutboundConnectionFactory.createConnection(
-              fakeSecondaryAddress,
-              decryptPackets: true,
-              tlsKeysSavePath: fakeTlsKeysSavePath,
-              pathToCerts: fakeCertsLocation))
-          .thenAnswer((_) async => mockOutboundConnection);
-
-      // Wait for the second delay timeout
-      await Future.delayed(monitor.connectDelays[1] * 1.1);
-
-      // Now the monitor state should be 'connected' again
+      muxable.reconnected();
+      await Future.delayed(const Duration(milliseconds: 20));
       expect(monitor.currentState, NotificationListenerState.listening);
 
-      // Finally, let's make sure that heartbeats are happening again, and the monitor is still happy
-      int lastHeartbeatCount = numHeartbeatsSent;
-      int additionalHeartbeatsToSend = 3;
-      await Future.delayed(atClientPreference.monitorHeartbeatInterval * 3.5);
-      int expectedHeartbeatCount =
-          lastHeartbeatCount + additionalHeartbeatsToSend;
-      expect(numHeartbeatsSent >= expectedHeartbeatCount, true);
-      expect(monitor.currentState, NotificationListenerState.listening);
+      expect(
+          states,
+          [
+            NotificationListenerState.listening,
+            NotificationListenerState.notConnected,
+            NotificationListenerState.listening,
+          ],
+          reason: 'noports subscribes to this stream for the life of its '
+              'daemon; every transition has to reach it');
     });
 
-    test('verify no race when stop is called', () async {
-      // When start is called, some amount of time passes before the connection
-      // is made. If stop is called while the connection is still being created
-      // then we want to avoid the possibility that the connection is there
-      // and being listened to even though the targetState is now `notConnected`
-
-      // To explain what's happening in a bit more detail:
-      // The Monitor.stayConnected loop (while targetState == listening)
-      //   starts by creating a "connectionDoneCompleter"
-      //   once the connection is established, currentState is set to listening
-      //   and we then await ConnectionDoneCompleter.future
-      // stop() sets targetState to notConnected
-      //   and then calls closeConnection
-      //   which among other things will call connectionDoneCompleter.complete()
-      //   (if there is a non-null connectionDoneCompleter)
-      // This test therefore creates a situation where stop() is called while
-      //   a connection is being established, and verifies that it is then closed
-      //   pretty much immediately, because connectionDoneCompleter.future has
-      //   been completed
-
-      // let's add a delay before returning the connection
-      Completer createConnectionCalled = Completer();
-      when(() => mockMonitorOutboundConnectionFactory.createConnection(
-          fakeSecondaryAddress,
-          decryptPackets: true,
-          tlsKeysSavePath: fakeTlsKeysSavePath,
-          pathToCerts: fakeCertsLocation)).thenAnswer((_) async {
-        createConnectionCalled.complete();
-        await Future.delayed(Duration(milliseconds: 50));
-        return mockOutboundConnection;
-      });
-
-      // let's make a completer for when the monitor command is issued,
-      Completer monitorCommandIssued = Completer();
-      when(() => mockOutboundConnection.write(any(that: startsWith('monitor'))))
-          .thenAnswer((Invocation invocation) async {
-        monitorCommandIssued.complete();
-      });
-
-      // monitor.logger.level = 'info';
+    test('an unchanged state is not republished', () async {
       monitor.start();
-      await createConnectionCalled.future;
+      await Future.delayed(const Duration(milliseconds: 20));
+      muxable.reconnected(); // already up
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      expect(states, [NotificationListenerState.listening],
+          reason: 'a repeated identical state is noise on a stream something '
+              'reacts to');
+    });
+  });
+
+  group('stop', () {
+    test('stops the muxable and reports notConnected', () async {
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+
       monitor.stop();
+      await Future.delayed(const Duration(milliseconds: 20));
 
-      // We've called stop, but we are still in the process of
-      // creating the monitor connection, and we expect the monitor
-      // command to be issued as usual
-      await monitorCommandIssued.future;
+      expect(monitor.targetState, NotificationListenerState.notConnected);
+      expect(monitor.currentState, NotificationListenerState.notConnected);
+      expect(muxable.started, isFalse);
+    });
 
-      // small wait to let things play out
-      await Future.delayed(Duration(milliseconds: 50));
-      expect(monitorStateHistory.length, 3);
-      expect(monitorStateHistory[0].$2, NotificationListenerState.notConnected);
-      expect(monitorStateHistory[1].$2, NotificationListenerState.listening);
-      expect(monitorStateHistory[2].$2, NotificationListenerState.notConnected);
+    test('start immediately after stop does not leave it deaf', () async {
+      // The MIRROR of the race above, and the one _start's post-await
+      // re-check does NOT cover. _stop awaits stopNotifications, which closes
+      // both controllers; if _start runs meanwhile its `??=` sees non-null
+      // subscription fields and keeps the OLD ones, pointed at controllers
+      // that are about to close - so at_lookup reconnects and notifies into a
+      // stream nobody is listening to.
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      monitor.stop();
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 60));
+
+      muxable.deliver('notification: {"id":"after-restart"}');
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      expect(received, ['notification: {"id":"after-restart"}'],
+          reason: 'a restarted monitor must still hear the atServer - the '
+              'failure here is silent, and looks exactly like an atServer '
+              'with nothing to say');
+      expect(monitor.currentState, NotificationListenerState.listening,
+          reason: 'and it must not report notConnected while at_lookup is '
+              'connected and notifying');
+    });
+
+    test('stop during start does not leave it listening', () async {
+      // The race the old implementation needed a done-completer for: stop()
+      // arriving while the connection is still being established. Here the
+      // ordering is the muxable's, but the observable requirement is the same
+      // - when the dust settles, nothing is listening.
+      monitor.start();
+      monitor.stop();
+      await Future.delayed(const Duration(milliseconds: 50));
+
+      expect(monitor.targetState, NotificationListenerState.notConnected);
+      expect(monitor.currentState, NotificationListenerState.notConnected);
+      expect(muxable.started, isFalse,
+          reason: 'a connection established after stop() was called must not '
+              'be left running');
     });
   });
 }

--- a/packages/at_client/test/monitor_test.dart
+++ b/packages/at_client/test/monitor_test.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/src/manager/monitor.dart';
-import 'package:at_client/src/service/notification_service.dart';
-import 'package:at_commons/at_commons.dart';
 import 'package:at_lookup/at_lookup.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:test/test.dart';
@@ -30,8 +28,16 @@ class FakeMuxable extends Fake implements AtLookupMuxable {
   // `notificationConnectionUp` builds a fresh one. A fake that reused a single
   // controller could not reproduce a stop-then-start race at all - the
   // subscriptions would keep working and the bug would be invisible.
-  StreamController<String> _notifications = StreamController<String>();
+  /// Counted so a test can prove the back-pressure seam is actually reached,
+  /// rather than inferring it from handling order.
+  int pauses = 0;
+  int resumes = 0;
+
+  late StreamController<String> _notifications = _newNotifications();
   StreamController<bool> _up = StreamController<bool>.broadcast();
+
+  StreamController<String> _newNotifications() => StreamController<String>(
+      onPause: () => pauses++, onResume: () => resumes++);
 
   bool started = false;
   int? startedWithWatermark;
@@ -78,7 +84,7 @@ class FakeMuxable extends Fake implements AtLookupMuxable {
     // Closed and replaced, as the real one does.
     final n = _notifications;
     final u = _up;
-    _notifications = StreamController<String>();
+    _notifications = _newNotifications();
     _up = StreamController<bool>.broadcast();
     unawaited(n.close());
     unawaited(u.close());
@@ -283,6 +289,47 @@ void main() {
       expect(monitor.lastReceipt, isNotNull);
     });
 
+    test('are handled one at a time, and pause the connection while they are',
+        () async {
+      final log = <String>[];
+      monitor = Monitor(
+        atSign: '@alice',
+        atClientPreference: AtClientPreference(),
+        lookUp: muxable,
+        handleNotification: (String n) async {
+          log.add('enter $n');
+          await Future.delayed(const Duration(milliseconds: 20));
+          log.add('exit $n');
+        },
+        getLastNotificationTime: () async => null,
+      );
+      monitor.logger.level = 'severe';
+
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+      muxable.deliver('A');
+      muxable.deliver('B');
+      await Future.delayed(const Duration(milliseconds: 120));
+
+      expect(log, ['enter A', 'exit A', 'enter B', 'exit B'],
+          reason: 'listen() discards the future an async handler returns, so '
+              'without the pause both run at once - the watermark is then '
+              'written out of arrival order and the atServer replays a window '
+              'on the next reconnect');
+      // Measured 1 and 1, not 2 and 2: the second notification is delivered
+      // out of the controller's buffer while it is still draining, and a
+      // pause during that does not re-fire onPause. What matters is that the
+      // seam is reached at all and left balanced.
+      expect(muxable.pauses, greaterThan(0),
+          reason: 'the pause reached the connection rather than being an '
+              'accident of handler timing: at_lookup carries it to the '
+              'socket, which is what keeps a reconnect backlog arriving at '
+              'the rate this client can absorb');
+      expect(muxable.resumes, muxable.pauses,
+          reason: 'and every pause was matched, so a handler cannot leave the '
+              'connection stopped for good');
+    });
+
     test('a handler that throws does not kill the stream', () async {
       monitor = Monitor(
         atSign: '@alice',
@@ -342,6 +389,75 @@ void main() {
       expect(states, [NotificationListenerState.listening],
           reason: 'a repeated identical state is noise on a stream something '
               'reacts to');
+    });
+  });
+
+  /// at_lookup recovers a connection that DROPS. It cannot see one that stays
+  /// up, answers every heartbeat, and delivers nothing - only this class knows
+  /// when a notification last arrived. Without these the client reports
+  /// `listening` for ever while deaf, which is what the public contract on
+  /// `NotificationService.currentListenerState` promises it will not do.
+  group('a connection that is up but silent', () {
+    Monitor monitorWithBudget(Duration budget) {
+      final m = Monitor(
+        atSign: '@alice',
+        atClientPreference: AtClientPreference()
+          ..monitorSilenceTimeout = budget,
+        lookUp: muxable,
+        handleNotification: (String n) async => received.add(n),
+        getLastNotificationTime: () async => null,
+      );
+      m.logger.level = 'severe';
+      return m;
+    }
+
+    test('is rebuilt', () async {
+      monitor = monitorWithBudget(const Duration(milliseconds: 40));
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 20));
+      expect(muxable.startCalls, 1);
+
+      await Future.delayed(const Duration(milliseconds: 150));
+
+      expect(muxable.startCalls, greaterThan(1),
+          reason: 'nothing arrived for longer than the budget on a connection '
+              'that never went down, so the monitor tore it down and asked '
+              'for a new one - at_lookup sees a healthy socket here and will '
+              'never do it');
+      monitor.stop();
+    });
+
+    test('is left alone while notifications keep arriving', () async {
+      // Budget comfortably longer than the delivery gap: the check fires one
+      // budget after connect, so a gap anywhere near it races the first tick.
+      monitor = monitorWithBudget(const Duration(milliseconds: 100));
+      monitor.start();
+
+      for (var i = 0; i < 12; i++) {
+        await Future.delayed(const Duration(milliseconds: 25));
+        muxable.deliver('notification: {"id":"$i"}');
+      }
+
+      expect(muxable.startCalls, 1,
+          reason: 'the check is about SILENCE, not about elapsed time - a busy '
+              'connection outlives many budgets and must not be rebuilt under '
+              'a working client');
+      // Handling is serialised now, so the last delivery is still in flight.
+      await Future.delayed(const Duration(milliseconds: 40));
+      expect(received, hasLength(12));
+      monitor.stop();
+    });
+
+    test('is left alone when the budget is zero', () async {
+      monitor = monitorWithBudget(Duration.zero);
+      monitor.start();
+      await Future.delayed(const Duration(milliseconds: 170));
+
+      expect(muxable.startCalls, 1,
+          reason: 'an atServer configured to send no stats notifications is '
+              'silent when healthy, so an operator must be able to turn the '
+              'check off rather than have it rebuild a good connection');
+      monitor.stop();
     });
   });
 

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -1729,15 +1729,16 @@ void main() {
               'change how often the notification connection is probed; the '
               'muxable owns the probe now, so a preference that does not '
               'reach it is not overridden, it is silently ignored');
-      expect(ns.monitor.lookUp.heartbeatResponseTimeout,
-          Duration(milliseconds: 7),
+      expect(
+          ns.monitor.lookUp.heartbeatResponseTimeout, Duration(milliseconds: 7),
           reason: 'and monitorHeartbeatResponseTimeout decides how long an '
               'unanswered probe waits before the connection is torn down and '
               'rebuilt. Both sides default to 10 seconds, so only a tuned '
               'value can tell a wired field from an unwired one');
     });
 
-    test('an untouched preference gives the documented 59s, not the 30s '
+    test(
+        'an untouched preference gives the documented 59s, not the 30s '
         'underneath', () async {
       final ns = await NotificationServiceImpl.create(mockAtClientImpl,
               secondaryAddressFinder: mockSecondaryAddressFinder)

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -1694,6 +1694,65 @@ void main() {
           NotificationListenerState.notConnected);
     });
   });
+
+  /// [AtClientPreference.monitorHeartbeatInterval] and
+  /// [AtClientPreference.monitorHeartbeatResponseTimeout] are the only public
+  /// controls over the notification connection's liveness probe, and nothing
+  /// between them and the socket reads them any more: Monitor holds the
+  /// preference but never looks at either field, because the muxable it drives
+  /// owns the heartbeat. This constructor is the one place the two values
+  /// cross that gap, so it is the only place a test can pin them. at_lookup's
+  /// own heartbeat tests set the interval on the implementation directly and
+  /// cannot see an AtClientPreference at all.
+  group('the heartbeat preferences reach the muxable', () {
+    late AtClientPreference preference;
+
+    setUp(() {
+      preference = AtClientPreference()
+        ..namespace = 'wavi'
+        ..monitorAutoStart = false;
+      when(() => mockAtClientImpl.getPreferences()).thenReturn(preference);
+    });
+
+    test('a tuned interval and response timeout are both carried across',
+        () async {
+      preference
+        ..monitorHeartbeatInterval = Duration(milliseconds: 20)
+        ..monitorHeartbeatResponseTimeout = Duration(milliseconds: 7);
+
+      final ns = await NotificationServiceImpl.create(mockAtClientImpl,
+              secondaryAddressFinder: mockSecondaryAddressFinder)
+          as NotificationServiceImpl;
+
+      expect(ns.monitor.lookUp.heartbeatInterval, Duration(milliseconds: 20),
+          reason: 'an application that tunes monitorHeartbeatInterval must '
+              'change how often the notification connection is probed; the '
+              'muxable owns the probe now, so a preference that does not '
+              'reach it is not overridden, it is silently ignored');
+      expect(ns.monitor.lookUp.heartbeatResponseTimeout,
+          Duration(milliseconds: 7),
+          reason: 'and monitorHeartbeatResponseTimeout decides how long an '
+              'unanswered probe waits before the connection is torn down and '
+              'rebuilt. Both sides default to 10 seconds, so only a tuned '
+              'value can tell a wired field from an unwired one');
+    });
+
+    test('an untouched preference gives the documented 59s, not the 30s '
+        'underneath', () async {
+      final ns = await NotificationServiceImpl.create(mockAtClientImpl,
+              secondaryAddressFinder: mockSecondaryAddressFinder)
+          as NotificationServiceImpl;
+
+      // A raw-literal pin on the default, not a second wiring test: every
+      // mutation that reddens this one reddens the test above too.
+      expect(ns.monitor.lookUp.heartbeatInterval, Duration(seconds: 59),
+          reason: 'the documented default is what a client that never touched '
+              'the preference gets, and at_lookup initialises 30 underneath. '
+              'Changing that default nearly doubles the idle traffic of '
+              'every such client, so this assertion is what an intended '
+              'change edits');
+    });
+  });
 }
 
 class StatsAtKeyMatcher extends Matcher {

--- a/packages/at_client/test/notification_service_test.dart
+++ b/packages/at_client/test/notification_service_test.dart
@@ -991,10 +991,12 @@ void main() {
           false,
           value: 'Got it');
 
-      String fromAtServer =
-          'notification: ${jsonEncode(atNotification.toJson())}\n'
-          '@${mockAtClientImpl.getCurrentAtSign()}@';
-      await ns.monitor.onSocketDataReceipt(fromAtServer.codeUnits);
+      // Delivered as the muxable delivers it: already framed. The byte-level
+      // framing that used to be tested here - Monitor.onSocketDataReceipt -
+      // now lives in at_lookup's listener and is covered by its own
+      // socket_delivery_test.dart.
+      await ns.monitor.handleNotification(
+          'notification: ${jsonEncode(atNotification.toJson())}');
 
       expect(ns.lastReceipt, isNotNull);
       expect(ns.lastReceipt!.microsecondsSinceEpoch,
@@ -1024,10 +1026,12 @@ void main() {
         received.add(n);
       });
 
-      String fromAtServer =
-          'notification: ${jsonEncode(atNotification.toJson())}\n'
-          '@${mockAtClientImpl.getCurrentAtSign()}@';
-      await ns.monitor.onSocketDataReceipt(fromAtServer.codeUnits);
+      // Delivered as the muxable delivers it: already framed. The byte-level
+      // framing that used to be tested here - Monitor.onSocketDataReceipt -
+      // now lives in at_lookup's listener and is covered by its own
+      // socket_delivery_test.dart.
+      await ns.monitor.handleNotification(
+          'notification: ${jsonEncode(atNotification.toJson())}');
 
       await Future.delayed(Duration(milliseconds: 1));
       expect(received, isNotEmpty);

--- a/packages/at_client/test/remote_secondary_test.dart
+++ b/packages/at_client/test/remote_secondary_test.dart
@@ -24,6 +24,30 @@ void main() {
           mockSecondaryAddressFinder;
     });
 
+    test(
+        'the lookup it builds is a muxable carrying an authenticator, not a '
+        'lookup with credentials parked on it', () async {
+      final preference = AtClientPreference()..privateKey = 'dummy_private_key';
+      final remoteSecondary = RemoteSecondary(atsign, preference);
+
+      expect(remoteSecondary.atLookUp, isA<AtLookupMuxable>(),
+          reason: 'withSecureSocket returns the muxable, which is the only '
+              'shape that carries an authenticator at all');
+      expect((remoteSecondary.atLookUp as AtLookupMuxable).authenticator,
+          isNotNull,
+          reason: 'credentials travel as an authenticator now; leaving this '
+              'null puts authentication back on the deprecated ladder, which '
+              'still works and so hides the regression from every live pack');
+    });
+
+    test('an injected lookup that is not a muxable is left alone', () async {
+      final remoteSecondary =
+          RemoteSecondary(atsign, atClientPreference, atLookUp: mockAtLookUp);
+
+      expect(remoteSecondary.atLookUp, same(mockAtLookUp),
+          reason: 'the caller supplied it, so it is used as given');
+    });
+
     test('test findSecondaryUrl', () async {
       RemoteSecondary remoteSecondary =
           RemoteSecondary(atsign, atClientPreference);

--- a/packages/at_client/test/storage/at_client_storage_release_test.dart
+++ b/packages/at_client/test/storage/at_client_storage_release_test.dart
@@ -246,6 +246,61 @@ void main() {
         reason: 'storage the client built itself is closed on release, and a '
             'closed store cannot be reopened');
   });
+
+  test('a closedByClient bundle is closed when the client stops', () async {
+    final storage = HiveAtClientStorage(
+        atSign: '@closedbyclient', storagePath: dir.path, closedByClient: true);
+    final client = await AtClient.create(
+        atSign: '@closedbyclient',
+        namespace: 'wavi',
+        preference: pref(),
+        storage: storage);
+
+    await client.stop();
+
+    final second =
+        HiveAtClientStorage(atSign: '@closedbyclient', storagePath: dir.path);
+    StateError? refused;
+    try {
+      await second.attach(FakeClient('@closedbyclient', 'e2'));
+    } on StateError catch (e) {
+      refused = e;
+    }
+    expect(refused, isNull,
+        reason: 'the bundle said the client closes it, so stop() closed it and '
+            'released the store rather than only detaching');
+    expect(second.isAttached, isTrue);
+    await second.close();
+  });
+
+  test(
+      'a borrowed bundle stays open when the client stops, and the caller '
+      'closes it', () async {
+    final storage =
+        HiveAtClientStorage(atSign: '@borrowedopen', storagePath: dir.path);
+    final client = await AtClient.create(
+        atSign: '@borrowedopen',
+        namespace: 'wavi',
+        preference: pref(),
+        storage: storage);
+
+    await client.stop();
+
+    final second =
+        HiveAtClientStorage(atSign: '@borrowedopen', storagePath: dir.path);
+    await expectLater(
+        () => second.attach(FakeClient('@borrowedopen', 'e2')),
+        throwsA(isA<StateError>()
+            .having((e) => e.message, 'message', contains('already open at'))),
+        reason: 'the default is borrowed, so stop() detached without closing '
+            'and the store is still held');
+
+    await storage.close();
+    await second.attach(FakeClient('@borrowedopen', 'e2'));
+    expect(second.isAttached, isTrue,
+        reason: 'and closing it is what releases the store');
+    await second.close();
+  });
 }
 
 /// Records whether [_storage] was already attached when the client asked this

--- a/packages/at_client_flutter/CHANGELOG.md
+++ b/packages/at_client_flutter/CHANGELOG.md
@@ -1,6 +1,18 @@
 # CHANGELOG
 
 ## 1.1.5
+- feat: `AuthService.createClient` turns a completed authentication into a
+  client the app owns, taking `storage` to decide the backend and the location.
+  Nothing registers it, so an app that manages its own client lifetimes no
+  longer has to go through `AtClientManager`; one that wants the shared
+  current-atSign client goes on calling `AtClientManager.fromAuthSession`.
+  The bundle is borrowed, not owned: the client detaches from it on stop and
+  closing it is the app's job.
+- feat: `FlutterEnrollmentService` takes an optional `atClient`, so it can work
+  against a client the app owns. With none it uses `AtClientManager`'s current
+  client, as it always has.
+- build: require `at_client` ^3.14.1, the first version carrying
+  `AtClient.create`; the floor still said ^3.11.0.
 - feat: `CramDialog` and `PkamDialog` take an optional `authService`, and
   `ApkamActivationDialog` an optional `enrollmentService`. Both default to the
   real service, so existing call sites are unaffected; passing one lets the

--- a/packages/at_client_flutter/CHANGELOG.md
+++ b/packages/at_client_flutter/CHANGELOG.md
@@ -18,7 +18,7 @@
   client and the enrollment UI works without `AtClientManager`; it previously
   reached the current-atSign client at five sites and threw for such an app.
   A service the widget did not build is no longer disposed with the widget.
-- build: require `at_client` ^3.14.1, the first version carrying
+- build: require `at_client` ^3.15.0-rc1, the first version carrying
   `AtClient.create`; the floor still said ^3.11.0.
 - feat: `CramDialog` and `PkamDialog` take an optional `authService`, and
   `ApkamActivationDialog` an optional `enrollmentService`. Both default to the

--- a/packages/at_client_flutter/CHANGELOG.md
+++ b/packages/at_client_flutter/CHANGELOG.md
@@ -3,14 +3,21 @@
 ## 1.1.5
 - feat: `AuthService.createClient` turns a completed authentication into a
   client the app owns, taking `storage` to decide the backend and the location.
-  Nothing registers it, so an app that manages its own client lifetimes no
-  longer has to go through `AtClientManager`; one that wants the shared
-  current-atSign client goes on calling `AtClientManager.fromAuthSession`.
-  The bundle is borrowed, not owned: the client detaches from it on stop and
-  closing it is the app's job.
+  The app owns its lifetime, so it no longer has to go through
+  `AtClientManager`; one that wants the shared current-atSign client goes on
+  calling `AtClientManager.fromAuthSession`. ⚠️ The client is not invisible to
+  `AtClientManager` — a later `setCurrentAtSign` for the same atSign adopts it
+  and stops it on the next switch, so do not mix the two for one atSign in
+  one process. The bundle is borrowed unless built with `closedByClient:
+  true`, in which case the client closes it on stop.
 - feat: `FlutterEnrollmentService` takes an optional `atClient`, so it can work
   against a client the app owns. With none it uses `AtClientManager`'s current
   client, as it always has.
+- feat: `EnrollmentRequestList` takes an optional `enrollmentService`, and
+  every client read now goes through it. Give it one built with an app-owned
+  client and the enrollment UI works without `AtClientManager`; it previously
+  reached the current-atSign client at five sites and threw for such an app.
+  A service the widget did not build is no longer disposed with the widget.
 - build: require `at_client` ^3.14.1, the first version carrying
   `AtClient.create`; the floor still said ^3.11.0.
 - feat: `CramDialog` and `PkamDialog` take an optional `authService`, and

--- a/packages/at_client_flutter/example/lib/walkthrough.dart
+++ b/packages/at_client_flutter/example/lib/walkthrough.dart
@@ -77,14 +77,23 @@ Future<void> onboard(BuildContext context) async {
     var dir = await getApplicationSupportDirectory();
     _logger.info('Application support directory: ${dir.path}');
 
-    var acp = AtClientPreference()
-      ..namespace = namespace
-      ..hiveStoragePath = dir.path;
+    var acp = AtClientPreference()..namespace = namespace;
+    // closedByClient: this app picks the location and the client still closes
+    // the store when it stops, so there is nothing to tear down.
+    var storage = HiveAtClientStorage(
+      atSign: response.atSign,
+      storagePath: dir.path,
+      closedByClient: true,
+    );
 
     _logger.info('Setting current atSign: ${response.atSign}');
     // Hand the client the session; it rebuilds its own authenticated connection
     // from the session's key source rather than adopting auth's.
-    await AtClientManager.getInstance().fromAuthSession(response.session!, acp);
+    await AtClientManager.getInstance().fromAuthSession(
+      response.session!,
+      acp,
+      storage: storage,
+    );
 
     _logger.info('Navigation to HomePage');
     if (context.mounted) {
@@ -327,9 +336,14 @@ Future<void> _setupAtClient(BuildContext context, AuthResponse response) async {
   var dir = await getApplicationSupportDirectory();
   _logger.info('Using directory: ${dir.path}');
 
-  var acp = AtClientPreference()
-    ..namespace = namespace
-    ..hiveStoragePath = dir.path;
+  var acp = AtClientPreference()..namespace = namespace;
+  // closedByClient: this app picks the location and the client still closes the
+  // store when it stops, so there is nothing to tear down.
+  var storage = HiveAtClientStorage(
+    atSign: response.atSign,
+    storagePath: dir.path,
+    closedByClient: true,
+  );
 
   if (response.enrollmentId == null) {
     _logger.warning("EnrollmentId is null");
@@ -338,7 +352,11 @@ Future<void> _setupAtClient(BuildContext context, AuthResponse response) async {
   if (session != null) {
     // Preferred path: hand over the session; the client rebuilds its own
     // authenticated connection from the session's key source.
-    await AtClientManager.getInstance().fromAuthSession(session, acp);
+    await AtClientManager.getInstance().fromAuthSession(
+      session,
+      acp,
+      storage: storage,
+    );
   } else {
     // Transitional fallback for flows that hand back only atAuthKeys with no
     // AtKeysIo source (e.g. APKAM enrollment): adopt auth's already-
@@ -350,6 +368,7 @@ Future<void> _setupAtClient(BuildContext context, AuthResponse response) async {
       enrollmentId: response.enrollmentId,
       atChops: response.atChops,
       atLookUp: response.atLookUp,
+      storage: storage,
     );
   }
 

--- a/packages/at_client_flutter/example/lib/walkthrough.dart
+++ b/packages/at_client_flutter/example/lib/walkthrough.dart
@@ -79,7 +79,6 @@ Future<void> onboard(BuildContext context) async {
 
     var acp = AtClientPreference()
       ..namespace = namespace
-      ..commitLogPath = dir.path
       ..hiveStoragePath = dir.path;
 
     _logger.info('Setting current atSign: ${response.atSign}');
@@ -330,7 +329,6 @@ Future<void> _setupAtClient(BuildContext context, AuthResponse response) async {
 
   var acp = AtClientPreference()
     ..namespace = namespace
-    ..commitLogPath = dir.path
     ..hiveStoragePath = dir.path;
 
   if (response.enrollmentId == null) {

--- a/packages/at_client_flutter/examples/dockerstats/lib/main_smoke.dart
+++ b/packages/at_client_flutter/examples/dockerstats/lib/main_smoke.dart
@@ -104,14 +104,20 @@ class _SmokeBootstrapState extends State<_SmokeBootstrap> {
       }
       _setStatus('Setting up AtClient...');
       final dir = await getApplicationSupportDirectory();
-      final acp = AtClientPreference()
-        ..namespace = applicationNamespace
-        ..hiveStoragePath = dir.path;
+      final acp = AtClientPreference()..namespace = applicationNamespace;
+      // closedByClient: this app picks the location and the client still closes
+      // the store when it stops, so there is nothing to tear down.
+      final storage = HiveAtClientStorage(
+        atSign: atSign,
+        storagePath: dir.path,
+        closedByClient: true,
+      );
       // Hand the client the session; it rebuilds its own authenticated
       // connection from the session's key source rather than adopting auth's.
       await AtClientManager.getInstance().fromAuthSession(
         response.session!,
         acp,
+        storage: storage,
       );
       _setStatus('AtClient ready, navigating to dashboard');
       if (!mounted) return;

--- a/packages/at_client_flutter/examples/dockerstats/lib/main_smoke.dart
+++ b/packages/at_client_flutter/examples/dockerstats/lib/main_smoke.dart
@@ -106,7 +106,6 @@ class _SmokeBootstrapState extends State<_SmokeBootstrap> {
       final dir = await getApplicationSupportDirectory();
       final acp = AtClientPreference()
         ..namespace = applicationNamespace
-        ..commitLogPath = dir.path
         ..hiveStoragePath = dir.path;
       // Hand the client the session; it rebuilds its own authenticated
       // connection from the session's key source rather than adopting auth's.

--- a/packages/at_client_flutter/examples/dockerstats/lib/onboarding.dart
+++ b/packages/at_client_flutter/examples/dockerstats/lib/onboarding.dart
@@ -100,14 +100,24 @@ Future<void> _setupAtClient(AuthResponse response) async {
   final dir = await getApplicationSupportDirectory();
   final acp = AtClientPreference()
     ..namespace = _namespace
-    ..hiveStoragePath = dir.path
     ..fetchOfflineNotifications = false;
+  // closedByClient: the app picks the backend and the location, and the client
+  // still closes the store when it stops, so there is nothing to tear down.
+  final storage = HiveAtClientStorage(
+    atSign: response.atSign,
+    storagePath: dir.path,
+    closedByClient: true,
+  );
 
   final session = response.session;
   if (session != null) {
     // Preferred path: hand over the session; the client rebuilds its own
     // connection from the session's key source.
-    await AtClientManager.getInstance().fromAuthSession(session, acp);
+    await AtClientManager.getInstance().fromAuthSession(
+      session,
+      acp,
+      storage: storage,
+    );
   } else {
     // Transitional fallback for flows that hand back only atAuthKeys with no
     // AtKeysIo source (e.g. APKAM enrollment): adopt auth's already-
@@ -119,6 +129,7 @@ Future<void> _setupAtClient(AuthResponse response) async {
       enrollmentId: response.enrollmentId,
       atChops: response.atChops,
       atLookUp: response.atLookUp,
+      storage: storage,
     );
   }
   _log.info('atClient ready for ${response.atSign}');

--- a/packages/at_client_flutter/examples/dockerstats/lib/onboarding.dart
+++ b/packages/at_client_flutter/examples/dockerstats/lib/onboarding.dart
@@ -100,7 +100,6 @@ Future<void> _setupAtClient(AuthResponse response) async {
   final dir = await getApplicationSupportDirectory();
   final acp = AtClientPreference()
     ..namespace = _namespace
-    ..commitLogPath = dir.path
     ..hiveStoragePath = dir.path
     ..fetchOfflineNotifications = false;
 

--- a/packages/at_client_flutter/examples/todos/lib/onboarding.dart
+++ b/packages/at_client_flutter/examples/todos/lib/onboarding.dart
@@ -100,7 +100,6 @@ Future<void> _setupAtClient(AuthResponse response) async {
   final dir = await getApplicationSupportDirectory();
   final acp = AtClientPreference()
     ..namespace = _namespace
-    ..commitLogPath = dir.path
     ..hiveStoragePath = dir.path;
 
   final session = response.session;

--- a/packages/at_client_flutter/examples/todos/lib/onboarding.dart
+++ b/packages/at_client_flutter/examples/todos/lib/onboarding.dart
@@ -98,15 +98,24 @@ Future<void> logout() async {
 
 Future<void> _setupAtClient(AuthResponse response) async {
   final dir = await getApplicationSupportDirectory();
-  final acp = AtClientPreference()
-    ..namespace = _namespace
-    ..hiveStoragePath = dir.path;
+  final acp = AtClientPreference()..namespace = _namespace;
+  // closedByClient: the app picks the backend and the location, and the client
+  // still closes the store when it stops, so there is nothing to tear down.
+  final storage = HiveAtClientStorage(
+    atSign: response.atSign,
+    storagePath: dir.path,
+    closedByClient: true,
+  );
 
   final session = response.session;
   if (session != null) {
     // Preferred path: hand over the session; the client rebuilds its own
     // connection from the session's key source.
-    await AtClientManager.getInstance().fromAuthSession(session, acp);
+    await AtClientManager.getInstance().fromAuthSession(
+      session,
+      acp,
+      storage: storage,
+    );
   } else {
     // Transitional fallback for flows that hand back only atAuthKeys with no
     // AtKeysIo source (e.g. APKAM enrollment): adopt auth's already-
@@ -118,6 +127,7 @@ Future<void> _setupAtClient(AuthResponse response) async {
       enrollmentId: response.enrollmentId,
       atChops: response.atChops,
       atLookUp: response.atLookUp,
+      storage: storage,
     );
   }
   _log.info('atClient ready for ${response.atSign}');

--- a/packages/at_client_flutter/lib/src/services/auth_service.dart
+++ b/packages/at_client_flutter/lib/src/services/auth_service.dart
@@ -97,19 +97,29 @@ class AuthService {
 
   /// Builds a client from a completed authentication, which the caller owns.
   ///
-  /// Nothing registers the client: it is unknown to [AtClientManager], and
-  /// stopping it is the caller's job. An app that wants the shared
+  /// Stopping it is the caller's job. An app that wants the shared
   /// current-atSign client calls [AtClientManager.fromAuthSession] instead,
   /// which is unchanged.
+  ///
+  /// ⚠️ The client is NOT invisible to [AtClientManager]. It is filed in
+  /// `AtClientImpl.atClientInstanceMap` like any other, so a later
+  /// [AtClientManager.setCurrentAtSign] for the same atSign adopts THIS
+  /// client, replaces its services without stopping the ones it had, and
+  /// stops it on the next atSign switch.
+  ///
+  /// To use this package's enrollment widgets against this client, hand it to
+  /// a [FlutterEnrollmentService] and give that to [EnrollmentRequestList];
+  /// with no service they read [AtClientManager]'s current client instead.
   ///
   ///   [session] - the [AtAuthSession] an [onboard] or [authenticate] produced.
   ///   Its root domain is destructured onto [preference].
   ///
   ///   [storage] - the client's local storage, which decides the backend and
   ///   the location and so leaves `preference.hiveStoragePath` unread.
-  ///   Borrowed rather than owned: the client detaches from it when it stops,
-  ///   and closing it is the caller's job. Leave it null and the client opens
-  ///   a Hive store under `hiveStoragePath` and closes that itself.
+  ///   Borrowed unless it was built with `closedByClient: true`: by default
+  ///   the client detaches from it when it stops and closing it is the
+  ///   caller's job. Leave it null and the client opens a Hive store under
+  ///   `hiveStoragePath` and closes that itself.
   ///
   ///   [reuse] - adopt the session's already-authenticated connection and skip
   ///   a second PKAM handshake. By default the client opens its own.

--- a/packages/at_client_flutter/lib/src/services/auth_service.dart
+++ b/packages/at_client_flutter/lib/src/services/auth_service.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:at_auth/at_auth.dart';
+import 'package:at_client/at_client.dart';
 import 'package:at_client_flutter/src/keychain/keychain_io_impl.dart';
 import 'package:at_utils/at_progress.dart';
 
@@ -92,5 +93,42 @@ class AuthService {
       rethrow;
     }
     return atAuthResponse;
+  }
+
+  /// Builds a client from a completed authentication, which the caller owns.
+  ///
+  /// Nothing registers the client: it is unknown to [AtClientManager], and
+  /// stopping it is the caller's job. An app that wants the shared
+  /// current-atSign client calls [AtClientManager.fromAuthSession] instead,
+  /// which is unchanged.
+  ///
+  ///   [session] - the [AtAuthSession] an [onboard] or [authenticate] produced.
+  ///   Its root domain is destructured onto [preference].
+  ///
+  ///   [storage] - the client's local storage, which decides the backend and
+  ///   the location and so leaves `preference.hiveStoragePath` unread.
+  ///   Borrowed rather than owned: the client detaches from it when it stops,
+  ///   and closing it is the caller's job. Leave it null and the client opens
+  ///   a Hive store under `hiveStoragePath` and closes that itself.
+  ///
+  ///   [reuse] - adopt the session's already-authenticated connection and skip
+  ///   a second PKAM handshake. By default the client opens its own.
+  Future<AtClient> createClient(
+    AtAuthSession session,
+    AtClientPreference preference, {
+    AtClientStorage? storage,
+    bool reuse = false,
+  }) async {
+    preference.rootDomain = session.rootDomain.rootDomain;
+    preference.rootPort = session.rootDomain.rootPort;
+    return AtClient.create(
+      atSign: session.atSign,
+      namespace: session.namespace,
+      preference: preference,
+      atKeysIo: session.atKeysIo,
+      atLookUp: reuse ? session.atLookUp : null,
+      enrollmentId: session.enrollmentId,
+      storage: storage,
+    );
   }
 }

--- a/packages/at_client_flutter/lib/src/services/enrollment_service.dart
+++ b/packages/at_client_flutter/lib/src/services/enrollment_service.dart
@@ -12,10 +12,15 @@ import 'package:at_utils/at_progress.dart';
 /// {@endtemplate}
 class FlutterEnrollmentService {
   /// {@macro flutter_enrollment_service}
-  FlutterEnrollmentService() {
+  ///
+  /// Pass [atClient] to work against a client the app owns; with none, the
+  /// service uses [AtClientManager]'s current one as it always has.
+  FlutterEnrollmentService({AtClient? atClient}) : _atClient = atClient {
     _logger.info('Initialising FlutterEnrollmentService');
     _enrollmentRequestsController!.onListen = _listenForNewRequests;
   }
+
+  final AtClient? _atClient;
 
   final AtSignLogger _logger = AtSignLogger('FlutterEnrollmentService');
   final AtEnrollment _atEnrollment = AtEnrollment.create();
@@ -23,7 +28,7 @@ class FlutterEnrollmentService {
   final KeychainAtKeysIo _keychainAtKeysIo = KeychainAtKeysIo();
 
   /// Instance of [AtClient] for the current atSign
-  AtClient get atClient => AtClientManager.getInstance().atClient;
+  AtClient get atClient => _atClient ?? AtClientManager.getInstance().atClient;
 
   static const _kDefaultExpiry = Duration(minutes: 5);
 

--- a/packages/at_client_flutter/lib/src/widgets/authorisation/containers/enrollment_request_list.dart
+++ b/packages/at_client_flutter/lib/src/widgets/authorisation/containers/enrollment_request_list.dart
@@ -10,16 +10,27 @@ import 'package:flutter/material.dart';
 /// It listens to real-time updates and provides approval/denial functionality.
 /// {@endtemplate}
 class EnrollmentRequestList extends StatefulWidget {
-  const EnrollmentRequestList({super.key, this.useShrinkWrap = false});
+  const EnrollmentRequestList({
+    super.key,
+    this.useShrinkWrap = false,
+    this.enrollmentService,
+  });
 
   final bool useShrinkWrap;
+
+  /// The service this widget works through, and with it the [AtClient] the
+  /// service holds. Pass one built with an app-owned client to use this
+  /// widget without [AtClientManager]; with none it uses the current-atSign
+  /// client, as it always has.
+  final FlutterEnrollmentService? enrollmentService;
 
   @override
   State<EnrollmentRequestList> createState() => _EnrollmentRequestListState();
 }
 
 class _EnrollmentRequestListState extends State<EnrollmentRequestList> {
-  final FlutterEnrollmentService _service = FlutterEnrollmentService();
+  late final FlutterEnrollmentService _service =
+      widget.enrollmentService ?? FlutterEnrollmentService();
   final List<ServerEnrollmentRequest> _requests = [];
   final List<Timer> _overlayTimers = [];
   StreamSubscription? _subscription;
@@ -65,9 +76,7 @@ class _EnrollmentRequestListState extends State<EnrollmentRequestList> {
           );
 
       // Initial fetch of pending requests
-      final atLookUp = AtClientManager.getInstance().atClient
-          .getRemoteSecondary()!
-          .atLookUp;
+      final atLookUp = _service.atClient.getRemoteSecondary()!.atLookUp;
       final initialRequests = await _service.list([
         EnrollmentStatus.pending,
       ], atLookUp);
@@ -94,10 +103,8 @@ class _EnrollmentRequestListState extends State<EnrollmentRequestList> {
 
   Future<void> _handleApprove(ServerEnrollmentRequest request) async {
     try {
-      final atSign = AtClientManager.getInstance().atClient.getCurrentAtSign()!;
-      final atLookUp = AtClientManager.getInstance().atClient
-          .getRemoteSecondary()!
-          .atLookUp;
+      final atSign = _service.atClient.getCurrentAtSign()!;
+      final atLookUp = _service.atClient.getRemoteSecondary()!.atLookUp;
       await _service.approve(
         EnrollmentRequestDecision.approved(
           enrollmentId: request.enrollmentId,
@@ -131,10 +138,8 @@ class _EnrollmentRequestListState extends State<EnrollmentRequestList> {
 
   Future<void> _handleDeny(ServerEnrollmentRequest request) async {
     try {
-      final atSign = AtClientManager.getInstance().atClient.getCurrentAtSign()!;
-      final atLookUp = AtClientManager.getInstance().atClient
-          .getRemoteSecondary()!
-          .atLookUp;
+      final atSign = _service.atClient.getCurrentAtSign()!;
+      final atLookUp = _service.atClient.getRemoteSecondary()!.atLookUp;
       await _service.deny(
         EnrollmentRequestDecision.denied(request.enrollmentId, atSign),
         atLookUp,
@@ -199,7 +204,9 @@ class _EnrollmentRequestListState extends State<EnrollmentRequestList> {
   @override
   void dispose() {
     _subscription?.cancel();
-    _service.dispose();
+    // Only a service this widget built. Disposing one the app supplied would
+    // close a controller the app still holds, and it cannot be reopened.
+    if (widget.enrollmentService == null) _service.dispose();
     for (var timer in _overlayTimers) {
       timer.cancel();
     }

--- a/packages/at_client_flutter/pubspec.yaml
+++ b/packages/at_client_flutter/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   at_chops: ^3.0.0
   at_lookup: ^3.5.0
   at_auth: ^4.0.0-rc1
-  at_client: ^3.14.1
+  at_client: ^3.15.0-rc1
   encrypt: ^5.0.3
   intl: ^0.20.2
   file_picker: ^11.0.02

--- a/packages/at_client_flutter/pubspec.yaml
+++ b/packages/at_client_flutter/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   at_chops: ^3.0.0
   at_lookup: ^3.5.0
   at_auth: ^4.0.0-rc1
-  at_client: ^3.11.0
+  at_client: ^3.14.1
   encrypt: ^5.0.3
   intl: ^0.20.2
   file_picker: ^11.0.02

--- a/packages/at_client_flutter/test/auth_service_create_client_test.dart
+++ b/packages/at_client_flutter/test/auth_service_create_client_test.dart
@@ -57,7 +57,8 @@ void main() {
     atKeysIo: mockAtKeysIo,
   );
 
-  test('the client holds the storage, and nothing registers it', () async {
+  test('the client holds the storage, and is filed but not made current',
+      () async {
     final storage = InMemoryAtClientStorage(atSign: atSign);
     final client = await AuthService(
       atAuth: MockAtAuth(),
@@ -78,6 +79,17 @@ void main() {
           'quietly opening a Hive store of its own',
     );
     expect(client.getCurrentAtSign(), atSign);
+    expect(
+      AtClientImpl.atClientInstanceMap[atSign],
+      same(client),
+      reason:
+          'AtClientImpl.create files every client it builds, this one '
+          'included - so a later setCurrentAtSign for this atSign adopts '
+          'THIS client rather than building its own. Asserting only that '
+          'the manager has no current client passes before createClient is '
+          'ever called, which is what made the previous version of this '
+          'test vacuous',
+    );
     expect(
       () => AtClientManager.getInstance().atClient,
       throwsStateError,

--- a/packages/at_client_flutter/test/auth_service_create_client_test.dart
+++ b/packages/at_client_flutter/test/auth_service_create_client_test.dart
@@ -57,50 +57,52 @@ void main() {
     atKeysIo: mockAtKeysIo,
   );
 
-  test('the client holds the storage, and is filed but not made current',
-      () async {
-    final storage = InMemoryAtClientStorage(atSign: atSign);
-    final client = await AuthService(
-      atAuth: MockAtAuth(),
-    ).createClient(session(), preference(), storage: storage);
+  test(
+    'the client holds the storage, and is filed but not made current',
+    () async {
+      final storage = InMemoryAtClientStorage(atSign: atSign);
+      final client = await AuthService(
+        atAuth: MockAtAuth(),
+      ).createClient(session(), preference(), storage: storage);
 
-    expect(
-      storage.isHeldBy(client),
-      isTrue,
-      reason:
-          'the bundle the app supplied is the one the client opened, so '
-          'a Flutter app chooses its own backend and location',
-    );
-    expect(
-      Directory('${dir.path}/never_opened').existsSync(),
-      isFalse,
-      reason:
-          'and hiveStoragePath went unread, rather than the client '
-          'quietly opening a Hive store of its own',
-    );
-    expect(client.getCurrentAtSign(), atSign);
-    expect(
-      AtClientImpl.atClientInstanceMap[atSign],
-      same(client),
-      reason:
-          'AtClientImpl.create files every client it builds, this one '
-          'included - so a later setCurrentAtSign for this atSign adopts '
-          'THIS client rather than building its own. Asserting only that '
-          'the manager has no current client passes before createClient is '
-          'ever called, which is what made the previous version of this '
-          'test vacuous',
-    );
-    expect(
-      () => AtClientManager.getInstance().atClient,
-      throwsStateError,
-      reason:
-          'the app owns this client; only fromAuthSession fills in the '
-          'shared current-atSign client',
-    );
+      expect(
+        storage.isHeldBy(client),
+        isTrue,
+        reason:
+            'the bundle the app supplied is the one the client opened, so '
+            'a Flutter app chooses its own backend and location',
+      );
+      expect(
+        Directory('${dir.path}/never_opened').existsSync(),
+        isFalse,
+        reason:
+            'and hiveStoragePath went unread, rather than the client '
+            'quietly opening a Hive store of its own',
+      );
+      expect(client.getCurrentAtSign(), atSign);
+      expect(
+        AtClientImpl.atClientInstanceMap[atSign],
+        same(client),
+        reason:
+            'AtClientImpl.create files every client it builds, this one '
+            'included - so a later setCurrentAtSign for this atSign adopts '
+            'THIS client rather than building its own. Asserting only that '
+            'the manager has no current client passes before createClient is '
+            'ever called, which is what made the previous version of this '
+            'test vacuous',
+      );
+      expect(
+        () => AtClientManager.getInstance().atClient,
+        throwsStateError,
+        reason:
+            'the app owns this client; only fromAuthSession fills in the '
+            'shared current-atSign client',
+      );
 
-    await client.stop();
-    await storage.close();
-  });
+      await client.stop();
+      await storage.close();
+    },
+  );
 
   test(
     'the session\'s root domain is destructured onto the preference',

--- a/packages/at_client_flutter/test/auth_service_create_client_test.dart
+++ b/packages/at_client_flutter/test/auth_service_create_client_test.dart
@@ -1,0 +1,115 @@
+import 'dart:io';
+
+import 'package:at_auth/at_auth.dart';
+import 'package:at_auth/at_auth_io.dart';
+import 'package:at_client/at_client.dart';
+import 'package:at_client/sqlite.dart';
+import 'package:at_client_flutter/src/services/auth_service.dart';
+import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockAtAuth extends Mock implements AtAuth {}
+
+class MockAtKeysIo extends Mock implements FileAtKeysIo {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const atSign = '@flutterowned';
+  late MockAtKeysIo mockAtKeysIo;
+  late Directory dir;
+
+  setUp(() {
+    dir = Directory.systemTemp.createTempSync('flutter_create_client_');
+    mockAtKeysIo = MockAtKeysIo();
+    when(() => mockAtKeysIo.read(any())).thenAnswer(
+      (_) async => AtKeys()
+        ..apkamPrivateKey = AtBytes.fromString('dummykey')
+        ..apkamPublicKey = AtBytes.fromString('dummykey')
+        ..defaultEncryptionPrivateKey = AtBytes.fromString('dummykey')
+        ..defaultEncryptionPublicKey = AtBytes.fromString('dummykey')
+        ..defaultSelfEncryptionKey = AtBytes.fromString('dummykey')
+        ..metadata = {'atsign': atSign},
+    );
+    AtClientManager.getInstance().reset();
+  });
+
+  tearDown(() async {
+    for (final c in List<AtClient>.from(
+      AtClientImpl.atClientInstanceMap.values,
+    )) {
+      await c.stop();
+    }
+    AtClientManager.getInstance().reset();
+    dir.deleteSync(recursive: true);
+  });
+
+  /// Names a Hive location the client would fall back on, so a bundle that
+  /// never reached it shows up as this directory being opened.
+  AtClientPreference preference() =>
+      AtClientPreference()..hiveStoragePath = '${dir.path}/never_opened';
+
+  AtAuthSession session() => AtAuthSession(
+    atSign: atSign,
+    rootDomain: AtRootDomain.parse('root.atsign.wtf:64'),
+    namespace: 'unit_test',
+    atKeysIo: mockAtKeysIo,
+  );
+
+  test('the client holds the storage, and nothing registers it', () async {
+    final storage = InMemoryAtClientStorage(atSign: atSign);
+    final client = await AuthService(
+      atAuth: MockAtAuth(),
+    ).createClient(session(), preference(), storage: storage);
+
+    expect(
+      storage.isHeldBy(client),
+      isTrue,
+      reason:
+          'the bundle the app supplied is the one the client opened, so '
+          'a Flutter app chooses its own backend and location',
+    );
+    expect(
+      Directory('${dir.path}/never_opened').existsSync(),
+      isFalse,
+      reason:
+          'and hiveStoragePath went unread, rather than the client '
+          'quietly opening a Hive store of its own',
+    );
+    expect(client.getCurrentAtSign(), atSign);
+    expect(
+      () => AtClientManager.getInstance().atClient,
+      throwsStateError,
+      reason:
+          'the app owns this client; only fromAuthSession fills in the '
+          'shared current-atSign client',
+    );
+
+    await client.stop();
+    await storage.close();
+  });
+
+  test(
+    'the session\'s root domain is destructured onto the preference',
+    () async {
+      final storage = InMemoryAtClientStorage(atSign: atSign);
+      final pref = preference();
+      final client = await AuthService(
+        atAuth: MockAtAuth(),
+      ).createClient(session(), pref, storage: storage);
+
+      expect(
+        pref.rootDomain,
+        'root.atsign.wtf',
+        reason:
+            'the client resolves the atSign against the atDirectory the '
+            'session authenticated against, not against the default',
+      );
+      expect(pref.rootPort, 64);
+
+      await client.stop();
+      await storage.close();
+    },
+  );
+}

--- a/packages/at_client_flutter/test/enrollment_request_list_test.dart
+++ b/packages/at_client_flutter/test/enrollment_request_list_test.dart
@@ -1,0 +1,59 @@
+import 'package:at_client/at_client.dart';
+import 'package:at_client_flutter/src/services/enrollment_service.dart';
+import 'package:at_client_flutter/src/widgets/authorisation/containers/enrollment_request_list.dart';
+import 'package:at_auth/at_auth.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockFlutterEnrollmentService extends Mock
+    implements FlutterEnrollmentService {}
+
+class MockAtClient extends Mock implements AtClient {}
+
+class MockRemoteSecondary extends Mock implements RemoteSecondary {}
+
+class MockAtLookUp extends Mock implements AtLookUp {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() => registerFallbackValue(MockAtLookUp()));
+
+  setUp(() => AtClientManager.getInstance().reset());
+  tearDown(() => AtClientManager.getInstance().reset());
+
+  testWidgets('works against an app-owned client, without AtClientManager',
+      (tester) async {
+    final service = MockFlutterEnrollmentService();
+    final atClient = MockAtClient();
+    final remoteSecondary = MockRemoteSecondary();
+
+    when(() => atClient.getRemoteSecondary()).thenReturn(remoteSecondary);
+    when(() => remoteSecondary.atLookUp).thenReturn(MockAtLookUp());
+    when(() => atClient.getCurrentAtSign()).thenReturn('@appowned');
+    when(() => service.atClient).thenReturn(atClient);
+    when(() =>
+            service.getEnrollments(statusFilters: any(named: 'statusFilters')))
+        .thenAnswer((_) => const Stream<EnrollmentServerResponse>.empty());
+    when(() => service.list(any(), any(),
+        drx: any(named: 'drx'),
+        arx: any(named: 'arx'))).thenAnswer((_) async => []);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(body: EnrollmentRequestList(enrollmentService: service)),
+    ));
+    await tester.pumpAndSettle();
+
+    // AtClientManager was reset, so its atClient getter throws. The widget
+    // catches everything and renders the message rather than crashing, which
+    // is what makes this a trap - so assert on the absence of that text.
+    expect(find.textContaining('No atClient yet'), findsNothing,
+        reason: 'every client read goes through the service the app supplied, '
+            'so an app that built its client with AuthService.createClient '
+            'can use this widget - reaching AtClientManager here would throw '
+            'for exactly the apps the new factory exists to serve');
+    verify(() => service.atClient).called(greaterThan(0));
+  });
+}

--- a/packages/at_client_flutter/test/enrollment_request_list_test.dart
+++ b/packages/at_client_flutter/test/enrollment_request_list_test.dart
@@ -24,8 +24,9 @@ void main() {
   setUp(() => AtClientManager.getInstance().reset());
   tearDown(() => AtClientManager.getInstance().reset());
 
-  testWidgets('works against an app-owned client, without AtClientManager',
-      (tester) async {
+  testWidgets('works against an app-owned client, without AtClientManager', (
+    tester,
+  ) async {
     final service = MockFlutterEnrollmentService();
     final atClient = MockAtClient();
     final remoteSecondary = MockRemoteSecondary();
@@ -34,26 +35,37 @@ void main() {
     when(() => remoteSecondary.atLookUp).thenReturn(MockAtLookUp());
     when(() => atClient.getCurrentAtSign()).thenReturn('@appowned');
     when(() => service.atClient).thenReturn(atClient);
-    when(() =>
-            service.getEnrollments(statusFilters: any(named: 'statusFilters')))
-        .thenAnswer((_) => const Stream<EnrollmentServerResponse>.empty());
-    when(() => service.list(any(), any(),
+    when(
+      () => service.getEnrollments(statusFilters: any(named: 'statusFilters')),
+    ).thenAnswer((_) => const Stream<EnrollmentServerResponse>.empty());
+    when(
+      () => service.list(
+        any(),
+        any(),
         drx: any(named: 'drx'),
-        arx: any(named: 'arx'))).thenAnswer((_) async => []);
+        arx: any(named: 'arx'),
+      ),
+    ).thenAnswer((_) async => []);
 
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(body: EnrollmentRequestList(enrollmentService: service)),
-    ));
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: EnrollmentRequestList(enrollmentService: service)),
+      ),
+    );
     await tester.pumpAndSettle();
 
     // AtClientManager was reset, so its atClient getter throws. The widget
     // catches everything and renders the message rather than crashing, which
     // is what makes this a trap - so assert on the absence of that text.
-    expect(find.textContaining('No atClient yet'), findsNothing,
-        reason: 'every client read goes through the service the app supplied, '
-            'so an app that built its client with AuthService.createClient '
-            'can use this widget - reaching AtClientManager here would throw '
-            'for exactly the apps the new factory exists to serve');
+    expect(
+      find.textContaining('No atClient yet'),
+      findsNothing,
+      reason:
+          'every client read goes through the service the app supplied, '
+          'so an app that built its client with AuthService.createClient '
+          'can use this widget - reaching AtClientManager here would throw '
+          'for exactly the apps the new factory exists to serve',
+    );
     verify(() => service.atClient).called(greaterThan(0));
   });
 }

--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## 1.16.1-rc2
+- feat: `AtOnboardingPreference.storagePath` says where the client's local
+  storage goes, replacing this package's use of the now-deprecated
+  `AtClientPreference.hiveStoragePath`. A caller that still sets the old field
+  keeps the location it had.
+- feat: the onboarding service now builds the client's storage itself — a Hive
+  bundle marked `closedByClient`, so the client closes it on stop exactly as it
+  closed the store it used to open. Supply `storage` to choose the backend or
+  the location yourself, in which case it is borrowed and you close it.
 - chore: stop setting `AtClientPreference.commitLogPath`, which at_client reads
   nowhere, and drop `HomeDirectoryUtil.getCommitLogPath` with its last caller.
   No behaviour changes: the value was never read.

--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.16.1-rc2
+- feat: `AtOnboardingPreference.storage` supplies the client's local storage,
+  which decides the backend and the location and so leaves `hiveStoragePath`
+  unread. Borrowed rather than owned: the client detaches from it when it
+  stops, and closing it is the caller's job. Leave it unset and the client
+  goes on opening a Hive store under `hiveStoragePath` and closing it itself.
+  `CLIBase` carries it through, so an at_cli_commons caller supplying its own
+  preference can inject storage without any change there.
+
 ## 1.16.1-rc1
 - fix: pass passPhrase to FileAtKeysIo during onboarding so password-protected atKeys files are written correctly
 

--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.16.1-rc2
+## 1.17.0-rc1
 - feat: `AtOnboardingPreference.storagePath` says where the client's local
   storage goes, replacing this package's use of the now-deprecated
   `AtClientPreference.hiveStoragePath`. A caller that still sets the old field
@@ -6,14 +6,16 @@
 - feat: the onboarding service now builds the client's storage itself — a Hive
   bundle marked `closedByClient`, so the client closes it on stop exactly as it
   closed the store it used to open. Supply `storage` to choose the backend or
-  the location yourself, in which case it is borrowed and you close it.
+  the location yourself; the client closes that too if you built it with
+  `closedByClient: true`, and otherwise you close it.
 - chore: stop setting `AtClientPreference.commitLogPath`, which at_client reads
   nowhere, and drop `HomeDirectoryUtil.getCommitLogPath` with its last caller.
   No behaviour changes: the value was never read.
 - feat: `AtOnboardingPreference.storage` supplies the client's local storage,
   which decides the backend and the location and so leaves `hiveStoragePath`
-  unread. Borrowed rather than owned: the client detaches from it when it
-  stops, and closing it is the caller's job. Leave it unset and the client
+  unread. Borrowed unless built with `closedByClient: true`: by default the
+  client detaches from it when it stops and closing it is the caller's job.
+  Leave it unset and the client
   goes on opening a Hive store under `hiveStoragePath` and closing it itself.
   `CLIBase` carries it through, so an at_cli_commons caller supplying its own
   preference can inject storage without any change there.

--- a/packages/at_onboarding_cli/CHANGELOG.md
+++ b/packages/at_onboarding_cli/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 1.16.1-rc2
+- chore: stop setting `AtClientPreference.commitLogPath`, which at_client reads
+  nowhere, and drop `HomeDirectoryUtil.getCommitLogPath` with its last caller.
+  No behaviour changes: the value was never read.
 - feat: `AtOnboardingPreference.storage` supplies the client's local storage,
   which decides the backend and the location and so leaves `hiveStoragePath`
   unread. Borrowed rather than owned: the client detaches from it when it

--- a/packages/at_onboarding_cli/example/util/atsign_preference.dart
+++ b/packages/at_onboarding_cli/example/util/atsign_preference.dart
@@ -7,8 +7,6 @@ class AtSignPreference {
     var preference = AtClientPreference();
     preference.hiveStoragePath = HomeDirectoryUtil.getHiveStoragePath(atSign,
         enrollmentId: enrollmentId);
-    preference.commitLogPath =
-        HomeDirectoryUtil.getCommitLogPath(atSign, enrollmentId: enrollmentId);
     preference.isLocalStoreRequired = true;
     preference.rootDomain = 'vip.ve.atsign.zone';
     return preference;

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -55,9 +55,11 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     enrollCheckpoint = EnrollmentCheckpoint(_atSign);
 
     // set default LocalStorage paths for this instance
-    atOnboardingPreference.hiveStoragePath ??=
-        HomeDirectoryUtil.getHiveStoragePath(_atSign,
-            enrollmentId: enrollmentId);
+    atOnboardingPreference.storagePath ??=
+        // ignore: deprecated_member_use
+        atOnboardingPreference.hiveStoragePath ??
+            HomeDirectoryUtil.getHiveStoragePath(_atSign,
+                enrollmentId: enrollmentId);
     atOnboardingPreference.atKeysFilePath ??=
         HomeDirectoryUtil.getAtKeysPath(_atSign);
   }
@@ -100,6 +102,18 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     }
   }
 
+  /// The bundle this client opens: the caller's if it supplied one, otherwise
+  /// a fresh Hive bundle the client closes when it stops.
+  ///
+  /// Fresh each time, because every call here stops the previous client first —
+  /// which closes the bundle it was given — and a closed bundle cannot reopen.
+  AtClientStorage _storageForClient() =>
+      atOnboardingPreference.storage ??
+      HiveAtClientStorage(
+          atSign: _atSign,
+          storagePath: atOnboardingPreference.storagePath!,
+          closedByClient: true);
+
   Future<void> _initAtClient(AtChops atChops, {String? enrollmentId}) async {
     AtClientManager atClientManager = AtClientManager.getInstance();
     if (atOnboardingPreference.skipSync) {
@@ -111,7 +125,7 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
         atLookUp: atLookUp,
         serviceFactory: atServiceFactory,
         enrollmentId: enrollmentId,
-        storage: atOnboardingPreference.storage);
+        storage: _storageForClient());
 
     // ??= to support mocking
     _atLookUp ??= atClientManager.atClient.getRemoteSecondary()?.atLookUp;

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -55,8 +55,6 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
     enrollCheckpoint = EnrollmentCheckpoint(_atSign);
 
     // set default LocalStorage paths for this instance
-    atOnboardingPreference.commitLogPath ??=
-        HomeDirectoryUtil.getCommitLogPath(_atSign, enrollmentId: enrollmentId);
     atOnboardingPreference.hiveStoragePath ??=
         HomeDirectoryUtil.getHiveStoragePath(_atSign,
             enrollmentId: enrollmentId);

--- a/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
+++ b/packages/at_onboarding_cli/lib/src/onboard/at_onboarding_service_impl.dart
@@ -112,7 +112,8 @@ class AtOnboardingServiceImpl implements AtOnboardingService {
         atChops: atChops,
         atLookUp: atLookUp,
         serviceFactory: atServiceFactory,
-        enrollmentId: enrollmentId);
+        enrollmentId: enrollmentId,
+        storage: atOnboardingPreference.storage);
 
     // ??= to support mocking
     _atLookUp ??= atClientManager.atClient.getRemoteSecondary()?.atLookUp;

--- a/packages/at_onboarding_cli/lib/src/util/at_onboarding_preference.dart
+++ b/packages/at_onboarding_cli/lib/src/util/at_onboarding_preference.dart
@@ -33,4 +33,12 @@ class AtOnboardingPreference extends AtClientPreference {
 
   /// The password (or pass-phrase) with which the atKeys file is encrypted/decrypted.
   String? passPhrase;
+
+  /// The local storage the client should use, which decides the backend and
+  /// the location and so leaves [hiveStoragePath] unread.
+  ///
+  /// Borrowed rather than owned: the client detaches from it when it stops,
+  /// and closing it is the caller's job. Leave it null and the client opens a
+  /// Hive store under [hiveStoragePath] and closes that itself.
+  AtClientStorage? storage;
 }

--- a/packages/at_onboarding_cli/lib/src/util/at_onboarding_preference.dart
+++ b/packages/at_onboarding_cli/lib/src/util/at_onboarding_preference.dart
@@ -34,11 +34,18 @@ class AtOnboardingPreference extends AtClientPreference {
   /// The password (or pass-phrase) with which the atKeys file is encrypted/decrypted.
   String? passPhrase;
 
+  /// Where to put the client's local storage when no [storage] is supplied.
+  ///
+  /// Defaults to a per-atSign directory under the user's home. The bundle
+  /// built here is closed by the client when it stops, so a CLI has nothing to
+  /// tear down.
+  String? storagePath;
+
   /// The local storage the client should use, which decides the backend and
-  /// the location and so leaves [hiveStoragePath] unread.
+  /// the location and so leaves [storagePath] unread.
   ///
   /// Borrowed rather than owned: the client detaches from it when it stops,
-  /// and closing it is the caller's job. Leave it null and the client opens a
-  /// Hive store under [hiveStoragePath] and closes that itself.
+  /// and closing it is the caller's job. Leave it null and a Hive bundle is
+  /// built under [storagePath], which the client closes itself.
   AtClientStorage? storage;
 }

--- a/packages/at_onboarding_cli/lib/src/util/at_onboarding_preference.dart
+++ b/packages/at_onboarding_cli/lib/src/util/at_onboarding_preference.dart
@@ -44,8 +44,9 @@ class AtOnboardingPreference extends AtClientPreference {
   /// The local storage the client should use, which decides the backend and
   /// the location and so leaves [storagePath] unread.
   ///
-  /// Borrowed rather than owned: the client detaches from it when it stops,
-  /// and closing it is the caller's job. Leave it null and a Hive bundle is
-  /// built under [storagePath], which the client closes itself.
+  /// Borrowed unless it was built with `closedByClient: true`: by default the
+  /// client detaches from it when it stops and closing it is the caller's job.
+  /// Leave it null and a Hive bundle is built under [storagePath], which the
+  /// client closes itself.
   AtClientStorage? storage;
 }

--- a/packages/at_onboarding_cli/lib/src/util/create_at_client_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/util/create_at_client_cli.dart
@@ -33,16 +33,14 @@ Future<AtClient> createAtClient(
       (atKeysFilePath ?? '$homeDir/.atsign/keys/${atSign}_key.atKeys')
           .replaceAll('/', Platform.pathSeparator);
   String? localStoragePathToUse = storageDir?.path;
-  String? commitLogStoragePathToUse =
-      ('${storageDir?.path}/commit').replaceAll('/', Platform.pathSeparator);
   String downloadPathToUse = ('$homeDir!/.atsign/downloads/$atSign/$nameSpace')
       .replaceAll('/', Platform.pathSeparator);
 
   String rootServer = rootDomain ?? AuthCliArgs.defaultAtDirectoryFqdn;
-  
+
   // Parse rootServer using AtRootDomain
   AtRootDomain parsedRootDomain = AtRootDomain.parse(rootServer);
-  
+
   AtOnboardingPreference atOnboardingPreference = AtOnboardingPreference()
     ..atKeysFilePath = atKeysFilePathToUse
     ..namespace = nameSpace
@@ -50,7 +48,6 @@ Future<AtClient> createAtClient(
     ..rootPort = parsedRootDomain.rootPort
     ..passPhrase = passPhrase
     ..hiveStoragePath = localStoragePathToUse
-    ..commitLogPath = commitLogStoragePathToUse
     ..downloadPath = downloadPathToUse;
 
   AtOnboardingService atOnboardingService = AtOnboardingServiceImpl(

--- a/packages/at_onboarding_cli/lib/src/util/create_at_client_cli.dart
+++ b/packages/at_onboarding_cli/lib/src/util/create_at_client_cli.dart
@@ -47,7 +47,7 @@ Future<AtClient> createAtClient(
     ..rootDomain = parsedRootDomain.rootDomain
     ..rootPort = parsedRootDomain.rootPort
     ..passPhrase = passPhrase
-    ..hiveStoragePath = localStoragePathToUse
+    ..storagePath = localStoragePathToUse
     ..downloadPath = downloadPathToUse;
 
   AtOnboardingService atOnboardingService = AtOnboardingServiceImpl(

--- a/packages/at_onboarding_cli/lib/src/util/home_directory_util.dart
+++ b/packages/at_onboarding_cli/lib/src/util/home_directory_util.dart
@@ -42,11 +42,6 @@ class HomeDirectoryUtil {
         homeDir!, '.atsign', 'at_onboarding_cli', 'storage', atsign);
   }
 
-  static String getCommitLogPath(String atsign, {String? enrollmentId}) {
-    return path.join(
-        getStorageDirectory(atsign, enrollmentId: enrollmentId), 'commitLog');
-  }
-
   static String getHiveStoragePath(String atsign, {String? enrollmentId}) {
     return path.join(
         HomeDirectoryUtil.getStorageDirectory(atsign,

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tools for initial client onboarding, subsequent client enrollment, and enrollment management.
-version: 1.16.1-rc2
+version: 1.17.0-rc1
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -1,6 +1,6 @@
 name: at_onboarding_cli
 description: Dart tools for initial client onboarding, subsequent client enrollment, and enrollment management.
-version: 1.16.1-rc1
+version: 1.16.1-rc2
 repository: https://github.com/atsign-foundation/at_client_sdk/tree/trunk/packages/at_onboarding_cli
 homepage: https://atsign.com
 documentation: https://docs.atsign.com/

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   zxing2: ^0.2.0
   at_auth: ^4.0.0-rc1
   at_chops: ^3.0.0
-  at_client: ^3.14.1
+  at_client: ^3.15.0-rc1
   at_commons: ^5.6.0
   at_lookup: ^3.6.0
   at_server_status: ^1.0.5

--- a/packages/at_onboarding_cli/pubspec.yaml
+++ b/packages/at_onboarding_cli/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   zxing2: ^0.2.0
   at_auth: ^4.0.0-rc1
   at_chops: ^3.0.0
-  at_client: ^3.10.0
+  at_client: ^3.14.1
   at_commons: ^5.6.0
   at_lookup: ^3.6.0
   at_server_status: ^1.0.5

--- a/packages/at_onboarding_cli/test/at_onboarding_storage_test.dart
+++ b/packages/at_onboarding_cli/test/at_onboarding_storage_test.dart
@@ -1,0 +1,135 @@
+import 'dart:io';
+
+import 'package:at_auth/at_auth.dart';
+import 'package:at_chops/at_chops.dart';
+import 'package:at_client/at_client.dart';
+import 'package:at_lookup/at_lookup.dart';
+import 'package:at_onboarding_cli/at_onboarding_cli.dart';
+import 'package:at_utils/at_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class MockAtLookupImpl extends Mock implements AtLookupImpl {}
+
+class MockAtAuthImpl extends Mock implements AtAuth {}
+
+class FakeAtAuthRequest extends Fake implements AtAuthRequest {}
+
+/// Records the storage the manager passes on to the client factory.
+class RecordingServiceFactory extends DefaultAtServiceFactory {
+  AtClientStorage? seen;
+  bool called = false;
+
+  @override
+  Future<AtClient> atClient(String atSign, String? namespace,
+      AtClientPreference preference, AtClientManager atClientManager,
+      {AtChops? atChops,
+      AtKeysIo? atKeysIo,
+      AtLookUp? atLookUp,
+      String? enrollmentId,
+      AtClientStorage? storage}) async {
+    called = true;
+    seen = storage;
+    return super.atClient(atSign, namespace, preference, atClientManager,
+        atKeysIo: atKeysIo,
+        atLookUp: atLookUp,
+        enrollmentId: enrollmentId,
+        storage: storage);
+  }
+}
+
+void main() {
+  AtSignLogger.root_level = 'SHOUT';
+  final atSign = '@alice🛠';
+  late Directory dir;
+  final mockAtLookup = MockAtLookupImpl();
+  final mockAtAuth = MockAtAuthImpl();
+
+  setUp(() {
+    dir = Directory.systemTemp.createTempSync('onboarding_storage_');
+    reset(mockAtLookup);
+    reset(mockAtAuth);
+    registerFallbackValue(FakeAtAuthRequest());
+    when(() => mockAtAuth.progressStream).thenAnswer((_) => Stream.empty());
+    AtClientManager.getInstance().reset();
+  });
+
+  tearDown(() async {
+    for (final c
+        in List<AtClient>.from(AtClientImpl.atClientInstanceMap.values)) {
+      await c.stop();
+    }
+    AtClientManager.getInstance().reset();
+    dir.deleteSync(recursive: true);
+  });
+
+  Future<AtOnboardingServiceImpl> authenticated(
+      AtOnboardingPreference preference, AtServiceFactory factory) async {
+    final service =
+        AtOnboardingServiceImpl(atSign, preference, atServiceFactory: factory);
+    service.atLookUp = mockAtLookup;
+    mockAtAuth.atChops = AtChopsImpl(AtChopsKeys());
+    service.atAuth = mockAtAuth;
+    when(() => mockAtLookup.pkamAuthenticate())
+        .thenAnswer((_) => Future.value(true));
+    when(() => mockAtAuth.atChops)
+        .thenAnswer((_) => AtChopsImpl(AtChopsKeys()));
+    when(() => mockAtAuth.authenticate(any()))
+        .thenAnswer((_) => Future.value(AtAuthResponse(atSign)
+          ..isSuccessful = true
+          ..atAuthKeys = (AtKeys()
+            ..apkamPublicKey = AtBytes.fromString('dumm')
+            ..apkamPrivateKey = AtBytes.fromString('dumm')
+            ..defaultSelfEncryptionKey = AtBytes.fromString('dumm')
+            ..defaultEncryptionPrivateKey = AtBytes.fromString('dumm')
+            ..defaultEncryptionPublicKey = AtBytes.fromString('dumm')
+            ..apkamSymmetricKey = AtBytes.fromString('dumm')
+            ..enrollmentId = 'dummy_enroll_id')));
+
+    expect(await service.authenticate(), isTrue);
+    return service;
+  }
+
+  test('the storage on the preference is the one the client holds', () async {
+    final storage = HiveAtClientStorage(atSign: atSign, storagePath: dir.path);
+    final factory = RecordingServiceFactory();
+    final service = await authenticated(
+        AtOnboardingPreference()
+          ..atKeysFilePath = 'test/data/${atSign}_key.atKeys'
+          ..namespace = 'unit_test'
+          ..hiveStoragePath = '${dir.path}/never_opened'
+          ..storage = storage,
+        factory);
+
+    expect(factory.seen, same(storage),
+        reason: 'the bundle put on the preference is the one that reached the '
+            'client factory, rather than being dropped on the way');
+    expect(storage.isHeldBy(service.atClient!), isTrue,
+        reason: 'and the client opened THAT bundle, rather than a Hive store '
+            'under hiveStoragePath');
+    expect(Directory('${dir.path}/never_opened').existsSync(), isFalse,
+        reason: 'hiveStoragePath goes unread when a bundle is supplied');
+
+    await service.atClient!.stop();
+    await storage.close();
+  });
+
+  test('no storage on the preference leaves today behaviour alone', () async {
+    final factory = RecordingServiceFactory();
+    final service = await authenticated(
+        AtOnboardingPreference()
+          ..atKeysFilePath = 'test/data/${atSign}_key.atKeys'
+          ..namespace = 'unit_test'
+          ..hiveStoragePath = '${dir.path}/opened_by_at_client',
+        factory);
+
+    expect(factory.called, isTrue);
+    expect(factory.seen, isNull,
+        reason: 'a caller that supplies no bundle passes none on, so the '
+            'client goes on opening one under hiveStoragePath');
+    expect(Directory('${dir.path}/opened_by_at_client').existsSync(), isTrue,
+        reason: 'which it did');
+
+    await service.atClient!.stop();
+  });
+}

--- a/packages/at_onboarding_cli/test/at_onboarding_storage_test.dart
+++ b/packages/at_onboarding_cli/test/at_onboarding_storage_test.dart
@@ -97,7 +97,7 @@ void main() {
         AtOnboardingPreference()
           ..atKeysFilePath = 'test/data/${atSign}_key.atKeys'
           ..namespace = 'unit_test'
-          ..hiveStoragePath = '${dir.path}/never_opened'
+          ..storagePath = '${dir.path}/never_opened'
           ..storage = storage,
         factory);
 
@@ -108,27 +108,49 @@ void main() {
         reason: 'and the client opened THAT bundle, rather than a Hive store '
             'under hiveStoragePath');
     expect(Directory('${dir.path}/never_opened').existsSync(), isFalse,
-        reason: 'hiveStoragePath goes unread when a bundle is supplied');
+        reason: 'storagePath goes unread when a bundle is supplied');
 
     await service.atClient!.stop();
     await storage.close();
   });
 
-  test('no storage on the preference leaves today behaviour alone', () async {
+  test('no bundle on the preference gets a client-closed one at storagePath',
+      () async {
     final factory = RecordingServiceFactory();
     final service = await authenticated(
         AtOnboardingPreference()
           ..atKeysFilePath = 'test/data/${atSign}_key.atKeys'
           ..namespace = 'unit_test'
-          ..hiveStoragePath = '${dir.path}/opened_by_at_client',
+          ..storagePath = '${dir.path}/built_for_the_cli',
         factory);
 
-    expect(factory.called, isTrue);
-    expect(factory.seen, isNull,
-        reason: 'a caller that supplies no bundle passes none on, so the '
-            'client goes on opening one under hiveStoragePath');
-    expect(Directory('${dir.path}/opened_by_at_client').existsSync(), isTrue,
-        reason: 'which it did');
+    expect(factory.seen, isA<HiveAtClientStorage>(),
+        reason: 'the CLI supplies a bundle of its own rather than leaving '
+            'at_client to open one from a preference path');
+    expect(factory.seen!.closedByClient, isTrue,
+        reason: 'and the client is what closes it, so a CLI still has nothing '
+            'to tear down');
+    expect(Directory('${dir.path}/built_for_the_cli').existsSync(), isTrue,
+        reason: 'the store landed where storagePath said');
+
+    await service.atClient!.stop();
+  });
+
+  test('the deprecated hiveStoragePath still decides where the store goes',
+      () async {
+    final factory = RecordingServiceFactory();
+    final service = await authenticated(
+        AtOnboardingPreference()
+          ..atKeysFilePath = 'test/data/${atSign}_key.atKeys'
+          ..namespace = 'unit_test'
+          // ignore: deprecated_member_use
+          ..hiveStoragePath = '${dir.path}/legacy_path',
+        factory);
+
+    expect(Directory('${dir.path}/legacy_path').existsSync(), isTrue,
+        reason: 'a caller that set the deprecated field before this change '
+            'keeps the location it had');
+    expect(factory.seen!.closedByClient, isTrue);
 
     await service.atClient!.stop();
   });

--- a/packages/at_policy/example/pubspec.yaml
+++ b/packages/at_policy/example/pubspec.yaml
@@ -21,6 +21,8 @@ dependency_overrides:
     path: ../../at_auth
   at_lookup:
     path: ../../at_lookup
+  at_onboarding_cli:
+    path: ../../at_onboarding_cli
 
 dependencies:
   at_policy:

--- a/tests/at_end2end_test/test/enrollment_teardown.dart
+++ b/tests/at_end2end_test/test/enrollment_teardown.dart
@@ -7,53 +7,89 @@ import 'package:at_end2end_test/src/test_initializers.dart';
 import 'package:at_end2end_test/utils/test_constants.dart';
 import 'package:test/test.dart';
 
+/// Whether [enrollment] is the atSign's root access: read-write on every
+/// namespace AND on `__manage`.
+///
+/// Mirrors the atServer's own rule. Write access to `*` alone does not
+/// qualify, and neither does `__manage` alone. The enrollments this suite
+/// creates are namespace-scoped, so none of them is a root.
+bool isRootEnrollment(Enrollment enrollment) {
+  final namespaces = enrollment.namespace ?? const <String, dynamic>{};
+  bool writable(Object? access) => access is String && access.contains('w');
+  return writable(namespaces[EnrollmentConstants.allNamespaces]) &&
+      writable(namespaces[EnrollmentConstants.enrollManageNamespace]);
+}
+
 void main() {
   List atSignList = ConfigUtil.getYaml()['enrollment']['atsignList'];
   String namespace = TestConstants.namespace;
 
+  // What went wrong, so tearDownAll can exit non-zero. This file is run with
+  // `dart run`, not the test runner, and the exit() below is what the CI step
+  // reads -- so without this every failure here was reported as success.
+  List<String> failures = [];
+
   for (var currentAtSign in atSignList) {
     test('A test to tear down the enrollment setup for $currentAtSign',
         () async {
-      await TestSuiteInitializer.getInstance().testInitializer(
-          currentAtSign, namespace, 'pkam',
-          enableInitialSync: false);
+      try {
+        await TestSuiteInitializer.getInstance().testInitializer(
+            currentAtSign, namespace, 'pkam',
+            enableInitialSync: false);
 
-      List<Enrollment>? pendingEnrollments = await AtClientManager.getInstance()
-          .atClient
-          .enrollmentService
-          ?.fetchEnrollmentRequests(
-              enrollmentListParams: EnrollmentListRequestParam()
-                ..enrollmentListFilter = [EnrollmentStatus.pending]);
+        List<Enrollment>? pendingEnrollments =
+            await AtClientManager.getInstance()
+                .atClient
+                .enrollmentService
+                ?.fetchEnrollmentRequests(
+                    enrollmentListParams: EnrollmentListRequestParam()
+                      ..enrollmentListFilter = [EnrollmentStatus.pending]);
 
-      // At end of the end-to-end test suite execution, deny all the pending enrollments.
-      if (pendingEnrollments != null && pendingEnrollments.isNotEmpty) {
-        for (Enrollment enrollment in pendingEnrollments) {
-          print('Denying the enrollment permission for id: $enrollment');
-          await AtClientManager.getInstance().atClient.enrollmentService?.deny(
-              EnrollmentRequestDecision.denied(enrollment.enrollmentId!, currentAtSign));
+        // At end of the end-to-end test suite execution, deny all the pending enrollments.
+        if (pendingEnrollments != null && pendingEnrollments.isNotEmpty) {
+          for (Enrollment enrollment in pendingEnrollments) {
+            print('Denying the enrollment permission for id: $enrollment');
+            await AtClientManager.getInstance()
+                .atClient
+                .enrollmentService
+                ?.deny(EnrollmentRequestDecision.denied(
+                    enrollment.enrollmentId!, currentAtSign));
+          }
         }
-      }
 
-      List<Enrollment>? approvedEnrollments =
-          await AtClientManager.getInstance()
-              .atClient
-              .enrollmentService
-              ?.fetchEnrollmentRequests(
-                  enrollmentListParams: EnrollmentListRequestParam()
-                    ..enrollmentListFilter = [EnrollmentStatus.approved]);
+        List<Enrollment>? approvedEnrollments =
+            await AtClientManager.getInstance()
+                .atClient
+                .enrollmentService
+                ?.fetchEnrollmentRequests(
+                    enrollmentListParams: EnrollmentListRequestParam()
+                      ..enrollmentListFilter = [EnrollmentStatus.approved]);
 
-      // At end of the end-to-end test suite execution, revoke all the approved enrollments.
-      if (approvedEnrollments != null && approvedEnrollments.isNotEmpty) {
-        for (Enrollment enrollment in approvedEnrollments) {
-          print('Revoking the enrollment permission for id: $enrollment');
-          await AtClientManager.getInstance()
-              .atClient
-              .enrollmentService
-              ?.revoke(EnrollmentRequestDecision.revoked(
-                  enrollment.enrollmentId!,
-                  currentAtSign,
-                  force: true));
+        // At end of the end-to-end test suite execution, revoke all the approved
+        // enrollments -- except the atSign's root access, which is not this
+        // suite's to remove. The atServer refuses a revoke that would leave no
+        // permanent fully privileged enrollment behind, because the atSign would
+        // then be unable to approve a replacement once the rest expire. `force`
+        // does not waive that; it waives only the rule against revoking the
+        // enrollment the caller is itself authenticated as.
+        if (approvedEnrollments != null && approvedEnrollments.isNotEmpty) {
+          for (Enrollment enrollment in approvedEnrollments) {
+            if (isRootEnrollment(enrollment)) {
+              print('Leaving the root enrollment in place: $enrollment');
+              continue;
+            }
+            print('Revoking the enrollment permission for id: $enrollment');
+            await AtClientManager.getInstance()
+                .atClient
+                .enrollmentService
+                ?.revoke(EnrollmentRequestDecision.revoked(
+                    enrollment.enrollmentId!, currentAtSign,
+                    force: true));
+          }
         }
+      } catch (e) {
+        failures.add('$currentAtSign: $e');
+        rethrow;
       }
     });
   }
@@ -65,6 +101,14 @@ void main() {
         .notificationService
         .stopAllSubscriptions();
     await AtClientManager.getInstance().atClient.stopCompactionJob();
-    exit(0);
+    // Forced, because the e2e client leaves the isolate alive; the code has to
+    // reflect the run or the CI step passes no matter what happened.
+    if (failures.isNotEmpty) {
+      print('Enrollment teardown FAILED for ${failures.length} atSign(s):');
+      for (final failure in failures) {
+        print('  $failure');
+      }
+    }
+    exit(failures.isEmpty ? 0 : 1);
   });
 }

--- a/tests/at_end2end_test/test/enrollment_teardown_test.dart
+++ b/tests/at_end2end_test/test/enrollment_teardown_test.dart
@@ -1,0 +1,39 @@
+import 'package:at_client/at_client.dart';
+import 'package:test/test.dart';
+
+import 'enrollment_teardown.dart' show isRootEnrollment;
+
+Enrollment withNamespaces(Map<String, dynamic> ns) =>
+    Enrollment()..namespace = ns;
+
+void main() {
+  test('the shape the atServer builds for the primary enrollment is a root',
+      () {
+    // Copied from at_server's EnrollmentManager, which constructs the primary
+    // enrollment with exactly this map.
+    expect(isRootEnrollment(withNamespaces({'*': 'rw', '__manage': 'rw'})),
+        isTrue);
+  });
+
+  test('the shape this suite creates is not a root', () {
+    expect(
+        isRootEnrollment(withNamespaces({'e2etest': 'rw', '__config': 'rw'})),
+        isFalse);
+  });
+
+  test('either half alone is not a root', () {
+    expect(isRootEnrollment(withNamespaces({'*': 'rw'})), isFalse);
+    expect(isRootEnrollment(withNamespaces({'__manage': 'rw'})), isFalse);
+  });
+
+  test('read-only on either half is not a root', () {
+    expect(isRootEnrollment(withNamespaces({'*': 'r', '__manage': 'rw'})),
+        isFalse);
+    expect(isRootEnrollment(withNamespaces({'*': 'rw', '__manage': 'r'})),
+        isFalse);
+  });
+
+  test('a null namespace map is not a root', () {
+    expect(isRootEnrollment(Enrollment()), isFalse);
+  });
+}

--- a/tests/at_functional_test/lib/src/functional_storage.dart
+++ b/tests/at_functional_test/lib/src/functional_storage.dart
@@ -76,8 +76,9 @@ class FunctionalStorage {
           InMemoryAtClientStorage(atSign: atSign),
       };
 
-  /// Closes every bundle this file opened. Nothing else does: a client only
-  /// borrows the storage it is given, and detaches from it on `stop()`.
+  /// Closes every bundle this file opened. Nothing else does: these bundles
+  /// are borrowed, so a client detaches from them on `stop()` without
+  /// closing them.
   Future<void> closeAll() async {
     for (final storage in _byAtSign.values) {
       await storage.close();

--- a/tests/at_functional_test/test/monitor_silence_test.dart
+++ b/tests/at_functional_test/test/monitor_silence_test.dart
@@ -1,0 +1,95 @@
+import 'package:at_client/at_client.dart';
+import 'package:at_functional_test/src/config_util.dart';
+import 'package:test/test.dart';
+
+import 'test_utils.dart';
+
+/// The socket-alive-but-silent watchdog, against a real atServer.
+///
+/// The atServer writes a stats notification to every monitor connection on its
+/// own timer (15s by default), so a healthy monitor connection is never quiet
+/// for long. That gives a real clock to bracket
+/// [AtClientPreference.monitorSilenceTimeout] around, with no server
+/// configuration and no test hook: a budget below the cadence makes a healthy
+/// connection look silent and must rebuild, one above it must not.
+///
+/// The two arms differ only in that budget, and run for the same length of
+/// time. They use different atSigns because [Monitor] holds the preference
+/// OBJECT it was built with, so a second client for the same atSign would be
+/// the same client, with the same budget.
+///
+/// What this cannot do is wedge a real atServer into answering heartbeats
+/// while delivering nothing. It reproduces the condition the watchdog keys on
+/// - nothing arrived inside the budget - which is the same code path.
+void main() {
+  TestUtils.isolateStorage('monitor_silence_test');
+
+  /// Long enough to span two stats notifications either way.
+  const window = Duration(seconds: 45);
+
+  /// Counts `notConnected` -> `listening` cycles, which is what a rebuild
+  /// looks like from outside: the public state stream, not a test seam.
+  Future<int> rebuildsDuring(AtClient atClient, Duration forHowLong) async {
+    var rebuilds = 0;
+    var wasListening = false;
+    // Registered before anything can happen: the stream is broadcast and does
+    // not replay.
+    final sub = atClient.notificationService.currentListenerStateStream
+        .listen((state) {
+      if (state == NotificationListenerState.listening) {
+        if (wasListening) return;
+        wasListening = true;
+      } else {
+        if (wasListening) rebuilds++;
+        wasListening = false;
+      }
+    });
+    atClient.notificationService.subscribe(regex: 'nothing.will.match');
+    await Future.delayed(forHowLong);
+    await sub.cancel();
+    return rebuilds;
+  }
+
+  test('a budget under the atServer stats cadence rebuilds the connection',
+      () async {
+    final atSign = ConfigUtil.getYaml()['atSign']['firstAtSign'];
+    final manager = await TestUtils.initAtClient(atSign, 'wavi',
+        preference: TestUtils.getPreference(atSign)
+          ..monitorSilenceTimeout = const Duration(seconds: 3));
+
+    final rebuilds = await rebuildsDuring(manager.atClient, window);
+
+    expect(rebuilds, greaterThan(0),
+        reason: 'nothing arrived inside a 3-second budget on a connection the '
+            'atServer never dropped, so the monitor tore it down and built a '
+            'new one. at_lookup cannot do this: it sees a socket that is up '
+            'and answering, and a client left on it reports listening while '
+            'receiving nothing');
+    expect(manager.atClient.notificationService.currentListenerState,
+        NotificationListenerState.listening,
+        reason: 'and the rebuild finished against the real atServer - a fresh '
+            'TLS connection, authenticated, monitoring again - rather than '
+            'leaving the client down');
+  }, timeout: Timeout(Duration(minutes: 2)));
+
+  test('a budget over it leaves the connection alone', () async {
+    final atSign = ConfigUtil.getYaml()['atSign']['secondAtSign'];
+    final manager = await TestUtils.initAtClient(atSign, 'wavi',
+        preference: TestUtils.getPreference(atSign)
+          ..monitorSilenceTimeout = const Duration(seconds: 40));
+
+    final rebuilds = await rebuildsDuring(manager.atClient, window);
+
+    // The premise first, so an atServer that has stopped sending stats fails
+    // as itself rather than looking like a broken watchdog.
+    expect(manager.atClient.notificationService.lastReceipt, isNotNull,
+        reason: 'the atServer sends a stats notification to every monitor '
+            'connection on its own timer, which is what makes silence a '
+            'usable signal at all. Nothing arrived here, so the arm below '
+            'would prove nothing');
+    expect(rebuilds, 0,
+        reason: 'those arrivals are inside a 40-second budget, so the check is '
+            'about SILENCE rather than elapsed time - otherwise it would '
+            'rebuild a perfectly good connection on a timer');
+  }, timeout: Timeout(Duration(minutes: 2)));
+}

--- a/tests/at_functional_test/test/test_utils.dart
+++ b/tests/at_functional_test/test/test_utils.dart
@@ -28,8 +28,8 @@ class TestUtils {
   /// Names this test file, giving its clients storage no other file opens.
   ///
   /// Call once, first thing in `main()`. Every bundle it hands out is closed
-  /// in a `tearDownAll` registered here, since a client only borrows the
-  /// storage it is given.
+  /// in a `tearDownAll` registered here, since these bundles are borrowed and
+  /// the client only detaches from them.
   static void isolateStorage(String testFile) {
     final storage = FunctionalStorage(testFile);
     _storage = storage;

--- a/tests/at_onboarding_cli_functional_tests_proxy/runLocal.sh
+++ b/tests/at_onboarding_cli_functional_tests_proxy/runLocal.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run the onboarding-CLI *proxy* functional suite locally, the way CI runs it
+# (.github/workflows/at_libraries.yaml, functional_tests_at_onboarding_cli,
+# matrix entry at_onboarding_cli_functional_tests_proxy).
+#
+# This pack existed with no runner for a long time, which made it invisible to
+# anyone enumerating the local suites with `find tests -name runLocal.sh` - it
+# is the fourth pack, not the third. That is the reason this file exists.
+#
+# It is a sibling of tests/at_onboarding_cli_functional_tests/runLocal.sh and
+# shares its two rules, for the same reasons:
+#
+#  1. pkamLoad is NOT started. These tests CRAM-onboard, so they need atSigns
+#     holding no PKAM key yet. Starting it makes onboarding fail as "already
+#     activated", which reads like a product bug and is not.
+#  2. check_test_env.dart is NOT run - this pack does not ship one, and the
+#     sibling's would hang anyway: it polls for state only pkamLoad creates.
+#     CI runs readiness, then a sleep, then the tests.
+#
+# What differs from the sibling: a second container, at_proxyserver, sits in
+# front of the virtualenv and the tests reach the atServer through it
+# (--rootServer proxy:vip.ve.atsign.zone:443). So this pack additionally needs
+# host port 443 free.
+#
+# PREREQUISITE, from README.md: the host must resolve vip.ve.atsign.zone to
+# 127.0.0.1. The compose file's extra_hosts only covers the containers; the
+# test process runs on the host and dials the proxy by that name.
+#
+#     127.0.0.1       vip.ve.atsign.zone
+#
+# Ports: 64, 25000-25999, 6379, 9001 and 443. The first three are the same ones
+# tests/at_functional_test and tests/at_onboarding_cli_functional_tests bind, so
+# none of the three packs can run at the same time as another.
+#
+# CRAM secrets are one-shot: a second run against a virtualenv that already
+# onboarded these atSigns fails. The compose down below is what makes a re-run
+# work, so do not skip it.
+#
+# The tests name their own keyfiles with a per-run uuid and delete them in
+# teardown, so unlike the sibling this one needs no throwaway HOME.
+
+cd "$(dirname "$0")"
+
+echo "*** Getting dependencies" && dart pub get
+
+echo "*** docker compose down" && docker compose down
+echo "*** docker compose pull" && docker compose pull
+echo "*** docker compose up" && docker compose up -d
+
+echo "*** Checking docker readiness" && dart run check_docker_readiness.dart
+
+echo "*** Waiting 10s for the atSigns to come up" && sleep 10
+
+echo "*** Running tests"
+# Let the run fail through to cleanup, then propagate its code - otherwise
+# set -e aborts before teardown on the very failure this exists to catch.
+set +e
+dart test --concurrency=1 -r expanded
+TEST_EXIT=$?
+set -e
+
+echo "*** docker compose down" && docker compose down
+
+exit "$TEST_EXIT"


### PR DESCRIPTION
## Intro / context

Last of three (#2208, #2210, this one). What the series delivers:
- at_client_web can inject whatever storage it needs — likely in-memory, ephemeral per session
- CLI apps can have ephemeral storage and leave nothing on disk
- We can switch away from Hive as the client default
- Storage tech-debt removal and structural cleanup

#2208 paved the way in at_client, #2210 moved the test pack onto it. This one moves the
*consumers* and adds the app-facing factory they use. It then carries a second, related piece:
at_client finally moving onto the at_lookup API that #2174 shipped in August.

Unlike #2208 and #2210, this has substantial lib changes. Most are refactoring, restructuring,
rewiring and tech debt removal — lib is net -14 lines. Two parts are not: the new app-facing API
(`AtClient.create`, `closedByClient`, `AuthService.createClient`), and the switch of
authentication from buried-inside-at_lookup to pass-an-authenticator function.

## Why

**An app cannot currently "own" its own client.** The only way to get an `AtClient` is `AtClientManager`, a
singleton with one "current atSign" that decides when the client starts and stops. It will likely go away in a future major, so apps need their own way before then, not during.

**Choosing where data lives meant taking on its lifetime.** A supplied storage bundle was only
borrowed — the app had to close it. An app with no teardown (a CLI, a Flutter app with no logout)
couldn't, so it was stuck with the one Hive directory the preference named.

**Connections were built in four places, differently** — so a client's second connection wasn't
configured like its first: different credentials, different identification sent to the atServer.
#2174 fixed this in at_lookup; at_client never moved onto it, and still called the constructor
that release deprecated.

## What

- **`AtClient.create` gives the caller a client it owns.** `AtClientManager` is untouched, so
  existing apps see no difference. ⚠️ The client is still filed in the instance map like any
  other, so do not mix the factory and the manager for one atSign in one process.
- **Ownership is a property of the bundle**, not of how it arrived: `closedByClient: true` hands
  the lifetime back, so choosing a backend costs no teardown.
- **Credentials travel as an `AtAuthenticator`, configuration as a transport** — both were
  previously poked onto a connection after construction, which is why two could differ.
- **`Monitor` stops owning a socket** — connect, auth, framing, heartbeat and reconnect existed
  twice; only at_lookup's copy survives.
- **What only a client can see stays with it** — a first-connect retry, one-at-a-time handling,
  and rebuilding a connection that answers heartbeats while delivering nothing. From at_lookup
  such a socket looks healthy.

**at_client**
- `client/at_client_spec.dart` — the `AtClient.create` factory.
- `client/at_client_impl.dart` — `buildRemoteSecondary`, the one place a connection is built, and
  `holdsLiveClient`; honours `closedByClient` on `stop()`.
- `client/remote_secondary.dart` — builds via `withSecureSocket`, installing an authenticator from
  whichever of four credential shapes the client holds.
- `manager/monitor.dart` — drives a connection it is given; 543 → 327 lines.
- `service/notification_service_impl.dart` — builds that connection, authenticating as Monitor did.
- `service/sync_service_impl.dart` — sync's connection gets the client's key material.
- `preference/at_client_preference.dart` — deprecates `hiveStoragePath` and `commitLogPath`;
  adds `monitorSilenceTimeout` (60s; `Duration.zero` off).
- `storage/at_client_storage.dart` — adds `closedByClient`; both backends forward it.

**at_onboarding_cli**
- `util/at_onboarding_preference.dart` — adds `storagePath` and `storage`.
- `onboard/at_onboarding_service_impl.dart` — builds a client-closed bundle itself.
- `util/create_at_client_cli.dart` — sets `storagePath`, not `hiveStoragePath`.
- `util/home_directory_util.dart` — removes `getCommitLogPath`, its last caller gone.

**at_cli_commons**
- `src/cli_base.dart` — sets `storagePath`; nothing else needed, as it already passes the caller's
  own preference through.

**at_client_flutter**
- `services/auth_service.dart` — `createClient`, turning a completed authentication into a client
  the app owns.
- `services/enrollment_service.dart` — optional client, so it can work against one.
- `widgets/.../enrollment_request_list.dart` — optional service, and every client read goes
  through it, so the enrollment UI works against an app-owned client.
- Four example apps supply a client-closed bundle instead of paths, gaining no teardown code.

⚠️ **at_client is 3.15.0-rc1** — a minor, since this adds `AtClient.create`, `closedByClient`
and `monitorSilenceTimeout`. 3.14.1 was never published, so the heading is renamed rather than
added to; `AtClientConfig.atClientVersion` moves with it, being the version sent to the atServer.
Floors move where the code needs them: at_client → `at_lookup ^3.7.0-rc1`; at_client_flutter,
at_cli_commons and at_onboarding_cli → `at_client ^3.15.0-rc1`; at_cli_commons →
`at_onboarding_cli ^1.17.0-rc1`. at_onboarding_cli is 1.17.0-rc1 (three `feat:` entries),
at_cli_commons 3.1.2.

## How to verify it

- `at_client_create_test.dart` (new) — the factory refuses a live atSign, files what it builds,
  and leaves nothing behind when service wiring throws.
- `remote_secondary_test.dart` — the connection carries an authenticator, not credentials.
- `at_client_storage_release_test.dart` — `closedByClient` closes on `stop()`; borrowed does not.
- `monitor_test.dart` — replaced, plus one-at-a-time handling and the watchdog with its control.
  Most of what the deleted tests guarded is at_lookup's `muxable_notifications_test.dart` (26
  tests); the two asserting the heartbeat *preference* are ported into
  `notification_service_test.dart`, which at_lookup cannot do — it cannot see a preference.
- `monitor_silence_test.dart` (new, functional) — a budget under the atServer's stats cadence
  rebuilds a real connection; one above it does not.
- `enrollment_request_list_test.dart` (new) — the enrollment UI against an app-owned client.
- `notification_service_test.dart` — notifications delivered framed, not as raw bytes.
- `at_client_termination_test.dart` — Monitor driven by a stub connection.
- `at_onboarding_storage_test.dart` (new) — the CLI's bundle reaches the client.
- `auth_service_create_client_test.dart` (new) — the Flutter client holds the app's bundle.
- `..._functional_tests_proxy/runLocal.sh` (new) — that pack had no local runner.

## A note on WASM

This series is groundwork for `at_client_web`, and it is worth being precise about what it
does and does not unlock.

**Unlocked:** an app can now choose its own storage (`AtClientStorage`) and its own key
source (`AtKeysIo`), and own the client's lifetime without `AtClientManager` — the three
things a web build has to supply for itself.

**Not unlocked: the transport.** Six production sites still hardcode
`secureSocketTransport(...)`: at_client's `remote_secondary.dart` and
`notification_service_impl.dart` (the only two files in at_client importing
`at_lookup_io.dart` — the sync service inherits the first), at_auth's `at_auth_impl.dart`
×2 and `enrollment_handshake.dart`, and at_server_status. So an app cannot yet hand in a
WebSocket transport, and at_auth matters as much as at_client here: a web app
authenticates *before* it has an `AtClient`.

Two things this PR did make cheaper. `Monitor` no longer owns a socket, so it is no longer
an `AtConnection`/`getSocket` caller — that audit is down to `remote_secondary.dart` alone.
And `AtLookUp.withSecureSocket` already takes an `AtLookupTransport`, with no `dart:io` in
the file that declares it; what remains is a neutral name and an io-free `AtLookupImpl`,
whose binding is five occurrences, not a rewrite.

Tracked as **T9** in [`docs/projects/wasm/implementation-plan.md`](docs/projects/wasm/implementation-plan.md),
with T1 and T4 corrected against the tree in the same commit.

## Description for the changelog

`AtClient.create` builds a client the caller owns; `AtClientManager` is unchanged.
`AtClientStorage.closedByClient` lets a bundle say the client closes it, so choosing a backend no
longer means taking on its lifetime. at_client builds its connections through
`AtLookUp.withSecureSocket`, carrying credentials as an authenticator, and `Monitor` drives one
instead of owning a socket, keeping what only a client can do — including
`monitorSilenceTimeout`, which rebuilds a connection that answers heartbeats while delivering
nothing. `hiveStoragePath` and `commitLogPath` are deprecated.



