### PR TITLE
fix(at_client): close the attach() race on AtClientStorageBase._openByLocation

### DIFF
--- a/packages/at_client/lib/src/storage/at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/at_client_storage.dart
@@ -88,8 +88,16 @@ abstract class AtClientStorageBase implements AtClientStorage {
           '${held == null ? '' : ', last held by $held'}; close it before '
           'opening a second there, or give this one its own location');
     }
-    await openBackend();
+    // Claimed before the await, not after: two attach() calls for the same
+    // location can otherwise both read no occupant and both pass the check
+    // above while the first is still suspended inside openBackend().
     _openByLocation[here] = this;
+    try {
+      await openBackend();
+    } catch (_) {
+      if (identical(_openByLocation[here], this)) _openByLocation.remove(here);
+      rethrow;
+    }
     _owner = owner;
     _lastPrincipal = principal;
   }

--- a/packages/at_client/test/storage/at_client_storage_release_test.dart
+++ b/packages/at_client/test/storage/at_client_storage_release_test.dart
@@ -1,10 +1,43 @@
+import 'dart:async';
 import 'dart:io';
 
 import 'package:at_client/at_client.dart';
 import 'package:at_client/sqlite.dart';
+import 'package:at_client/src/sync/at_sync_queue.dart';
+import 'package:at_persistence_secondary_server/at_persistence_secondary_server.dart';
 import 'package:test/test.dart';
 
 import 'storage_contract.dart';
+
+/// A storage whose [openBackend] can be held open on [gate], so a test can
+/// interleave a second [attach] while the first is still inside it.
+class _GatedStorage extends AtClientStorageBase {
+  _GatedStorage(this._location, {Completer<void>? gate}) : _gate = gate;
+  final String _location;
+  final Completer<void>? _gate;
+
+  @override
+  String get location => _location;
+
+  @override
+  Future<void> openBackend() async {
+    final gate = _gate;
+    if (gate != null) await gate.future;
+  }
+
+  @override
+  Future<void> closeBackend() async {}
+
+  @override
+  Future<void> clearData() async {}
+
+  @override
+  AtKeyValueStore<String, AtData, AtMetaData?> get keyStore =>
+      throw UnimplementedError();
+
+  @override
+  AtSyncQueue get syncQueue => throw UnimplementedError();
+}
 
 void main() {
   late Directory dir;
@@ -40,6 +73,32 @@ void main() {
     expect(sameStore.isAttached, isTrue,
         reason: 'stop() closed the first storage, releasing the store');
     await sameStore.close();
+  });
+
+  test(
+      'a second attach() racing the first cannot claim the same location '
+      'before the first finishes opening', () async {
+    final gate = Completer<void>();
+    final first = _GatedStorage('@race-loc', gate: gate);
+    final second = _GatedStorage('@race-loc');
+
+    final firstAttach = first.attach(FakeClient('@race', 'e1'));
+    // first is now suspended inside openBackend(), still awaiting gate.
+
+    await expectLater(
+        () => second.attach(FakeClient('@race', 'e2')),
+        throwsA(isA<StateError>()
+            .having((e) => e.message, 'message', contains('already open at'))),
+        reason: 'the claim must be visible to a second attach() as soon as '
+            'the first has passed its own checks, not only once the first '
+            'has finished opening its backend — otherwise both attach and '
+            'the loser\'s later close() tears down the backend the winner '
+            'still uses');
+
+    gate.complete();
+    await firstAttach;
+    expect(first.isAttached, isTrue);
+    await first.close();
   });
 
   test('two storages for one atSign at different locations both open',


### PR DESCRIPTION
## Summary
- Fixes a concurrency bug found while reviewing #2208 (see [inline comment](https://github.com/atsign-foundation/at_client_sdk/pull/2208#discussion_r3944595998)): `AtClientStorageBase.attach()` recorded its claim on `_openByLocation` *after* `await openBackend()`, so two concurrent `attach()` calls for the same location could both pass the occupancy check before either claimed it.
- Concurrent `AtClientImpl.create()` calls for the same atSign + storage path would then both attach successfully instead of the second throwing `StateError` as the guard intends. Stopping the first client would close the backend the second was still using.

## How
- `_openByLocation[here] = this` now happens before `await openBackend()`, with a rollback in a `catch` if `openBackend()` throws, so the check-then-claim is atomic with respect to the await.
- Added a regression test (`a second attach() racing the first cannot claim the same location before the first finishes opening`) using a gated fake storage to deterministically interleave two `attach()` calls; confirmed it fails against the pre-fix code and passes with the fix.
- `dart analyze` clean; full `test/storage/` suite (38 tests) passes.

Opened against `gkc-at-client-storage-release` so it can be merged straight into that branch before #2208 lands on trunk.

## Test plan
- [x] New regression test fails on pre-fix source, passes on fixed source
- [x] `dart test test/storage/` — 38/38 pass
- [x] `dart analyze` on changed files — no issues