### PR TITLE
fix(at_chops): name the sibling exception the decrypt path actually throws

### DIFF
--- a/packages/at_chops/lib/src/algorithm/at_pqc.dart
+++ b/packages/at_chops/lib/src/algorithm/at_pqc.dart
@@ -66,11 +66,12 @@ abstract final class AtPqc {
   /// That interchangeability holds only for a 16-byte IV. Any other IV makes
   /// the choice of backend observable, and in both directions: the pure-Dart
   /// path substitutes 16 zero bytes for a missing IV and right-pads a shorter
-  /// one into the counter block, while the FFI path rejects both with an
-  /// [AtEncryptionException]. Callers that reach this method with an IV they
-  /// did not choose — one parsed from a record, or from an older writer — get
-  /// a failure that depends on whether the host has libcrypto. Pass exactly
-  /// 16 bytes.
+  /// one into the counter block, while the FFI path rejects both — with
+  /// [AtEncryptionException] on encrypt, [AtDecryptionException] on decrypt;
+  /// the two are siblings, so catching one does not catch the other. Callers
+  /// that reach this method with an IV they did not choose — one parsed from
+  /// a record, or from an older writer — get a failure that depends on
+  /// whether the host has libcrypto. Pass exactly 16 bytes.
   static SymmetricEncryptionAlgorithm<Uint8List, Uint8List> aesCtr(
           AESKey key) =>
       _aesCtrSupported

--- a/packages/at_chops/test/aes_ctr_ffi_test.dart
+++ b/packages/at_chops/test/aes_ctr_ffi_test.dart
@@ -206,6 +206,10 @@ void main() {
                   'counter block rather than rejecting it');
           await expectLater(makeAlgo(key).encrypt(plain, iv: iv),
               throwsA(isA<AtEncryptionException>()));
+          await expectLater(makeAlgo(key).decrypt(plain, iv: iv),
+              throwsA(isA<AtDecryptionException>()),
+              reason: 'the decrypt direction rejects with its own sibling '
+                  'exception, not AtEncryptionException');
         });
       }
 


### PR DESCRIPTION
**- What I did**

Review fix for #2226, branched off `gkc-aes-ctr-ffi-review-fixes`.

- Corrected the `AtPqc.aesCtr` dartdoc: the FFI path's bad-IV rejection is `AtEncryptionException` on encrypt but `AtDecryptionException` on decrypt — siblings under `AtClientException`, not one covering the other.
- Pinned the decrypt-side exception type alongside the existing encrypt-side assertion in the backend-divergence test.

**- Why**

An [adversarial PR review](https://github.com/atsign-foundation/at_client_sdk/pull/2226) of #2226 confirmed: the new dartdoc names `AtEncryptionException` as the failure for a missing/short IV and explicitly calls out the decrypt-path case (an IV parsed from a record, or from an older writer) as the motivating example — but `AesCtrFfiAlgo.decrypt` → `_nonceBytesForDecrypt` throws `AtDecryptionException`, not `AtEncryptionException`. A caller that follows the doc and catches `AtEncryptionException` lets the decrypt failure escape uncaught. No test pinned the decrypt-side type before this change.

**- How to verify it**

```
dart test packages/at_chops/test/aes_ctr_ffi_test.dart -t ffi
```
All 27 tests pass, including the new decrypt-side assertion.