### PR TITLE
fix(at_client): restore clientConfig, and close two storage races

### DIFF
--- a/packages/at_client/CHANGELOG.md
+++ b/packages/at_client/CHANGELOG.md
@@ -152,6 +152,12 @@
   crashed for a non-nullable item type).
 - fix: `AtCollection` reads no longer duplicate the preceding item when a key
   expires or is deleted between the scan and its per-key read.
+- fix: `RemoteSecondary`'s authenticator path sends client version, id,
+  appName and platform on every authenticated connection.
+- fix: `AtClientImpl.create()` rejects a caller-supplied `storage` that a
+  cached client for the same atSign isn't already holding.
+- fix: closing one client's storage can no longer race a concurrent
+  `attach()` into opening a backend over it mid-teardown.
 
 ## 3.14.0
 - feat (experimental): per-APKAM same-atSign secret-sharing substrate —

--- a/packages/at_client/lib/src/client/at_client_impl.dart
+++ b/packages/at_client/lib/src/client/at_client_impl.dart
@@ -357,6 +357,14 @@ class AtClientImpl implements AtClient {
     AtClientImpl? atClientImpl;
     if (atClientInstanceMap.containsKey(currentAtSign)) {
       atClientImpl = atClientInstanceMap[currentAtSign];
+      // Refuse a storage the cached client doesn't already hold.
+      if (storage != null && !storage.isHeldBy(atClientImpl!)) {
+        throw IllegalArgumentException(
+            'AtClientImpl.create($currentAtSign, ...): a client for this '
+            'atSign already exists and holds different storage. Call '
+            'stop() on it first, or omit storage to keep reusing the '
+            'storage the existing client already holds.');
+      }
       await atClientImpl!.start();
       // Re-using a cached AtClient skips _init. Adopt the supplied preference's
       // crypto config so providers (and a changed defaultProviderId) added

--- a/packages/at_client/lib/src/client/remote_secondary.dart
+++ b/packages/at_client/lib/src/client/remote_secondary.dart
@@ -72,6 +72,7 @@ class RemoteSecondary implements Secondary {
         _atSign,
         enrollmentId: lookUp.enrollmentId,
         chops: _atChops,
+        clientConfig: _getClientConfig(),
       );
       return;
     }
@@ -90,6 +91,7 @@ class RemoteSecondary implements Secondary {
         // The same preference fields the constructor stamps on the lookup, so
         // the authenticator and the ladder it replaces read them alike.
         hashingAlgo: _preference.hashingAlgoType,
+        clientConfig: _getClientConfig(),
       );
       return;
     }
@@ -102,6 +104,7 @@ class RemoteSecondary implements Secondary {
         _atSign,
         privateKey,
         enrollmentId: lookUp.enrollmentId,
+        clientConfig: _getClientConfig(),
       );
       return;
     }
@@ -112,7 +115,11 @@ class RemoteSecondary implements Secondary {
     // and must keep working through the seam.
     final cramSecret = _cramSecret;
     if (cramSecret != null) {
-      lookUp.authenticator = authenticatorForCramSecret(_atSign, cramSecret);
+      lookUp.authenticator = authenticatorForCramSecret(
+        _atSign,
+        cramSecret,
+        clientConfig: _getClientConfig(),
+      );
       return;
     }
 

--- a/packages/at_client/lib/src/storage/at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/at_client_storage.dart
@@ -149,9 +149,11 @@ abstract class AtClientStorageBase implements AtClientStorage {
     _closed = true;
     _owner = null;
     final here = location;
-    // Released after closeBackend() finishes, not before.
-    await closeBackend();
-    if (identical(_openByLocation[here], this)) _openByLocation.remove(here);
+    try {
+      await closeBackend();
+    } finally {
+      if (identical(_openByLocation[here], this)) _openByLocation.remove(here);
+    }
   }
 
   /// Opens the backend. Idempotent.

--- a/packages/at_client/lib/src/storage/at_client_storage.dart
+++ b/packages/at_client/lib/src/storage/at_client_storage.dart
@@ -149,8 +149,9 @@ abstract class AtClientStorageBase implements AtClientStorage {
     _closed = true;
     _owner = null;
     final here = location;
-    if (identical(_openByLocation[here], this)) _openByLocation.remove(here);
+    // Released after closeBackend() finishes, not before.
     await closeBackend();
+    if (identical(_openByLocation[here], this)) _openByLocation.remove(here);
   }
 
   /// Opens the backend. Idempotent.

--- a/packages/at_client/test/remote_secondary_test.dart
+++ b/packages/at_client/test/remote_secondary_test.dart
@@ -5,6 +5,18 @@ import 'package:test/test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'test_utils/mocks.dart';
 
+/// Captures the command sent via [sendSync].
+class _CapturingCommandExecutor implements AtCommandExecutor {
+  String? lastCommand;
+
+  @override
+  Future<String> sendSync(String command,
+      {int? maxWaitMilliSeconds, int? transientWaitTimeMillis}) async {
+    lastCommand = command;
+    return '';
+  }
+}
+
 void main() {
   AtLookupImpl mockAtLookUp = MockAtLookUpImpl();
   SecondaryAddressFinder mockSecondaryAddressFinder =
@@ -46,6 +58,30 @@ void main() {
 
       expect(remoteSecondary.atLookUp, same(mockAtLookUp),
           reason: 'the caller supplied it, so it is used as given');
+    });
+
+    test(
+        'the installed authenticator still carries clientConfig, so the '
+        'from: command it sends keeps naming this client to the atServer',
+        () async {
+      final preference = AtClientPreference()
+        ..privateKey = 'dummy_private_key'
+        ..atClientParticulars.appName = 'remote_secondary_test_app';
+      final remoteSecondary = RemoteSecondary(atsign, preference);
+      final authenticator =
+          (remoteSecondary.atLookUp as AtLookupMuxable).authenticator;
+      expect(authenticator, isNotNull);
+
+      final capturingExecutor = _CapturingCommandExecutor();
+      await authenticator!(capturingExecutor);
+
+      expect(capturingExecutor.lastCommand, contains(':clientConfig:'),
+          reason: '_installAuthenticator builds authenticatorForPrivateKey '
+              'without threading _getClientConfig() through, so the from: '
+              'command it sends drops the client version/id/appName the '
+              'atServer used to receive from every authenticated connection');
+      expect(
+          capturingExecutor.lastCommand, contains('remote_secondary_test_app'));
     });
 
     test('test findSecondaryUrl', () async {

--- a/packages/at_client/test/storage/at_client_storage_release_test.dart
+++ b/packages/at_client/test/storage/at_client_storage_release_test.dart
@@ -13,9 +13,13 @@ import 'storage_contract.dart';
 /// A storage whose [openBackend] can be held open on [gate], so a test can
 /// interleave a second [attach] while the first is still inside it.
 class _GatedStorage extends AtClientStorageBase {
-  _GatedStorage(this._location, {Completer<void>? gate}) : _gate = gate;
+  _GatedStorage(this._location, {Completer<void>? gate, this.closeGate})
+      : _gate = gate;
   final String _location;
   final Completer<void>? _gate;
+
+  /// Held open during closeBackend(), if given.
+  final Completer<void>? closeGate;
 
   @override
   String get location => _location;
@@ -27,7 +31,10 @@ class _GatedStorage extends AtClientStorageBase {
   }
 
   @override
-  Future<void> closeBackend() async {}
+  Future<void> closeBackend() async {
+    final gate = closeGate;
+    if (gate != null) await gate.future;
+  }
 
   @override
   Future<void> clearData() async {}
@@ -100,6 +107,35 @@ void main() {
     await firstAttach;
     expect(first.isAttached, isTrue);
     await first.close();
+  });
+
+  test(
+      'close() does not release its location claim until closeBackend() '
+      'finishes, so a racing attach() cannot open a second backend over the '
+      'one still being torn down', () async {
+    final closeGate = Completer<void>();
+    final first = _GatedStorage('@close-race', closeGate: closeGate);
+    await first.attach(FakeClient('@close-race', 'e1'));
+
+    final closeFuture = first.close();
+    // first is now suspended inside closeBackend(), still awaiting closeGate.
+
+    final second = _GatedStorage('@close-race');
+    await expectLater(
+        () => second.attach(FakeClient('@close-race', 'e2')),
+        throwsA(isA<StateError>()
+            .having((e) => e.message, 'message', contains('already open at'))),
+        reason: 'the claim must still read as held for the whole of '
+            'closeBackend(), or a second attach() at the same location opens '
+            'a backend over the boxes/db the first is still tearing down — '
+            'the mirror of the race attach() already guards against');
+
+    closeGate.complete();
+    await closeFuture;
+    await second.attach(FakeClient('@close-race', 'e3'));
+    expect(second.isAttached, isTrue,
+        reason: 'once close() actually finishes, the location is free again');
+    await second.close();
   });
 
   test('two storages for one atSign at different locations both open',
@@ -185,6 +221,35 @@ void main() {
         reason: 'an injected store outlives the client that borrowed it - the '
             'caller owns its lifetime, so stop() must not have closed it');
     await injected.close();
+  });
+
+  test(
+      'AtClientImpl.create() refuses a caller-supplied storage that differs '
+      'from what the cached client for this atSign already holds', () async {
+    final held = InMemoryAtClientStorage(atSign: '@guarded');
+    final first = await AtClientImpl.create(
+            '@guarded', 'wavi', AtClientPreference(), storage: held)
+        as AtClientImpl;
+
+    final other = InMemoryAtClientStorage(atSign: '@guarded');
+    await expectLater(
+        () => AtClientImpl.create('@guarded', 'wavi', AtClientPreference(),
+            storage: other),
+        throwsA(isA<IllegalArgumentException>()),
+        reason: 'silently keeping the cached client on its original storage '
+            'would leave `other` unattached while the caller believes it is '
+            'live, and every put/get would land in `held` instead');
+    expect(other.isAttached, isFalse,
+        reason: 'the rejected storage was never attached');
+
+    final again = await AtClientImpl.create(
+            '@guarded', 'wavi', AtClientPreference(), storage: held)
+        as AtClientImpl;
+    expect(identical(again, first), isTrue,
+        reason: 're-offering the storage the cached client already holds is '
+            'not a change, and must still reuse it');
+
+    await first.stop();
   });
 
   test(

--- a/packages/at_client/test/storage/at_client_storage_release_test.dart
+++ b/packages/at_client/test/storage/at_client_storage_release_test.dart
@@ -13,13 +13,17 @@ import 'storage_contract.dart';
 /// A storage whose [openBackend] can be held open on [gate], so a test can
 /// interleave a second [attach] while the first is still inside it.
 class _GatedStorage extends AtClientStorageBase {
-  _GatedStorage(this._location, {Completer<void>? gate, this.closeGate})
+  _GatedStorage(this._location,
+      {Completer<void>? gate, this.closeGate, this.throwOnClose = false})
       : _gate = gate;
   final String _location;
   final Completer<void>? _gate;
 
   /// Held open during closeBackend(), if given.
   final Completer<void>? closeGate;
+
+  /// Makes closeBackend() throw once it is done waiting on [closeGate].
+  final bool throwOnClose;
 
   @override
   String get location => _location;
@@ -34,6 +38,7 @@ class _GatedStorage extends AtClientStorageBase {
   Future<void> closeBackend() async {
     final gate = closeGate;
     if (gate != null) await gate.future;
+    if (throwOnClose) throw StateError('closeBackend boom');
   }
 
   @override
@@ -135,6 +140,21 @@ void main() {
     await second.attach(FakeClient('@close-race', 'e3'));
     expect(second.isAttached, isTrue,
         reason: 'once close() actually finishes, the location is free again');
+    await second.close();
+  });
+
+  test('close() still releases its location claim when closeBackend() throws',
+      () async {
+    final first = _GatedStorage('@close-throw', throwOnClose: true);
+    await first.attach(FakeClient('@close-throw', 'e1'));
+
+    await expectLater(() => first.close(), throwsA(isA<StateError>()));
+
+    final second = _GatedStorage('@close-throw');
+    await second.attach(FakeClient('@close-throw', 'e2'));
+    expect(second.isAttached, isTrue,
+        reason: 'a failed closeBackend() must not leave the location '
+            'claimed forever');
     await second.close();
   });
 

--- a/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
+++ b/packages/at_onboarding_cli/test/at_onboarding_cli_test.dart
@@ -63,8 +63,6 @@ void main() {
       onboardingService.atLookUp = mockAtLookup;
       mockAtAuth.atChops = AtChopsImpl(AtChopsKeys());
       onboardingService.atAuth = mockAtAuth;
-      onboardingService.atClient = await AtClientImpl.create(
-          atSign, 'unit_test', getAtClientPreferenceAlice());
       when(() => mockAtLookup.pkamAuthenticate())
           .thenAnswer((_) => Future.value(true));
       when(() => mockAtAuth.authenticate(any()))
@@ -764,14 +762,6 @@ Future<void> tearDownFunc() async {
   if (isExists) {
     Directory('test/storage').deleteSync(recursive: true);
   }
-}
-
-AtClientPreference getAtClientPreferenceAlice() {
-  var preference = AtClientPreference();
-  preference.hiveStoragePath = 'test/storage/hive/client';
-  preference.commitLogPath = 'test/storage/hive/client/commit';
-  preference.rootDomain = 'vip.ve.atsign.zone';
-  return preference;
 }
 
 AtOnboardingPreference getOnboardingPreference() {


### PR DESCRIPTION
## Summary
- Three regressions from the auth/storage refactor landed in [#2204](https://github.com/atsign-foundation/at_client_sdk/pull/2204)–[#2211](https://github.com/atsign-foundation/at_client_sdk/pull/2211), found by adversarial review of [#2208](https://github.com/atsign-foundation/at_client_sdk/pull/2208) and [#2211](https://github.com/atsign-foundation/at_client_sdk/pull/2211).
- `RemoteSecondary._installAuthenticator()` never threaded `_getClientConfig()` into any of the four authenticator shapes it builds, so every authenticated connection now sends `from:@alice` with no `:clientConfig:` segment — the atServer stops receiving client version/id/appName/platform.
- `AtClientImpl.create()` silently discarded a caller-supplied `storage` whenever a client for that atSign was already cached: the returned client kept its old store, and the caller's storage sat unattached while believed live.
- `AtClientStorageBase.close()` released its `_openByLocation` claim *before* awaiting `closeBackend()`, reopening (in reverse) the exact race `attach()` guards against — a concurrent `attach()` at the same location could open a backend over boxes/db still being torn down.

## How
- `remote_secondary.dart`: pass `clientConfig: _getClientConfig()` on all four `authenticatorFor*()` calls in `_installAuthenticator()`.
- `at_client_impl.dart`: on a cache hit in `create()`, throw `IllegalArgumentException` if `storage != null` and isn't already held by the cached client — mirrors the `_storageIsUnchanged` guard `AtClientManager.setCurrentAtSign` already has, which this lower-level factory had no equivalent of.
- `at_client_storage.dart`: move the `_openByLocation` release in `close()` to *after* `await closeBackend()`, matching `attach()`'s claim-before-await ordering.
- Added regression tests for all three (each fails on the pre-fix code, confirmed by reverting locally and re-running).
- Two-line CHANGELOG entries under the still-unpublished `3.15.0-rc1` heading.

## Test plan
- [x] `dart test test/remote_secondary_test.dart` — new clientConfig test fails without the fix, passes with it
- [x] `dart test test/storage/at_client_storage_release_test.dart` — new close()-race and create()-guard tests fail without the fix, pass with it
- [x] `dart test` (full `at_client` suite) — 718 passed, 0 failed
- [x] `dart analyze` on all three changed lib files — no new issues (only pre-existing deprecation infos)
- [x] `dart format` clean
