### PR TITLE
fix(at_chops): the FFI inl guard throws the algo's own exception type

### DIFF
--- a/packages/at_chops/lib/src/algorithm/encryption/aes_ctr_ffi_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/encryption/aes_ctr_ffi_algo.dart
@@ -107,7 +107,8 @@ class AesCtrFfiAlgo
     // Padding is required for AESEncryptionAlgo parity.
     final Uint8List paddedData =
         Uint8List.fromList(paddingAlgo!.addPadding(plainData));
-    checkInlLength(paddedData.length, 'paddedData', 'EVP_EncryptUpdate');
+    checkInlLength(paddedData.length, 'paddedData', 'EVP_EncryptUpdate',
+        AtEncryptionException.new);
 
     final Pointer<EVP_CIPHER_CTX> ctx = _ctxNew();
     if (ctx == nullptr) throw StateError('EVP_CIPHER_CTX_new failed');
@@ -171,7 +172,8 @@ class AesCtrFfiAlgo
       {InitialisationVector? iv}) async {
     final Uint8List keyBytes = _keyBytesForDecrypt();
     final List<int> nonce = _nonceBytesForDecrypt(iv);
-    checkInlLength(encryptedData.length, 'encryptedData', 'EVP_DecryptUpdate');
+    checkInlLength(encryptedData.length, 'encryptedData', 'EVP_DecryptUpdate',
+        AtDecryptionException.new);
 
     final Pointer<EVP_CIPHER_CTX> ctx = _ctxNew();
     if (ctx == nullptr) throw StateError('EVP_CIPHER_CTX_new failed');

--- a/packages/at_chops/lib/src/algorithm/encryption/aes_ctr_ffi_cipher.dart
+++ b/packages/at_chops/lib/src/algorithm/encryption/aes_ctr_ffi_cipher.dart
@@ -129,7 +129,8 @@ final class AesCtrFfiCipher {
       throw StateError('AesCtrFfiCipher.update called after dispose');
     }
     if (input.isEmpty) return Uint8List(0);
-    checkInlLength(input.length, 'input', 'EVP_EncryptUpdate');
+    checkInlLength(
+        input.length, 'input', 'EVP_EncryptUpdate', AtEncryptionException.new);
 
     _state.ensureCapacity(input.length);
     _state.inBuf.asTypedList(input.length).setAll(0, input);
@@ -162,7 +163,8 @@ final class AesCtrFfiCipher {
       throw StateError('AesCtrFfiCipher.updateView called after dispose');
     }
     if (input.isEmpty) return Uint8List(0);
-    checkInlLength(input.length, 'input', 'EVP_EncryptUpdate');
+    checkInlLength(
+        input.length, 'input', 'EVP_EncryptUpdate', AtEncryptionException.new);
 
     _state.ensureCapacity(input.length);
     _state.inBuf.asTypedList(input.length).setAll(0, input);

--- a/packages/at_chops/lib/src/algorithm/encryption/aes_gcm_ffi_algo.dart
+++ b/packages/at_chops/lib/src/algorithm/encryption/aes_gcm_ffi_algo.dart
@@ -75,8 +75,10 @@ final class AesGcm256FfiAlgo
       {InitialisationVector? iv, List<int> aad = const []}) async {
     final Uint8List keyBytes = _keyBytesForEncrypt();
     final List<int> nonce = _nonceBytesForEncrypt(iv);
-    checkInlLength(aad.length, 'aad', 'EVP_EncryptUpdate');
-    checkInlLength(plainData.length, 'plainData', 'EVP_EncryptUpdate');
+    checkInlLength(
+        aad.length, 'aad', 'EVP_EncryptUpdate', AtEncryptionException.new);
+    checkInlLength(plainData.length, 'plainData', 'EVP_EncryptUpdate',
+        AtEncryptionException.new);
 
     final Pointer<EVP_CIPHER_CTX> ctx = _ctxNew();
     if (ctx == nullptr) throw StateError('EVP_CIPHER_CTX_new failed');
@@ -197,8 +199,10 @@ final class AesGcm256FfiAlgo
         encryptedData.sublist(0, encryptedData.length - tagLength);
     final Uint8List tag =
         encryptedData.sublist(encryptedData.length - tagLength);
-    checkInlLength(aad.length, 'aad', 'EVP_DecryptUpdate');
-    checkInlLength(cipherText.length, 'encryptedData', 'EVP_DecryptUpdate');
+    checkInlLength(
+        aad.length, 'aad', 'EVP_DecryptUpdate', AtDecryptionException.new);
+    checkInlLength(cipherText.length, 'encryptedData', 'EVP_DecryptUpdate',
+        AtDecryptionException.new);
 
     final Pointer<EVP_CIPHER_CTX> ctx = _ctxNew();
     if (ctx == nullptr) throw StateError('EVP_CIPHER_CTX_new failed');

--- a/packages/at_chops/lib/src/algorithm/ffi/openssl_ffi_bindings.dart
+++ b/packages/at_chops/lib/src/algorithm/ffi/openssl_ffi_bindings.dart
@@ -1,4 +1,6 @@
 import 'dart:ffi';
+
+import 'package:at_commons/at_commons.dart';
 import 'package:ffi/ffi.dart';
 
 // ── OpenSSL EVP opaque types ─────────────────────────────────────────────────
@@ -230,9 +232,15 @@ typedef EvpDecryptUpdateDart = int Function(Pointer<EVP_CIPHER_CTX>,
 /// `EVP_EncryptUpdate`/`EVP_DecryptUpdate` take `inl` as a C `int`. Dart FFI
 /// silently truncates an out-of-range length to its low 32 bits, so reject it
 /// before the native call.
-void checkInlLength(int length, String name, String fn) {
+///
+/// [thrower] supplies the exception the calling algo reports every other
+/// failure with, so an over-length input keeps the `AtException` chaining
+/// `CryptoRuntime` applies to the rest of them. An `ArgumentError` here would
+/// escape that.
+void checkInlLength(int length, String name, String fn,
+    AtClientException Function(String) thrower) {
   if (length > 0x7fffffff) {
-    throw ArgumentError.value(length, name, 'exceeds the int32 limit of $fn');
+    throw thrower('$name exceeds the int32 limit of $fn');
   }
 }
 

--- a/packages/at_chops/test/aes_ctr_ffi_cipher_test.dart
+++ b/packages/at_chops/test/aes_ctr_ffi_cipher_test.dart
@@ -348,13 +348,21 @@ void main() {
     });
 
     group('inl length guard', () {
-      test('a length beyond the C int limit throws', () {
-        expect(() => checkInlLength(0x80000000, 'input', 'EVP_EncryptUpdate'),
-            throwsArgumentError);
+      test('a length beyond the C int limit throws the supplied type', () {
+        expect(
+            () => checkInlLength(0x80000000, 'input', 'EVP_EncryptUpdate',
+                AtEncryptionException.new),
+            throwsA(isA<AtEncryptionException>()));
+        expect(
+            () => checkInlLength(0x80000000, 'input', 'EVP_DecryptUpdate',
+                AtDecryptionException.new),
+            throwsA(isA<AtDecryptionException>()));
       });
 
       test('a length at the C int limit is accepted', () {
-        expect(() => checkInlLength(0x7fffffff, 'input', 'EVP_EncryptUpdate'),
+        expect(
+            () => checkInlLength(0x7fffffff, 'input', 'EVP_EncryptUpdate',
+                AtEncryptionException.new),
             returnsNormally);
       });
     });

--- a/packages/at_chops/test/aes_ctr_ffi_test.dart
+++ b/packages/at_chops/test/aes_ctr_ffi_test.dart
@@ -178,7 +178,8 @@ void main() {
       }
     });
 
-    test('a nonce of the wrong length is rejected', () async {
+    test('a nonce of the wrong length is rejected in both directions',
+        () async {
       final AESKey key = AESKey.generate(32);
       final AesCtrFfiAlgo algo = makeAlgo(key);
       final Uint8List plain = Uint8List.fromList([1, 2, 3]);
@@ -187,6 +188,11 @@ void main() {
       await expectLater(
           algo.encrypt(plain, iv: InitialisationVector.random(12)),
           throwsA(isA<AtEncryptionException>()));
+      await expectLater(
+          algo.decrypt(plain), throwsA(isA<AtDecryptionException>()));
+      await expectLater(
+          algo.decrypt(plain, iv: InitialisationVector.random(12)),
+          throwsA(isA<AtDecryptionException>()));
     });
 
     /// The backends are interchangeable for a 16-byte IV and for no other

--- a/packages/at_chops/test/at_pqc_test.dart
+++ b/packages/at_chops/test/at_pqc_test.dart
@@ -81,7 +81,7 @@ void main() {
           await AESEncryptionAlgo(key).encrypt(plain, iv: iv),
           reason: 'whichever backend this host resolves, its output is what '
               'the other end of a connection has to be able to read');
-    });
+    }, skip: !aesCtrFfi);
 
     test('aesGcm256 encrypt/decrypt round-trip', () async {
       final AESKey key = AESKey.generate(32);


### PR DESCRIPTION
## What

Rebased onto `trunk` and cut down to what is still outstanding. Two of the three findings from the #2226 review survive; the third landed independently.

- **SR-1** — `checkInlLength` threw `ArgumentError`, which is not an `AtException` and so escapes the chaining `CryptoRuntime` applies to every other failure in these algos. It now takes the exception constructor the caller reports everything else with and throws that.
- **SR-2** — the `AtPqc.aesCtr` cross-backend parity test compared `AESEncryptionAlgo` to itself on hosts without libcrypto. It is now skipped there.
- **~~c01-F1~~** (`AtPqc.aesCtr` dartdoc naming only `AtEncryptionException`) — **dropped**, already fixed on trunk by `919da288` via #2228.

## How

- `openssl_ffi_bindings.dart` — `checkInlLength(int length, String name, String fn, AtClientException Function(String) thrower)`; throws `thrower('$name exceeds the int32 limit of $fn')`.
- `aes_ctr_ffi_algo.dart`, `aes_gcm_ffi_algo.dart` — one-shot algos pass `AtEncryptionException.new` / `AtDecryptionException.new` per direction.
- `aes_ctr_ffi_cipher.dart` — **both** call sites (`update` and the `updateView` added by `7a25cf7c`) pass `AtEncryptionException.new`. CTR encrypt and decrypt are the same operation, so this class is one direction per instance and already reports every failure — IV length, init, transform, dispose — as `AtEncryptionException`. A direction parameter for the length guard alone would contradict the line beneath it.
- `aes_ctr_ffi_cipher_test.dart` — the `inl length guard` tests assert the supplied type instead of `ArgumentError`, in both directions.
- `aes_ctr_ffi_test.dart` — the wrong-length-nonce test was encrypt-only; it now pins the decrypt direction too.
- `at_pqc_test.dart` — parity test gets `skip: !aesCtrFfi`.

## Verification

`dart analyze`: no issues. Full at_chops suite: **480 tests pass**. The FFI-tagged tests and the parity test both ran unskipped on the verifying host, so the decrypt-direction assertions exercised the real FFI path.
