### PR TITLE
fix(at_chops): say where the AES-CTR backends really diverge, and pin it

### DIFF
--- a/docs/projects/wasm/design.md
+++ b/docs/projects/wasm/design.md
@@ -86,7 +86,7 @@ covered by [`acceptance.md`](acceptance.md) T3.1 and X1.
 `at_chops.dart` exports only pure-Dart algorithms, including the PQ ones
 (`ml_kem_768_pure_dart.dart`, `ml_dsa_65_pure_dart.dart`, `x_wing_pure_dart.dart`,
 `x25519_pure_dart_algo.dart`). `at_chops_ffi.dart`, documented "not web/wasm
-compatible", re-exports it plus the eight OpenSSL-backed FFI files. **No package's
+compatible", re-exports it plus the ten OpenSSL-backed FFI files. **No package's
 `lib/` imports the FFI barrel** — only at_chops's own tests and examples.
 
 The island is correctly quarantined; it is held by convention, which is what T0

--- a/packages/at_chops/CHANGELOG.md
+++ b/packages/at_chops/CHANGELOG.md
@@ -3,6 +3,9 @@
 - feat: AES-CTR via OpenSSL when libcrypto is present, in one-shot (`AtPqc.aesCtr`)
   and incremental (`AesCtrFfiCipher`, for streams) form. Ciphertext is unchanged;
   hosts without libcrypto keep the pure-Dart path.
+- fix: `AesGcm256FfiAlgo` rejects a plaintext, ciphertext or AAD longer than the
+  C `int` its OpenSSL binding passes, rather than letting the length wrap. The
+  AES-CTR backends already carried this guard.
 
 ## 3.6.1
 

--- a/packages/at_chops/README.md
+++ b/packages/at_chops/README.md
@@ -4,7 +4,7 @@ data signing, key agreement, and hashing that can be leveraged by client applica
 ## Features
 
 - Asymmetric encryption/decryption using RSA-2048 and RSA-4096
-- Symmetric encryption/decryption using AES-128, AES-192, and AES-256 (CTR and GCM modes)
+- Symmetric encryption/decryption using AES-128, AES-192, and AES-256 (CTR and GCM modes) — pure-Dart and OpenSSL FFI backends
 - Digest signing and verification for PKAM authentication (RSA, ECC secp256r1, Ed25519)
 - Data signing and verification for public data in the Atsign Protocol
 - Post-quantum digital signatures: ML-DSA-65 (FIPS 204) — pure-Dart and OpenSSL FFI backends
@@ -227,6 +227,10 @@ ML-DSA-65, ML-KEM-768, and X25519 each have an OpenSSL FFI backend (`MlDsa65FfiA
 X-Wing (`XWingFfiAlgo`) composes the FFI backends for maximum performance when `libcrypto` is available.
 
 AES-256-GCM also has an OpenSSL FFI backend (`AesGcm256FfiAlgo`) alongside its pure-Dart counterpart (`AesGcm256EncryptionAlgo`); the two are fully interoperable. `AtPqc.aesGcm256(key)` auto-selects FFI or pure-Dart when AAD is not needed. If you need AAD (e.g. for PQ-HPKE), construct `AesGcm256FfiAlgo.fromLib(lib, key)` or `AesGcm256EncryptionAlgo(key)` directly — both expose `encrypt`/`decrypt` with `{List<int> aad}`.
+
+AES-CTR has an OpenSSL FFI backend (`AesCtrFfiAlgo`) alongside its pure-Dart counterpart (`AESEncryptionAlgo`). Both PKCS7-pad before encrypting, so their output is byte-identical at all three key lengths and either can read the other's records. `AtPqc.aesCtr(key)` auto-selects between them; pass an IV of exactly 16 bytes, which is the only length on which the two agree — the pure-Dart path also accepts a missing or shorter IV, and the FFI path rejects both.
+
+For a byte stream whose chunk boundaries the caller does not control, `AtPqc.aesCtrStreamCipher(key, iv)` returns an `AesCtrFfiCipher` holding one OpenSSL cipher context across many `update()` calls, or `null` where libcrypto is unavailable. It is raw CTR — no padding, so it is *not* wire-compatible with `AtPqc.aesCtr` — and the caller owns the context and must `dispose()` it. CTR is unauthenticated in both shapes; add a MAC, or use GCM, where integrity matters.
 
 FFI backends are exported from `package:at_chops/at_chops_ffi.dart`, not the
 main `at_chops.dart` barrel, so pure-Dart-only consumers aren't forced to

--- a/packages/at_chops/benchmark/aes_ctr_throughput.dart
+++ b/packages/at_chops/benchmark/aes_ctr_throughput.dart
@@ -11,29 +11,45 @@
 /// Three contenders per row:
 ///
 /// - **at_chops FFI** — one long-lived [AesCtrFfiCipher], as a tunnel uses it.
-/// - **DartAesCtr (stream)** — `encryptStream`, throttle and all. This is the
-///   real replaced behaviour: `Cipher.encryptStream` sleeps 1 ms every 4 MB to
-///   yield the event loop. Stripping it would flatter the FFI number.
+/// - **DartAesCtr (stream)** — `encryptStream`, throttle and all:
+///   `Cipher.encryptStream` sleeps 1 ms every 4 MB to yield the event loop,
+///   and stripping it would flatter the FFI number. This arm is
+///   `package:cryptography`, not the `better_cryptography` fork behind
+///   [AESEncryptionAlgo] — it models the streaming consumer being replaced,
+///   not at_chops's own one-shot fallback.
 /// - **DartAesCtr (raw)** — the same primitive driven chunk by chunk with no
 ///   stream machinery, so the primitive-vs-primitive comparison stays visible.
+///
+/// Every cell is sampled [repetitions] times, interleaved across sizes and
+/// contenders rather than measured one size at a time. Repeated runs of a
+/// contiguous size-at-a-time pass disagree by several times on the same cell,
+/// and by more than the chunk-size difference the table exists to show, so
+/// such a pass reports position-in-run as though it were chunk size. The cause
+/// of that drift is not established here, so the table prints the median and
+/// the observed spread instead of assuming it away: **a row whose spread is
+/// comparable to the gap between rows says nothing about chunk size.**
 library;
 
 import 'dart:convert';
 import 'dart:ffi';
 import 'dart:io';
+import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:at_chops/at_chops_ffi.dart';
 import 'package:cryptography/cryptography.dart';
 import 'package:cryptography/dart.dart';
 
-/// Bytes pushed through each contender in a timed pass.
-const int totalBytes = 256 * 1024 * 1024;
+/// Bytes pushed through each contender in one timed sample.
+const int totalBytes = 64 * 1024 * 1024;
 
 /// A warmup pass at a fraction of [totalBytes] — enough to reach steady state
 /// and to fault in the cipher's scratch buffers, without paying for a second
 /// full run of everything.
 const int warmupBytes = 16 * 1024 * 1024;
+
+/// Timed samples per cell. Three is the fewest that gives a median.
+const int repetitions = 3;
 
 const List<int> chunkSizes = <int>[1024, 4096, 16384, 65536];
 
@@ -51,60 +67,92 @@ void main() async {
   final Uint8List ivBytes =
       Uint8List.fromList(List<int>.generate(16, (int i) => i * 11 & 0xff));
 
+  final int warmupChunk = chunkSizes.reduce(max);
+  _ffiPass(warmupBytes, warmupChunk, lib, keyBytes, ivBytes);
+  await _dartStreamPass(warmupBytes, warmupChunk, keyBytes, ivBytes);
+  await _dartRawPass(warmupBytes, warmupChunk, keyBytes, ivBytes);
+
+  final Map<int, List<double>> ffi = _emptySamples();
+  final Map<int, List<double>> dartStream = _emptySamples();
+  final Map<int, List<double>> dartRaw = _emptySamples();
+
+  for (int rep = 1; rep <= repetitions; rep++) {
+    for (final int size in chunkSizes) {
+      stderr.write('\rsample $rep/$repetitions at ${size ~/ 1024} KB     ');
+      ffi[size]!.add(_ffiPass(totalBytes, size, lib, keyBytes, ivBytes));
+      dartStream[size]!
+          .add(await _dartStreamPass(totalBytes, size, keyBytes, ivBytes));
+      dartRaw[size]!
+          .add(await _dartRawPass(totalBytes, size, keyBytes, ivBytes));
+    }
+  }
+  stderr.writeln('\r                              ');
+
   stdout
     ..writeln('Host:      ${Platform.operatingSystemVersion}')
     ..writeln('Dart:      ${Platform.version}')
     ..writeln('libcrypto: $libPath')
     ..writeln('Ceiling:   ${_opensslCeiling()}')
-    ..writeln('Pass:      ${totalBytes ~/ (1024 * 1024)} MB')
+    ..writeln('Sample:    ${totalBytes ~/ (1024 * 1024)} MB '
+        '× $repetitions, interleaved; median (spread)')
     ..writeln()
     ..writeln(
         '| Chunk | at_chops FFI | DartAesCtr (stream) | DartAesCtr (raw) |')
     ..writeln('|---|---|---|---|');
 
-  final Map<int, double> ffi = <int, double>{};
-  final Map<int, double> dartStream = <int, double>{};
-
   for (final int size in chunkSizes) {
-    _ffiPass(warmupBytes, size, lib, keyBytes, ivBytes);
-    ffi[size] = _ffiPass(totalBytes, size, lib, keyBytes, ivBytes);
-
-    await _dartStreamPass(warmupBytes, size, keyBytes, ivBytes);
-    dartStream[size] =
-        await _dartStreamPass(totalBytes, size, keyBytes, ivBytes);
-
-    await _dartRawPass(warmupBytes, size, keyBytes, ivBytes);
-    final double raw = await _dartRawPass(totalBytes, size, keyBytes, ivBytes);
-
     stdout.writeln('| ${size ~/ 1024} KB '
-        '| ${ffi[size]!.toStringAsFixed(0)} MB/s '
-        '| ${dartStream[size]!.toStringAsFixed(0)} MB/s '
-        '| ${raw.toStringAsFixed(0)} MB/s |');
+        '| ${_cell(ffi[size]!)} '
+        '| ${_cell(dartStream[size]!)} '
+        '| ${_cell(dartRaw[size]!)} |');
   }
 
   stdout
     ..writeln()
-    ..writeln(_verdict(ffi, dartStream));
+    ..writeln(_verdict(_medians(ffi), _medians(dartStream)));
+}
+
+Map<int, List<double>> _emptySamples() =>
+    <int, List<double>>{for (final int s in chunkSizes) s: <double>[]};
+
+Map<int, double> _medians(Map<int, List<double>> samples) => samples
+    .map((int size, List<double> s) => MapEntry<int, double>(size, _median(s)));
+
+/// The reported figure. A mean would let one slow sample move the row.
+double _median(List<double> samples) {
+  final List<double> sorted = List<double>.of(samples)..sort();
+  final int mid = sorted.length ~/ 2;
+  return sorted.length.isOdd
+      ? sorted[mid]
+      : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/// Median plus half-range, so a reader can tell a resolved row from noise.
+String _cell(List<double> samples) {
+  final double lo = samples.reduce(min);
+  final double hi = samples.reduce(max);
+  final double half = 100 * (hi - lo) / (hi + lo);
+  return '${_median(samples).toStringAsFixed(0)} MB/s '
+      '(±${half.toStringAsFixed(0)}%)';
 }
 
 /// The line the stream adapter's design depends on: below a crossover, the
 /// adapter has to coalesce chunks or route them to pure-Dart.
 String _verdict(Map<int, double> ffi, Map<int, double> dartStream) {
-  final List<int> losses = chunkSizes
-      .where((int size) => ffi[size]! <= dartStream[size]!)
-      .toList();
+  final List<int> sizes = List<int>.of(chunkSizes)..sort();
+  final List<int> losses =
+      sizes.where((int size) => ffi[size]! <= dartStream[size]!).toList();
   if (losses.isEmpty) {
-    final double worst = chunkSizes
-        .map((int size) => ffi[size]! / dartStream[size]!)
-        .reduce((double a, double b) => a < b ? a : b);
+    final double worst =
+        sizes.map((int size) => ffi[size]! / dartStream[size]!).reduce(min);
     return 'VERDICT: no crossover — FFI wins at every size tested, by '
         '${worst.toStringAsFixed(1)}x at worst. No coalescing needed.';
   }
   final int largestLoss = losses.last;
-  final Iterable<int> wins = chunkSizes.where((int s) => s > largestLoss);
+  final Iterable<int> wins = sizes.where((int s) => s > largestLoss);
   return 'VERDICT: FFI loses at or below ${largestLoss ~/ 1024} KB, and wins '
-      'from ${wins.isEmpty ? 'nowhere up to 64 KB' : '${wins.first ~/ 1024} KB'} '
-      'up. The adapter must coalesce to ${largestLoss ~/ 1024} KB, or route '
+      '${wins.isEmpty ? 'at no size tested' : 'from ${wins.first ~/ 1024} KB up'}'
+      '. The adapter must coalesce to ${largestLoss ~/ 1024} KB, or route '
       'smaller chunks to pure-Dart.';
 }
 

--- a/packages/at_chops/lib/src/algorithm/at_pqc.dart
+++ b/packages/at_chops/lib/src/algorithm/at_pqc.dart
@@ -61,10 +61,16 @@ abstract final class AtPqc {
   ///
   /// Both backends PKCS7-pad the plaintext prior to encryption, so they are
   /// wire-interchangeable — an invariant a future edit must not break, since
-  /// the two ends of a connection may resolve to different backends. The one
-  /// exception: pass an explicit IV on every call. The pure-Dart path defaults
-  /// a missing IV to 16 zero bytes and the FFI path rejects it, so omitting it
-  /// is the one way to make the choice of backend observable.
+  /// the two ends of a connection may resolve to different backends.
+  ///
+  /// That interchangeability holds only for a 16-byte IV. Any other IV makes
+  /// the choice of backend observable, and in both directions: the pure-Dart
+  /// path substitutes 16 zero bytes for a missing IV and right-pads a shorter
+  /// one into the counter block, while the FFI path rejects both with an
+  /// [AtEncryptionException]. Callers that reach this method with an IV they
+  /// did not choose — one parsed from a record, or from an older writer — get
+  /// a failure that depends on whether the host has libcrypto. Pass exactly
+  /// 16 bytes.
   static SymmetricEncryptionAlgorithm<Uint8List, Uint8List> aesCtr(
           AESKey key) =>
       _aesCtrSupported

--- a/packages/at_chops/lib/src/algorithm/encryption/aes_ctr_ffi_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/encryption/aes_ctr_ffi_algo.dart
@@ -18,15 +18,19 @@ import 'package:ffi/ffi.dart';
 /// malleable and carries no tag; a caller needing integrity must add its own
 /// MAC, or use [AesGcm256FfiAlgo] instead.
 ///
-/// One deliberate divergence from the pure-Dart path: [AESEncryptionAlgo]
-/// substitutes 16 zero bytes for a missing IV ("the bad old days"), and this
-/// class rejects one. Pass an explicit IV and the two stay interchangeable.
+/// Wire format and padding semantics are identical to [AESEncryptionAlgo]
+/// (the pure-Dart counterpart) so the two implementations are interoperable:
+/// data encrypted by one decrypts correctly with the other. Both use PKCS7
+/// padding, despite CTR being a stream cipher, to maintain backward
+/// compatibility.
 ///
-/// Wire format, nonce handling, and padding semantics are identical to
-/// [AESEncryptionAlgo] (the pure-Dart counterpart) so the two
-/// implementations are interoperable: data encrypted by one decrypts
-/// correctly with the other. Both use PKCS7 padding, despite CTR being a
-/// stream cipher, to maintain backward compatibility.
+/// Nonce handling is the one place they differ, and it is a deliberate
+/// narrowing. [AESEncryptionAlgo] accepts any IV: it substitutes 16 zero
+/// bytes for a missing one ("the bad old days") and right-pads a shorter one
+/// into the counter block. This class requires exactly [ivLength] bytes and
+/// throws otherwise, because a short IV read through a native pointer is an
+/// out-of-bounds read rather than a wrong answer. The two are interchangeable
+/// for every 16-byte IV and for no other.
 ///
 /// The caller loads libcrypto (e.g. via [tryLoadLibCrypto]) and passes the
 /// resulting [DynamicLibrary] via [AesCtrFfiAlgo.fromLib].

--- a/packages/at_chops/lib/src/algorithm/encryption/aes_ctr_ffi_cipher.dart
+++ b/packages/at_chops/lib/src/algorithm/encryption/aes_ctr_ffi_cipher.dart
@@ -23,8 +23,13 @@ import 'package:ffi/ffi.dart';
 /// not mix the two on one channel.
 ///
 /// Encryption and decryption are the same operation in CTR, so there is one
-/// class and one direction per instance — construct a second instance, with
-/// the same key and IV, for the other end.
+/// class and one direction per instance. The instance that decrypts a stream
+/// takes the same key and IV as the one that encrypted it.
+///
+/// **A duplex channel is two streams, and each needs its own IV.** Running
+/// both directions of a tunnel from one (key, IV) pair XORs the two plaintexts
+/// together under a single keystream, which recovers both from the ciphertext
+/// alone. Derive or transmit a separate IV per direction.
 ///
 /// ## Ownership
 ///

--- a/packages/at_chops/lib/src/algorithm/encryption/aes_gcm_ffi_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/encryption/aes_gcm_ffi_algo.dart
@@ -75,6 +75,8 @@ final class AesGcm256FfiAlgo
       {InitialisationVector? iv, List<int> aad = const []}) async {
     final Uint8List keyBytes = _keyBytesForEncrypt();
     final List<int> nonce = _nonceBytesForEncrypt(iv);
+    checkInlLength(aad.length, 'aad', 'EVP_EncryptUpdate');
+    checkInlLength(plainData.length, 'plainData', 'EVP_EncryptUpdate');
 
     final Pointer<EVP_CIPHER_CTX> ctx = _ctxNew();
     if (ctx == nullptr) throw StateError('EVP_CIPHER_CTX_new failed');
@@ -195,6 +197,8 @@ final class AesGcm256FfiAlgo
         encryptedData.sublist(0, encryptedData.length - tagLength);
     final Uint8List tag =
         encryptedData.sublist(encryptedData.length - tagLength);
+    checkInlLength(aad.length, 'aad', 'EVP_DecryptUpdate');
+    checkInlLength(cipherText.length, 'encryptedData', 'EVP_DecryptUpdate');
 
     final Pointer<EVP_CIPHER_CTX> ctx = _ctxNew();
     if (ctx == nullptr) throw StateError('EVP_CIPHER_CTX_new failed');

--- a/packages/at_chops/test/aes_ctr_ffi_test.dart
+++ b/packages/at_chops/test/aes_ctr_ffi_test.dart
@@ -46,29 +46,47 @@ void main() {
     });
 
     group('FFI / pure-Dart interop (padding-parity guard)', () {
-      test('FFI encrypts, pure-Dart decrypts', () async {
-        final AESKey key = AESKey.generate(32);
-        final AesCtrFfiAlgo ffiAlgo = makeAlgo(key);
-        final AESEncryptionAlgo pureAlgo = AESEncryptionAlgo(key);
-        final InitialisationVector iv = InitialisationVector.random(16);
-        final Uint8List plain = Uint8List.fromList(utf8.encode('ffi→pure'));
+      // Every key length AesCtrFactory accepts, not just 256-bit: accepting
+      // 16 and 24 is what keeps a pure-Dart caller working after it resolves
+      // to FFI, so those are the lengths the parity claim is about.
+      for (final int len in <int>[16, 24, 32]) {
+        test('${len * 8}-bit: FFI encrypts, pure-Dart decrypts', () async {
+          final AESKey key = AESKey.generate(len);
+          final AesCtrFfiAlgo ffiAlgo = makeAlgo(key);
+          final AESEncryptionAlgo pureAlgo = AESEncryptionAlgo(key);
+          final InitialisationVector iv = InitialisationVector.random(16);
+          final Uint8List plain = Uint8List.fromList(utf8.encode('ffi→pure'));
 
-        final Uint8List encrypted = await ffiAlgo.encrypt(plain, iv: iv);
-        final Uint8List decrypted = await pureAlgo.decrypt(encrypted, iv: iv);
-        expect(utf8.decode(decrypted), 'ffi→pure');
-      });
+          final Uint8List encrypted = await ffiAlgo.encrypt(plain, iv: iv);
+          final Uint8List decrypted = await pureAlgo.decrypt(encrypted, iv: iv);
+          expect(utf8.decode(decrypted), 'ffi→pure');
+        });
 
-      test('pure-Dart encrypts, FFI decrypts', () async {
-        final AESKey key = AESKey.generate(32);
-        final AesCtrFfiAlgo ffiAlgo = makeAlgo(key);
-        final AESEncryptionAlgo pureAlgo = AESEncryptionAlgo(key);
-        final InitialisationVector iv = InitialisationVector.random(16);
-        final Uint8List plain = Uint8List.fromList(utf8.encode('pure→ffi'));
+        test('${len * 8}-bit: pure-Dart encrypts, FFI decrypts', () async {
+          final AESKey key = AESKey.generate(len);
+          final AesCtrFfiAlgo ffiAlgo = makeAlgo(key);
+          final AESEncryptionAlgo pureAlgo = AESEncryptionAlgo(key);
+          final InitialisationVector iv = InitialisationVector.random(16);
+          final Uint8List plain = Uint8List.fromList(utf8.encode('pure→ffi'));
 
-        final Uint8List encrypted = await pureAlgo.encrypt(plain, iv: iv);
-        final Uint8List decrypted = await ffiAlgo.decrypt(encrypted, iv: iv);
-        expect(utf8.decode(decrypted), 'pure→ffi');
-      });
+          final Uint8List encrypted = await pureAlgo.encrypt(plain, iv: iv);
+          final Uint8List decrypted = await ffiAlgo.decrypt(encrypted, iv: iv);
+          expect(utf8.decode(decrypted), 'pure→ffi');
+        });
+
+        test('${len * 8}-bit: both backends emit the same ciphertext',
+            () async {
+          final AESKey key = AESKey.generate(len);
+          final InitialisationVector iv = InitialisationVector.random(16);
+          final Uint8List plain =
+              Uint8List.fromList(utf8.encode('byte-for-byte'));
+
+          expect(await makeAlgo(key).encrypt(plain, iv: iv),
+              await AESEncryptionAlgo(key).encrypt(plain, iv: iv),
+              reason: 'a cross-decrypt still passes if both backends are '
+                  'wrong in the same way; this does not');
+        });
+      }
 
       // The IV's low 8 bytes are all 0xFF, so block 1 encrypts with the
       // counter at 2^64 - 1 and block 2 carries into the IV's high half. A
@@ -169,6 +187,38 @@ void main() {
       await expectLater(
           algo.encrypt(plain, iv: InitialisationVector.random(12)),
           throwsA(isA<AtEncryptionException>()));
+    });
+
+    /// The backends are interchangeable for a 16-byte IV and for no other
+    /// length, so a caller handed an IV it did not choose gets an outcome
+    /// that depends on whether the host has libcrypto. Pinned here so the
+    /// dartdoc on [AtPqc.aesCtr] cannot drift away from the behaviour.
+    group('a non-16-byte IV is where the two backends part company', () {
+      for (final int len in <int>[8, 12, 15]) {
+        test('$len-byte IV: pure-Dart accepts, FFI rejects', () async {
+          final AESKey key = AESKey.generate(32);
+          final InitialisationVector iv = InitialisationVector.random(len);
+          final Uint8List plain = Uint8List.fromList(utf8.encode('short iv'));
+
+          expect(
+              await AESEncryptionAlgo(key).encrypt(plain, iv: iv), isNotEmpty,
+              reason: 'the pure-Dart path right-pads a short IV into the '
+                  'counter block rather than rejecting it');
+          await expectLater(makeAlgo(key).encrypt(plain, iv: iv),
+              throwsA(isA<AtEncryptionException>()));
+        });
+      }
+
+      test('16 bytes is the length on which they agree', () async {
+        final AESKey key = AESKey.generate(32);
+        final InitialisationVector iv = InitialisationVector.random(16);
+        final Uint8List plain = Uint8List.fromList(utf8.encode('short iv'));
+
+        expect(await makeAlgo(key).encrypt(plain, iv: iv),
+            await AESEncryptionAlgo(key).encrypt(plain, iv: iv),
+            reason: 'the control for the divergence tests above: without it '
+                'they would pass against a backend that rejected every IV');
+      });
     });
 
     test('a key that is not 16/24/32 bytes throws AtEncryptionException',

--- a/packages/at_chops/test/at_pqc_test.dart
+++ b/packages/at_chops/test/at_pqc_test.dart
@@ -10,6 +10,7 @@ void main() {
   final bool xWingFfi = lib != null && libCryptoSupportsMlKem768(lib);
   final bool mlDsaFfi = lib != null && libCryptoSupportsMlDsa65(lib);
   final bool aesGcmFfi = lib != null && libCryptoSupportsAesGcm(lib);
+  final bool aesCtrFfi = lib != null && libCryptoSupportsAesCtr(lib);
 
   group('AtPqc — host-agnostic', () {
     test('AtPqc.xWing is FFI when supported, else pure', () {
@@ -35,6 +36,51 @@ void main() {
       } else {
         expect(AtPqc.aesGcm256(key), isA<AesGcm256EncryptionAlgo>());
       }
+    });
+
+    test('AtPqc.aesCtr is FFI when supported, else pure', () {
+      final AESKey key = AESKey.generate(32);
+      if (aesCtrFfi) {
+        expect(AtPqc.aesCtr(key), isA<AesCtrFfiAlgo>());
+      } else {
+        expect(AtPqc.aesCtr(key), isA<AESEncryptionAlgo>());
+      }
+    });
+
+    test('AtPqc.aesCtrStreamCipher is non-null exactly when FFI is available',
+        () {
+      final AesCtrFfiCipher? cipher = AtPqc.aesCtrStreamCipher(
+          AESKey.generate(32), InitialisationVector.random(16));
+      try {
+        expect(cipher == null, !aesCtrFfi);
+      } finally {
+        cipher?.dispose();
+      }
+    });
+
+    test('aesCtr encrypt/decrypt round-trips at every accepted key length',
+        () async {
+      for (final int len in <int>[16, 24, 32]) {
+        final AESKey key = AESKey.generate(len);
+        final InitialisationVector iv = InitialisationVector.random(16);
+        final Uint8List plain = Uint8List.fromList(utf8.encode('hello ctr'));
+
+        final Uint8List encrypted =
+            await AtPqc.aesCtr(key).encrypt(plain, iv: iv);
+        expect(await AtPqc.aesCtr(key).decrypt(encrypted, iv: iv), plain,
+            reason: '${len * 8}-bit key failed to round-trip');
+      }
+    });
+
+    test('aesCtr agrees byte-for-byte with the pure-Dart path', () async {
+      final AESKey key = AESKey.generate(32);
+      final InitialisationVector iv = InitialisationVector.random(16);
+      final Uint8List plain = Uint8List.fromList(utf8.encode('wire parity'));
+
+      expect(await AtPqc.aesCtr(key).encrypt(plain, iv: iv),
+          await AESEncryptionAlgo(key).encrypt(plain, iv: iv),
+          reason: 'whichever backend this host resolves, its output is what '
+              'the other end of a connection has to be able to read');
     });
 
     test('aesGcm256 encrypt/decrypt round-trip', () async {


### PR DESCRIPTION
**- What I did**

Review follow-ups on #2220, branched off `st/aes-ctr-ffi`. Docs, tests and one guard - the AES-CTR implementation itself is untouched.

- Corrected the dartdoc on `AtPqc.aesCtr` and `AesCtrFfiAlgo`, and pinned both the divergence and the parity as tests.
- Added the `AtPqc.aesCtr` and `AtPqc.aesCtrStreamCipher` resolver tests.
- Added AES-CTR to the README's FFI backends section, and fixed the FFI file count in `docs/projects/wasm/design.md`.
- `AesGcm256FfiAlgo` now calls `checkInlLength` on its four `EVP_{En,De}cryptUpdate` calls.
- Reworked the throughput benchmark to sample each cell three times, interleaved.

**- Why**

- The dartdoc said a missing IV was the only way to tell the two backends apart. Any IV that isn't 16 bytes does it too: pure-Dart right-pads a short one into the counter block and encrypts, FFI throws. There's already a 15-byte IV in the tree on the path this would be swapped onto - `at_chops_compatibility_test.dart`, through `AtChopsImpl.encryptBytes`.
- Accepting 16 and 24-byte keys is justified by pure-Dart parity, but all three interop tests used a 32-byte key. 128 and 192 do match byte for byte, so this is coverage rather than a bug.
- The two new `AtPqc` methods had no test at all, and the resolver is what picks a caller's backend.
- The benchmark's chunk column wasn't measuring chunk size. Two runs of the shipped script disagreed by 3.6x on the same cell, and a third with only the size list reversed came out flat, so the table was reporting position-in-run. The verdict - no crossover, FFI wins everywhere - survives.
- #2220 narrowed the shared `inl` typedef to `Int32`. GCM shares that typedef and didn't get the guard.

**- How I did it**

See commits.

**- How to verify it**

Tests pass.

**- Description for the changelog**

`AesGcm256FfiAlgo` rejects an input longer than the C `int` its OpenSSL binding passes, rather than letting the length wrap.
